### PR TITLE
ci: promotion-freshness gate — block merging stale promotion PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2002,6 +2002,47 @@ jobs:
           retention-days: 30
 
   # ============================================================================
+  # PROMOTION FRESHNESS GATE
+  # ============================================================================
+  # A develop->qa (or qa->main) promotion PR must contain the LATEST commits of
+  # its source branch. Promotion PRs deliberately use a fixed `release/...` head
+  # (so incoming feat->develop merges can't synchronize/cancel the run), but that
+  # means develop can advance *after* the PR is opened, leaving the PR snapshot
+  # stale — merging it would DROP the newer commits (the #992 failure, where 47
+  # paths / #983/#984/#988/#990 were omitted). This gate fails if the source
+  # branch has commits not in the PR head, blocking the merge until the PR is
+  # refreshed. Skips on non-promotion PRs (and push events); ci-success treats a
+  # `skipped` result as pass.
+  promotion-freshness:
+    name: Promotion Freshness (head must contain source branch)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(fromJson('["qa", "main"]'), github.base_ref)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: merge-base --is-ancestor must walk back to the source
+          # branch's merge point, which a shallow clone cannot prove.
+          fetch-depth: 0
+      - name: Verify PR head contains the latest source branch
+        run: |
+          set -euo pipefail
+          case "${{ github.base_ref }}" in
+            qa)   SRC="develop" ;;  # develop -> qa promotion
+            main) SRC="qa" ;;        # qa -> main promotion
+            *)    echo "::notice::not a promotion PR (${{ github.base_ref }}); nothing to check"; exit 0 ;;
+          esac
+          git fetch origin "$SRC"
+          if git merge-base --is-ancestor "origin/$SRC" HEAD; then
+            echo "::notice::PR head contains latest origin/$SRC — fresh."
+          else
+            echo "::error::PR head is STALE: origin/$SRC has commits NOT in this PR. Merging now would DROP them. Refresh this PR from origin/$SRC and rerun CI."
+            echo "::group::commits on origin/$SRC missing from this PR"
+            git log --oneline HEAD.."origin/$SRC" | head -25
+            echo "::endgroup::"
+            exit 1
+          fi
+
+  # ============================================================================
   # SUMMARY - Final status check
   # ============================================================================
   ci-success:
@@ -2052,8 +2093,21 @@ jobs:
       # gates that encode load-bearing decisions as checks
       - docs-authority
       - risk-coverage
+      # promotion correctness — a promotion PR must not be a stale snapshot
+      - promotion-freshness
     if: always()
     steps:
+      # HARD GATE — a promotion PR must contain the latest source-branch commits.
+      # Promotion PRs use a fixed `release/...` head (churn-immune), so the source
+      # branch can advance after the PR opens and leave it stale — merging would
+      # DROP commits (#992). `promotion-freshness` skips on non-promotion PRs, so
+      # block only on failure/cancelled and treat skipped as pass.
+      - name: Require promotion freshness
+        if: ${{ needs.promotion-freshness.result == 'failure' || needs.promotion-freshness.result == 'cancelled' }}
+        run: |
+          echo "::error::Promotion PR is stale — refresh from the source branch before merging (else commits are dropped). See the 'Promotion Freshness' job for the missing commits."
+          exit 1
+
       # HARD GATE — Rust lib + test compile (the `rust-compile` matrix) must pass
       # whenever it runs. `rust-compile` is gated on the comprehensive `compile`
       # path filter (a SUPERSET of all code paths), so it is `skipped` ONLY for a


### PR DESCRIPTION
## Problem
Promotion PRs use a fixed `release/...` head (churn-immune by design), so the source branch can advance *after* the PR opens and leave the PR snapshot stale. **Merging a stale promotion drops the newer commits** — the #992 failure, where 47 paths (#983/#984/#988/#990) were omitted and the review had to flag "do not merge #992 in its current state."

Re-enabling `cancel-in-progress` does **not** fix this: it governs same-branch run dedup, and develop pushes don't touch a fixed-head PR — so #992's staleness was a snapshot-aging issue, not a cancellation issue.

## Fix
A required **`promotion-freshness`** job that, on any PR targeting `qa` or `main`, asserts the PR head contains the latest source branch:
- `develop -> qa` ⇒ checks `origin/develop ⊆ HEAD`
- `qa -> main` ⇒ checks `origin/qa ⊆ HEAD`

via `git merge-base --is-ancestor origin/<src> HEAD`. It **fails (blocking)** if stale and lists the missing commits; **skips** on non-promotion PRs and push events (ci-success treats `skipped` as pass). Wired into `ci-success.needs` + a HARD GATE step, so it's automatically required via the existing `CI Success` check — no branch-protection change needed.

This keeps the efficient fixed-head + `cancel-in-progress:false` design (one CI run, completes reliably under churn) while **guaranteeing a stale promotion can't be merged**.

## Validation
YAML parses; job present and in `ci-success.needs`. The job skips on this PR itself (targets `develop`), so it's first exercised on the next real promotion PR. CI-only change; no Rust touched.