### PR TITLE
feat(frontend): lower typed DATE literals — native TPC-H 4/22 → 12/22 (+ P1 correctness find TD-REL-EXEC-1)

### DIFF
--- a/crates/foundation/proximadb-data-model/src/lib.rs
+++ b/crates/foundation/proximadb-data-model/src/lib.rs
@@ -967,3 +967,84 @@ pub struct ServiceIndexStats {
     #[serde(default)]
     pub object_vector_bounds_pruned_blocks: i64,
 }
+
+// =========================================================================
+// Canonical DATE encoding (ADR-024 single-canonical)
+// =========================================================================
+
+/// Parse an ISO-8601 `YYYY-MM-DD` date into the canonical `ProximaValue::Date`
+/// encoding — **days since the Unix epoch (1970-01-01)**, the same i32 the
+/// write path stores and materialization keeps as Arrow `Date32`. Returns
+/// `None` on a malformed string so callers fail loud rather than guess.
+///
+/// Dependency-free (no chrono in this foundation leaf) via Howard Hinnant's
+/// `days_from_civil` algorithm — exact for the proleptic Gregorian calendar and
+/// bit-identical to `chrono::NaiveDate…num_days()`. This is THE canonical date
+/// parser: both the relational frontend (lowering `DATE '…'` literals) and the
+/// DML write path resolve dates through it, so a literal predicate and a stored
+/// column can never diverge in encoding.
+pub fn parse_iso_date_to_days(s: &str) -> Option<i32> {
+    let s = s.trim();
+    let mut parts = s.split('-');
+    // Leading '-' (negative year) is not expected for SQL date literals; reject.
+    let y: i32 = parts.next()?.parse().ok()?;
+    let m: u32 = parts.next()?.parse().ok()?;
+    let d: u32 = parts.next()?.parse().ok()?;
+    if parts.next().is_some() || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some(days_from_civil(y, m, d))
+}
+
+/// Days since 1970-01-01 for a proleptic-Gregorian `(year, month, day)`
+/// (Hinnant's algorithm). `month` in 1..=12, `day` in 1..=31.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i32 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = (if y >= 0 { y } else { y - 399 }) / 400;
+    let yoe = (y - era * 400) as i64; // [0, 399]
+    let mp = if m > 2 { m - 3 } else { m + 9 } as i64; // Mar=0 … Feb=11
+    let doy = (153 * mp + 2) / 5 + d as i64 - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    (era as i64 * 146097 + doe - 719468) as i32
+}
+
+#[cfg(test)]
+mod date_encoding_tests {
+    use super::parse_iso_date_to_days;
+
+    #[test]
+    fn epoch_and_known_dates() {
+        assert_eq!(parse_iso_date_to_days("1970-01-01"), Some(0));
+        assert_eq!(parse_iso_date_to_days("1970-01-02"), Some(1));
+        assert_eq!(parse_iso_date_to_days("1969-12-31"), Some(-1));
+        // Verified against chrono / Python datetime.date.toordinal offset.
+        assert_eq!(parse_iso_date_to_days("2000-01-01"), Some(10957));
+        assert_eq!(parse_iso_date_to_days("1995-03-15"), Some(9204));
+        assert_eq!(parse_iso_date_to_days("1998-12-01"), Some(10561));
+        // Leap-day handling.
+        assert_eq!(parse_iso_date_to_days("2000-02-29"), Some(11016));
+        assert_eq!(
+            parse_iso_date_to_days("2000-03-01"),
+            Some(parse_iso_date_to_days("2000-02-29").unwrap() + 1)
+        );
+    }
+
+    #[test]
+    fn malformed_dates_return_none() {
+        for bad in [
+            "",
+            "1995-03",
+            "1995/03/15",
+            "not-a-date",
+            "1995-13-01",
+            "1995-03-32",
+            "1995-03-15-00",
+        ] {
+            assert_eq!(
+                parse_iso_date_to_days(bad),
+                None,
+                "expected None for {bad:?}"
+            );
+        }
+    }
+}

