### PR TITLE
docs(td): TD-WLP-9 — WS8 VOE centroid-prune recall ratchet is an intentional fail-closed gate (not a regression)

### DIFF
--- a/docs/10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc
+++ b/docs/10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-WLP-9: WS8 VOE centroid-prune recall ratchet — intentional fail-closed qa-gate (not a regression)
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open (gate).** Intentionally **RED** on the develop→qa qa-gate as of the 2026-07-15 promotion (#992). This is a fail-closed gate, *not* a regression — the serving cascade path is unaffected. Advisory/non-blocking: develop→qa requires only `CI Success`, so the promotion merges despite this ratchet.
+| Severity | Low — qa-gate recall floor only; no durability or serving-quality impact. It *blocks* the VOE centroid-prune default-ON flip until the clustering is tuned.
+| Component | `tests/sift_pax_recall_ratchet_test.rs::sift_voe_centroid_prune_recall_at_10_ratchet` (assertion at ~L594); VOE centroid-prune path (`src/storage/engines/sst/readers/block_pruning.rs`, `object_economy_directory.rs`, `try_pax_cascade`).
+| Follows | #983 (introduced the fail-closed promotion ratchet + measured evidence); #995 / link:TD-WLP-4-appendbulk-clustering-at-compaction.adoc[TD-WLP-4] (AppendBulk PCA/IVF clustering, merged — the *fix direction*, not the cause).
+| Relates | link:TD-WLP-3-land-radius-lower-bound-prune.adoc[TD-WLP-3] (radius_k calibration), link:TD-WLP-6-profile-aware-search-defaults-observability.adoc[TD-WLP-6] (calibrated default + close-out), link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5] (VOE activation flip)
+| Pillar | PERF (recall gate for the VOE centroid-prune default-ON flip)
+|===
+
+toc::[]
+
+== Finding (determination, 2026-07-15)
+
+On qa-promotion #992 (develop→qa, wave 2: storage recovery/durability + sccache CI fix),
+the WS8 job *"SIFT1M PAX RaBitQ recall ratchet"* FAILED on a single test,
+`sift_voe_centroid_prune_recall_at_10_ratchet`. Measured output (real SIFT1M subset,
+`PROXIMADB_SIFT_N=100000`, `PROXIMADB_SIFT_QUERIES=1000`, top-10, Euclidean):
+
+* `SIFT PAX cascade recall@10 = 0.9891` over 1000 queries (floor 0.9) — **PASS**.
+* `SIFT VOE recall@10: unpruned=0.9891, pruned=0.8087` (centroid blocks total=35000, pruned=15000).
+* Panicked: `SIFT VOE centroid-prune recall@10 = 0.8087 < 0.9 floor (N=100000) — default-ON flip BLOCKED until the clustering/nprobe is tuned`.
+
+Job: GitHub Actions run `29383429342` / job `87261088930`.
+
+== Determination: not a regression
+
+This is the **intentional fail-closed ratchet introduced by #983** — "keep VOE centroid pruning
+dark while the real SIFT result regresses … the QA promotion ratchet intentionally fails on the
+current pruning algorithm, blocking a default-ON flip until recall is non-regressive." The measured
+numbers (cascade 0.9891, VOE unpruned 0.9891, VOE pruned 0.8087) match #983's recorded evidence
+*exactly*.
+
+* It is **not** caused by #995 (TD-WLP-4 AppendBulk PCA/IVF clustering at compaction) — #995 is the
+  *fix direction*, and it had not yet changed these numbers at promotion time.
+* The **serving** cascade path is unaffected (0.9891, well above floor). The red is confined to the
+  *experimental VOE centroid-prune* path, which stays dark until tuned.
+* The qa-gate is advisory/non-blocking for develop→qa (only `CI Success` is required), so #992
+  merged by design despite this ratchet.
+
+== Why it is red
+
+Flush writes vectors in insertion order, so PAX blocks carry no spatial coherence; the per-block
+centroids do not separate query-relevant blocks from the rest, so pruning 15000/35000 centroid
+blocks drops recall to 0.8087. This is the same root cause TD-WLP-3 measured directly: weak clusters
+⇒ large, undifferentiated radii ⇒ the centroid-prune lower bound adds no signal yet (k=1 does not
+beat the k=0 baseline at fixed keep).
+
+== Unblock chain (the work this gate asks for)
+
+. **TD-WLP-4 (#995, MERGED)** — AppendBulk PCA/IVF clustering at compaction differentiates block
+  radii / creates spatial coherence. Mechanism landed, armed; calibration pending.
+. **TD-WLP-3** — calibrate `radius_k` (the `d(q,centroid) − k·radius` lower-bound prune) now that
+  radii are differentiated.
+. **TD-WLP-6** — profile-aware calibrated default `BlockPruneConfig` + observability; re-run the
+  TD-WLP-3 sweep under the profile-default path. *This is where the calibrated ratchet + default
+  land and the gate goes green.*
+. **TD-RDSTRAT-5** — activate the VOE directory (compute PAX centroids → restore emission → wire
+  centroid probe-prune) — the default-ON flip this gate exists to protect.
+
+When VOE pruned recall@10 ≥ 0.9 on the real SIFT N=100k subset, `sift_voe_centroid_prune_recall_at_10_ratchet`
+passes and the VOE-prune default-ON flip may proceed.
+
+== Verification reference
+
+* WS8 job: run `29383429342` / job `87261088930` (qa-promotion #992).
+* Env: `PROXIMADB_SIFT_N=100000`, `PROXIMADB_SIFT_QUERIES=1000`,
+  `PROXIMADB_RECALL_DATASET_REQUIRED=1`, `PROXIMADB_SIFT_CENTROID_MAX_RECALL_DROP=0`.
+* Assertion: `tests/sift_pax_recall_ratchet_test.rs:594`.
+
+== History
+
+* 2026-07-14 — #983 introduced the fail-closed VOE centroid-prune ratchet (evidence: pruned 0.8087 < 0.9).
+* 2026-07-15 — observed RED on qa-promotion #992; determined not a regression (cascade 0.9891
+  unaffected); filed this TD to make the gate self-documenting and record the unblock chain.


### PR DESCRIPTION
## Summary

Files **TD-WLP-9** to document the red `SIFT1M PAX RaBitQ recall ratchet (WS8)` job seen on qa-promotion **#992**, so the next person looking at it understands it immediately instead of re-investigating.

## Determination (from the WS8 job logs)

The single failing test is `sift_voe_centroid_prune_recall_at_10_ratchet`:

| Path | recall@10 | floor | result |
|---|---|---|---|
| **Serving cascade** (RaBitQ→SQ8) | **0.9891** | 0.9 | ✅ PASS |
| VOE unpruned | 0.9891 | — | — |
| VOE centroid-**pruned** | 0.8087 | 0.9 | ❌ fail-closed |

**This is not a recall regression.** It is the *intentional fail-closed ratchet introduced by #983* ("keep VOE centroid pruning dark while the real SIFT result regresses … blocking a default-ON flip until recall is non-regressive") — the measured numbers match #983's recorded evidence exactly. The serving cascade path is unaffected (0.9891). It is **not** caused by #995 (TD-WLP-4 AppendBulk PCA/IVF clustering) — #995 is the *fix direction*. The qa-gate is advisory/non-blocking for develop→qa (only `CI Success` required), so #992 merged by design.

Root cause: flush writes vectors in insertion order ⇒ PAX blocks have no spatial coherence ⇒ per-block centroids don't separate query-relevant blocks ⇒ pruning 15000/35000 blocks drops recall. (Same root cause TD-WLP-3 measured: weak clusters ⇒ undifferentiated radii.)

## Unblock chain (what the gate asks for)

1. **TD-WLP-4 (#995, MERGED)** — AppendBulk PCA/IVF clustering differentiates block radii.
2. **TD-WLP-3** — calibrate `radius_k` now that radii are differentiated.
3. **TD-WLP-6** — calibrated profile default + observability + re-run the sweep (where the gate goes green).
4. **TD-RDSTRAT-5** — activate the VOE directory (the default-ON flip this gate protects).

When VOE pruned recall@10 ≥ 0.9 on the real SIFT N=100k subset, the ratchet passes and the flip may proceed.

## Validation
- `python3 scripts/check_td_adr_unique.py` → 0 errors (TD-WLP-9 unique)
- `python3 scripts/check_td_status_consistency.py` → passed
- docs-only change; `cargo fmt --check` clean