### PR TITLE
ci(qa-gate): cloud-emulator --all at jobs=1 to stop 16GB OOM

### DIFF
--- a/scripts/run_cloud_emulator_tests.sh
+++ b/scripts/run_cloud_emulator_tests.sh
@@ -93,13 +93,15 @@ cargo test -p proximadb-object-store --features aws,azure,gcp -- --ignored --noc
   put_with_tier_against_fake_gcs
 
 if [ "$SCOPE" = "all" ]; then
-  # Compiles the full main `proximadb` crate (~8400-test binary). CARGO_BUILD_JOBS=2
-  # caps compile parallelism low enough to keep the 16GB hosted runner off the OOM
-  # cliff (the "runner received a shutdown signal" failure that jobs=1 was added to
-  # dodge), while halving the serialized ~35-40m compile that grew past the 60m job
-  # budget and got cancelled mid-build. 2 (not the .cargo/config.toml default of 3)
-  # is the deliberate middle ground: faster than 1, safer than 3 on a 16GB runner.
-  CARGO_BUILD_JOBS=2 cargo test -p proximadb --features azure -- --ignored --nocapture \
+  # Compiles the full main `proximadb` crate (~8400-test binary). CARGO_BUILD_JOBS=1
+  # (serial): a single root-crate rustc peaks at ~12.8GB, so jobs>=2 is a HARD OOM on
+  # the 16GB hosted runner (12.8 + concurrent >= 16) — jobs=2 failed at ~26m with
+  # "runner received a shutdown signal" on the #992 promotion's cold compile. jobs=1
+  # caps peak RSS at one ~12.8GB rustc (fits), trading speed for reliability — this
+  # mirrors the rust-test ci.yml job, which also runs jobs=1 for the same reason.
+  # The 90m qa-gate budget + sccache absorb the ~35-40m serialized cold compile;
+  # warm runs compile far less. Durable fix = root-crate extraction (lower peak RSS).
+  CARGO_BUILD_JOBS=1 cargo test -p proximadb --features azure -- --ignored --nocapture \
     cold_graph_record_store_round_trips_on_real_azure
 fi
 


### PR DESCRIPTION
## Problem
The qa-gate `Cloud object-store emulators` job's `--all` scope compiles the full main `proximadb` crate. The script set `CARGO_BUILD_JOBS=2` claiming it "keeps the 16GB runner off the OOM cliff" — but it does **not**: a single root-crate rustc peaks at ~12.8GB, so `jobs=2` (12.8 + concurrent ≥ 16) is a **hard OOM**. On the #992 promotion's cold compile it failed at ~26m with `"runner received a shutdown signal"`. (The sccache fix #986 had already removed the separate 60m *timeout*, which exposed this OOM.)

## Fix
Drop the `--all` compile to `CARGO_BUILD_JOBS=1` (serial): peak RSS = one ~12.8GB rustc, which fits 16GB — the same reason the `rust-test` ci.yml job already runs `jobs=1`. The 90m qa-gate budget + sccache absorb the ~35–40m serialized cold compile; warm runs compile far less.

Trade-off: slower than `jobs=2` *in theory*, but `jobs=2` fails every cold compile in practice — so `jobs=1` is strictly better here. Durable fix remains root-crate extraction (lower peak RSS).

Shell-only change; `bash -n` clean. Non-blocking advisory job, but this stops a recurring red qa-gate.