### PR TITLE
docs(td): record zero-vector restart blocker in TD-OBJSTORE-1

### DIFF
--- a/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-1-object-store-durability-end-to-end.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **In progress** — batch 1 (this PR) fixes the full path-construction class + the WAL/eventlog/audit local-fs escapes; deferred items enumerated below. Updated each deploy/test cycle with anvaiops until all modalities are proven on a live object store.
+| Status | **In progress — batch 3 is the active durability blocker.** Catalog and real-vector recovery now pass on the live object-store deployment, but dim-1 records written with `vector: [0.0]` are not recovered after restart. The deferred items below remain outside the single-VM MVP unless their triggering scale, multi-writer, or feature conditions are introduced.
 | Severity | Critical — with `storage.metadata_url = adls://…` (or `s3://`, `gcs://`) the server constructs invalid `file://adls://…` URLs and/or drives `std::fs`/`tokio::fs` at object-store URLs; metrics, document WAL, audit/event-log, and timeseries subsystems fail at startup or silently write to wrong local paths. Blocks the ADR-0028 anvaiops object-store deployment (issue #960).
 | Component | `src/network/shared_services.rs` (subsystem path wiring), `src/storage/persistence/write_ahead_log/wal_operations.rs` (unified WAL), `src/storage/engines/eventlog/*` (audit event log), `src/audit/*` (security audit storage), `crates/control/proximadb-catalog/src/delta.rs`, defensive: disk caches + tantivy log index.
 | Tracked-by | https://github.com/vjsingh1984/proximaDB/issues/960[#960]; deploy consumer: anvaiops ADR-0028.
@@ -143,6 +143,77 @@ The bug class has two shapes:
 | ✅ Fixed (batch 2; follow-ups TD-CAT-4)
 |===
 
+== Batch 3 — zero-vector (dim-1 KV) records not recovered on restart
+
+The anvaiops live durability proof pinned `sha-81248181f4f4-full`
+(`sha256:f4bddeb5…`, qa), deployed it to the single-VM `adls://` testbed, and ran
+the seed → `az vm restart` → verify sequence.
+
+=== What now works
+
+* Catalog recovery: `Found 16 collections in catalog` post-restart. ✅
+* Real-vector/document recovery: `WAL recovery complete: 47 total vectors
+  recovered` (previously 0 before #989). ✅ HELIX replay by collection URL works;
+  flushed segments are durable at
+  `adls://…/collections/{id}/data/L0_*.helix`.
+
+=== Active blocker
+
+Dim-1 zero-vector KV records are not recovered. The collections recover but come
+back empty:
+
+[source,text]
+----
+post-restart stats:
+  anvaiops_api_keys        record_count=0  storage=0
+  anvaiops_tenant_registry record_count=0  storage=0
+----
+
+These collections were populated and queryable before the restart. After restart,
+the API-key record lookup returns 404 and authentication returns 401, which also
+blocks verification of the recovered documents.
+
+The same WAL-recovery boot pass reports 47 real vectors recovered but zero records
+for the KV collections. These records are written through
+`POST /api/v2/collections/{c}/records/batch` with an explicit zero vector. This is
+the documented KV-store use: the engine skips embedding for zero-vector rows, and
+anvaiops uses it for API keys, the tenant registry, and workspace/billing rows. The
+recovery/replay path appears to handle embedded-vector records but not zero-vector
+KV records: either the skip-embedding write path is not represented in the WAL or
+replay filters on vector presence.
+
+=== Engine-only reproduction
+
+. Configure the cloud object-store layout with one `${OBJ}/collections` root for
+  storage, SST, and VIPER, and set `enable_mmap=false`. Set both
+  `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCOUNT_NAME` as described below.
+. Create a dim-1 collection and use `POST …/records/batch` to write a record with
+  `vector: [0.0]`.
+. Restart the process with an empty local disk.
+. Request the collection and record. `GET …/collections/{c}` reports
+  `record_count=0`, and `GET …/records/{id}` returns 404.
+
+Expected: the zero-vector record survives restart in the same way as
+embedded-vector records.
+
+=== Azure account environment keys
+
+The WAL/SST `FilesystemFactory` (`azure_blob.rs`) reads
+`AZURE_STORAGE_ACCOUNT`, while the catalog-snapshot store
+(`ProximaObjectStore` → `object_store::parse_url_opts`) reads
+`AZURE_STORAGE_ACCOUNT_NAME`. Both must be set or boot fails with
+`parse_url(az://…): Account must be specified`. If the KV-record recovery path
+opens object stores through another constructor, it must use the same account
+resolution.
+
+=== Batch-3 verification gate
+
+Run anvaiops `scripts/prove_object_store_durability.sh`. Its
+`test_durability_collection_kv_and_stats` case is the exact dim-1 KV gate: seed
+passes today, while verify fails with `record rec-… gone after restart: 404`.
+Re-pin the newly published `runtime-full` digest and rerun the proof after the
+engine fix lands.
+
 == Deferred (documented limitations — next cycles)
 
 [cols="3,3", options="header"]
@@ -220,3 +291,7 @@ The bug class has two shapes:
   `FileSystem` (TD-CAT-4 follow-ups). Design review vs Polaris/Horizon/Nessie/
   Delta: `docs/12-design/CATALOG_OBJECT_STORE_DESIGN_REVIEW_2026_07_14.adoc`;
   cache eviction finding: TD-CAT-5.
+* 2026-07-14 — batch 3 filed: the live seed → VM restart → verify proof confirms
+  catalog recovery and 47 real-vector WAL recoveries, but dim-1 zero-vector KV
+  rows recover as empty collections. This is the active last-mile blocker for
+  full anvaiops record durability.


### PR DESCRIPTION
## Summary

- append batch 3 live durability findings to TD-OBJSTORE-1
- record that catalog recovery and 47 real-vector recoveries pass while dim-1 zero-vector KV rows return empty after restart
- include the engine-only repro, both Azure account environment keys, and the anvaiops verification gate
- retain the existing deferred limitations and clarify that batch 3 is the active blocker

## Validation

- git diff --check
- python3 scripts/check_td_adr_unique.py
- python3 scripts/check_td_status_consistency.py
- make docs-claim-check
- bash scripts/check_no_commercial_docs.sh

Refs #960