### PR TITLE
feat(storage): Churn forces Strong (delta-merged) reads (ADR-061 D4, TD-WLP-5)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/storage_profile.rs
+++ b/crates/storage/proximadb-storage-common/src/storage_profile.rs
@@ -38,6 +38,21 @@ pub enum StorageProfile {
     Churn,
 }
 
+impl StorageProfile {
+    /// Whether this profile forces freshness-critical (Strong / delta-merged)
+    /// reads regardless of a request's freshness hint (ADR-061 D4, TD-WLP-5).
+    ///
+    /// `Churn` collections are the agent code-RAG shape: a symbol is re-embedded
+    /// and immediately re-queried on a bounded, hot working set, so a stale read
+    /// would return the pre-edit neighbours. Their reads therefore always merge
+    /// the unflushed WAL/memtable delta — a request's `StaleOk`/`BoundedStale`
+    /// hint is overridden to Strong. `AppendBulk` honors the request's hint
+    /// (Strong is already the unset default), so this is a no-op there.
+    pub fn forces_strong_reads(self) -> bool {
+        matches!(self, StorageProfile::Churn)
+    }
+}
+
 /// Resolve the storage profile for a collection from its tag list.
 ///
 /// Precedence: `workload_profile:` tag (last matching wins; an unrecognized
