### PR TITLE
docs(qa): record PAX ratchet waiver for promotion

### DIFF
--- a/docs/10-quality/td/TD-WLP-3-land-radius-lower-bound-prune.adoc
+++ b/docs/10-quality/td/TD-WLP-3-land-radius-lower-bound-prune.adoc
@@ -16,6 +16,45 @@
 
 toc::[]
 
+== QA promotion exception: PR #992 (2026-07-14)
+
+PR #992's SIFT1M promotion run measured the same known weak-cluster result recorded above:
+unpruned/default recall@10 `0.9891`, forced centroid-pruned recall@10 `0.8087`, with 15,000 of
+35,000 block visits pruned. The `0.90` optimized floor correctly failed. This is not accepted as
+adequate recall and does not clear the default-ON flip.
+
+One promotion exception is accepted for PR #992 under ADR-061 D8 because
+`PROXIMADB_PAX_CENTROID_PRUNE` remains default-OFF and the shipped unpruned path passed. The
+exception applies only to `SIFT1M PAX RaBitQ recall ratchet (WS8)` on that PR; every other required
+promotion check must be green before merge.
+
+Risk:: An operator who manually enables both block clustering and centroid pruning at the current
+`0.5` keep ratio can reduce recall materially (measured drop `0.1804`).
+
+Mitigation:: Keep centroid pruning default-OFF; do not recommend or enable the flag in deployment
+configuration. Whole-scan/unpruned search remains the production path.
+
+Owner and review date:: Storage/search owner; review by 2026-07-29 or before any proposal to make
+centroid pruning default-ON, whichever comes first.
+
+Closure gate:: Tune clustering/nprobe/keep-ratio (prefer TD-WLP-4 fp32-PCA/IVF geometry over
+weakening the floor), then rerun the same SIFT1M N=100000 / 1000-query gate. Close only when the
+prune engages, optimized recall is at least `0.90`, and the permitted same-run recall drop is
+explicitly approved. Never "fix" this by removing the unpruned differential or allowing a silent
+full-scan fallback.
+
+=== Handoff prompt
+
+----
+Investigate TD-WLP-3 / PR #992's default-off VOE centroid-prune recall failure. Reproduce with
+SIFT1M N=100000, 1000 queries: unpruned recall@10 was 0.9891; keep-ratio 0.5 pruned recall was
+0.8087 (15,000/35,000 block visits pruned). Preserve the fail-closed assertions that pruning
+actually engages and compare against the same-run unpruned baseline. Run the ignored nprobe x
+radius-k sweep, then prefer improving fp32-PCA/IVF clustering (TD-WLP-4) or a measured keep-ratio
+over lowering the 0.90 floor. Keep PROXIMADB_PAX_CENTROID_PRUNE default-OFF. Deliver code, the
+SIFT evidence table, ADR/TD updates, and a PR whose promotion ratchet passes without a waiver.
+----
+
 == Why
 
 The centroid prune ranks blocks by raw centroid distance, which ignores block spread and drops

--- a/docs/12-design/adr/ADR-061-per-collection-workload-profiles.adoc
+++ b/docs/12-design/adr/ADR-061-per-collection-workload-profiles.adoc
@@ -143,6 +143,24 @@ Fold in the measured lever: rank blocks by the distance lower bound `d(q, centro
 payoff that D3's clustering unlocks — it keeps spread-out blocks that a centre-only rank would
 wrongly prune.
 
+=== D8 — Default-off optimization ratchets gate activation, not unrelated releases
+
+A recall ratchet that deliberately forces an experimental, default-off read optimization ON is
+the activation gate for that optimization. It does not by itself prove a regression in the shipped
+default path. A release may waive such a ratchet for one named promotion only when all of the
+following are recorded and true:
+
+* the optimization and every prerequisite that changes read selection remain default-OFF;
+* the same-run unoptimized/default baseline clears its recall floor;
+* the failed optimized result, risk, mitigation, owner, and review date are recorded in the
+  governing TD;
+* every other required promotion check is green; and
+* the merge explicitly identifies the single waived check. No blanket red-check bypass is allowed.
+
+A failure in a shipped default path is not eligible for this exception. The exception does not
+authorize enabling the optimization: its default may flip only after the original recall ratchet
+passes without a waiver.
+
 == First principles / rationale
 
 * **Co-design against the trace, not the component.** For a serverless-on-object-store DB the


### PR DESCRIPTION
Records the one-PR #992 exception for the default-off VOE centroid-prune recall ratchet. The unpruned shipped path passed at 0.9891; forced pruning measured 0.8087 and remains blocked from default activation. Adds ADR-061 D8 waiver criteria plus TD-WLP-3 risk, mitigation, review date, closure gate, and troubleshooting handoff.\n\nValidation:\n- python3 scripts/check_td_adr_unique.py\n- python3 scripts/check_td_status_consistency.py\n- git diff --check