### PR TITLE
ci(flake-rerun): extend #941 auto-rerun to QA Gate runner-shutdown kills

### DIFF
--- a/.github/workflows/flake-rerun.yml
+++ b/.github/workflows/flake-rerun.yml
@@ -1,11 +1,14 @@
-# Auto-rerun CI jobs killed by runner infrastructure (NOT by test failures).
+# Auto-rerun CI / QA Gate jobs killed by runner infrastructure (NOT by test failures).
 #
-# The long compile-bound jobs (Rust Tests (unit) in particular) occasionally
-# die with "The runner has received a shutdown signal" / exit 143 — a hosted-
-# runner reclamation/OOM kill, not a code failure. Historically a human had to
-# notice and run `gh run rerun <id> --failed`. This workflow does that once,
-# automatically, and ONLY when every failed job carries the infra-kill
-# signature — a genuine test failure is never retried.
+# The long compile-bound jobs (Rust Tests (unit) in CI; the QA Gate's
+# cloud-emulator / coverage / SIFT1M jobs) occasionally die with "The runner has
+# received a shutdown signal" / exit 143 — a hosted-runner reclamation/OOM kill,
+# not a code failure. Historically a human had to notice and run
+# `gh run rerun <id> --failed`. This workflow does that once, automatically, and
+# ONLY when every failed job carries the infra-kill signature — a genuine test
+# failure is never retried. (This is a SAFETY NET for non-deterministic infra
+# kills; the deterministic cold-compile OOM is fixed at the source — e.g. the
+# cloud-emulator job runs CARGO_BUILD_JOBS=1, see run_cloud_emulator_tests.sh.)
 #
 # NOTE: workflow_run triggers execute from the DEFAULT branch's copy of this
 # file, so this becomes active once promoted to main.
@@ -13,7 +16,7 @@ name: Flake Rerun
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "QA Gate"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## What
PR #941's `flake-rerun.yml` auto-reruns jobs killed by runner infrastructure (`"The runner has received a shutdown signal"`), but its `workflow_run` trigger only watched `["CI"]`. The **QA Gate** workflow's compile-bound jobs (cloud-emulator, coverage, SIFT1M) suffer the exact same hosted-runner reclamation/OOM kills — e.g. the cloud-emulator job died with that signature on the #992 promotion. This adds `"QA Gate"` to the trigger so those infra-kills get the same one-shot auto-rerun.

## Scope / design (unchanged from #941)
- The job logic is workflow-agnostic (operates on `workflow_run` regardless of source), so this is a one-line trigger widening + a comment update.
- The conservative **"every failed job must carry the infra-kill signature"** rule is unchanged — a genuine test failure is **never** retried. (This also means it won't fire when a real failure co-occurs with an infra-kill, e.g. #992 had coverage's timeout alongside the cloud-emulator kill — correct behavior.)
- `run_attempt == 1` → exactly one retry, never a loop.

## Relationship to jobs=1 (#1001, merged)
This is a **safety net** for *non-deterministic* infra kills (runner preemption/reclamation). The *deterministic* cold-compile OOM is fixed at the source — the cloud-emulator `--all` compile now runs `CARGO_BUILD_JOBS=1`. The two are complementary: jobs=1 prevents the OOM; flake-rerun recovers the rest.

## Activation
`workflow_run` triggers run from **main's** copy of this file, so this takes effect once promoted to main (develop → qa → main).

YAML-only change.