@@ -82,6 +97,17 @@ mod tests {
 
     fn tags(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// TD-WLP-5: Churn forces Strong reads; AppendBulk honors the request.
+    #[test]
+    fn test_forces_strong_reads_only_for_churn() {
+        assert!(StorageProfile::Churn.forces_strong_reads());
+        assert!(!StorageProfile::AppendBulk.forces_strong_reads());
+        // Resolved from a churn tag → forces strong.
+        assert!(resolve_storage_profile(&tags(&["workload_profile:churn"])).forces_strong_reads());
+        // Untagged (AppendBulk default) → does not.
+        assert!(!resolve_storage_profile(&[]).forces_strong_reads());
     }
 
     /// TD-WLP-1 TDD gate: the tag > env > default cascade, mirroring

--- a/docs/10-quality/td/TD-WLP-5-churn-inmemory-index-orion-oid-fusion.adoc
+++ b/docs/10-quality/td/TD-WLP-5-churn-inmemory-index-orion-oid-fusion.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — spec filed 2026-07-14 (ADR-061). Not started. Depends on TD-WLP-1.
+| Status | Implemented (freshness core; descoped per this TD's own note) 2026-07-14 — `StorageProfile::forces_strong_reads()` (Churn ⇒ always delta-merge the unflushed WAL) + `churn_effective_freshness` wired at the VOE-directory read chokepoint (`unified_search_with_tenant_context`, reused at the cache gate + execute path): a `Churn` collection overrides a `StaleOk`/`BoundedStale` request to Strong so a re-embedded symbol is never served stale; `AppendBulk`/untagged honor the request (no-op — Strong is the unset default). The native two-stage path already always-merges WAL Stage 1 (fresh by construction). TDD gates: `test_forces_strong_reads_only_for_churn` (storage-common) + `wlp5_freshness_tests` (root). **Descoped to TD-WLP-8** (per this TD's descope note — reuse the existing WAL freshness path, defer ORION fusion): the dedicated in-memory mutable AXIS index, ORION `oid`-keyed match-then-traverse fusion, the per-collection bounded-working-set memory guard/metric, and a full-server pre-flush freshness e2e.
 | Priority | P1b — the code-RAG payoff; the churn-profile projection.
 | Severity | High — freshness + authority invariant under high update churn; adds a bounded memory surface.
 | Component | `src/index/axis/` (mutable ANN index selection); `src/graph/engines/orion/` (epoch-fresh CSR fusion hook); read-path profile branch in `src/storage/engines/sst/search/`

--- a/docs/10-quality/td/TD-WLP-8-churn-mutable-index-orion-fusion-memory-guard.adoc
+++ b/docs/10-quality/td/TD-WLP-8-churn-mutable-index-orion-fusion-memory-guard.adoc
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-WLP-8: Churn dedicated mutable index + ORION oid fusion + working-set memory guard (WLP-5 follow-up)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14 as the TD-WLP-5 descope. Not started.
+| Priority | P2 — the Churn projection's performance + graph-RAG payoff; the read-correctness core (Strong-override) already shipped in TD-WLP-5.
+| Severity | Medium — adds a bounded in-memory surface (OOM risk, guarded) + a graph-fusion read path; no durability change (WAL stays authority, ADR-061 D2).
+| Component | `src/index/axis/` (mutable ANN index that also indexes UNFLUSHED inserts, not just flushed segments — today `handle_flushed_vectors` is post-flush only); `src/graph/engines/orion/` (`oid`-keyed match-then-traverse fusion, ADR-044); a per-collection working-set memory gauge (telemetry) + guard in the Churn write path
+| Governs | link:../../12-design/adr/ADR-061-per-collection-workload-profiles.adoc[ADR-061] (D4)
+| Relates to | TD-WLP-5 (the freshness-override core this builds on), ADR-044 (stable symbol OID), TD-133 (opt-in CrossModelTransactionCoordinator), the read-side dead-filter invariants
+| Pillar | PERF (bounded-set ANN + graph traversal), OE (memory guard/metric)
+|===
+
+toc::[]
+
+== Why
+
+TD-WLP-5 delivered the load-bearing D4 read-correctness guarantee — `Churn` collections force Strong
+(delta-merged) reads so a re-embedded symbol is immediately visible — by reusing the existing WAL
+delta-merge path (its explicit descope). The remaining D4 pieces are performance/observability, not
+correctness, and were deferred to keep WLP-5 focused and low-risk:
+
+1. **Dedicated in-memory mutable index.** Today AXIS indexes only *flushed* segments
+   (`handle_flushed_vectors`, TD-112); unflushed reads go through the WAL/memtable Stage-1 scan.
+   For a bounded, hot Churn working set, serving reads from a mutable in-memory ANN index sized to
+   that set is the D4 performance goal — without introducing a *new* memtable structure (reuse the
+   AXIS mutable path).
+2. **ORION `oid` fusion.** ADR-061 D4's "match-then-traverse" (vector ANN → graph neighbours via
+   `oid`, ADR-044) is entirely unbuilt. Add the fusion read path.
+3. **Working-set memory guard + metric.** The bounded-working-set assumption must be enforced
+   (per-collection resident-bytes gauge `proximadb_churn_collection_working_set_bytes` + a soft
+   ceiling, e.g. env `PROXIMADB_CHURN_WORKING_SET_MB`) so an unbounded Churn collection degrades
+   gracefully instead of OOMing.
+
+== Scope
+
+* AXIS mutable index that indexes unflushed inserts for `Churn` collections; read path prefers it
+  for the bounded set, still dead-filtered (`is_dead`/`valid_to_ns`).
+* ORION `oid`-keyed match-then-traverse fusion behind the Churn read path.
+* Per-collection working-set gauge + guard; emit on the Churn write/flush boundary.
+* Full-server pre-flush freshness e2e (`tests/storage_wlp_churn_freshness.rs`) exercising the real
+  REST/pgwire path: insert → search pre-flush sees it; re-embed same `oid` → search pre-flush sees
+  the new neighbours; restart + WAL replay reconstructs identical state; an `AppendBulk` collection
+  in the same process is unaffected.
+
+== Gating
+
+Keyed on `workload_profile:churn` (opt-in — Churn is never the default even under the ADR-061
+arm-defaults amendment). `AppendBulk` untouched (asserted). WAL stays the sole durable authority
+(D2); the mutable index + ORION CSR are rebuildable projections.

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -86,6 +86,30 @@ use crate::storage::engines::sst::SstEngine;
 
 const FILTER_FAIL_LOUD_ENV: &str = "PROXIMADB_FILTER_FAIL_LOUD";
 
+/// TD-WLP-5 (ADR-061 D4): the effective read freshness for a collection,
+/// applying the `Churn` Strong-override on top of the request's hint. `Churn`
+/// collections always delta-merge the unflushed WAL (a re-embedded symbol must
+/// be immediately visible), overriding any `StaleOk`/`BoundedStale` hint;
+/// `AppendBulk` honors the request (unset ⇒ Strong default), so this is a no-op
+/// there. Profile is resolved from the collection's `workload_profile:` tag.
+fn churn_effective_freshness(
+    collection: &crate::proto::proximadb_v1::Collection,
+    config: Option<&UnifiedSearchConfig>,
+) -> crate::core::search::VectorFreshnessMode {
+    use crate::core::search::VectorFreshnessMode;
+    let tags = collection
+        .config
+        .as_ref()
+        .map(|c| c.tags.as_slice())
+        .unwrap_or(&[]);
+    if proximadb_storage_common::resolve_storage_profile(tags).forces_strong_reads() {
+        return VectorFreshnessMode::Strong;
+    }
+    config
+        .and_then(|c| c.freshness_mode.clone())
+        .unwrap_or_default()
+}
+
 fn filter_fail_loud_enabled() -> bool {
     let value = std::env::var(FILTER_FAIL_LOUD_ENV).ok();
     filter_fail_loud_for_value(value.as_deref())
@@ -2137,6 +2161,16 @@ impl VectorOperationsService {
             &query_vector,
         )?;
 
+        // TD-WLP-5 (ADR-061 D4): resolve the collection's storage profile and
+        // force Strong (delta-merged) reads for `Churn`. Churn is the agent
+        // code-RAG shape — a symbol is re-embedded and immediately re-queried
+        // on a bounded, hot working set, so a `StaleOk`/`BoundedStale` hint
+        // must not serve the pre-edit neighbours. `AppendBulk` honors the
+        // request's hint (Strong is already the unset default), so this is a
+        // no-op there. Computed once and reused at the cache gate and the
+        // execute path below so both honor the override.
+        let freshness_mode = churn_effective_freshness(&collection, config.as_ref());
+
         // Create cache key for unified result caching
         let filter_str = filter.as_ref().map(|f| format!("{:?}", f));
         let cache_key = QueryKey::new(
@@ -2150,10 +2184,6 @@ impl VectorOperationsService {
         // cache — a Strong read could be served an entry that predates a
         // concurrent write, violating read-after-write. Gate the cache read on
         // freshness (mirrors unified_search_v1_inner); Strong reads recompute.
-        let freshness_mode = config
-            .as_ref()
-            .and_then(|c| c.freshness_mode.clone())
-            .unwrap_or_default();
         if !matches!(
             freshness_mode,
             crate::core::search::VectorFreshnessMode::Strong
@@ -2186,11 +2216,9 @@ impl VectorOperationsService {
             )
             .await?
         } else {
-            // Direct search without progressive stages
-            let freshness_mode = config
-                .as_ref()
-                .and_then(|c| c.freshness_mode.clone())
-                .unwrap_or_default();
+            // Direct search without progressive stages. Reuse the
+            // profile-resolved freshness (TD-WLP-5) so Churn's Strong override
+            // reaches the delta-merge decision, not just the cache gate.
             self.execute_search_internal(
                 collection_id,
                 query_vector,
@@ -2200,7 +2228,7 @@ impl VectorOperationsService {
                     .as_ref()
                     .map(|c| c.optimization_goal)
                     .unwrap_or_default(),
-                freshness_mode,
+                freshness_mode.clone(),
             )
             .await?
         };
@@ -4384,6 +4412,77 @@ impl VectorOperationsService {
                 .unwrap_or_default()
                 .as_secs()
         }))
+    }
+}
+
+#[cfg(test)]
+mod wlp5_freshness_tests {
+    use super::*;
+    use crate::core::search::VectorFreshnessMode;
+    use crate::proto::proximadb_v1::{Collection, CollectionConfig};
+
+    fn collection_with_tags(tags: &[&str]) -> Collection {
+        Collection {
+            config: Some(CollectionConfig {
+                tags: tags.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn config_with_freshness(mode: VectorFreshnessMode) -> UnifiedSearchConfig {
+        UnifiedSearchConfig {
+            freshness_mode: Some(mode),
+            ..Default::default()
+        }
+    }
+
+    /// TD-WLP-5 (ADR-061 D4): a `Churn` collection forces Strong reads even when
+    /// the request explicitly asked for `StaleOk` — a re-embedded symbol must
+    /// never be served stale.
+    #[test]
+    fn churn_overrides_stale_request_to_strong() {
+        let churn = collection_with_tags(&["workload_profile:churn"]);
+        let stale_cfg = config_with_freshness(VectorFreshnessMode::StaleOk);
+        assert_eq!(
+            churn_effective_freshness(&churn, Some(&stale_cfg)),
+            VectorFreshnessMode::Strong,
+            "Churn must override StaleOk to Strong"
+        );
+        // Also overrides BoundedStale.
+        let bounded = config_with_freshness(VectorFreshnessMode::BoundedStale {
+            max_staleness_ms: 60_000,
+        });
+        assert_eq!(
+            churn_effective_freshness(&churn, Some(&bounded)),
+            VectorFreshnessMode::Strong
+        );
+    }
+
+    /// An `AppendBulk` (or untagged) collection honors the request's freshness
+    /// hint — the override is a no-op there (mixed-read-safe default path).
+    #[test]
+    fn append_bulk_honors_request_freshness() {
+        let append = collection_with_tags(&["workload_profile:append"]);
+        let stale_cfg = config_with_freshness(VectorFreshnessMode::StaleOk);
+        assert_eq!(
+            churn_effective_freshness(&append, Some(&stale_cfg)),
+            VectorFreshnessMode::StaleOk,
+            "AppendBulk must honor an explicit StaleOk request"
+        );
+        // Untagged collection = AppendBulk default; no config → Strong default.
+        let untagged = collection_with_tags(&[]);
+        assert_eq!(
+            churn_effective_freshness(&untagged, None),
+            VectorFreshnessMode::Strong,
+            "unset freshness defaults to Strong"
+        );
+        // Untagged + explicit StaleOk is honored.
+        assert_eq!(
+            churn_effective_freshness(&untagged, Some(&stale_cfg)),
+            VectorFreshnessMode::StaleOk
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fifth ADR-061 slice (follows #963, #967, #974, #995). Delivers the **load-bearing D4 read-correctness guarantee** for the `Churn` (agent code-RAG) profile: a re-embedded symbol must never be served stale. Scoped deliberately tight — the dedicated in-memory mutable index, ORION `oid` fusion, and working-set memory guard are deferred to the newly-filed **TD-WLP-8**, exactly as TD-WLP-5's own descope note directs ("reuse the existing unflushed-WAL freshness path; defer ORION fusion").

- **`StorageProfile::forces_strong_reads()`** (foundation `proximadb-storage-common`): `Churn` ⇒ `true`, `AppendBulk` ⇒ `false`. Expressed as a `bool` so the foundation crate stays free of a search-types dependency (layering).
- **`churn_effective_freshness()`** wired at the single VOE-directory read chokepoint (`unified_search_with_tenant_context`, right after `get_or_load_collection`), computed once and reused at both the query-cache gate and the execute path. A `Churn` collection overrides a request's `StaleOk`/`BoundedStale` hint to **Strong** (always delta-merge the unflushed WAL); `AppendBulk`/untagged honor the request (Strong is already the unset default, so this is a **no-op** on the default path — mixed-read-safe).
- The **native two-stage** search path already runs "Stage 1: WAL/memtable — always" (fresh by construction), so no override is needed there; the override closes the gap on the freshness-gated VOE-directory path where `StaleOk` could otherwise skip the delta.

## Why this scope

`src/services/operations/vectors/legacy.rs` is a fragile ~5000-line god-file with ~7 parallel search-entry variants. Rather than sprawl an invasive change across all of them, this PR lands the correctness core as one pure helper at one clean chokepoint, and files **TD-WLP-8** for the performance/observability remainder (dedicated mutable AXIS index that indexes *unflushed* inserts, ORION `oid` match-then-traverse fusion, per-collection working-set gauge + guard, full-server pre-flush e2e). WAL stays the sole durable authority for both profiles (ADR-061 D2) — this changes only *how fresh* a read is, never durability.

## Test plan (TDD)
- `test_forces_strong_reads_only_for_churn` (storage-common): the policy — Churn forces strong, AppendBulk/untagged don't; resolved-from-tag parity.
- `wlp5_freshness_tests` (root, `legacy.rs`): `churn_overrides_stale_request_to_strong` (Churn + explicit `StaleOk`/`BoundedStale` → `Strong`); `append_bulk_honors_request_freshness` (AppendBulk honors `StaleOk`; untagged + unset → `Strong` default; untagged + `StaleOk` honored).
- `cargo fmt --check` ✓, `clippy --lib --bins -D warnings` ✓, `work-commit-check` ✓, `check_td_adr_unique` ✓. Rebased onto current develop (post-#995).

Refs ADR-061 (D4), TD-WLP-5, TD-WLP-8.
