### PR TITLE
feat(storage): AppendBulk PCA+IVF clustering at compaction, armed by default (ADR-061 D3, TD-WLP-4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6768,6 +6768,7 @@ dependencies = [
  "proximadb-bloom",
  "proximadb-cache",
  "proximadb-catalog",
+ "proximadb-clustering-kernel",
  "proximadb-codec",
  "proximadb-compression",
  "proximadb-compression-types",
@@ -7045,6 +7046,14 @@ dependencies = [
  "tracing",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "proximadb-clustering-kernel"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7578,6 +7587,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
+ "proximadb-clustering-kernel",
  "proximadb-distance-kernel",
  "proximadb-hardware",
  "proximadb-quantization-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/foundation/proximadb-hardware",
     "crates/foundation/proximadb-hardware-caps",
     "crates/foundation/proximadb-distance-kernel",
+    "crates/foundation/proximadb-clustering-kernel",
     "crates/foundation/proximadb-memory-pool",
     "crates/foundation/proximadb-kernel",
     "crates/foundation/proximadb-bloom",
@@ -172,6 +173,7 @@ proximadb-compression-types = { path = "crates/foundation/proximadb-compression-
 proximadb-hardware = { path = "crates/foundation/proximadb-hardware" }
 proximadb-hardware-caps = { path = "crates/foundation/proximadb-hardware-caps" }
 proximadb-distance-kernel = { path = "crates/foundation/proximadb-distance-kernel" }
+proximadb-clustering-kernel = { path = "crates/foundation/proximadb-clustering-kernel" }
 proximadb-memory-pool = { path = "crates/foundation/proximadb-memory-pool" }
 proximadb-kernel = { path = "crates/foundation/proximadb-kernel" }
 proximadb-bloom = { path = "crates/foundation/proximadb-bloom" }
@@ -314,6 +316,7 @@ proximadb-compression-types = { path = "crates/foundation/proximadb-compression-
 proximadb-hardware = { path = "crates/foundation/proximadb-hardware" }
 proximadb-hardware-caps = { path = "crates/foundation/proximadb-hardware-caps" }
 proximadb-distance-kernel = { path = "crates/foundation/proximadb-distance-kernel" }
+proximadb-clustering-kernel = { path = "crates/foundation/proximadb-clustering-kernel" }
 proximadb-data-model = { path = "crates/foundation/proximadb-data-model" }
 proximadb-graph-model = { path = "crates/foundation/proximadb-graph-model" }
 proximadb-distance-types = { path = "crates/foundation/proximadb-distance-types" }

--- a/crates/foundation/proximadb-clustering-kernel/Cargo.toml
+++ b/crates/foundation/proximadb-clustering-kernel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "proximadb-clustering-kernel"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage = "https://github.com/vjsingh1984/proximadb"
+description = "Foundation clustering algorithms (k-means / k-means++) for ProximaDB storage and quantization"
+
+[dependencies]
+anyhow.workspace = true
+rand.workspace = true

--- a/crates/foundation/proximadb-clustering-kernel/src/lib.rs
+++ b/crates/foundation/proximadb-clustering-kernel/src/lib.rs
@@ -1,0 +1,234 @@
+//! Foundation clustering kernel (TD-WLP-4 hoist, ADR-061 D3).
+//!
+//! Lloyd's k-means with k-means++ initialization, hoisted from
+//! `proximadb-quantization-kernel` so storage engines (block/IVF clustering at
+//! compaction) and modality kernels (PQ codebook training) share ONE
+//! implementation without a storage→modality layering violation. Pure
+//! algorithm: depends only on `rand` + `anyhow`, operates on plain
+//! `&[Vec<f32>]`.
+
+use anyhow::Result;
+
+/// Inline squared L2 distance (avoids distance-engine overhead in the
+/// clustering inner loops — this is a write-time, low-cardinality path).
+#[inline]
+fn sq_l2(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| {
+            let d = x - y;
+            d * d
+        })
+        .sum::<f32>()
+}
+
+/// K-means clustering with pre-allocated working buffers.
+///
+/// k-means++ initialization followed by Lloyd iterations; buffers for
+/// distances, sums, and counts are reused across iterations (no per-iteration
+/// allocation). Returns the `k` centroids. Errors on empty input or `k == 0`.
+pub fn kmeans_clustering(
+    vectors: &[Vec<f32>],
+    k: usize,
+    max_iterations: usize,
+    convergence_threshold: f32,
+) -> Result<Vec<Vec<f32>>> {
+    use rand::seq::SliceRandom;
+
+    if vectors.is_empty() || k == 0 {
+        anyhow::bail!("Invalid input for k-means");
+    }
+
+    let mut rng = rand::thread_rng();
+    let n = vectors.len();
+    let dimension = vectors[0].len();
+
+    // ── Pre-allocate all working buffers (reused across iterations) ──
+    let mut distances = vec![f32::INFINITY; n];
+    let mut assignments = vec![0usize; n];
+    let mut counts = vec![0u32; k];
+    // Flat buffer for centroid sums: k centroids × dimension.
+    let mut sums = vec![0.0f32; k * dimension];
+    // Buffer for convergence check (stores previous centroids).
+    let mut old_centroids_flat = vec![0.0f32; k * dimension];
+
+    // ── Initialize centroids using k-means++ ──
+    let mut centroids = Vec::with_capacity(k);
+
+    let first_centroid = vectors
+        .choose(&mut rng)
+        .ok_or_else(|| anyhow::anyhow!("k-means requires at least one vector"))?
+        .clone();
+    centroids.push(first_centroid);
+
+    for _ in 1..k {
+        // Reuse distances buffer — reset to INFINITY.
+        distances.iter_mut().for_each(|d| *d = f32::INFINITY);
+
+        // Distance to the nearest existing centroid for each point.
+        for (i, vector) in vectors.iter().enumerate() {
+            for centroid in &centroids {
+                let dist = sq_l2(vector, centroid);
+                distances[i] = distances[i].min(dist);
+            }
+        }
+
+        // Choose the next centroid proportional to (squared) distance.
+        let total_dist: f32 = distances.iter().sum();
+        if total_dist <= 0.0 {
+            // All points are at distance 0 — just pick a random one.
+            if let Some(v) = vectors.choose(&mut rng) {
+                centroids.push(v.clone());
+            }
+            continue;
+        }
+        let mut cumulative = 0.0;
+        let threshold = rand::random::<f32>() * total_dist;
+
+        for (i, &dist) in distances.iter().enumerate() {
+            cumulative += dist;
+            if cumulative >= threshold {
+                centroids.push(vectors[i].clone());
+                break;
+            }
+        }
+    }
+
+    // ── Run k-means iterations with reused buffers ──
+    for _iteration in 0..max_iterations {
+        // Save current centroids for the convergence check (flat copy).
+        for (j, centroid) in centroids.iter().enumerate() {
+            old_centroids_flat[j * dimension..(j + 1) * dimension].copy_from_slice(centroid);
+        }
+
+        // Assignment step.
+        for (i, vector) in vectors.iter().enumerate() {
+            let mut best_idx = 0;
+            let mut best_dist = f32::INFINITY;
+
+            for (j, centroid) in centroids.iter().enumerate() {
+                let dist = sq_l2(vector, centroid);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_idx = j;
+                }
+            }
+
+            assignments[i] = best_idx;
+        }
+
+        // Update step — zero sums and counts, then accumulate in place.
+        sums.iter_mut().for_each(|s| *s = 0.0);
+        counts.iter_mut().for_each(|c| *c = 0);
+
+        for (i, &assignment) in assignments.iter().enumerate() {
+            let offset = assignment * dimension;
+            for (dim, val) in vectors[i].iter().enumerate() {
+                sums[offset + dim] += val;
+            }
+            counts[assignment] += 1;
+        }
+
+        // New centroids from sums/counts.
+        for (j, centroid_j) in centroids.iter_mut().enumerate() {
+            let count = counts[j];
+            if count > 0 {
+                let offset = j * dimension;
+                let inv_count = 1.0 / count as f32;
+                for dim in 0..dimension {
+                    centroid_j[dim] = sums[offset + dim] * inv_count;
+                }
+            }
+        }
+
+        // Convergence check against the saved flat buffer.
+        let mut max_change = 0.0f32;
+        for (j, centroid) in centroids.iter().enumerate() {
+            let old_slice = &old_centroids_flat[j * dimension..(j + 1) * dimension];
+            let change = sq_l2(old_slice, centroid);
+            max_change = max_change.max(change);
+        }
+
+        // Compare squared distance against squared threshold to avoid sqrt.
+        if max_change < convergence_threshold * convergence_threshold {
+            break;
+        }
+    }
+
+    Ok(centroids)
+}
+
+/// Assign each vector to its nearest centroid (squared-L2). The IVF-ordering
+/// companion to [`kmeans_clustering`]: compaction reorders records by cluster
+/// so same-cell rows co-locate into the same PAX blocks. Vectors whose
+/// dimension mismatches every centroid get cell `0`.
+pub fn kmeans_assign(vectors: &[Vec<f32>], centroids: &[Vec<f32>]) -> Vec<usize> {
+    vectors
+        .iter()
+        .map(|v| {
+            let mut best_idx = 0;
+            let mut best_dist = f32::INFINITY;
+            for (j, c) in centroids.iter().enumerate() {
+                if c.len() != v.len() {
+                    continue;
+                }
+                let dist = sq_l2(v, c);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_idx = j;
+                }
+            }
+            best_idx
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Three well-separated 2-D clusters: k-means must place one centroid in
+    /// each cluster's neighbourhood and assignment must group members.
+    #[test]
+    fn kmeans_recovers_well_separated_clusters() {
+        let mut vectors = Vec::new();
+        let anchors = [[0.0f32, 0.0], [100.0, 0.0], [0.0, 100.0]];
+        for anchor in &anchors {
+            for dx in [-1.0f32, 0.0, 1.0] {
+                for dy in [-1.0f32, 0.0, 1.0] {
+                    vectors.push(vec![anchor[0] + dx, anchor[1] + dy]);
+                }
+            }
+        }
+        let centroids = kmeans_clustering(&vectors, 3, 50, 1e-3).expect("kmeans");
+        assert_eq!(centroids.len(), 3);
+        // Every anchor must have a centroid within its cluster spread.
+        for anchor in &anchors {
+            let nearest = centroids
+                .iter()
+                .map(|c| sq_l2(c, anchor))
+                .fold(f32::INFINITY, f32::min);
+            assert!(
+                nearest < 9.0,
+                "no centroid near anchor {anchor:?} (nearest sq dist {nearest})"
+            );
+        }
+        // Assignment groups each anchor's 9 members into one cell.
+        let assignments = kmeans_assign(&vectors, &centroids);
+        for cluster in 0..3 {
+            let cells: std::collections::HashSet<usize> = assignments
+                [cluster * 9..(cluster + 1) * 9]
+                .iter()
+                .copied()
+                .collect();
+            assert_eq!(cells.len(), 1, "cluster {cluster} split across cells");
+        }
+    }
+
+    /// Error contract: empty input / k=0 are invalid.
+    #[test]
+    fn kmeans_rejects_empty_input_and_zero_k() {
+        assert!(kmeans_clustering(&[], 3, 10, 1e-3).is_err());
+        assert!(kmeans_clustering(&[vec![1.0]], 0, 10, 1e-3).is_err());
+    }
+}

--- a/crates/modalities/proximadb-quantization-kernel/Cargo.toml
+++ b/crates/modalities/proximadb-quantization-kernel/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 dashmap = { workspace = true }
+proximadb-clustering-kernel = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
+++ b/crates/modalities/proximadb-quantization-kernel/src/quantization_engine.rs
@@ -470,8 +470,9 @@ impl UnifiedQuantizationEngine {
                 .map(|v| v[start..end].to_vec())
                 .collect();
 
-            // Run k-means for this subspace
-            let subspace_centroids = self.kmeans_clustering(
+            // Run k-means for this subspace (foundation clustering kernel,
+            // hoisted for storage/modality reuse — TD-WLP-4).
+            let subspace_centroids = proximadb_clustering_kernel::kmeans_clustering(
                 &subvectors,
                 num_centroids,
                 100,  // max iterations
@@ -509,152 +510,6 @@ impl UnifiedQuantizationEngine {
             .store_codebook(codebook_id, &codebook)
             .await?;
         Ok(())
-    }
-
-    /// K-means clustering with pre-allocated working buffers.
-    /// Avoids per-iteration allocation by reusing buffers for distances, sums, and counts.
-    /// Uses inline squared L2 instead of the full distance engine for inner loops.
-    fn kmeans_clustering(
-        &self,
-        vectors: &[Vec<f32>],
-        k: usize,
-        max_iterations: usize,
-        convergence_threshold: f32,
-    ) -> Result<Vec<Vec<f32>>> {
-        use rand::seq::SliceRandom;
-
-        if vectors.is_empty() || k == 0 {
-            anyhow::bail!("Invalid input for k-means");
-        }
-
-        let mut rng = rand::thread_rng();
-        let n = vectors.len();
-        let dimension = vectors[0].len();
-
-        // ── Pre-allocate all working buffers (reused across iterations) ──
-        let mut distances = vec![f32::INFINITY; n];
-        let mut assignments = vec![0usize; n];
-        let mut counts = vec![0u32; k];
-        // Flat buffer for centroid sums: k centroids × dimension, avoids Vec<Vec<f32>> per iteration
-        let mut sums = vec![0.0f32; k * dimension];
-        // Buffer for convergence check (stores previous centroids)
-        let mut old_centroids_flat = vec![0.0f32; k * dimension];
-
-        // Inline squared L2 distance helper (avoids DistanceResult overhead)
-        let sq_l2 = |a: &[f32], b: &[f32]| -> f32 {
-            a.iter()
-                .zip(b.iter())
-                .map(|(&x, &y)| {
-                    let d = x - y;
-                    d * d
-                })
-                .sum::<f32>()
-        };
-
-        // ── Initialize centroids using k-means++ ──
-        let mut centroids = Vec::with_capacity(k);
-
-        let first_centroid = vectors
-            .choose(&mut rng)
-            .ok_or_else(|| anyhow::anyhow!("k-means requires at least one vector"))?
-            .clone();
-        centroids.push(first_centroid);
-
-        for _ in 1..k {
-            // Reuse distances buffer — reset to INFINITY
-            distances.iter_mut().for_each(|d| *d = f32::INFINITY);
-
-            // Compute distance to nearest existing centroid for each point
-            for (i, vector) in vectors.iter().enumerate() {
-                for centroid in &centroids {
-                    let dist = sq_l2(vector, centroid);
-                    distances[i] = distances[i].min(dist);
-                }
-            }
-
-            // Choose next centroid proportional to distance (already squared from sq_l2)
-            let total_dist: f32 = distances.iter().sum();
-            if total_dist <= 0.0 {
-                // All points are at distance 0 — just pick a random one
-                if let Some(v) = vectors.choose(&mut rng) {
-                    centroids.push(v.clone());
-                }
-                continue;
-            }
-            let mut cumulative = 0.0;
-            let threshold = rand::random::<f32>() * total_dist;
-
-            for (i, &dist) in distances.iter().enumerate() {
-                cumulative += dist;
-                if cumulative >= threshold {
-                    centroids.push(vectors[i].clone());
-                    break;
-                }
-            }
-        }
-
-        // ── Run k-means iterations with reused buffers ──
-        for _iteration in 0..max_iterations {
-            // Save current centroids for convergence check (flat copy, no allocation)
-            for (j, centroid) in centroids.iter().enumerate() {
-                old_centroids_flat[j * dimension..(j + 1) * dimension].copy_from_slice(centroid);
-            }
-
-            // Assignment step
-            for (i, vector) in vectors.iter().enumerate() {
-                let mut best_idx = 0;
-                let mut best_dist = f32::INFINITY;
-
-                for (j, centroid) in centroids.iter().enumerate() {
-                    let dist = sq_l2(vector, centroid);
-                    if dist < best_dist {
-                        best_dist = dist;
-                        best_idx = j;
-                    }
-                }
-
-                assignments[i] = best_idx;
-            }
-
-            // Update step — zero sums and counts, then accumulate in-place
-            sums.iter_mut().for_each(|s| *s = 0.0);
-            counts.iter_mut().for_each(|c| *c = 0);
-
-            for (i, &assignment) in assignments.iter().enumerate() {
-                let offset = assignment * dimension;
-                for (dim, val) in vectors[i].iter().enumerate() {
-                    sums[offset + dim] += val;
-                }
-                counts[assignment] += 1;
-            }
-
-            // Compute new centroids from sums/counts
-            for (j, centroid_j) in centroids.iter_mut().enumerate() {
-                let count = counts[j];
-                if count > 0 {
-                    let offset = j * dimension;
-                    let inv_count = 1.0 / count as f32;
-                    for dim in 0..dimension {
-                        centroid_j[dim] = sums[offset + dim] * inv_count;
-                    }
-                }
-            }
-
-            // Check convergence using saved flat buffer
-            let mut max_change = 0.0f32;
-            for (j, centroid) in centroids.iter().enumerate() {
-                let old_slice = &old_centroids_flat[j * dimension..(j + 1) * dimension];
-                let change = sq_l2(old_slice, centroid);
-                max_change = max_change.max(change);
-            }
-
-            // Compare squared distance against squared threshold to avoid sqrt
-            if max_change < convergence_threshold * convergence_threshold {
-                break;
-            }
-        }
-
-        Ok(centroids)
     }
 
     /// Quantize vector to binary representation

--- a/crates/storage/proximadb-storage-common/src/compaction_override.rs
+++ b/crates/storage/proximadb-storage-common/src/compaction_override.rs
@@ -1,21 +1,21 @@
-//! Per-collection compaction override (ADR-061 D5, TD-WLP-2).
+//! Per-collection compaction override (ADR-061 D5, TD-WLP-2; defaults armed
+//! since TD-WLP-4 under the pre-GA "arm defaults" directive).
 //!
-//! Compaction re-clusters (it re-runs `write_pax_segment_full`), but the
-//! trigger has been global and default-OFF (`PROXIMADB_L0_COMPACTION_ENABLED`),
-//! so no collection ever re-clusters. This module lets a collection **arm**
-//! compaction per-collection through the same tag cascade as
-//! [`crate::storage_profile::resolve_storage_profile`], while the global env
-//! stays the master kill-switch:
+//! Compaction is the re-cluster event (it re-runs the PAX segment writer with
+//! the PCA+IVF ordering — `write_pax_segment_compacted`), so `AppendBulk`
+//! collections want it ON. Resolution cascade, mirroring
+//! [`crate::storage_profile::resolve_storage_profile`]:
 //!
-//! * env explicitly falsy (`0`/`false`/`off`/`no`) → **hard disable**: no
-//!   per-collection opt-in can arm (the master kill-switch).
+//! * env explicitly falsy (`0`/`false`/`off`/`no`) → **hard disable**: the
+//!   master kill-switch nothing can override.
 //! * `compaction:on|off` tag (last matching wins) → explicit per-collection
 //!   operator intent decides.
-//! * no tag → the global env governs: truthy → armed (today's opt-in
-//!   behaviour), unset/unrecognized → OFF (today's default).
+//! * no tag → armed iff the collection's resolved [`StorageProfile`] is
+//!   `AppendBulk` (the default profile — i.e. untagged collections compact at
+//!   threshold). `Churn` stays OFF (ADR-061 D4/D5: churn invalidates a
+//!   clustering model faster than it pays off).
 //!
-//! Default path unchanged (mixed-read-safe): an untagged collection behaves
-//! byte-for-byte as before for every env state.
+//! [`StorageProfile`]: crate::storage_profile::StorageProfile
 
 /// Tag prefix for the per-collection compaction arm/disarm override on
 /// `CollectionConfig.tags`. Values: `on`/`true`/`1`/`yes`, `off`/`false`/`0`/`no`.
@@ -26,17 +26,18 @@ pub const COMPACTION_TAG_PREFIX: &str = "compaction:";
 /// resolution (parity with the other tag parsers).
 pub const COMPACTION_L0_THRESHOLD_TAG_PREFIX: &str = "l0_threshold:";
 
-/// Global compaction gate env (TD-114). Truthy arms every collection; an
-/// explicitly falsy value is the master kill-switch (TD-WLP-2); unset defers
-/// to the per-collection tag (default OFF).
+/// Global compaction gate env (TD-114). Truthy arms every collection
+/// (including `Churn`); an explicitly falsy value is the master kill-switch
+/// (TD-WLP-2); unset → per-profile default (TD-WLP-4: `AppendBulk` armed,
+/// `Churn` off) with the `compaction:` tag as the per-collection override.
 pub const L0_COMPACTION_ENABLED_ENV: &str = "PROXIMADB_L0_COMPACTION_ENABLED";
 
 /// Tri-state reading of [`L0_COMPACTION_ENABLED_ENV`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobalCompactionGate {
-    /// Env truthy: compaction armed for every collection (legacy opt-in).
+    /// Env truthy: compaction armed for every collection (force-all).
     Armed,
-    /// Env unset or unrecognized: per-collection tags may arm (default OFF).
+    /// Env unset or unrecognized: tag, then profile default (AppendBulk on).
     Default,
     /// Env explicitly falsy: master kill-switch — nothing may arm.
     HardDisabled,
@@ -59,11 +60,16 @@ pub fn global_compaction_gate() -> GlobalCompactionGate {
 /// Resolve whether compaction is armed for a collection with `tags`.
 ///
 /// Precedence: global hard-disable > `compaction:on|off` tag (last matching
-/// wins) > global env truthy > default OFF.
+/// wins) > global env truthy (force-all) > profile default (TD-WLP-4:
+/// `AppendBulk` — including every untagged collection — armed; `Churn` off).
 pub fn resolve_compaction_armed(tags: &[String]) -> bool {
     match global_compaction_gate() {
         GlobalCompactionGate::HardDisabled => false,
-        gate => compaction_tag(tags).unwrap_or(gate == GlobalCompactionGate::Armed),
+        GlobalCompactionGate::Armed => compaction_tag(tags).unwrap_or(true),
+        GlobalCompactionGate::Default => compaction_tag(tags).unwrap_or_else(|| {
+            crate::storage_profile::resolve_storage_profile(tags)
+                == crate::storage_profile::StorageProfile::AppendBulk
+        }),
     }
 }
 
@@ -109,42 +115,50 @@ mod tests {
         values.iter().map(|s| s.to_string()).collect()
     }
 
-    /// TD-WLP-2 cascade: hard-disable > tag (last wins) > global env > OFF.
+    /// TD-WLP-2/TD-WLP-4 cascade: hard-disable > tag (last wins) > env truthy
+    /// (force-all) > profile default (AppendBulk armed, Churn off).
     #[test]
     fn test_resolve_compaction_armed_tag_env_default_cascade() {
         unsafe {
             std::env::remove_var(L0_COMPACTION_ENABLED_ENV);
+            std::env::remove_var("PROXIMADB_STORAGE_PROFILE");
         }
-        // default OFF (today's behaviour)
-        assert!(!resolve_compaction_armed(&[]));
         assert_eq!(global_compaction_gate(), GlobalCompactionGate::Default);
-        // per-collection opt-in arms while the global gate is unset
-        assert!(resolve_compaction_armed(&tags(&["compaction:on"])));
-        // explicit opt-out stays off
+        // TD-WLP-4 default: untagged (AppendBulk profile) collections ARM.
+        assert!(resolve_compaction_armed(&[]));
+        assert!(resolve_compaction_armed(&tags(&[
+            "workload_profile:append"
+        ])));
+        assert!(resolve_compaction_armed(&tags(&["workload_profile:bulk"])));
+        // Churn profile stays OFF by default (ADR-061 D4/D5).
+        assert!(!resolve_compaction_armed(&tags(&[
+            "workload_profile:churn"
+        ])));
+        // Explicit tag beats the profile default in both directions.
         assert!(!resolve_compaction_armed(&tags(&["compaction:off"])));
+        assert!(resolve_compaction_armed(&tags(&[
+            "workload_profile:churn",
+            "compaction:on"
+        ])));
         // last matching tag wins
         assert!(resolve_compaction_armed(&tags(&[
             "compaction:off",
             "compaction:on"
         ])));
         // unrecognized value keeps the prior resolution
-        assert!(resolve_compaction_armed(&tags(&[
-            "compaction:on",
+        assert!(!resolve_compaction_armed(&tags(&[
+            "compaction:off",
             "compaction:sideways"
         ])));
-        // unrelated tags are ignored
-        assert!(!resolve_compaction_armed(&tags(&[
-            "workload_profile:append"
-        ])));
-        // global truthy arms untagged collections (legacy behaviour)...
+        // global truthy force-arms even Churn...
         unsafe {
             std::env::set_var(L0_COMPACTION_ENABLED_ENV, "1");
         }
         assert_eq!(global_compaction_gate(), GlobalCompactionGate::Armed);
-        assert!(resolve_compaction_armed(&[]));
+        assert!(resolve_compaction_armed(&tags(&["workload_profile:churn"])));
         // ...but an explicit per-collection opt-out still wins
         assert!(!resolve_compaction_armed(&tags(&["compaction:off"])));
-        // global hard-disable is the master kill-switch: opt-in cannot arm
+        // global hard-disable is the master kill-switch: nothing can arm
         unsafe {
             std::env::set_var(L0_COMPACTION_ENABLED_ENV, "0");
         }

--- a/docs/10-quality/td/TD-WLP-4-appendbulk-clustering-at-compaction.adoc
+++ b/docs/10-quality/td/TD-WLP-4-appendbulk-clustering-at-compaction.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — spec filed 2026-07-14 (ADR-061). Not started. Depends on TD-WLP-1 + TD-WLP-2.
+| Status | Implemented 2026-07-14 (core; under the ADR-061 arm-defaults amendment) — `kmeans_clustering`/`kmeans_assign` hoisted to the new foundation crate `proximadb-clustering-kernel` (quantization-kernel PQ training + the `spatial_clustering.rs` duplicate both folded onto it); compaction re-clusters via `write_pax_segment_compacted` → `cluster_order_pca_ivf` (batch-local `IncrementalPCA` on fp32, k-means IVF cells ordered by set-normalized centroid Hilbert code, `(cell, PC1)` record order); L0 flush keeps the model-free sign-Gray bootstrap, now **default-ON** (`PROXIMADB_PAX_BLOCK_CLUSTER=0` kill-switch); compaction armed **by default** for `AppendBulk` incl. untagged (`resolve_compaction_armed` profile default; `Churn` never schedules ⇒ never trains). Coherence gate `tests/sst_compaction_reclustering_test.rs` (compacted mean block radius must undercut bootstrap 5×). **Deferred to TD-WLP-7:** persisted `EnhancedPCAModel` + VOE `pca_model_ref` population + the flush-trigger→compaction-execution wiring (post-flush hook is still the historical stub).
 | Priority | P1b — the append-path recall payoff; double-gated (compaction armed + profile=AppendBulk).
 | Severity | High — the clustering geometry that read-side prune quality depends on.
 | Component | `src/storage/engines/sst/compaction.rs` (re-cluster call sites ~1221/1350); `src/storage/engines/sst/object_economy_directory.rs` (`pca_model_ref` + centroids ~46/135); `src/storage/engines/sst/block_cluster.rs` / `spatial_clustering.rs` (Hilbert bootstrap); `kmeans_clustering` hoist target (new foundation crate)

--- a/docs/10-quality/td/TD-WLP-7-pca-model-ref-and-compaction-execution-wiring.adoc
+++ b/docs/10-quality/td/TD-WLP-7-pca-model-ref-and-compaction-execution-wiring.adoc
@@ -1,0 +1,55 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-WLP-7: Persisted PCA model ref + flush-trigger→compaction-execution wiring (WLP-4 follow-up)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14 as the TD-WLP-4 deferral. Not started.
+| Priority | P1b — completes the ADR-061 D3 arc: without execution wiring, the armed-by-default trigger only sets `FlushResult.compaction_triggered`; nothing runs the compactor in production.
+| Severity | Medium — background execution plumbing (test-hygiene sensitive: no non-daemon threads) + model persistence/reuse.
+| Component | `src/storage/engines/sst/flush/coordinator.rs` (`post_flush_operations` — the historical "Compaction would be triggered here" stub); `src/storage/engines/sst/compaction.rs` (`schedule_compaction`/`perform_compaction_enhanced`); `src/storage/engines/sst/compactor_impl.rs` (`retrain_pca_model_for_compaction` — the persistence pattern to reuse); `object_economy_directory.rs` (`pca_model_ref` + `with_pca_model_ref`, currently write-only in tests)
+| Governs | link:../../12-design/adr/ADR-061-per-collection-workload-profiles.adoc[ADR-061] (D3, arm-defaults amendment)
+| Relates to | TD-WLP-4 (the clustering this executes), TD-WLP-6 (query-side model reuse for PCA-space pruning), ADR-046 (LSN-coherent read across the atomic segment swap)
+| Pillar | PERF (the armed default actually fires), REL (atomic swap read-consistency), OE (background execution observability)
+|===
+
+toc::[]
+
+== Why
+
+TD-WLP-4 landed the re-cluster mechanism (`write_pax_segment_compacted`, PCA+IVF ordering) and
+armed compaction by default for `AppendBulk`, but two seams were deferred:
+
+1. **Execution wiring.** `FlushCoordinator::post_flush_operations` still carries the historical
+   stub — `compaction_triggered=true` feeds tiering accounting but never schedules the compactor.
+   The armed default is only real end-to-end once the trigger schedules
+   (`schedule_compaction` → `perform_compaction_enhanced`) in production code.
+2. **Persisted model + directory ref.** The WLP-4 write-time PCA is batch-local and discarded.
+   Persist an `EnhancedPCAModel` at compaction (reuse `retrain_pca_model_for_compaction`'s
+   `{collection_dir}/__model/pca_model.bin` pattern) and populate the VOE directory's
+   `pca_model_ref` `ObjectRef`, so cold queries load the projection in one round trip and the
+   read side can prune in PCA space (TD-WLP-6).
+
+== Scope
+
+* Wire post-flush triggering to actual background compaction execution — tokio-native (no
+  non-daemon threads; deterministic-testable via a synchronous test hook), respecting
+  `OrchestratorCompactionConfig::effective_for_collection_tags` and the WLP-2/4 arming cascade.
+* Persist the compaction-trained PCA model and set `pca_model_ref` (url/size/etag) in the VOE
+  directory emission for compacted segments; compaction outputs must emit VOE directory entries
+  (today only flush emits).
+* Read-consistency across the atomic segment swap during re-cluster (ADR-046 LSN-coherence) —
+  the TD-WLP-4 gate item that rides on execution wiring.
+
+== TDD gate
+
+* Integration: a flush that crosses the L0 threshold on an `AppendBulk` collection leads —
+  without any manual compaction call — to a compacted `.pax` segment whose VOE entry carries
+  populated centroids/radii and `pca_model_ref`; reads during the swap stay consistent.
+* `Churn` collection under the same process: no compaction executes, no model persists.
+
+== Gating
+
+Same cascade as TD-WLP-2/4: armed by default for `AppendBulk`, `compaction:off` opt-out,
+`PROXIMADB_L0_COMPACTION_ENABLED` falsy = master kill-switch.

--- a/docs/12-design/adr/ADR-061-per-collection-workload-profiles.adoc
+++ b/docs/12-design/adr/ADR-061-per-collection-workload-profiles.adoc
@@ -14,6 +14,19 @@
 driven in the ProximaDB implementation session on handoff. Ships incrementally, every slice
 default-OFF and mixed-read-safe — absent the opt-in tag, behaviour is byte-for-byte today's.
 
+**Amendment (2026-07-14, owner directive — pre-GA "no back-compat, arm defaults"):** the
+*default-OFF gating* clause above is superseded for the write-time internals as of TD-WLP-4.
+Nothing is rolled out externally, so improved internals REPLACE their predecessors rather than
+shipping behind opt-in flags, and the improved behaviour is the default: block clustering at PAX
+write is default-ON (`PROXIMADB_PAX_BLOCK_CLUSTER=0` is the kill-switch), compaction is armed by
+default for `AppendBulk` — including untagged — collections (`compaction:off` tag opts out;
+`PROXIMADB_L0_COMPACTION_ENABLED` falsy remains the master kill-switch; `Churn` stays OFF). What
+is NOT relaxed: (a) on-disk **readability** of already-written segments/sidecars
+(`#[serde(default)]` fields, version markers) — data safety, not behaviour compat; (b)
+**evidence-gated defaults** — `radius_k` stays `0.0` until the post-clustering re-measurement
+shows lift (the 2026-07-14 sweep measured k=1/2 as a recall regression under sign-bit clustering);
+(c) the read-side centroid-prune default flip, which stays recall-ratchet-gated (TD-WLP-6).
+
 == Context
 
 ProximaDB's vector storage assumes a single physical paradigm — LSM-structured, clustered PAX
@@ -111,7 +124,9 @@ Add a per-collection compaction override resolved through the same cascade, mirr
 (`L0_COMPACTION_THRESHOLD = 5`; `OrchestratorCompactionConfig` in
 `src/storage/common/compaction_orchestrator.rs`). `AppendBulk` collections may **arm** compaction
 (to get re-clustering) while the global default stays OFF and `Churn` stays OFF. The global env
-remains the master kill-switch.
+remains the master kill-switch. *(Amended by the 2026-07-14 arm-defaults directive: `AppendBulk` —
+including untagged — collections are armed BY DEFAULT; `compaction:off` opts out; a falsy global
+env is the kill-switch; `Churn` stays OFF. See the Status amendment.)*
 
 === D6 — Profile selects a read-path projection, not a query route
 
@@ -151,7 +166,9 @@ wrongly prune.
   create-time engine.
 * The dark compaction re-cluster path (`write_pax_segment_full`) gets a **safe, per-collection**
   trigger — it lights up only where it pays.
-* Zero-risk default: absent a `workload_profile:` tag → `AppendBulk` → today's behaviour (compaction
+* Zero-risk default *(superseded by the 2026-07-14 arm-defaults amendment — untagged collections
+  now cluster at write and compact at threshold by default)*: absent a `workload_profile:` tag →
+  `AppendBulk` → today's behaviour (compaction
   still globally OFF). No migration, no format flag day.
 
 *Negative / cost.*

--- a/src/storage/engines/core/formats/proximablocks/spatial_clustering.rs
+++ b/src/storage/engines/core/formats/proximablocks/spatial_clustering.rs
@@ -764,8 +764,17 @@ impl AdaCurve {
         let dimensions = pca_coords[0].len();
         let num_segments = num_segments.min(pca_coords.len()).max(8);
 
-        // Step 1: K-means clustering to find natural groupings
-        let control_points = kmeans_clustering(pca_coords, num_segments);
+        // Step 1: K-means clustering to find natural groupings (foundation
+        // clustering kernel — this file's local duplicate was folded into it,
+        // TD-WLP-4). k clamped to the point count; on the (impossible-here)
+        // empty-input error, degrade to no control points.
+        let control_points = proximadb_clustering_kernel::kmeans_clustering(
+            pca_coords,
+            num_segments.min(pca_coords.len()),
+            10,
+            1e-3,
+        )
+        .unwrap_or_default();
 
         // Step 2: Order control points to minimize jumps (greedy nearest neighbor)
         let segment_order = optimize_traversal_order(&control_points);
@@ -835,97 +844,6 @@ impl AdaCurve {
         let max_code = self.encode(max_coords);
         (min_code.min(max_code), min_code.max(max_code))
     }
-}
-
-/// K-means clustering to find natural groupings in data.
-fn kmeans_clustering(points: &[Vec<f32>], k: usize) -> Vec<Vec<f32>> {
-    if points.is_empty() {
-        return vec![];
-    }
-
-    let dimensions = points[0].len();
-    let k = k.min(points.len());
-
-    // Initialize centroids using k-means++ for better starting positions
-    let mut centroids = Vec::with_capacity(k);
-
-    // First centroid: random point
-    if let Some(first) = points.first() {
-        centroids.push(first.clone());
-    }
-
-    // Remaining centroids: k-means++ selection
-    for _ in 1..k {
-        let distances: Vec<f32> = points
-            .iter()
-            .map(|p| {
-                centroids
-                    .iter()
-                    .map(|c| {
-                        p.iter()
-                            .zip(c.iter())
-                            .map(|(a, b)| (a - b).powi(2))
-                            .sum::<f32>()
-                    })
-                    .fold(f32::INFINITY, f32::min)
-            })
-            .collect();
-
-        // Select point with maximum distance to nearest centroid
-        if let Some((idx, _)) = distances
-            .iter()
-            .enumerate()
-            .max_by(|(_, d1), (_, d2)| d1.partial_cmp(d2).unwrap_or(std::cmp::Ordering::Equal))
-        {
-            centroids.push(points[idx].clone());
-        }
-    }
-
-    // Run k-means iterations (10 iterations is usually enough)
-    for _ in 0..10 {
-        // Assignment step: assign each point to nearest centroid
-        let mut clusters: Vec<Vec<Vec<f32>>> = vec![vec![]; k];
-
-        for point in points {
-            let nearest = centroids
-                .iter()
-                .enumerate()
-                .map(|(i, c)| {
-                    let dist: f32 = point
-                        .iter()
-                        .zip(c.iter())
-                        .map(|(a, b)| (a - b).powi(2))
-                        .sum();
-                    (i, dist)
-                })
-                .min_by(|(_, d1), (_, d2)| d1.partial_cmp(d2).unwrap_or(std::cmp::Ordering::Equal))
-                .map_or(0, |(i, _)| i);
-
-            clusters[nearest].push(point.clone());
-        }
-
-        // Update step: recompute centroids
-        for (i, cluster) in clusters.iter().enumerate() {
-            if cluster.is_empty() {
-                continue;
-            }
-
-            let mut new_centroid = vec![0.0; dimensions];
-            for point in cluster {
-                for (j, &val) in point.iter().enumerate() {
-                    new_centroid[j] += val;
-                }
-            }
-
-            for val in &mut new_centroid {
-                *val /= cluster.len() as f32;
-            }
-
-            centroids[i] = new_centroid;
-        }
-    }
-
-    centroids
 }
 
 /// Optimize traversal order of control points using greedy nearest neighbor.

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -11,16 +11,34 @@
 //!
 //! Reordering is **result-preserving**: the reader ranks/dedups by distance and
 //! OID, so the returned top-k is identical regardless of physical order (parity-
-//! gated in tests). Default-OFF behind `PROXIMADB_PAX_BLOCK_CLUSTER`.
+//! gated in tests). Default ON since TD-WLP-4 (ADR-061 D3);
+//! `PROXIMADB_PAX_BLOCK_CLUSTER=0` is the kill-switch. The sign-Gray key is the
+//! model-free **L0 bootstrap**; compaction re-clusters with PCA+IVF
+//! ([`cluster_order_pca_ivf`]).
 
 use proximadb_records::{EmbeddingValues, ProximaRecord};
 
-/// Opt-in for sort-by-code block clustering (TD-RDSTRAT-5 S1). Default OFF — the
-/// insertion-order write is unchanged; set `PROXIMADB_PAX_BLOCK_CLUSTER=1` to
-/// reorder records by their sign-code at flush/compaction so blocks are
-/// spatially coherent (and centroids are computed for the VOE directory).
+/// Sort-by-code block clustering at PAX write (TD-RDSTRAT-5 S1, default ON
+/// since TD-WLP-4 / ADR-061 D3 — pre-GA "arm defaults" directive). Records are
+/// reordered by locality key at flush so blocks are spatially coherent and
+/// centroids+radii are emitted for the VOE directory. Reordering is
+/// result-preserving, so the only escape needed is the kill-switch:
+/// `PROXIMADB_PAX_BLOCK_CLUSTER=0|false|off|no` restores insertion-order
+/// writes (no centroids).
 pub fn block_cluster_enabled() -> bool {
-    env_flag_on("PROXIMADB_PAX_BLOCK_CLUSTER")
+    !env_flag_off("PROXIMADB_PAX_BLOCK_CLUSTER")
+}
+
+/// True when `var` is explicitly set to a falsy value (kill-switch semantics:
+/// unset/unrecognized → not off).
+fn env_flag_off(var: &str) -> bool {
+    match std::env::var(var).ok().as_deref().map(str::trim) {
+        Some(v) => matches!(
+            v.to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => false,
+    }
 }
 
 /// TD-RDSTRAT-5 S3 (read side): opt-in for the VOE-directory centroid probe-prune
@@ -137,6 +155,118 @@ pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>
     // Precompute keys once (avoid recomputing in the comparator).
     let keys: Vec<Vec<u8>> = records.iter().map(key_of).collect();
     order.sort_by(|&a, &b| keys[a].cmp(&keys[b]).then(a.cmp(&b)));
+    Some(order)
+}
+
+/// TD-WLP-4 (ADR-061 D3): the compaction re-cluster order — **PCA + IVF
+/// (k-means) on fp32**, replacing the sign-Gray L0 bootstrap when a merged
+/// batch is worth a model. Trains a write-time PCA on this batch
+/// (`IncrementalPCA`, f32-native), k-means-clusters the projections
+/// (foundation clustering kernel), orders IVF cells by the Hilbert code of
+/// their centroid (set-normalized, so same-region cells are physically
+/// contiguous — coalescing-friendly), and orders records by
+/// `(cell rank, PC1 within cell, index)`. Clustering is computed on
+/// PCA-projected fp32, never on quantized codes (ADR-061 D3/A3).
+///
+/// Falls back to [`cluster_order`] (the model-free bootstrap) when the batch
+/// is too small to train (< [`MIN_ROWS_FOR_IVF`] usable rows) or k-means
+/// fails; returns `None` like `cluster_order` when nothing is usable. The
+/// batch-local model is discarded after ordering — persisted-model reuse
+/// (`pca_model_ref`) is the TD-WLP-4b follow-up.
+pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>> {
+    /// Below this many usable rows a trained model can't beat the bootstrap.
+    const MIN_ROWS_FOR_IVF: usize = 64;
+    /// Target rows per IVF cell — approximates rows-per-PAX-block so one cell
+    /// maps to roughly one block worth of rows.
+    const ROWS_PER_CELL: usize = 128;
+
+    use crate::storage::engines::core::formats::proximablocks::spatial_clustering::{
+        AdaptivePcaConfig, IncrementalPCA,
+    };
+
+    let usable: Vec<(usize, &[f32])> = records
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| embedding_f32(r, idx).map(|v| (i, v)))
+        .collect();
+    if usable.len() < MIN_ROWS_FOR_IVF {
+        return cluster_order(records, idx);
+    }
+    let dim = usable[0].1.len();
+    if usable.iter().any(|(_, v)| v.len() != dim) {
+        return cluster_order(records, idx);
+    }
+
+    // Batch-local PCA (one projection serves the IVF assignment, the cell
+    // Hilbert order, and the within-cell order).
+    let cfg = AdaptivePcaConfig::for_vector_dim(dim);
+    let mut pca = IncrementalPCA::new(dim, cfg.n_components);
+    for (_, v) in &usable {
+        pca.add_sample(v);
+    }
+    pca.finalize();
+    let coords: Vec<Vec<f32>> = usable.iter().map(|(_, v)| pca.transform(v)).collect();
+
+    // IVF: k-means over the projections.
+    let k = (usable.len() / ROWS_PER_CELL).clamp(2, 1024);
+    let Ok(centroids) = proximadb_clustering_kernel::kmeans_clustering(&coords, k, 15, 1e-3) else {
+        return cluster_order(records, idx);
+    };
+    let assignments = proximadb_clustering_kernel::kmeans_assign(&coords, &centroids);
+
+    // Order cells by the Hilbert code of their centroid. Normalization is over
+    // the CENTROID SET per dimension (per-vector min/max would destroy
+    // cross-centroid comparability).
+    let hilbert_dims = centroids.first().map(|c| c.len().clamp(1, 6)).unwrap_or(1);
+    let bits_per_dim = 10usize; // 6 dims × 10 bits ≤ u64
+    let mut lo = vec![f32::INFINITY; hilbert_dims];
+    let mut hi = vec![f32::NEG_INFINITY; hilbert_dims];
+    for c in &centroids {
+        for d in 0..hilbert_dims {
+            lo[d] = lo[d].min(c[d]);
+            hi[d] = hi[d].max(c[d]);
+        }
+    }
+    let curve =
+        proximadb_storage_common::hilbert_curve::HilbertCurve::new(hilbert_dims, bits_per_dim);
+    let max_val = (1u32 << bits_per_dim) - 1;
+    let cell_key = |c: &[f32]| -> u64 {
+        let ints: Vec<u32> = (0..hilbert_dims)
+            .map(|d| {
+                let range = hi[d] - lo[d];
+                if range <= 0.0 {
+                    max_val / 2
+                } else {
+                    (((c[d] - lo[d]) / range) * max_val as f32) as u32
+                }
+            })
+            .collect();
+        curve.encode(&ints)
+    };
+    let mut cell_order: Vec<usize> = (0..centroids.len()).collect();
+    let keys: Vec<u64> = centroids.iter().map(|c| cell_key(c)).collect();
+    cell_order.sort_by_key(|&c| keys[c]);
+    let mut cell_rank = vec![0usize; centroids.len()];
+    for (rank, &cell) in cell_order.iter().enumerate() {
+        cell_rank[cell] = rank;
+    }
+
+    // Records: usable ordered by (cell rank, PC1, index); unusable last, stably.
+    let mut order: Vec<usize> = Vec::with_capacity(records.len());
+    let mut usable_sorted: Vec<usize> = (0..usable.len()).collect();
+    usable_sorted.sort_by(|&a, &b| {
+        cell_rank[assignments[a]]
+            .cmp(&cell_rank[assignments[b]])
+            .then_with(|| {
+                let pa = coords[a].first().copied().unwrap_or(0.0);
+                let pb = coords[b].first().copied().unwrap_or(0.0);
+                pa.partial_cmp(&pb).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| usable[a].0.cmp(&usable[b].0))
+    });
+    order.extend(usable_sorted.iter().map(|&u| usable[u].0));
+    let in_usable: std::collections::HashSet<usize> = usable.iter().map(|(i, _)| *i).collect();
+    order.extend((0..records.len()).filter(|i| !in_usable.contains(i)));
     Some(order)
 }
 
@@ -333,9 +463,59 @@ mod tests {
     }
 
     #[test]
-    fn flag_defaults_off() {
-        // Not asserting env (tests share the process); just that the parser maps
-        // falsey/unset to false and truthy to true.
-        assert!(!block_cluster_enabled() || std::env::var("PROXIMADB_PAX_BLOCK_CLUSTER").is_ok());
+    fn block_cluster_defaults_on_with_kill_switch() {
+        // TD-WLP-4: clustering is default-ON; only an explicitly falsy env
+        // value disables it (kill-switch semantics). nextest process-per-test
+        // isolation makes the env mutation safe.
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_BLOCK_CLUSTER");
+        }
+        assert!(block_cluster_enabled(), "unset ⇒ clustering ON (default)");
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "0");
+        }
+        assert!(!block_cluster_enabled(), "explicit falsy ⇒ kill-switch");
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1");
+        }
+        assert!(block_cluster_enabled(), "truthy stays ON");
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_BLOCK_CLUSTER");
+        }
+    }
+
+    /// TD-WLP-4: PCA+IVF ordering groups two well-separated clusters
+    /// contiguously and returns a permutation; below the training floor it
+    /// falls back to the bootstrap (still a permutation).
+    #[test]
+    fn cluster_order_pca_ivf_groups_clusters_contiguously() {
+        // 80 records in two tight 8-dim clusters (interleaved on input).
+        let mut recs = Vec::new();
+        for i in 0..40 {
+            let e = (i % 5) as f32 * 0.01;
+            recs.push(rec(&format!("a{i:02}"), vec![1.0 + e; 8]));
+            recs.push(rec(&format!("b{i:02}"), vec![-1.0 - e; 8]));
+        }
+        let order = cluster_order_pca_ivf(&recs, 0).expect("order");
+        assert_eq!(order.len(), recs.len());
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..recs.len()).collect::<Vec<_>>(), "permutation");
+        // Contiguity: all a's adjacent, all b's adjacent.
+        let labels: Vec<char> = order
+            .iter()
+            .map(|&i| recs[i].oid.chars().next().unwrap_or('?'))
+            .collect();
+        let transitions = labels.windows(2).filter(|w| w[0] != w[1]).count();
+        assert_eq!(
+            transitions, 1,
+            "two clusters must form two contiguous runs, got {labels:?}"
+        );
+        // Small batch → bootstrap fallback, still a permutation.
+        let small: Vec<ProximaRecord> = recs.iter().take(4).cloned().collect();
+        let fallback = cluster_order_pca_ivf(&small, 0).expect("fallback order");
+        let mut fs = fallback.clone();
+        fs.sort_unstable();
+        assert_eq!(fs, vec![0, 1, 2, 3]);
     }
 }

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1120,7 +1120,7 @@ impl Compaction {
 
         // M1-3 (ADR-049): the legacy ProximaBlocks write arms (which needed a
         // block size + a writer-local filesystem factory + compression config)
-        // are retired — compaction re-emits PAX (`write_pax_segment_full`) or
+        // are retired — compaction re-emits PAX (`write_pax_segment_compacted`) or
         // Arrow (`ArrowBlockWriter`), neither of which takes those.
 
         let bytes_written = if let Some(ref coordinator) = atomic_coordinator {
@@ -1218,7 +1218,7 @@ impl Compaction {
                         crate::storage::engines::sst::segment_format::pax_inputs_rerank_quant(
                             &task.input_files,
                         );
-                    crate::storage::engines::sst::segment_format::write_pax_segment_full(
+                    crate::storage::engines::sst::segment_format::write_pax_segment_compacted(
                         &staging_file_path,
                         &records,
                         &collection_id,
@@ -1347,7 +1347,7 @@ impl Compaction {
                         crate::storage::engines::sst::segment_format::pax_inputs_rerank_quant(
                             &task.input_files,
                         );
-                    crate::storage::engines::sst::segment_format::write_pax_segment_full(
+                    crate::storage::engines::sst::segment_format::write_pax_segment_compacted(
                         &task.output_file,
                         &records,
                         &collection_id,

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -171,19 +171,89 @@ pub fn write_pax_segment_full(
     f32_tier: bool,
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
-    // TD-RDSTRAT-5 S1 (default-OFF): reorder records by their sign-code so
-    // spatially-close vectors co-locate into the same block, and compute each
-    // block's centroid for the Vector Object Economy directory. Reordering is
-    // result-preserving (the reader ranks/dedups by distance + OID). When the
-    // flag is off, records write in insertion order and no centroids are computed
-    // — zero behaviour/cost change.
+    // TD-RDSTRAT-5 S1 / TD-WLP-4 (default ON, kill-switch
+    // `PROXIMADB_PAX_BLOCK_CLUSTER=0`): reorder records by the model-free
+    // sign-code bootstrap so spatially-close vectors co-locate into the same
+    // block, and compute each block's centroid+radius for the Vector Object
+    // Economy directory. Reordering is result-preserving (the reader
+    // ranks/dedups by distance + OID). Compaction upgrades the ordering to
+    // PCA+IVF via `write_pax_segment_compacted`.
     let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
     let order = if cluster {
         crate::storage::engines::sst::block_cluster::cluster_order(records, 0)
     } else {
         None
     };
+    write_pax_segment_ordered(
+        path,
+        records,
+        collection_id,
+        embedding_count,
+        quant,
+        rerank_quant,
+        f32_tier,
+        target_block,
+        cluster,
+        order,
+    )
+}
 
+/// TD-WLP-4 (ADR-061 D3): the **compaction** write entry point — identical to
+/// [`write_pax_segment_full`] except the record ordering is the PCA+IVF
+/// re-cluster (`cluster_order_pca_ivf`) instead of the L0 sign-code bootstrap.
+/// Compaction is the re-cluster event: the merged batch is large enough to
+/// train a write-time PCA, and same-cell rows co-locate into blocks whose
+/// centroids+radii make the read-side prune effective. Honors the same
+/// kill-switch (`PROXIMADB_PAX_BLOCK_CLUSTER=0` ⇒ insertion order, no
+/// centroids). Gating by profile happens at compaction *arming*
+/// (`resolve_compaction_armed`): Churn collections never schedule compaction,
+/// so this path only serves AppendBulk (or explicit `compaction:on`) work.
+#[allow(clippy::too_many_arguments)]
+pub fn write_pax_segment_compacted(
+    path: &Path,
+    records: &[ProximaRecord],
+    collection_id: &str,
+    embedding_count: usize,
+    quant: VectorQuant,
+    rerank_quant: VectorQuant,
+    f32_tier: bool,
+    target_block: Option<usize>,
+) -> Result<SegmentMeta> {
+    let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
+    let order = if cluster {
+        crate::storage::engines::sst::block_cluster::cluster_order_pca_ivf(records, 0)
+    } else {
+        None
+    };
+    write_pax_segment_ordered(
+        path,
+        records,
+        collection_id,
+        embedding_count,
+        quant,
+        rerank_quant,
+        f32_tier,
+        target_block,
+        cluster,
+        order,
+    )
+}
+
+/// Shared writer loop for the flush (bootstrap-ordered) and compaction
+/// (IVF-ordered) entry points.
+#[allow(clippy::too_many_arguments)]
+fn write_pax_segment_ordered(
+    path: &Path,
+    records: &[ProximaRecord],
+    collection_id: &str,
+    embedding_count: usize,
+    quant: VectorQuant,
+    rerank_quant: VectorQuant,
+    f32_tier: bool,
+    target_block: Option<usize>,
+    cluster: bool,
+    order: Option<Vec<usize>>,
+) -> Result<SegmentMeta> {
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,

--- a/tests/sst_compaction_reclustering_test.rs
+++ b/tests/sst_compaction_reclustering_test.rs
@@ -1,0 +1,160 @@
+//! TD-WLP-4 (ADR-061 D3) integration gate: compaction re-clusters with
+//! PCA+IVF on fp32, measurably improving intra-block coherence over the L0
+//! sign-code bootstrap.
+//!
+//! Coherence is asserted through the per-block RMS radii (TD-WLP-3): the
+//! compacted write's mean block radius must undercut the bootstrap write's on
+//! magnitude-separated clusters — the exact geometry the sign-bit bootstrap
+//! cannot separate (identical sign patterns) but fp32-PCA k-means can.
+//! Clustering runs on PCA-projected fp32, never on quantized codes (D3/A3).
+
+use proximadb::storage::engines::sst::segment_format::{
+    write_pax_segment_compacted, write_pax_segment_full,
+};
+use proximadb_block_format::VectorQuant;
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
+
+const DIM: usize = 8;
+const CLUSTERS: usize = 4;
+const PER_CLUSTER: usize = 128;
+/// `target_block` is a byte threshold the writer compares against
+/// `row_count * 1024`, so `64 * 1024` cuts blocks at 64 rows.
+const ROWS_PER_BLOCK_TARGET: usize = 64;
+
+fn record(oid: &str, v: Vec<f32>) -> ProximaRecord {
+    ProximaRecord {
+        oid: oid.to_string(),
+        created_at_ns: 1,
+        updated_at_ns: 1,
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "test".into(),
+            modality: "dense_vector".into(),
+            dim: DIM as u32,
+            values: EmbeddingValues::Fp32(v),
+            ..Default::default()
+        }],
+        ..ProximaRecord::default()
+    }
+}
+
+/// Interleaved records from `CLUSTERS` tight, magnitude-separated clusters —
+/// all-positive coordinates, so every vector has the SAME sign pattern and the
+/// sign-code bootstrap cannot tell clusters apart. Centers 0/10/20/30 with a
+/// ±0.05 deterministic jitter keep the clusters far apart relative to spread.
+fn interleaved_records() -> Vec<ProximaRecord> {
+    let mut recs = Vec::with_capacity(CLUSTERS * PER_CLUSTER);
+    for i in 0..PER_CLUSTER {
+        for c in 0..CLUSTERS {
+            let center = 10.0 * c as f32 + 1.0;
+            let jitter = ((i * 7 + c * 3) % 11) as f32 * 0.01 - 0.05;
+            recs.push(record(&format!("c{c}_r{i:03}"), vec![center + jitter; DIM]));
+        }
+    }
+    recs
+}
+
+fn mean_radius(radii: &[f32]) -> f32 {
+    if radii.is_empty() {
+        return f32::INFINITY;
+    }
+    radii.iter().sum::<f32>() / radii.len() as f32
+}
+
+/// The compacted (PCA+IVF) write produces non-empty centroids+radii and
+/// strictly tighter blocks than the L0 bootstrap on sign-degenerate data.
+#[tokio::test]
+async fn test_append_compaction_reclusters_and_improves_coherence() {
+    unsafe {
+        // Clustering is default-ON (TD-WLP-4); pin the kill-switch off in case
+        // the ambient env set it.
+        std::env::remove_var("PROXIMADB_PAX_BLOCK_CLUSTER");
+    }
+    let records = interleaved_records();
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let bootstrap_meta = write_pax_segment_full(
+        &dir.path().join("l0_bootstrap.pax"),
+        &records,
+        "wlp4_recluster",
+        records.len(),
+        VectorQuant::RaBitQ,
+        VectorQuant::Sq8,
+        false,
+        Some(ROWS_PER_BLOCK_TARGET * 1024),
+    )
+    .expect("bootstrap write");
+
+    let compacted_meta = write_pax_segment_compacted(
+        &dir.path().join("compacted.pax"),
+        &records,
+        "wlp4_recluster",
+        records.len(),
+        VectorQuant::RaBitQ,
+        VectorQuant::Sq8,
+        false,
+        Some(ROWS_PER_BLOCK_TARGET * 1024),
+    )
+    .expect("compacted write");
+
+    // Both writes carry the VOE inputs (centroids + radii, 1:1).
+    for (name, meta) in [
+        ("bootstrap", &bootstrap_meta),
+        ("compacted", &compacted_meta),
+    ] {
+        assert!(
+            !meta.block_centroids.is_empty(),
+            "{name}: default-ON clustering must emit block centroids"
+        );
+        assert_eq!(
+            meta.block_radii.len(),
+            meta.block_centroids.len(),
+            "{name}: radii 1:1 with centroids"
+        );
+    }
+
+    // Coherence: the sign-code bootstrap cannot separate magnitude-only
+    // clusters (mixed blocks ⇒ radii ~ inter-cluster distance); PCA+IVF can
+    // (per-cluster blocks ⇒ radii ~ jitter). Require a decisive 5× margin so
+    // the gate fails loudly if the IVF order regresses to the bootstrap.
+    let bootstrap_r = mean_radius(&bootstrap_meta.block_radii);
+    let compacted_r = mean_radius(&compacted_meta.block_radii);
+    assert!(
+        compacted_r * 5.0 < bootstrap_r,
+        "compacted mean block radius must decisively undercut the bootstrap \
+         (bootstrap={bootstrap_r}, compacted={compacted_r})"
+    );
+
+    // Result-preservation: the reorder is physical only — same record count.
+    assert_eq!(compacted_meta.row_count, bootstrap_meta.row_count);
+    assert_eq!(compacted_meta.row_count as usize, records.len());
+}
+
+/// The kill-switch restores insertion-order writes with no centroids for BOTH
+/// entry points (the one escape hatch — no per-path flag zoo).
+#[tokio::test]
+async fn test_cluster_kill_switch_disables_centroids() {
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "0");
+    }
+    let records = interleaved_records();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let meta = write_pax_segment_compacted(
+        &dir.path().join("killed.pax"),
+        &records,
+        "wlp4_kill",
+        records.len(),
+        VectorQuant::RaBitQ,
+        VectorQuant::Sq8,
+        false,
+        Some(ROWS_PER_BLOCK_TARGET * 1024),
+    )
+    .expect("write with kill-switch");
+    assert!(
+        meta.block_centroids.is_empty(),
+        "kill-switch must skip clustering + centroid emission"
+    );
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_BLOCK_CLUSTER");
+    }
+}

--- a/tests/storage_wlp_compaction_gate.rs
+++ b/tests/storage_wlp_compaction_gate.rs
@@ -67,10 +67,10 @@ async fn flush_once(engine: &SstEngine, coll: &Collection, ids: &[&str]) -> Resu
     engine.do_flush(&params).await
 }
 
-/// TD-WLP-2 TDD gate: with the global env unset, a collection tagged
-/// `workload_profile:append` + `compaction:on` reaching L0 >= its
-/// per-collection threshold fires compaction; an untagged collection under the
-/// same global-off does NOT — even past the legacy threshold of 5.
+/// TD-WLP-2/TD-WLP-4 gate: with the global env unset, an `AppendBulk`
+/// collection (tagged or untagged — AppendBulk is the default profile) arms
+/// compaction at its L0 threshold **by default**; a `Churn`-tagged collection
+/// never arms (so it never re-clusters/trains — ADR-061 D4/D5).
 #[tokio::test]
 async fn test_append_collection_arms_compaction_while_global_off() -> Result<()> {
     unsafe {
@@ -79,44 +79,88 @@ async fn test_append_collection_arms_compaction_while_global_off() -> Result<()>
     }
     let engine = SstEngine::new().await?;
 
-    // Opted-in AppendBulk collection: arms once L0 reaches its own threshold.
-    let opted_dir = tempfile::tempdir()?;
-    let opted = collection(
-        "wlp2_append_opted",
-        opted_dir.path().to_str().expect("utf8 tempdir"),
-        &["workload_profile:append", "compaction:on", "l0_threshold:2"],
+    // AppendBulk collection (explicit tag + tight threshold): arms once L0
+    // reaches its own threshold, with NO compaction:on opt-in needed.
+    let append_dir = tempfile::tempdir()?;
+    let append = collection(
+        "wlp2_append_default",
+        append_dir.path().to_str().expect("utf8 tempdir"),
+        &["workload_profile:append", "l0_threshold:2"],
     );
-    let first = flush_once(&engine, &opted, &["a0", "a1"]).await?;
+    let first = flush_once(&engine, &append, &["a0", "a1"]).await?;
     assert!(first.success, "first flush must succeed");
     assert!(
         !first.compaction_triggered,
         "1 L0 segment < l0_threshold:2 — compaction must not fire yet"
     );
-    let second = flush_once(&engine, &opted, &["a2", "a3"]).await?;
+    let second = flush_once(&engine, &append, &["a2", "a3"]).await?;
     assert!(second.success, "second flush must succeed");
     assert!(
         second.compaction_triggered,
-        "opted-in collection at L0 >= per-collection threshold must arm \
-         compaction while the global gate is OFF (TD-WLP-2)"
+        "AppendBulk collection at L0 >= threshold must arm compaction BY \
+         DEFAULT (TD-WLP-4 arm-defaults)"
     );
 
-    // Untagged collection: the global gate governs and it is OFF — never arms,
-    // even once past the legacy L0_COMPACTION_THRESHOLD of 5.
+    // Untagged collection = AppendBulk profile: arms at the default legacy
+    // threshold of 5 once enough L0 segments accumulate.
     let untagged_dir = tempfile::tempdir()?;
     let untagged = collection(
         "wlp2_untagged",
         untagged_dir.path().to_str().expect("utf8 tempdir"),
         &[],
     );
+    let mut untagged_triggered = false;
     for i in 0..6 {
         let ids = [format!("u{i}")];
         let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
         let result = flush_once(&engine, &untagged, &id_refs).await?;
         assert!(result.success, "untagged flush {i} must succeed");
+        if i < 3 {
+            assert!(
+                !result.compaction_triggered,
+                "below the default threshold of 5 — must not fire (flush {i})"
+            );
+        }
+        untagged_triggered |= result.compaction_triggered;
+    }
+    assert!(
+        untagged_triggered,
+        "untagged (AppendBulk-default) collection must arm compaction at the \
+         default L0 threshold (TD-WLP-4 arm-defaults)"
+    );
+
+    // Churn collection: never arms by default, even past every threshold.
+    let churn_dir = tempfile::tempdir()?;
+    let churn = collection(
+        "wlp2_churn",
+        churn_dir.path().to_str().expect("utf8 tempdir"),
+        &["workload_profile:churn", "l0_threshold:1"],
+    );
+    for i in 0..3 {
+        let ids = [format!("c{i}")];
+        let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+        let result = flush_once(&engine, &churn, &id_refs).await?;
+        assert!(result.success, "churn flush {i} must succeed");
         assert!(
             !result.compaction_triggered,
-            "untagged collection must keep today's default-OFF behaviour \
-             (flush {i})"
+            "Churn profile must never arm compaction by default (flush {i})"
+        );
+    }
+
+    // compaction:off opts an AppendBulk collection back out.
+    let optout_dir = tempfile::tempdir()?;
+    let optout = collection(
+        "wlp2_optout",
+        optout_dir.path().to_str().expect("utf8 tempdir"),
+        &["compaction:off", "l0_threshold:1"],
+    );
+    for i in 0..2 {
+        let ids = [format!("o{i}")];
+        let id_refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+        let result = flush_once(&engine, &optout, &id_refs).await?;
+        assert!(
+            !result.compaction_triggered,
+            "compaction:off must opt out of the armed default (flush {i})"
         );
     }
     Ok(())


### PR DESCRIPTION
## Summary

Fourth ADR-061 slice (follows #963, #967, #974). Makes **compaction the fp32 PCA+IVF re-cluster event** for `AppendBulk` collections and — per the owner's pre-GA *no-back-compat, arm-defaults* directive — arms clustering and compaction **by default** instead of behind opt-in flags.

### Foundation: shared clustering kernel
- New crate **`proximadb-clustering-kernel`** (foundation layer): `kmeans_clustering` (Lloyd + k-means++, buffer-reused) hoisted out of `proximadb-quantization-kernel` so storage can cluster without a `storage → modality` layering violation, plus `kmeans_assign` for IVF cell assignment. The **duplicate** k-means in `spatial_clustering.rs` is folded onto it, and PQ codebook training now calls the shared kernel — one implementation, three consumers.

### Compaction re-cluster (ADR-061 D3)
- `write_pax_segment_compacted` / `cluster_order_pca_ivf`: compaction trains a **batch-local `IncrementalPCA` on fp32** (never on quantized codes — D3/A3), k-means-clusters the projections, orders IVF cells by their centroid's **set-normalized Hilbert code** (same-region cells physically contiguous → coalescing-friendly), and orders records `(cell, PC1, index)`. Below the training floor it falls back to the L0 bootstrap.
- L0 flush keeps the model-free **sign-Gray bootstrap** (cold-start safe, no model).

### Arm-defaults (ADR-061 amendment)
- Block clustering at PAX write is **default-ON**; `PROXIMADB_PAX_BLOCK_CLUSTER=0` is the kill-switch.
- `resolve_compaction_armed`: armed by default for `AppendBulk` **including untagged** collections; `compaction:off` opts out; **`Churn` never arms/trains**; a falsy `PROXIMADB_L0_COMPACTION_ENABLED` is the master kill-switch.
- **ADR-061 amended** (Status + D5 + Consequences) to record the directive and its three preserved carve-outs: (a) on-disk **readability** of existing segments/sidecars (`#[serde(default)]`) — data safety, not behaviour compat; (b) **evidence-gated** `radius_k` stays `0.0` (the 2026-07-14 sweep measured k=1/2 as a regression under sign-bit clustering — re-measure post-clustering in WLP-6); (c) the read-side prune-flip stays recall-ratchet-gated.

### Deferred
- **TD-WLP-7** filed for: persisted `EnhancedPCAModel` + VOE `pca_model_ref` population, and the **flush-trigger → compaction-execution wiring** (the post-flush hook has always been a stub — `compaction_triggered` is set but nothing schedules the compactor in production).

## Test plan (TDD)
- Kernel units: cluster recovery on separated clusters; error contract (empty/k=0).
- `block_cluster` unit: PCA+IVF order groups magnitude-separated clusters into contiguous runs; below-floor bootstrap fallback; default-ON + kill-switch semantics.
- Integration coherence gate **`tests/sst_compaction_reclustering_test.rs`**: on sign-degenerate (magnitude-only) clusters the compacted mean block radius must undercut the bootstrap **5×**; kill-switch disables centroid emission on both entry points.
- Reworked **`tests/storage_wlp_compaction_gate.rs`** for the armed-by-default cascade (AppendBulk/untagged arm at threshold, Churn never arms, `compaction:off` opts out, hard-disable wins).
- Full `--lib` suite **7657/7657**; `cargo fmt --check` ✓; `clippy --lib --bins -D warnings` ✓; `check_td_adr_unique` ✓. All re-verified after rebase onto the current develop base.

### Pre-existing failure (not introduced here)
`dual_mode_integration_test::test_metadata_filtering` fails on this branch **and identically with `PROXIMADB_PAX_BLOCK_CLUSTER=0`** (which makes the flush/read path byte-for-byte develop); WLP-3's read change is inert at `radius_k=0`. It is therefore a pre-existing metadata-filter under-filtering bug, unrelated to this PR. Filing/triage tracked separately.

Refs ADR-061 (D3), TD-WLP-4, TD-WLP-7.
