### PR TITLE
fix: make async document admission route-stable

### DIFF
--- a/crates/modalities/proximadb-embedding/src/config.rs
+++ b/crates/modalities/proximadb-embedding/src/config.rs
@@ -85,6 +85,66 @@ impl EmbedRoute {
     }
 }
 
+/// Credential-free identity of an embedding route. Durable work may persist
+/// this shape to pin model, endpoint, geometry, precision, and batching
+/// semantics without copying tenant credentials into a queue or WAL.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum EmbedRouteIdentity {
+    BgeSmall,
+    BgeLarge,
+    BgeM3,
+    AzureOpenAi {
+        model: AzureModel,
+    },
+    OpenAi {
+        model: OpenAiModel,
+    },
+    Cohere {
+        model: CohereModel,
+    },
+    Byo {
+        url: String,
+        declared_dim: usize,
+        declared_precision: EmbeddingScalarType,
+        batch_size: usize,
+        timeout_ms: u64,
+    },
+}
+
+impl From<&EmbedRoute> for EmbedRouteIdentity {
+    fn from(route: &EmbedRoute) -> Self {
+        match route {
+            EmbedRoute::BgeSmall => Self::BgeSmall,
+            EmbedRoute::BgeLarge => Self::BgeLarge,
+            EmbedRoute::BgeM3 => Self::BgeM3,
+            EmbedRoute::AzureOpenAi { model } => Self::AzureOpenAi {
+                model: model.clone(),
+            },
+            EmbedRoute::OpenAi { model } => Self::OpenAi {
+                model: model.clone(),
+            },
+            EmbedRoute::Cohere { model } => Self::Cohere {
+                model: model.clone(),
+            },
+            EmbedRoute::Byo {
+                url,
+                declared_dim,
+                declared_precision,
+                batch_size,
+                timeout_ms,
+                ..
+            } => Self::Byo {
+                url: url.clone(),
+                declared_dim: *declared_dim,
+                declared_precision: *declared_precision,
+                batch_size: *batch_size,
+                timeout_ms: *timeout_ms,
+            },
+        }
+    }
+}
+
 /// OpenAI embedding model selection.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -889,5 +949,36 @@ mod collection_route_tests {
         };
         let route = choice.route();
         assert_eq!(route.native_precision(), EmbeddingScalarType::Fp16);
+    }
+
+    #[test]
+    fn durable_route_identity_excludes_credentials_but_detects_route_drift() {
+        let route = EmbedRoute::Byo {
+            url: "https://embed.example.com".into(),
+            auth: ByoAuth::Bearer {
+                secret_ref: "tenant-secret".into(),
+            },
+            declared_dim: 768,
+            declared_precision: EmbeddingScalarType::Fp16,
+            batch_size: 16,
+            timeout_ms: 5000,
+        };
+        let mut rotated = route.clone();
+        let EmbedRoute::Byo { auth, .. } = &mut rotated else {
+            unreachable!()
+        };
+        *auth = ByoAuth::Bearer {
+            secret_ref: "rotated-secret".into(),
+        };
+        let mut changed_endpoint = route.clone();
+        let EmbedRoute::Byo { url, .. } = &mut changed_endpoint else {
+            unreachable!()
+        };
+        *url = "https://other.example.com".into();
+
+        let identity = EmbedRouteIdentity::from(&route);
+        assert_eq!(identity, EmbedRouteIdentity::from(&rotated));
+        assert_ne!(identity, EmbedRouteIdentity::from(&changed_endpoint));
+        assert!(!serde_json::to_string(&identity).unwrap().contains("secret"));
     }
 }

--- a/crates/modalities/proximadb-embedding/src/lib.rs
+++ b/crates/modalities/proximadb-embedding/src/lib.rs
@@ -54,7 +54,7 @@ pub mod scheduler;
 pub mod service;
 pub mod tokenizer;
 
-pub use config::{ChunkConfig, EmbedRoute, EmbeddingConfig};
+pub use config::{ChunkConfig, EmbedRoute, EmbedRouteIdentity, EmbeddingConfig};
 pub use models::{BatchConversionSummary, ModelRegistry};
 // INT-1 (mini-phase): typed embedding values for native-precision
 // inference output. Re-exported from proximadb-records so callers don't

--- a/crates/modalities/proximadb-embedding/src/service.rs
+++ b/crates/modalities/proximadb-embedding/src/service.rs
@@ -10,7 +10,7 @@ use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use tracing::info;
 
-use crate::config::{EmbedRoute, EmbeddingConfig};
+use crate::config::{EmbedRoute, EmbedRouteIdentity, EmbeddingConfig};
 use crate::models::ModelRegistry;
 use crate::scheduler::{EmbedScheduler, EmbedSchedulerConfig, IngestMode, SchedulerStats};
 use crate::tokenizer::SharedTokenizer;
@@ -132,6 +132,25 @@ impl EmbeddingService {
         self.default_config.route.clone()
     }
 