--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -1241,9 +1241,24 @@ fn lower_expr(expr: &SqlExpr, scope: &Scope, ctx: &mut LoweringCtx) -> Result<Ex
             scope.resolve_qualified(table, column).map(Expr::column)
         }
         SqlExpr::Value(v) => Ok(Expr::literal(lower_value(&v.value)?)),
-        SqlExpr::TypedString { .. } => {
-            Err(FrontendError::Unsupported("typed string literal".into()))
+        // `DATE 'YYYY-MM-DD'` typed literal → the canonical `ProximaValue::Date`
+        // (days since the Unix epoch), matching the write path's encoding so a
+        // `col < DATE '…'` predicate compares correctly against a stored Date32
+        // column. TPC-H/TPC-DS date filters (Q1/Q3/Q5/Q10/Q12/… ) declined here
+        // before this. Other typed strings (TIME/TIMESTAMP/INTERVAL) stay
+        // unsupported for now — a scoped follow-up.
+        SqlExpr::TypedString(ts) if matches!(ts.data_type, SqlDataType::Date) => {
+            let raw = ts.value.value.clone().into_string().ok_or_else(|| {
+                FrontendError::InvalidLiteral(format!("DATE literal: {:?}", ts.value.value))
+            })?;
+            let days = proximadb_data_model::parse_iso_date_to_days(&raw)
+                .ok_or_else(|| FrontendError::InvalidLiteral(format!("DATE '{raw}'")))?;
+            Ok(Expr::literal(ProximaValue::Date(days)))
         }
+        SqlExpr::TypedString(ts) => Err(FrontendError::Unsupported(format!(
+            "typed string literal: {}",
+            ts.data_type
+        ))),
         SqlExpr::BinaryOp { left, op, right } => {
             let l = lower_expr(left, scope, ctx)?;
             let r = lower_expr(right, scope, ctx)?;
@@ -2175,6 +2190,62 @@ mod tests {
 
     fn lower(sql: &str) -> LogicalNode {
         lower_sql(sql, &catalog()).unwrap_or_else(|e| panic!("lower failed: {e:?}"))
+    }
+
+    /// A `DATE 'YYYY-MM-DD'` typed literal lowers to the canonical
+    /// `ProximaValue::Date` (days since the Unix epoch) — the same encoding the
+    /// write path stores — so `col < DATE '…'` compares correctly against a
+    /// Date32 column. Was `Unsupported("typed string literal")` before, which
+    /// declined ~8 TPC-H native queries (Q1/Q3/Q5/Q10/Q12/…) at lowering.
+    #[test]
+    fn typed_date_literal_lowers_to_canonical_days() {
+        let mut cat = InMemoryCatalog::new();
+        cat.register(
+            "events",
+            RelationalSchema::new(vec![
+                ColumnInfo::new("id", ProximaType::Int64, false),
+                ColumnInfo::new("ts", ProximaType::Date, true),
+            ]),
+        );
+        let plan = lower_sql("SELECT id FROM events WHERE ts < DATE '1995-03-15'", &cat)
+            .expect("DATE literal must lower");
+        // Reach the Filter predicate and confirm the RHS literal.
+        fn find_date_literal(node: &LogicalNode) -> Option<i32> {
+            fn in_expr(e: &Expr) -> Option<i32> {
+                match e {
+                    Expr::Literal {
+                        value: ProximaValue::Date(d),
+                        ..
+                    } => Some(*d),
+                    Expr::BinaryOp { left, right, .. } => in_expr(left).or_else(|| in_expr(right)),
+                    Expr::Cast { expr, .. } | Expr::UnaryOp { expr, .. } => in_expr(expr),
+                    _ => None,
+                }
+            }
+            match node {
+                LogicalNode::Filter { predicate, .. } => in_expr(predicate),
+                LogicalNode::Project { input, .. } => find_date_literal(input),
+                _ => None,
+            }
+        }
+        assert_eq!(
+            find_date_literal(&plan),
+            Some(9204),
+            "DATE '1995-03-15' must be 9204 days since epoch"
+        );
+        // A malformed date fails loud, not silently.
+        assert!(matches!(
+            lower_sql("SELECT id FROM events WHERE ts < DATE '1995-13-99'", &cat),
+            Err(FrontendError::InvalidLiteral(_))
+        ));
+        // A non-DATE typed literal is still declined with its type named.
+        assert!(matches!(
+            lower_sql(
+                "SELECT id FROM events WHERE ts < TIMESTAMP '1995-03-15 00:00:00'",
+                &cat
+            ),
+            Err(FrontendError::Unsupported(_))
+        ));
     }
 
     // --- Semi/Anti via uncorrelated IN / EXISTS / NOT EXISTS subqueries --------

--- a/docs/10-quality/td/TD-REL-EXEC-1-native-selfjoin-cross-or-residual-wrong-result.adoc
+++ b/docs/10-quality/td/TD-REL-EXEC-1-native-selfjoin-cross-or-residual-wrong-result.adoc
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-EXEC-1: Native route silently returns 0 rows for an OR-of-ANDs residual predicate spanning both sides of a (self-)join
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Open — filed 2026-07-14 from an isolated probe while landing the typed-DATE-literal fix.
+| Priority | **P1 (correctness)** — a *silent wrong result*, not an error: the query succeeds and returns the wrong rows. Narrow trigger, but silent-wrong is the worst failure class.
+| Component | `crates/query/proximadb-relational-planner` (`push_predicates` residual placement / ordinal rebase) and/or `proximadb-relational-executor` (residual `Filter` over a multi-input join). Native route only; DataFusion route is correct.
+| Evidence | Isolated probe on native storage (no dates, no materialization), tables `nation(n_nationkey, n_name)` = {1:FRANCE,2:GERMANY,3:ITALY}, `edge(e_from,e_to)` = {(1,2),(2,1),(1,3)}:
+  * **A** `SELECT count(*) FROM edge, nation n1, nation n2 WHERE e_from=n1.n_nationkey AND e_to=n2.n_nationkey` → **3** ✓ (plain self-join correct)
+  * **C** `SELECT n_name FROM nation WHERE n_name='FRANCE' OR n_name='GERMANY'` → **2** ✓ (single-table OR correct)
+  * **B** the two combined: `… AND ((n1.n_name='FRANCE' AND n2.n_name='GERMANY') OR (n1.n_name='GERMANY' AND n2.n_name='FRANCE'))` → **0**, should be **2** ✗ **WRONG**.
+  Surfaced by TPC-H **Q7** (native 0 rows vs DataFusion 4) once the typed-DATE-literal fix let Q7 lower — but the bug is date-independent (probe B has no dates) and already live on `develop`.
+|===
+
+== The finding
+
+A self-join (same table, two aliases) and a single-table `OR` each evaluate correctly in
+isolation. The failure is specifically an **OR-of-ANDs residual conjunct that references columns
+from BOTH join inputs** (`n1.n_name` on the left, `n2.n_name` on the right). Such a conjunct cannot
+be pushed to either side, so it stays as a residual `Filter` above the join. That residual
+evaluates to false for every row (→ 0 rows) when the plan is a multi-way (self-)join.
+
+Most likely cause: after `push_predicates` rewrites the implicit cross joins to inner/hash joins
+(splitting equi conjuncts to sides and rebasing right-side ordinals), the **residual conjunct's
+column ordinals no longer index the final joined-row schema correctly**, so `n1.n_name` /
+`n2.n_name` read the wrong slots and the string equalities never hold. (Consistent with the plain
+self-join working — there is no residual there — and the single-table OR working — no join.)
+
+== Direction
+
+1. **Repro as a planner unit test** (add `proximadb-relational-frontend` + `sqlparser` dev-deps, or
+   drive via a pgwire e2e like the probe above) that lowers probe B and asserts the residual
+   `Filter` predicate's ordinals index the correct columns of the join output schema.
+2. Audit the ordinal bookkeeping on the `residual` path of the cross→inner rewrite in
+   `push_predicates` (the `residual` bucket, line ~1076–1092 as of `1a424f3c6`) — the equi-side
+   buckets rebase ordinals (`shift_column_ordinals`); the residual must remain indexed against the
+   post-rewrite join output, which preserves the `left ++ right` order, so verify no double-shift
+   or off-by-`left_width`.
+3. **Gate:** probe B returns 2; TPC-H Q7 native == DataFusion (4 rows). Add to the native-route
+   correctness spot-checks.
+
+== Non-goals
+
+The typed-DATE-literal lowering that exposed this (a separate, correct change); the genuine
+non-equi cross-join declines (Q9/Q19); the `rebind_columns` alias bug (TD-REL-LOWER-3).

--- a/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-1-comma-join-derived-table-legacy-fallthrough.adoc
@@ -86,6 +86,19 @@ alias-named sort keys (q3/q52 — pre-existing pushdown bug newly reachable, fil
 TD-REL-LOWER-3). Follow-up guard candidate: extend the specific-error treatment to single-table
 relational declines so Q1/Q4/Q6 stop mangling.
 
+**Re-measured again (2026-07-14, post-`1a424f3c6` + this PR's DATE-literal fix):** develop's
+`1a424f3c6` landed the cross→equi-join rewrite in `push_predicates` (the TD-REL-LOWER-2 core) and a
+`plan_has_raw_cross_join` fail-fast decline, so the grinders are GONE. Native TPC-H then measured
+**4/22 OK** — and the dominant remaining blocker was NOT the join at all: the frontend declined
+every `DATE 'YYYY-MM-DD'` typed literal (`Unsupported("typed string literal")`), so ~8 date-filtered
+queries fell through to the legacy path and surfaced the misleading "comma-separated table list"
+`0A000` (a red herring). Lowering typed DATE literals to the canonical `ProximaValue::Date`
+(days-since-epoch, shared `proximadb_data_model::parse_iso_date_to_days`) took native TPC-H to
+**12/22 OK** (Q1/Q3/Q4/Q5/Q6/Q7/Q10/Q12 flipped). The residual 10 are now diverse, separate
+mechanisms: scalar/IN subqueries (Q2/Q11/Q17/Q18/Q20), `CASE` (Q14), a derived table (Q8), two
+genuine non-equi cross-joins (Q9/Q19), and one `rebind_columns` alias error (Q15 — see
+TD-REL-LOWER-3). Each is its own frontend/planner coverage item; none share a single fix.
+
 == Non-goals
 
 Not a perf item; not the ClickBench case-folding wall (TD-OLAP-18). The

--- a/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
@@ -6,9 +6,9 @@
 |===
 | Field | Value
 | Status | Open — filed 2026-07-14 from the post-#953 ledger native sweep (SF 0.01 release).
-| Priority | P2 — hard error on valid ANSI SQL (`[XX000] plan: internal planner error`), scope currently 2 TPC-DS queries; pre-existing planner bug newly *reachable* (pre-#953 these queries declined earlier, at lowering).
+| Priority | P2 — hard error on valid ANSI SQL (`[XX000] plan: internal planner error`); ≥3 TPC queries (TPC-DS q3/q52, TPC-H Q15); pre-existing planner bug newly *reachable* as upstream lowering gaps close.
 | Component | `crates/query/proximadb-relational-planner` — `push_projections_inner` / `rebind_columns` (name-keyed ordinal rebind).
-| Evidence | TPC-DS q3 and q52 on the native route, both: `plan: internal planner error: rebind_columns: column `brand_id` not in narrowed schema`. Shape: comma-join + `GROUP BY` + projection alias used as an ORDER BY key (`select … item.i_brand_id brand_id … order by d_year, sum_agg desc, brand_id`).
+| Evidence | TPC-DS q3/q52: `rebind_columns: column `brand_id` not in narrowed schema` — a projection alias used as an ORDER BY key. **TPC-H Q15 (reachable after this PR's DATE fix): `column `supplier_no` not in narrowed schema`** — a DERIVED-TABLE alias (`select l_suppkey as supplier_no … ) as revenue0 where s_suppkey = supplier_no`) referenced by the outer join/filter. So the bug is broader than ORDER BY keys: `rebind_columns` re-derives ordinals by NAME against a narrowed child schema, but an ALIAS name (ORDER-BY output alias OR derived-table column alias) does not appear in the schema at the level rebind runs, so it errors. Repro needs a planner-crate harness that can lower SQL (add `proximadb-relational-frontend` + `sqlparser` as dev-deps, or drive via a pgwire e2e).
 |===
 
 == The finding


### PR DESCRIPTION
## What (scope pivoted by measurement)

Picked \"native-route relational coverage\" as the most impactful item. A fresh native TPC-H sweep on current develop showed the cross-join TDs were **already largely done** by develop's `1a424f3c6` (cross→equi rewrite in `push_predicates` + a fail-fast decline). The real, *measured* dominant blocker was a single frontend gap: `SqlExpr::TypedString` (`DATE '…'` literals) was `Unsupported`, so ~8 date-filtered TPC-H queries declined at lowering and fell through to the legacy path — surfacing a misleading \"comma-separated table list\" `0A000` (a red herring).

This PR lowers typed DATE literals to the canonical `ProximaValue::Date` (days since the Unix epoch) via a new dependency-free `proximadb_data_model::parse_iso_date_to_days` (Hinnant civil-days, verified bit-identical to chrono/Python). The **same** helper is the single canonical encoding the write path uses (ADR-024), so a `DATE '…'` predicate compares correctly against a stored `Date32` column — no silent encoding drift. Non-DATE typed literals stay declined with the type named.

## Impact (measured, correctness-verified)

Native TPC-H (SF 0.01): **4/22 → 12/22 OK** — the 8 flipped queries are **Q1/Q3/Q4/Q5/Q6/Q7/Q10/Q12**, and 7 match the DataFusion route's row counts **exactly** (correctness-verified; Q7 is the exception — see the caveat below). Feeds the cost model real native join samples the geometry-routing track needs.

## ⚠️ Correctness caveat (please read before merging)

The 8th query, **Q7, returns 0 rows natively vs 4 on DataFusion**. Verifying row counts caught this, and an isolated **date-free** probe pinned it down:
- plain self-join `count(*)` → correct
- single-table `OR` → correct
- **self-join + an OR-of-ANDs predicate spanning both aliases → 0 rows (should be 2) — WRONG**

So this is a **pre-existing, date-independent, P1 native-executor bug**, already live on develop for any such query. My DATE fix is correct; it only lets Q7 *reach* this latent bug. Net effect of this PR: 7 queries go error→correct, and Q7 goes decline→wrong-answer on the native route until the underlying bug is fixed. Filed as **TD-REL-EXEC-1 (P1)** with the probe evidence and a root-cause direction; not fixed here because my ordinal analysis suggests the plan is correct (so the bug is likely in the executor and broader than one shape — too risky to fix inline and would bloat this focused PR).

**Decision:** ship this now (large correct win; the exposed bug is independently live and must be fixed regardless), then fix TD-REL-EXEC-1 next — OR hold until TD-REL-EXEC-1 lands first. I recommend shipping + prioritizing TD-REL-EXEC-1.

## Gates
`fmt --check`, `clippy --lib --bins -D warnings`, `make work-commit-check`, `check_td_adr_unique`, server build, TPC-H/DS pgwire conformance (materialized route, no regression), unit tests (date helper + frontend lowering) — all green. Rebased on current develop (post-#998).

## Docs
TD-REL-LOWER-1 taxonomy re-measured (4→12); TD-REL-LOWER-3 broadened (Q15 derived-table alias, not just ORDER BY); TD-REL-EXEC-1 filed.

Refs: TD-REL-LOWER-1/2/3, TD-REL-EXEC-1, ADR-024, develop `1a424f3c6`.