+    /// Resolve the executable route for durable work that already pinned a
+    /// credential-free identity. A fresh live route wins; if the cache TTL
+    /// elapsed, the last cached route remains usable only when its identity
+    /// still matches the admitted job. This keeps queue delay independent of
+    /// the routing-cache TTL without allowing model or endpoint drift.
+    pub fn resolve_admitted_route(
+        &self,
+        tenant_id: &str,
+        admitted: &EmbedRouteIdentity,
+    ) -> Option<EmbedRoute> {
+        let live = self.resolve_route(tenant_id);
+        if EmbedRouteIdentity::from(&live) == *admitted {
+            return Some(live);
+        }
+        self.tenant_cache.get(tenant_id).and_then(|cached| {
+            (EmbedRouteIdentity::from(&cached.route) == *admitted).then(|| cached.route.clone())
+        })
+    }
+
     /// Refresh the cached route for a tenant. Typically called after a
     /// tenant registry lookup.
     pub fn update_tenant_route(&self, tenant_id: impl Into<String>, route: EmbedRoute) {
@@ -156,6 +175,18 @@ impl EmbeddingService {
             self.resolve_route(&batch.records[0].tenant_id)
         };
 
+        self.embed_sync_with_route(batch, route).await
+    }
+
+    /// Embed with a route already resolved by the caller. Durable async
+    /// producers use this to ensure execution honors the route admitted when
+    /// the work was accepted, even if the tenant's live route changes before
+    /// the queue is drained.
+    pub async fn embed_sync_with_route(
+        self: &Arc<Self>,
+        batch: EmbedBatch,
+        route: EmbedRoute,
+    ) -> Result<EmbedResult> {
         let service = self.clone();
         let texts: Vec<String> = batch.records.iter().map(|r| r.text.clone()).collect();
         let route_inner = route.clone();

--- a/crates/modalities/proximadb-queue/src/consumer.rs
+++ b/crates/modalities/proximadb-queue/src/consumer.rs
@@ -21,7 +21,7 @@ use tracing::{debug, warn};
 use crate::QueueClient;
 use crate::error::{QueueError, Result};
 use crate::memory_tier::MemoryEntry;
-use crate::message::{Message, MessageId};
+use crate::message::{Delivery, MessageId};
 use crate::topic::PartitionId;
 
 #[derive(Clone)]
@@ -174,7 +174,7 @@ impl Consumer {
 
     /// Poll up to `max_batch` messages across owned partitions. Blocks up to
     /// `max_wait` for at least one message to arrive.
-    pub async fn poll(&self, max_batch: usize, max_wait: Duration) -> Result<Vec<Message>> {
+    pub async fn poll(&self, max_batch: usize, max_wait: Duration) -> Result<Vec<Delivery>> {
         let deadline = tokio::time::Instant::now() + max_wait;
         loop {
             let mut out = Vec::with_capacity(max_batch);
@@ -200,7 +200,10 @@ impl Consumer {
                     }
                     drop(tracker);
                     for memo in batch {
-                        out.push(memo.message);
+                        out.push(Delivery {
+                            message_id: memo.message_id,
+                            message: memo.message,
+                        });
                     }
                 }
             }

--- a/crates/modalities/proximadb-queue/src/lib.rs
+++ b/crates/modalities/proximadb-queue/src/lib.rs
@@ -52,7 +52,7 @@ pub mod topic;
 pub use config::{QueueConfig, SyncMode, TopicConfig};
 pub use consumer::Consumer;
 pub use error::{QueueError, Result};
-pub use message::{Message, MessageId, MessageReceipt};
+pub use message::{Delivery, Message, MessageId, MessageReceipt};
 pub use producer::Producer;
 pub use topic::{PartitionId, partition_for};
 

--- a/crates/modalities/proximadb-queue/src/message.rs
+++ b/crates/modalities/proximadb-queue/src/message.rs
@@ -48,6 +48,22 @@ pub struct Message {
     pub attempt_count: u32,
 }
 
+/// A message handed to a consumer together with the stable identity required
+/// to acknowledge that exact delivery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Delivery {
+    pub message_id: MessageId,
+    pub message: Message,
+}
+
+impl std::ops::Deref for Delivery {
+    type Target = Message;
+
+    fn deref(&self) -> &Self::Target {
+        &self.message
+    }
+}
+
 fn default_now() -> SystemTime {
     SystemTime::now()
 }

--- a/crates/modalities/proximadb-queue/src/python.rs
+++ b/crates/modalities/proximadb-queue/src/python.rs
@@ -27,7 +27,6 @@
 //! `proximadb_queue_embedded` Python module re-exports these with
 //! ergonomic wrappers.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -141,7 +140,7 @@ impl PyProducer {
         let payload_bytes = payload.as_bytes().to_vec();
         let msg = RsMessage::new(topic, tenant_id, payload_bytes);
         let receipt = py
-            .allow_threads(|| rt().block_on(self.inner.send(msg)))
+            .detach(|| rt().block_on(self.inner.send(msg)))
             .map_err(err)?;
         Ok(PyMessageReceipt {
             message_id: receipt.message_id.0,
@@ -170,28 +169,29 @@ impl PyConsumer {
     fn poll(&self, py: Python<'_>, max_batch: usize, max_wait_ms: u64) -> PyResult<Vec<PyMessage>> {
         let wait = Duration::from_millis(max_wait_ms);
         let msgs = py
-            .allow_threads(|| rt().block_on(self.inner.poll(max_batch, wait)))
+            .detach(|| rt().block_on(self.inner.poll(max_batch, wait)))
             .map_err(err)?;
         Ok(msgs
             .into_iter()
-            .map(|m| PyMessage {
-                topic: m.topic,
-                tenant_id: m.tenant_id,
-                payload: m.payload,
-                attempt_count: m.attempt_count,
+            .map(|delivery| PyMessage {
+                message_id: delivery.message_id.0,
+                topic: delivery.message.topic,
+                tenant_id: delivery.message.tenant_id,
+                payload: delivery.message.payload,
+                attempt_count: delivery.message.attempt_count,
             })
             .collect())
     }
 
     fn ack(&self, py: Python<'_>, message_ids: Vec<String>) -> PyResult<()> {
         let ids: Vec<RsMessageId> = message_ids.into_iter().map(RsMessageId).collect();
-        py.allow_threads(|| rt().block_on(self.inner.ack(&ids)))
+        py.detach(|| rt().block_on(self.inner.ack(&ids)))
             .map_err(err)
     }
 
     fn nack(&self, py: Python<'_>, message_ids: Vec<String>) -> PyResult<()> {
         let ids: Vec<RsMessageId> = message_ids.into_iter().map(RsMessageId).collect();
-        py.allow_threads(|| rt().block_on(self.inner.nack(&ids)))
+        py.detach(|| rt().block_on(self.inner.nack(&ids)))
             .map_err(err)
     }
 }
@@ -199,6 +199,8 @@ impl PyConsumer {
 #[pyclass(name = "Message", module = "proximadb_queue_embedded._native")]
 #[derive(Clone)]
 pub struct PyMessage {
+    #[pyo3(get)]
+    pub message_id: String,
     #[pyo3(get)]
     pub topic: String,
     #[pyo3(get)]

--- a/crates/modalities/proximadb-queue/tests/offset_store.rs
+++ b/crates/modalities/proximadb-queue/tests/offset_store.rs
@@ -51,12 +51,9 @@ async fn ack_commits_offset_to_disk() {
         .expect("poll");
     assert_eq!(batch.len(), 7, "should poll 7 messages");
 
-    // To ack, we need the MessageIds. The consumer's in_flight tracker
-    // has them but isn't part of the public API; we reconstruct them
-    // from the deterministic memory-tier offset assignment (partition
-    // 0, segment 0, offsets 0..7).
-    let ack_ids: Vec<proximadb_queue::MessageId> = (0..7u64)
-        .map(|offset| proximadb_queue::MessageId::new(0, 0, offset))
+    let ack_ids: Vec<proximadb_queue::MessageId> = batch
+        .iter()
+        .map(|delivery| delivery.message_id.clone())
         .collect();
     consumer.ack(&ack_ids).await.expect("ack");
 
@@ -91,25 +88,22 @@ async fn offset_commit_is_atomic() {
     let consumer = Arc::new(client.consumer("g"));
     consumer.subscribe("t", &[0]).await.expect("subscribe");
     // Drain so the in_flight tracker has all 100.
-    let mut polled = 0;
+    let mut delivery_ids = Vec::new();
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    while polled < 100 && std::time::Instant::now() < deadline {
+    while delivery_ids.len() < 100 && std::time::Instant::now() < deadline {
         let batch = consumer
             .poll(32, Duration::from_millis(50))
             .await
             .expect("poll");
-        polled += batch.len();
+        delivery_ids.extend(batch.into_iter().map(|delivery| delivery.message_id));
     }
-    assert_eq!(polled, 100, "should poll all 100 first");
+    assert_eq!(delivery_ids.len(), 100, "should poll all 100 first");
 
-    // 100 ack tasks, one per offset. Each task acks a single MessageId.
+    // 100 ack tasks, one per delivered identity.
     let mut handles = Vec::new();
-    for offset in 0..100u64 {
+    for id in delivery_ids {
         let c = consumer.clone();
-        handles.push(tokio::spawn(async move {
-            let id = proximadb_queue::MessageId::new(0, 0, offset);
-            c.ack(&[id]).await
-        }));
+        handles.push(tokio::spawn(async move { c.ack(&[id]).await }));
     }
     for h in handles {
         h.await.unwrap().expect("ack");

--- a/crates/modalities/proximadb-queue/tests/roundtrip.rs
+++ b/crates/modalities/proximadb-queue/tests/roundtrip.rs
@@ -66,9 +66,14 @@ async fn produce_and_consume_round_trip() {
         received.extend(batch);
     }
     assert_eq!(received.len(), 8, "should receive all 8 sent messages");
+    let received_ids: Vec<_> = received
+        .iter()
+        .map(|delivery| delivery.message_id.clone())
+        .collect();
+    assert!(sent_ids.iter().all(|id| received_ids.contains(id)));
 
     // Ack everything; subsequent polls should return empty.
-    consumer.ack(&sent_ids).await.expect("ack");
+    consumer.ack(&received_ids).await.expect("ack");
     let empty = consumer
         .poll(16, Duration::from_millis(50))
         .await

--- a/src/network/rest/v2/documents.rs
+++ b/src/network/rest/v2/documents.rs
@@ -315,9 +315,12 @@ async fn ingest_documents_inner(
     // real embedding dimension before inserting.
     if mode == "async"
         && embed_source == "native"
-        && existing_dimension.is_some()
+        && let Some(expected_dimension) = existing_dimension
+        && records.iter().all(|record| record.embeddings.is_empty())
         && let Some(queue) = state.queue_client.clone()
     {
+        let embedding_route_identity =
+            admit_native_async(&records, &collection, &tenant_id, expected_dimension)?;
         let producer = queue.producer();
         // Build the EmbedIngestPayload directly from `records`'
         // props (where the text was hoisted during the build-loop
@@ -340,6 +343,8 @@ async fn ingest_documents_inner(
         let payload = crate::services::EmbedIngestPayload {
             target_collection: collection.clone(),
             tenant_id: tenant_id.clone(),
+            embedding_route_identity,
+            expected_dimension,
             records: drainer_records,
         };
         let payload_bytes = serde_json::to_vec(&payload)
@@ -357,9 +362,7 @@ async fn ingest_documents_inner(
                         .iter()
                         .map(|r| IngestedRecord {
                             id: r.oid.clone(),
-                            // Vector dim unknown until drainer
-                            // embeds; 0 = pending.
-                            dim: 0,
+                            dim: expected_dimension,
                         })
                         .collect(),
                     retry_after_ms: None,
@@ -518,6 +521,52 @@ async fn ingest_documents_inner(
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+/// Validate all facts needed to make a durable native-embedding job
+/// admissible before returning 202. The returned credential-free identity is
+/// serialized into the queue payload; the drainer accepts credential rotation
+/// but rejects any model, endpoint, or geometry drift before inference.
+fn admit_native_async(
+    records: &[ProximaRecord],
+    collection: &str,
+    tenant_id: &str,
+    expected_dimension: u32,
+) -> ApiResult<proximadb_embedding::config::EmbedRouteIdentity> {
+    let missing_text: Vec<&str> = records
+        .iter()
+        .filter(|record| {
+            extract_text(record)
+                .as_deref()
+                .is_none_or(|text| text.trim().is_empty())
+        })
+        .map(|record| record.oid.as_str())
+        .collect();
+    if !missing_text.is_empty() {
+        return Err(ApiError::InvalidArgument(format!(
+            "{} record(s) have no text to embed: {}",
+            missing_text.len(),
+            missing_text.join(", ")
+        )));
+    }
+
+    let embed_service = proximadb_embedding::EmbeddingService::try_global().ok_or_else(|| {
+        ApiError::Internal("native embedding service is not initialized".to_string())
+    })?;
+    let route = embed_service.resolve_route(tenant_id);
+    let route_dimension = u32::try_from(route.dimension()).map_err(|_| {
+        ApiError::Internal(format!(
+            "embedding route dimension {} exceeds the supported range",
+            route.dimension()
+        ))
+    })?;
+    if route_dimension != expected_dimension {
+        return Err(ApiError::InvalidArgument(format!(
+            "native embedding route produces dimension {route_dimension} but collection \
+             '{collection}' expects dimension {expected_dimension}"
+        )));
+    }
+    Ok((&route).into())
+}
+
 /// #951: create a missing target collection at the embedding dimension the
 /// handler just produced, through the same unified create path the v2
 /// `POST /collections` handler uses (full registration + tenant tagging —
@@ -663,6 +712,8 @@ fn json_to_proxima_value(value: serde_json::Value) -> ProximaValue {
 mod tests {
     use super::*;
     use crate::services::operations::BatchOperationResult;
+    use proximadb_embedding::config::{ChunkConfig, EmbedRoute, EmbeddingConfig};
+    use proximadb_embedding::scheduler::EmbedSchedulerConfig;
 
     fn record_with_props(entries: &[(&str, ProximaValue)]) -> ProximaRecord {
         ProximaRecord {
@@ -732,5 +783,41 @@ mod tests {
             batch_failure_to_api_error("docs", &opaque),
             ApiError::Internal(_)
         ));
+    }
+
+    fn ensure_embedding_singleton() {
+        if proximadb_embedding::EmbeddingService::try_global().is_some() {
+            return;
+        }
+        let _ = proximadb_embedding::EmbeddingService::initialize(
+            EmbeddingConfig {
+                route: EmbedRoute::BgeSmall,
+                chunk: ChunkConfig::default(),
+            },
+            EmbedSchedulerConfig::default(),
+        );
+    }
+
+    #[test]
+    fn async_native_admission_rejects_route_dimension_mismatch() {
+        ensure_embedding_singleton();
+        let record = record_with_props(&[(
+            "text",
+            ProximaValue::String("dimensionally checked before enqueue".to_string()),
+        )]);
+
+        let result = admit_native_async(&[record], "docs", "tenant-admission", 1024);
+
+        assert!(matches!(result, Err(ApiError::InvalidArgument(_))));
+    }
+
+    #[test]
+    fn async_native_admission_rejects_blank_text() {
+        ensure_embedding_singleton();
+        let record = record_with_props(&[("text", ProximaValue::String("   ".to_string()))]);
+
+        let result = admit_native_async(&[record], "docs", "tenant-admission", 384);
+
+        assert!(matches!(result, Err(ApiError::InvalidArgument(_))));
     }
 }

--- a/src/services/embedding_drainer.rs
+++ b/src/services/embedding_drainer.rs
@@ -55,7 +55,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use proximadb_embedding::EmbeddingService;
-use proximadb_embedding::config::EmbedRoute;
+use proximadb_embedding::config::{EmbedRoute, EmbedRouteIdentity};
 use proximadb_embedding::scheduler::IngestMode;
 use proximadb_embedding::service::{EmbedBatch, EmbedRecord};
 use proximadb_queue::QueueClient;
@@ -85,7 +85,17 @@ pub struct EmbedIngestRecord {
 pub struct EmbedIngestPayload {
     pub target_collection: String,
     pub tenant_id: String,
+    /// Credential-free route identity admitted by the producer. The drainer
+    /// resolves fresh credentials but rejects model or geometry drift.
+    pub embedding_route_identity: EmbedRouteIdentity,
+    /// Collection geometry observed during admission.
+    pub expected_dimension: u32,
     pub records: Vec<EmbedIngestRecord>,
+}
+
+struct ReadyEmbedIngestPayload {
+    payload: EmbedIngestPayload,
+    route: EmbedRoute,
 }
 
 /// Insert path the drainer calls once embedding has populated vectors.
@@ -273,181 +283,224 @@ impl EmbeddingDrainer {
     async fn process_batch(
         &self,
         consumer: &proximadb_queue::Consumer,
-        messages: Vec<proximadb_queue::Message>,
+        deliveries: Vec<proximadb_queue::Delivery>,
     ) -> anyhow::Result<()> {
-        let mut acked: Vec<proximadb_queue::MessageId> = Vec::with_capacity(messages.len());
+        let delivery_ids: Vec<proximadb_queue::MessageId> = deliveries
+            .iter()
+            .map(|delivery| delivery.message_id.clone())
+            .collect();
+        let mut partition_queues: std::collections::BTreeMap<
+            proximadb_queue::PartitionId,
+            std::collections::VecDeque<ReadyEmbedIngestPayload>,
+        > = std::collections::BTreeMap::new();
 
-        // Parse + flatten — group records across messages so one
-        // embed_sync call serves the whole batch.
-        let mut batch_records: Vec<EmbedRecord> = Vec::new();
-        let mut payload_indices: Vec<(EmbedIngestPayload, std::ops::Range<usize>)> = Vec::new();
-        for msg in &messages {
-            let payload: EmbedIngestPayload = match serde_json::from_slice(&msg.payload) {
+        for delivery in &deliveries {
+            let payload: EmbedIngestPayload = match serde_json::from_slice(&delivery.payload) {
                 Ok(p) => p,
                 Err(e) => {
                     warn!(error = %e, "drainer: malformed payload; acking to avoid hot-looping");
-                    // Compute the message_id from partition/offset
-                    // exposed via the Message envelope. proximadb_queue
-                    // doesn't surface the MessageId back to Consumer
-                    // callers directly; ack uses the partition/offset
-                    // derived id mirrored by the in_flight tracker.
                     continue;
                 }
             };
-            let start = batch_records.len();
-            for rec in &payload.records {
-                batch_records.push(EmbedRecord {
-                    id: rec.oid.clone(),
-                    text: rec.text.clone(),
-                    tenant_id: payload.tenant_id.clone(),
-                });
+            if payload.tenant_id != delivery.tenant_id {
+                anyhow::bail!(
+                    "drainer: envelope tenant '{}' does not match payload tenant '{}'",
+                    delivery.tenant_id,
+                    payload.tenant_id
+                );
             }
-            let end = batch_records.len();
-            payload_indices.push((payload, start..end));
+            if payload.records.is_empty() {
+                anyhow::bail!("drainer: payload contains no records");
+            }
+            if let Some(record) = payload
+                .records
+                .iter()
+                .find(|record| record.text.trim().is_empty())
+            {
+                anyhow::bail!("drainer: record '{}' contains no text", record.oid);
+            }
+            let route = self
+                .embed_service
+                .resolve_admitted_route(&payload.tenant_id, &payload.embedding_route_identity)
+                .ok_or_else(|| {
+                    let current = self.embed_service.resolve_route(&payload.tenant_id);
+                    anyhow::anyhow!(
+                        "drainer: tenant route identity changed after admission: expected {:?}, got {:?}",
+                        payload.embedding_route_identity,
+                        EmbedRouteIdentity::from(&current)
+                    )
+                })?;
+            let route_dimension = u32::try_from(route.dimension())
+                .map_err(|_| anyhow::anyhow!("drainer: route dimension exceeds u32"))?;
+            if route_dimension != payload.expected_dimension {
+                anyhow::bail!(
+                    "drainer: admitted dimension {} does not match route dimension {}",
+                    payload.expected_dimension,
+                    route_dimension
+                );
+            }
+            let partition = delivery
+                .message_id
+                .partition()
+                .ok_or_else(|| anyhow::anyhow!("drainer: malformed delivery id"))?;
+            partition_queues
+                .entry(partition)
+                .or_default()
+                .push_back(ReadyEmbedIngestPayload { payload, route });
         }
 
-        if batch_records.is_empty() {
-            return Ok(());
+        // Preserve FIFO within each queue partition. At each step, batch all
+        // compatible jobs currently at independent partition heads; consume
+        // consecutive same-route jobs from each selected partition.
+        while let Some(route) = partition_queues
+            .values()
+            .find_map(|queue| queue.front().map(|ready| ready.route.clone()))
+        {
+            let mut payloads = Vec::new();
+            for queue in partition_queues.values_mut() {
+                while queue.front().is_some_and(|ready| ready.route == route) {
+                    let Some(ready) = queue.pop_front() else {
+                        break;
+                    };
+                    payloads.push(ready.payload);
+                }
+            }
+            self.process_route_group(route, payloads).await?;
+        }
+
+        if !delivery_ids.is_empty() {
+            consumer
+                .ack(&delivery_ids)
+                .await
+                .map_err(|e| anyhow::anyhow!("drainer ack failed: {e}"))?;
+            debug!(count = delivery_ids.len(), "drainer batch ack'd");
+        }
+        Ok(())
+    }
+
+    async fn process_route_group(
+        &self,
+        route: EmbedRoute,
+        payloads: Vec<EmbedIngestPayload>,
+    ) -> anyhow::Result<()> {
+        let mut batch_records = Vec::new();
+        let mut payload_ranges = Vec::with_capacity(payloads.len());
+        for payload in &payloads {
+            let start = batch_records.len();
+            batch_records.extend(payload.records.iter().map(|record| EmbedRecord {
+                id: record.oid.clone(),
+                text: record.text.clone(),
+                tenant_id: payload.tenant_id.clone(),
+            }));
+            payload_ranges.push(start..batch_records.len());
         }
 
         let result = self
             .embed_service
-            .embed_sync(EmbedBatch {
-                records: batch_records,
-                mode: IngestMode::Async,
-            })
+            .embed_sync_with_route(
+                EmbedBatch {
+                    records: batch_records,
+                    mode: IngestMode::Async,
+                },
+                route.clone(),
+            )
             .await
             .map_err(|e| anyhow::anyhow!("drainer embed failed: {e}"))?;
-
-        // Record KEU metering for embedding operations (TD-134)
-        // We record after the embedding call to capture the actual work done
-        let embedding_count = result.vectors.len() as u64;
-        // Estimate token counts (this would be more accurate with actual tokenization)
-        let estimated_input_tokens = embedding_count.saturating_mul(512); // ~512 tokens per record average
-        let estimated_output_tokens =
-            embedding_count.saturating_mul(result.route.dimension() as u64);
-
-        // Record KEU for the tenant (use the first payload's tenant_id)
-        if !payload_indices.is_empty() {
-            let tenant_id = &payload_indices[0].0.tenant_id;
-            // Simple provider/model name extraction from route
-            let (provider, model): (&'static str, String) = match &result.route {
-                proximadb_embedding::config::EmbedRoute::BgeSmall => {
-                    ("victor", "bge-small-en-v1.5".to_string())
-                }
-                proximadb_embedding::config::EmbedRoute::BgeLarge => {
-                    ("victor", "bge-large-en-v1.5".to_string())
-                }
-                proximadb_embedding::config::EmbedRoute::BgeM3 => ("victor", "bge-m3".to_string()),
-                proximadb_embedding::config::EmbedRoute::AzureOpenAi { model } => {
-                    ("azure_openai", std::format!("azure_{:?}", model))
-                }
-                proximadb_embedding::config::EmbedRoute::OpenAi { model } => {
-                    ("openai", std::format!("openai_{:?}", model))
-                }
-                proximadb_embedding::config::EmbedRoute::Cohere { model } => {
-                    ("cohere", std::format!("cohere_{:?}", model))
-                }
-                proximadb_embedding::config::EmbedRoute::Byo { url, .. } => ("byo", url.clone()),
-            };
-            crate::metrics::consumption_metrics::record_keu_units(
-                Some(tenant_id),
-                provider,
-                &model,
-                "embed_batch",
-                estimated_input_tokens,
-                estimated_output_tokens,
+        if result.vectors.len() != batch_record_count(&payload_ranges) {
+            anyhow::bail!(
+                "drainer: provider returned {} vectors for {} records",
+                result.vectors.len(),
+                batch_record_count(&payload_ranges)
             );
         }
+        let dimension = u32::try_from(route.dimension())
+            .map_err(|_| anyhow::anyhow!("drainer: route dimension exceeds u32"))?;
 
-        // Re-split the result back to per-payload + insert.
-        let dim = result.route.dimension() as u32;
-        for ((payload, range), msg) in payload_indices.iter().zip(messages.iter()) {
-            // Resolve per-payload canonical precision once (so all records
-            // in this payload — which belong to the same collection —
-            // share the same target). When no resolver is wired or the
-            // lookup fails, the records ship with `target_precision: None`
-            // and the sink keeps the legacy fp32 path.
-            let target_precision = match &self.precision_resolver {
-                None => None,
-                Some(resolver) => {
-                    let table_id = Self::collection_to_table_identifier(&payload.target_collection);
-                    match resolver.resolve(&table_id).await {
-                        Ok(precision) => Some(precision),
-                        Err(e) => {
-                            warn!(
-                                collection = %payload.target_collection,
-                                tenant = %payload.tenant_id,
-                                error = %e,
-                                "drainer: precision resolver failed; falling back to fp32"
-                            );
-                            None
-                        }
-                    }
-                }
-            };
-
-            let mut embedded: Vec<EmbeddedRecord> = Vec::with_capacity(range.end - range.start);
-            for (i, rec) in payload.records.iter().enumerate() {
-                let vector = result
-                    .vectors
-                    .get(range.start + i)
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("drainer: embed result shape mismatch"))?;
-                embedded.push(EmbeddedRecord {
-                    oid: rec.oid.clone(),
-                    text: rec.text.clone(),
-                    vector,
-                    vector_dim: dim,
-                    metadata: rec.metadata.clone(),
-                    target_precision,
-                });
+        for (payload, range) in payloads.iter().zip(payload_ranges) {
+            let vectors = result
+                .vectors
+                .get(range)
+                .ok_or_else(|| anyhow::anyhow!("drainer: embed result shape mismatch"))?;
+            if let Some(vector) = vectors
+                .iter()
+                .find(|vector| vector.len() != payload.expected_dimension as usize)
+            {
+                anyhow::bail!(
+                    "drainer: provider returned dimension {} for admitted dimension {}",
+                    vector.len(),
+                    payload.expected_dimension
+                );
             }
+
+            record_embedding_consumption(payload, &route);
+            let target_precision = self.resolve_target_precision(payload).await;
+            let embedded = payload
+                .records
+                .iter()
+                .zip(vectors.iter())
+                .map(|(record, vector)| EmbeddedRecord {
+                    oid: record.oid.clone(),
+                    text: record.text.clone(),
+                    vector: vector.clone(),
+                    vector_dim: dimension,
+                    metadata: record.metadata.clone(),
+                    target_precision,
+                })
+                .collect();
             self.sink
                 .insert(&payload.target_collection, &payload.tenant_id, embedded)
                 .await
                 .map_err(|e| anyhow::anyhow!("drainer sink insert failed: {e}"))?;
-
-            // Reconstruct MessageId from the polled message. The
-            // queue's Message envelope doesn't carry MessageId so we
-            // derive it from the in-flight tracker via consumer's
-            // ack-by-id. For now we use the offset / partition derivable
-            // from the tracker — Phase 2G follow-up exposes
-            // MessageId on Message.
-            let id = derive_message_id(msg);
-            acked.push(id);
-        }
-
-        if !acked.is_empty() {
-            consumer
-                .ack(&acked)
-                .await
-                .map_err(|e| anyhow::anyhow!("drainer ack failed: {e}"))?;
-            debug!(count = acked.len(), "drainer batch ack'd");
         }
         Ok(())
     }
+
+    async fn resolve_target_precision(
+        &self,
+        payload: &EmbedIngestPayload,
+    ) -> Option<proximadb_records::EmbeddingScalarType> {
+        let resolver = self.precision_resolver.as_ref()?;
+        let table_id = Self::collection_to_table_identifier(&payload.target_collection);
+        match resolver.resolve(&table_id).await {
+            Ok(precision) => Some(precision),
+            Err(e) => {
+                warn!(
+                    collection = %payload.target_collection,
+                    tenant = %payload.tenant_id,
+                    error = %e,
+                    "drainer: precision resolver failed; falling back to fp32"
+                );
+                None
+            }
+        }
+    }
 }
 
-/// Derive a `MessageId` from a polled `Message`. The queue's Message
-/// type doesn't currently expose its MessageId back to consumers; we
-/// reconstruct it from the partition_for(tenant_id) hash + a sentinel
-/// segment id. This is the most fragile part of the drainer and is the
-/// first target of the Phase 2G follow-up that surfaces MessageId on
-/// Message directly.
-fn derive_message_id(msg: &proximadb_queue::Message) -> proximadb_queue::MessageId {
-    // The consumer's in_flight tracker holds the actual MessageIds.
-    // Until the queue exposes them on Message, we use the partition +
-    // a synthetic offset that the tracker will retain-match against
-    // (which is permissive because ack() retains pending entries on
-    // matched ids and silently no-ops unknown ones).
-    let partition = proximadb_queue::partition_for(&msg.tenant_id, 16);
-    proximadb_queue::MessageId::new(partition, 0, 0)
+fn batch_record_count(ranges: &[std::ops::Range<usize>]) -> usize {
+    ranges.last().map_or(0, |range| range.end)
 }
 
-#[allow(unused_variables)]
-fn _route_dim(route: EmbedRoute) -> u32 {
-    route.dimension() as u32
+fn record_embedding_consumption(payload: &EmbedIngestPayload, route: &EmbedRoute) {
+    let embedding_count = payload.records.len() as u64;
+    let estimated_input_tokens = embedding_count.saturating_mul(512);
+    let estimated_output_tokens = embedding_count.saturating_mul(route.dimension() as u64);
+    let (provider, model): (&'static str, String) = match route {
+        EmbedRoute::BgeSmall => ("victor", "bge-small-en-v1.5".to_string()),
+        EmbedRoute::BgeLarge => ("victor", "bge-large-en-v1.5".to_string()),
+        EmbedRoute::BgeM3 => ("victor", "bge-m3".to_string()),
+        EmbedRoute::AzureOpenAi { model } => ("azure_openai", format!("azure_{model:?}")),
+        EmbedRoute::OpenAi { model } => ("openai", format!("openai_{model:?}")),
+        EmbedRoute::Cohere { model } => ("cohere", format!("cohere_{model:?}")),
+        EmbedRoute::Byo { url, .. } => ("byo", url.clone()),
+    };
+    crate::metrics::consumption_metrics::record_keu_units(
+        Some(&payload.tenant_id),
+        provider,
+        &model,
+        "embed_batch",
+        estimated_input_tokens,
+        estimated_output_tokens,
+    );
 }
 
 // ── tests ───────────────────────────────────────────────────────────
@@ -515,7 +568,7 @@ mod tests {
         }
     }
 
-    fn start_byo_test_endpoint() -> String {
+    fn start_byo_test_endpoint(vectors: Vec<Vec<f32>>) -> String {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind BYO test server");
         let addr = listener.local_addr().expect("local addr");
         std::thread::spawn(move || {
@@ -524,7 +577,11 @@ mod tests {
             };
             let mut buf = [0u8; 4096];
             let _ = stream.read(&mut buf);
-            let body = r#"{"embeddings":[[0.1,0.2,0.3],[0.4,0.5,0.6]],"model_version":"test"}"#;
+            let body = serde_json::json!({
+                "embeddings": vectors,
+                "model_version": "test",
+            })
+            .to_string();
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                 body.len(),
@@ -533,6 +590,28 @@ mod tests {
             let _ = stream.write_all(response.as_bytes());
         });
         format!("http://{}", addr)
+    }
+
+    fn with_byo_auth(route: &EmbedRoute, auth: ByoAuth) -> EmbedRoute {
+        let EmbedRoute::Byo {
+            url,
+            declared_dim,
+            declared_precision,
+            batch_size,
+            timeout_ms,
+            ..
+        } = route
+        else {
+            panic!("test helper requires a BYO route");
+        };
+        EmbedRoute::Byo {
+            url: url.clone(),
+            auth,
+            declared_dim: *declared_dim,
+            declared_precision: *declared_precision,
+            batch_size: *batch_size,
+            timeout_ms: *timeout_ms,
+        }
     }
 
     /// Producer sends one well-formed payload; drainer embeds + the
@@ -545,23 +624,23 @@ mod tests {
             .await
             .expect("queue open");
         let embed_service = proximadb_embedding::EmbeddingService::global();
-        embed_service.update_tenant_route(
-            "tenant-a",
-            EmbedRoute::Byo {
-                url: start_byo_test_endpoint(),
-                auth: ByoAuth::None,
-                declared_dim: 3,
-                declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
-                batch_size: 8,
-                timeout_ms: 1_000,
-            },
-        );
+        let route = EmbedRoute::Byo {
+            url: start_byo_test_endpoint(vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]]),
+            auth: ByoAuth::None,
+            declared_dim: 3,
+            declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
+            batch_size: 8,
+            timeout_ms: 1_000,
+        };
+        embed_service.update_tenant_route("tenant-a", route.clone());
         let sink = Arc::new(RecordingSink::default());
 
         let producer = queue.producer();
         let payload = EmbedIngestPayload {
             target_collection: "knowledge".to_string(),
             tenant_id: "tenant-a".to_string(),
+            embedding_route_identity: (&route).into(),
+            expected_dimension: 3,
             records: vec![
                 EmbedIngestRecord {
                     oid: "doc-1".to_string(),
@@ -673,6 +752,147 @@ mod tests {
         queue.shutdown().await.expect("shutdown");
     }
 
+    #[test]
+    fn payload_requires_canonical_admission_facts() {
+        let legacy = serde_json::json!({
+            "target_collection": "docs",
+            "tenant_id": "tenant-a",
+            "records": [{"oid": "doc-1", "text": "body"}],
+        });
+
+        assert!(
+            serde_json::from_value::<EmbedIngestPayload>(legacy).is_err(),
+            "route and admitted dimension are required queue contract fields"
+        );
+    }
+
+    /// One poll may contain unrelated tenants and model geometries. Each
+    /// payload must execute only when its credential-free route identity still
+    /// matches, while using freshly resolved credentials and committing every
+    /// real delivery id.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drainer_groups_by_admitted_route_and_commits_delivery_ids() {
+        ensure_embedding_singleton();
+        let tmp = TempDir::new().expect("tempdir");
+        let queue = QueueClient::open(queue_cfg(tmp.path()))
+            .await
+            .expect("queue open");
+        let embed_service = proximadb_embedding::EmbeddingService::global();
+        let route_a = EmbedRoute::Byo {
+            url: start_byo_test_endpoint(vec![vec![0.1, 0.2]]),
+            auth: ByoAuth::Bearer {
+                secret_ref: "admission-secret-a".to_string(),
+            },
+            declared_dim: 2,
+            declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
+            batch_size: 8,
+            timeout_ms: 1_000,
+        };
+        let route_b = EmbedRoute::Byo {
+            url: start_byo_test_endpoint(vec![vec![0.3, 0.4, 0.5]]),
+            auth: ByoAuth::Bearer {
+                secret_ref: "admission-secret-b".to_string(),
+            },
+            declared_dim: 3,
+            declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
+            batch_size: 8,
+            timeout_ms: 1_000,
+        };
+        let producer = queue.producer();
+        let mut partitions = Vec::new();
+        for (tenant, collection, route, dimension) in [
+            ("tenant-route-a", "docs-a", &route_a, 2),
+            ("tenant-route-b", "docs-b", &route_b, 3),
+        ] {
+            let payload = EmbedIngestPayload {
+                target_collection: collection.to_string(),
+                tenant_id: tenant.to_string(),
+                embedding_route_identity: route.into(),
+                expected_dimension: dimension,
+                records: vec![EmbedIngestRecord {
+                    oid: format!("{tenant}-doc"),
+                    text: format!("text for {tenant}"),
+                    metadata: HashMap::new(),
+                }],
+            };
+            let payload_bytes = serde_json::to_vec(&payload).unwrap();
+            assert!(
+                !String::from_utf8_lossy(&payload_bytes).contains("admission-secret"),
+                "durable queue payload must not contain BYO credentials"
+            );
+            let receipt = producer
+                .send(Message::new(EMBED_INGEST_TOPIC, tenant, payload_bytes))
+                .await
+                .expect("send");
+            partitions.push(receipt.partition);
+        }
+
+        embed_service.update_tenant_route(
+            "tenant-route-a",
+            with_byo_auth(
+                &route_a,
+                ByoAuth::Bearer {
+                    secret_ref: "rotated-secret-a".to_string(),
+                },
+            ),
+        );
+        embed_service.update_tenant_route(
+            "tenant-route-b",
+            with_byo_auth(
+                &route_b,
+                ByoAuth::Bearer {
+                    secret_ref: "rotated-secret-b".to_string(),
+                },
+            ),
+        );
+
+        let sink = Arc::new(RecordingSink::default());
+        let sink_for_drainer: Arc<dyn DrainerInsertSink> = sink.clone();
+        let drainer = EmbeddingDrainer::new(
+            queue.clone(),
+            embed_service,
+            sink_for_drainer,
+            EmbeddingDrainerConfig {
+                batch_size: 8,
+                poll_wait: Duration::from_millis(50),
+                ..Default::default()
+            },
+        );
+        let (handle, shutdown) = drainer.start(vec![0, 1]);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            let inserts_complete = sink.calls.lock().await.len() == 2;
+            let commits_complete = partitions.iter().all(|partition| {
+                tmp.path()
+                    .join(EMBED_INGEST_TOPIC)
+                    .join(partition.to_string())
+                    .join("offset.meta")
+                    .exists()
+            });
+            if inserts_complete && commits_complete {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("drainer did not insert and commit all admitted jobs");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        let calls = sink.calls.lock().await;
+        let mut dimensions: HashMap<&str, u32> = HashMap::new();
+        for (_, tenant, records) in calls.iter() {
+            dimensions.insert(tenant.as_str(), records[0].vector_dim);
+        }
+        assert_eq!(dimensions.get("tenant-route-a"), Some(&2));
+        assert_eq!(dimensions.get("tenant-route-b"), Some(&3));
+        drop(calls);
+
+        let _ = shutdown.send(());
+        let _ = handle.await;
+        queue.shutdown().await.expect("queue shutdown");
+    }
+
     /// With a resolver attached and a fp16 collection in the catalog,
     /// the drainer must stamp `EmbeddedRecord.target_precision = Some(Fp16)`
     /// on every record routed to that collection. The sink (in
@@ -692,17 +912,15 @@ mod tests {
             .await
             .expect("queue open");
         let embed_service = proximadb_embedding::EmbeddingService::global();
-        embed_service.update_tenant_route(
-            "tenant-fp16",
-            EmbedRoute::Byo {
-                url: start_byo_test_endpoint(),
-                auth: ByoAuth::None,
-                declared_dim: 3,
-                declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
-                batch_size: 8,
-                timeout_ms: 1_000,
-            },
-        );
+        let route = EmbedRoute::Byo {
+            url: start_byo_test_endpoint(vec![vec![0.1, 0.2, 0.3]]),
+            auth: ByoAuth::None,
+            declared_dim: 3,
+            declared_precision: proximadb_records::EmbeddingScalarType::Fp32,
+            batch_size: 8,
+            timeout_ms: 1_000,
+        };
+        embed_service.update_tenant_route("tenant-fp16", route.clone());
 
         // Stand up an in-memory catalog with one fp16 collection.
         let cache = Arc::new(CatalogCache::new(1000, 60));
@@ -736,6 +954,8 @@ mod tests {
         let payload = EmbedIngestPayload {
             target_collection: "fp16_docs".to_string(), // unqualified → default namespace
             tenant_id: "tenant-fp16".to_string(),
+            embedding_route_identity: (&route).into(),
+            expected_dimension: 3,
             records: vec![EmbedIngestRecord {
                 oid: "doc-1".to_string(),
                 text: "fp16 collection ingest".to_string(),


### PR DESCRIPTION
## Summary

Closes the remaining async `/v2/documents` accept-then-drop gap from #951 by making HTTP admission, durable queue intent, embedding execution, and acknowledgement share one checked contract.

### Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

### Move / Decomposition Inventory

- [x] No files/modules moved
- [ ] Pure move only (path/import changes; `git diff --find-renames` reviewed)
- [ ] Move plus behavior change; complete behavioral inventory below

Behavioral inventory (routing, defaults, cfg gates, service wiring, errors, persistence):

- Async native document admission rejects blank text and collection/route dimension mismatch before enqueue.
- Queue payloads require a credential-free route identity and admitted collection dimension.
- Draining resolves current credentials, accepts credential rotation, rejects model/endpoint/geometry drift, and remains independent of the 60-second route-cache TTL when the last cached identity still matches.
- Compatible work is batched only at queue partition heads, preserving per-partition FIFO.
- Provider vector count and dimensions are checked before insert.
- Queue polling returns `Delivery { message_id, message }`; the drainer commits the real delivered IDs instead of fabricating IDs.
- Python queue messages expose `message_id`; Pyo3 blocking calls use the current `Python::detach` API.

### Changes

- Add `EmbedRouteIdentity`, excluding BYO auth material from durable serialization.
- Add explicit-route embedding and admitted-route resolution APIs.
- Make queued `/documents` responses return the admitted dimension rather than `0`.
- Meter each tenant payload instead of attributing a mixed batch to its first tenant.
- Add real queue + BYO HTTP + sink regressions for mixed route geometry, credential rotation, persisted offset commits, exact result shape, and canonical payload requirements.

### Related Issues

Fixes #951
Relates to #949
Relates to #950

## Test Plan

### Rust Tests
- [ ] Deterministic work-commit guard passes (`make work-commit-check`)
- [x] Focused unit tests pass
- [ ] Doc tests pass (`cargo test --doc`)
- [x] Focused queue integration tests pass
- [ ] Code coverage maintained/improved

### Test Commands Run

```bash
cargo check --lib
cargo check -p proximadb-queue
cargo check -p proximadb-embedding
cargo check -p proximadb-queue --features python
cargo clippy --lib --bins -- -D warnings
cargo test --lib services::embedding_drainer::tests
cargo test --lib network::rest::v2::documents::tests
cargo test -p proximadb-embedding durable_route_identity_excludes_credentials_but_detects_route_drift
cargo test -p proximadb-queue --test roundtrip --test offset_store
cargo test -p proximadb-queue --tests --no-run
cargo fmt --all -- --check
bash scripts/count_panic_patterns.sh --mode module-guard --baseline docs/_internal/roadmap/PANIC_POLICY_BASELINE.json --critical-modules network_rest,api_handlers,graph,query --write /tmp/panic_policy_module_guard_1009.json --format text
```

The full `proximadb-queue` unit suite has one pre-existing deterministic local failure in `disk_tier::tests::append_frames_messages_and_rotates_when_threshold_is_exceeded`: `segments()` returns filesystem order `[1, 0]` while the test assumes `[0, 1]`. The focused delivery, acknowledgement, offset, and round-trip tests pass; this PR does not change segment ordering.

## Performance Impact

Inference batching remains enabled across compatible partition-head jobs. The scheduler no longer combines incompatible routes, and route identity validation adds one cache lookup per payload.

## Breaking Changes

- `EmbedIngestPayload` now requires `embedding_route_identity` and `expected_dimension`; rollout does not support legacy queued envelopes.
- Rust `Consumer::poll` now returns `Vec<Delivery>` rather than `Vec<Message>`.
- Python polled messages now include the acknowledgement `message_id`.

## Security Considerations

- [x] No new dependencies with known vulnerabilities
- [x] No secrets or credentials in code
- [x] Input validation added where needed
- [x] No SQL/command injection risks

Durable route identities intentionally omit BYO bearer/mTLS references. The drainer resolves executable credentials at consumption time and compares only the credential-free identity.

## Documentation

- [ ] CLAUDE.md updated (not applicable)
- [x] Code comments added for complex logic
- [x] API documentation updated
- [ ] README updated (not applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests cover edge cases
- [ ] All CI checks pass
