### PR TITLE
fix(storage): canonicalize recovered point reads

### DIFF
--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -207,6 +207,24 @@ async fn assert_recovered(base: &str, collection: &str, phase: &str) -> anyhow::
     );
 
     let response = http
+        .get(format!(
+            "{base}/api/v2/collections/{collection}/records/durable-0"
+        ))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    anyhow::ensure!(
+        status.is_success(),
+        "{phase}: recovered point read failed: {status} {body}"
+    );
+    let record: Value = serde_json::from_str(&body)?;
+    anyhow::ensure!(
+        record.get("id").and_then(Value::as_str) == Some("durable-0"),
+        "{phase}: point read returned the wrong record: {body}"
+    );
+
+    let response = http
         .post(format!("{base}/api/v2/collections/{collection}/search"))
         .json(&json!({
             "vector": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7],

--- a/docs/10-quality/td/TD-OBJSTORE-2.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-2.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Implemented; live ADLS/S3 proof required before closure.** Code and process-boundary harness are in this change; `scripts/prove_object_store_durability.sh` is the closure gate.
+| Status | **Implemented; live ADLS/S3 proof rerun required before closure.** The 2026-07-15 live run proved catalog + HELIX WAL recovery, then exposed a recovered-record point-read escape fixed by the follow-up below. `scripts/prove_object_store_durability.sh` remains the closure gate.
 | Severity | Critical — WAL objects survive, but a replacement VM recovers zero collections when the collection catalog is only in the lost local `data_dir`; the durable WAL cannot be attached or replayed.
 | Component | `SystemCatalog`, collection/WAL recovery, SST/VIPER storage assignment, graph/discovery catalog sidecars, cloud deployment configuration.
 | Follows | PR #966 / `TD-OBJSTORE-1` (scheme-safe WAL and metadata path construction).
@@ -52,6 +52,13 @@ collections' storage engines. Recovery found the catalog rows and WAL segments, 
 could not flush them (`No storage engine registered for collection`). A redundant
 second replay in `ProximaDB::start()` repeated the failure while startup still became
 healthy because per-collection replay errors were only warnings.
+
+The 2026-07-15 live proof exposed a final read-boundary escape after WAL replay
+itself succeeded. `VectorOperationsService::vector()` checked the recovered WAL,
+then used the service-wide SST file lister and reader for every WAL miss. A recovered
+HELIX record was therefore flushed to ADLS successfully while a subsequent v2 GET
+tried the local SST filesystem and returned 404. AnvaiOps API-key validation uses the
+same point-read path, so the same defect also presented as a 401 after restart.
 
 == Fix
 
@@ -100,6 +107,18 @@ remains unchanged: HELIX is a supported production engine on object storage, not
 silently downgraded. The resolved engine is also persisted in `StorageAssignment`
 and used for compression defaults.
 
+=== Canonical point-read boundary
+
+`VectorReadCoordinator` now owns the complete WAL-first point-read boundary. On a
+WAL miss it resolves the collection, passes the persisted
+`StorageAssignment.base_location` to that collection's configured engine, and calls
+the engine-neutral batch-capable `point_lookup` contract. The public
+`VectorOperationsService::vector()` surface remains stable as a thin delegate while
+the original service is decomposed; protocols cannot create parallel SST-specific
+fallbacks. Typed collection identity is carried from the storage assignment into the
+engine contract, and insert-only existence checks reuse this same authority. Projection
+flags are applied once to the canonical returned record.
+
 === Local-filesystem escape audit
 
 * Graph collection metadata now resolves to
@@ -133,6 +152,11 @@ namespace/table, performs no explicit checkpoint or graceful shutdown, and prove
 second instance recovers the table solely from object storage. This fails with the old
 1,000-mutation threshold.
 
+`wal_miss_routes_to_collection_engine_and_object_store_base_path` installs a HELIX
+engine for a recovered collection with an `adls://` base and proves a WAL miss reaches
+that engine's `point_lookup` with the object-store path. The old global-SST
+implementation returns no record and fails this test.
+
 === Real process / real backend integration
 
 `apps/proximadb-server/tests/object_store_restart_recovery.rs` launches the production
@@ -140,10 +164,10 @@ server binary three times against one unique `s3://` or `adls://` prefix and cre
 both SST and HELIX collections:
 
 . VM 1: create both collections + insert records; SIGKILL.
-. VM 2 with empty local disk: recover catalog, replay WAL, and find both records; SIGINT
-  to materialize SST/HELIX files and reclaim flushed WAL.
-. VM 3 with another empty local disk: recover catalog and find both records from cold
-  object-store files.
+. VM 2 with empty local disk: recover catalog, replay WAL, and find both records by
+  v2 point GET and vector search; SIGINT to materialize SST/HELIX files and reclaim WAL.
+. VM 3 with another empty local disk: recover catalog and find both records by point
+  GET and search from cold object-store files.
 
 Run:
 
@@ -157,6 +181,13 @@ identity/IAM credentials. It is ignored in credential-free CI and is the anvaiop
 deployment proof.
 
 == Closure evidence
+
+The 2026-07-15 attempt using runtime-full digest
+`sha256:f4bddeb506186ee572ee1e18469d966f0dbc1f821f31cbedd2cbadae2da64b4a`
+is diagnostic evidence, not closure evidence. Startup registered HELIX for collection
+12 and recovered two vectors from two ADLS files, while the post-restart GET returned
+404 and logged local `Failed to list files for collection 12`. The point-read fix must
+be merged, republished, deployed, and the complete proof rerun.
 
 Before marking this TD closed, attach:
 
@@ -178,3 +209,8 @@ Before marking this TD closed, attach:
   caching filesystem remained bound to `file://`; routed HELIX operations through the
   collection-assigned backend and corrected the persisted resolved engine. A passing
   rerun remains the closure gate.
+* 2026-07-15 — canonical QA runtime-full digest `sha256:f4bddeb5...da64b4a`
+  recovered the HELIX catalog and two probe records from ADLS, but v2 point GET and
+  API-key lookup still used the global SST/local path. Converged point reads behind
+  `VectorReadCoordinator` and the configured engine contract; a passing
+  republished-image rerun remains the closure gate.

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2059,27 +2059,9 @@ impl VectorOperationsService {
     }
 
     async fn record_exists_unchecked(&self, collection_id: &str, record_id: &str) -> Result<bool> {
-        if self
-            .wal_manager
-            .search_vector_by_id(collection_id, &record_id.to_string())
-            .await?
-            .is_some()
-        {
-            return Ok(true);
-        }
-
-        let collection = self.get_or_load_collection(collection_id).await?;
-        let base_path = collection
-            .storage_assignment
-            .as_ref()
-            .map(|assignment| assignment.base_location.as_str())
-            .unwrap_or("");
-        let engine = self.get_engine_for_collection(collection_id).await?;
-
-        Ok(!engine
-            .point_lookup(collection_id, base_path, &[record_id.to_string()], None)
-            .await?
-            .is_empty())
+        self.read_coordinator()
+            .contains(collection_id, record_id)
+            .await
     }
 
     /// Return lightweight, default planning/pruning hints without executing search.
@@ -4078,47 +4060,9 @@ impl VectorOperationsService {
         include_vector: bool,
         include_metadata: bool,
     ) -> Result<Option<ProximaRecord>> {
-        // First check WAL for unflushed vectors
-        if let Some(record) = self
-            .wal_manager
-            .search_vector_by_id(collection_id, &vector_id.to_string())
-            .await?
-        {
-            let mut result = record;
-            if !include_vector {
-                result.embeddings.clear();
-            }
-            if !include_metadata {
-                result.props.clear();
-            }
-            return Ok(Some(result));
-        }
-
-        // WAL miss → point-lookup in SST files. Read the FULL record straight from the SST
-        // reader (bloom-filter reject + B+ tree O(log n) block lookup), rather than the
-        // search-shaped `OptimizedSearchRecord`, so `labels` + `variation_id` are preserved.
-        // Document-facade projections (`proxima_record_to_legacy_document`) require the
-        // `document` label, which the search shape drops (TD-DOC-CONV-1).
-        let file_paths = self
-            .storage_engine
-            .list_collection_files(collection_id)
+        self.read_coordinator()
+            .vector(collection_id, vector_id, include_vector, include_metadata)
             .await
-            .unwrap_or_default();
-
-        let reader = self.storage_engine.sstable_reader();
-        for file_path in &file_paths {
-            if let Ok(Some(mut record)) = reader.vector(file_path, vector_id).await {
-                if !include_vector {
-                    record.embeddings.clear();
-                }
-                if !include_metadata {
-                    record.props.clear();
-                }
-                return Ok(Some(record));
-            }
-        }
-
-        Ok(None)
     }
 
     /// Unified search by ID for embedded API
@@ -4176,6 +4120,16 @@ impl VectorOperationsService {
             self.wal_manager.clone(),
             self.bulk_write_router.clone(),
             self.pseudo_query_generator.clone(),
+            self.collection_resolver(),
+        )
+    }
+
+    /// Build the canonical point-read coordinator on demand. The collaborator
+    /// owns the WAL-first → configured-engine boundary; this service retains the
+    /// stable public API while the original god object is decomposed.
+    fn read_coordinator(&self) -> super::read::VectorReadCoordinator {
+        super::read::VectorReadCoordinator::new(
+            self.wal_manager.clone(),
             self.collection_resolver(),
         )
     }

--- a/src/services/operations/vectors/mod.rs
+++ b/src/services/operations/vectors/mod.rs
@@ -54,6 +54,9 @@ mod flush;
 // Collection-resolution + engine-resolution collaborator (Phase 2.1 decomposition)
 mod resolver;
 
+// WAL-first, per-collection-engine point-read collaborator
+mod read;
+
 // Pure input validators for inserts/queries (Phase 2.1 decomposition)
 mod input_validation;
 

--- a/src/services/operations/vectors/read.rs
+++ b/src/services/operations/vectors/read.rs
@@ -1,0 +1,313 @@
+//! Canonical point-read collaborator for `VectorOperationsService`.
+//!
+//! Owns the WAL-to-persisted-engine boundary for get-by-id operations. A read
+//! checks the write buffer first, then resolves the collection's persisted
+//! storage assignment and delegates to that engine's neutral `point_lookup`
+//! contract. Keeping this boundary in one place prevents protocol surfaces from
+//! inventing SST-specific fallbacks that bypass HELIX/VIPER/NOVA or object-store
+//! routing.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use proximadb_records::ProximaRecord;
+
+use crate::storage::persistence::write_ahead_log::WriteAheadLogManager;
+
+use super::resolver::CollectionResolver;
+
+/// Owns the handles required for a canonical point read. Constructed on demand
+/// from cheap `Arc` clones by `VectorOperationsService::read_coordinator`.
+pub(crate) struct VectorReadCoordinator {
+    wal_manager: Arc<WriteAheadLogManager>,
+    resolver: CollectionResolver,
+}
+
+impl VectorReadCoordinator {
+    pub(crate) fn new(
+        wal_manager: Arc<WriteAheadLogManager>,
+        resolver: CollectionResolver,
+    ) -> Self {
+        Self {
+            wal_manager,
+            resolver,
+        }
+    }
+
+    /// Fetch one canonical record by id, preferring the write buffer and then
+    /// routing the persisted lookup through the collection's configured engine.
+    pub(crate) async fn vector(
+        &self,
+        collection_id: &str,
+        vector_id: &str,
+        include_vector: bool,
+        include_metadata: bool,
+    ) -> Result<Option<ProximaRecord>> {
+        let record = if let Some(record) = self
+            .wal_manager
+            .search_vector_by_id(collection_id, &vector_id.to_string())
+            .await?
+        {
+            Some(record)
+        } else {
+            let collection = self.resolver.get_or_load_collection(collection_id).await?;
+            let storage_assignment = collection.storage_assignment.as_ref();
+            let base_path = storage_assignment
+                .map(|assignment| assignment.base_location.as_str())
+                .unwrap_or("");
+            let identity = crate::storage::trait_components::path_resolver::typed_identity_from_storage_assignment(
+                storage_assignment,
+            );
+            let engine = self
+                .resolver
+                .get_engine_for_collection(collection_id)
+                .await?;
+
+            engine
+                .point_lookup(collection_id, base_path, &[vector_id.to_string()], identity)
+                .await?
+                .into_iter()
+                .next()
+        };
+
+        Ok(record.map(|mut record| {
+            if !include_vector {
+                record.embeddings.clear();
+            }
+            if !include_metadata {
+                record.props.clear();
+            }
+            record
+        }))
+    }
+
+    /// Test whether an id exists through the exact same WAL/engine authority as
+    /// get-by-id. Insert-only conflict detection must not grow a parallel read path.
+    pub(crate) async fn contains(&self, collection_id: &str, vector_id: &str) -> Result<bool> {
+        Ok(self
+            .vector(collection_id, vector_id, false, false)
+            .await?
+            .is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use async_trait::async_trait;
+    use dashmap::DashMap;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+
+    use crate::storage::traits::{
+        CompactionParameters, CompactionResult, FlushParameters, FlushResult,
+        StorageFormatStrategy, StorageQueryContext, UnifiedStorageFormat,
+    };
+
+    use super::*;
+
+    type PointLookupCall = (
+        String,
+        String,
+        Vec<String>,
+        Option<crate::core::stable_id::CollectionIdentity>,
+    );
+
+    struct PointLookupProbeEngine {
+        record: ProximaRecord,
+        calls: Arc<Mutex<Vec<PointLookupCall>>>,
+    }
+
+    #[async_trait]
+    impl UnifiedStorageFormat for PointLookupProbeEngine {
+        fn engine_name(&self) -> &'static str {
+            "point-lookup-probe"
+        }
+
+        fn engine_version(&self) -> &'static str {
+            "1"
+        }
+
+        fn strategy(&self) -> StorageFormatStrategy {
+            StorageFormatStrategy::Helix
+        }
+
+        async fn do_flush(&self, _params: &FlushParameters) -> Result<FlushResult> {
+            Ok(FlushResult::default())
+        }
+
+        async fn do_compact(&self, _params: &CompactionParameters) -> Result<CompactionResult> {
+            Ok(CompactionResult::default())
+        }
+
+        async fn collect_engine_metrics(&self) -> Result<HashMap<String, serde_json::Value>> {
+            Ok(HashMap::new())
+        }
+
+        async fn vector_by_id(
+            &self,
+            _collection_id: &str,
+            _base_path: &str,
+            _vector_id: &str,
+        ) -> Result<Option<ProximaRecord>> {
+            Ok(None)
+        }
+
+        async fn point_lookup(
+            &self,
+            collection_id: &str,
+            base_path: &str,
+            ids: &[String],
+            identity: Option<crate::core::stable_id::CollectionIdentity>,
+        ) -> Result<Vec<ProximaRecord>> {
+            self.calls.lock().await.push((
+                collection_id.to_string(),
+                base_path.to_string(),
+                ids.to_vec(),
+                identity,
+            ));
+            Ok(ids
+                .iter()
+                .any(|id| id == &self.record.oid)
+                .then(|| self.record.clone())
+                .into_iter()
+                .collect())
+        }
+
+        async fn search_vectors_unified(
+            &self,
+            _ctx: &StorageQueryContext,
+        ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn record_with_vector(id: &str, values: Vec<f32>) -> ProximaRecord {
+        ProximaRecord {
+            oid: id.to_string(),
+            embeddings: vec![proximadb_records::EmbeddingCell {
+                model_id: "default".to_string(),
+                modality: "vector".to_string(),
+                dim: values.len() as u32,
+                values: proximadb_records::EmbeddingValues::Fp32(values),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    async fn create_test_coordinator() -> Result<(
+        VectorReadCoordinator,
+        Arc<Mutex<Vec<PointLookupCall>>>,
+        TempDir,
+    )> {
+        let temp_dir = TempDir::new()?;
+        let filesystem = Arc::new(
+            crate::storage::persistence::filesystem::FilesystemFactory::create(Default::default())
+                .await?,
+        );
+        let wal_config = crate::storage::persistence::write_ahead_log::WALConfig::default();
+        let strategy =
+            crate::storage::persistence::write_ahead_log::WALBatchFactory::create_batch_serialization_strategy(
+                crate::storage::persistence::write_ahead_log::config::WriteBufferStrategyType::BincodeBatch,
+                &wal_config,
+                filesystem,
+            )
+            .await?;
+        let wal_manager = Arc::new(
+            crate::storage::persistence::write_ahead_log::WriteAheadLogManager::new(
+                strategy, wal_config,
+            )
+            .await?,
+        );
+
+        let metadata_url = format!("file://{}", temp_dir.path().join("metadata").display());
+        let mut config = crate::core::Config::default();
+        config.storage.metadata_url = metadata_url.clone();
+        let catalog_manager = Arc::new(crate::catalog::CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &metadata_url)
+            .await?;
+        let collection_port = Arc::new(
+            crate::services::collection::manager::CollectionService::new(config.storage)
+                .await?
+                .with_catalog_manager(catalog_manager),
+        );
+
+        let collection_id = "recovered-helix";
+        let base_path = "adls://proximadb/collections";
+        let collection_cache = Arc::new(DashMap::new());
+        collection_cache.insert(
+            collection_id.to_string(),
+            Arc::new(crate::proto::proximadb_v1::Collection {
+                id: collection_id.to_string(),
+                config: Some(crate::proto::proximadb_v1::CollectionConfig {
+                    name: collection_id.to_string(),
+                    storage_engine: Some(crate::proto::proximadb_v1::StorageEngine::Helix as i32),
+                    ..Default::default()
+                }),
+                storage_assignment: Some(crate::proto::proximadb_v1::StorageAssignment {
+                    primary_path: base_path.to_string(),
+                    base_location: base_path.to_string(),
+                    engine: crate::proto::proximadb_v1::StorageEngine::Helix as i32,
+                    typed_account_id: Some(7),
+                    typed_namespace_id: Some(11),
+                    typed_collection_id: Some(13),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        );
+
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let engine_cache: Arc<DashMap<String, Arc<dyn UnifiedStorageFormat>>> =
+            Arc::new(DashMap::new());
+        engine_cache.insert(
+            collection_id.to_string(),
+            Arc::new(PointLookupProbeEngine {
+                record: record_with_vector("persisted-record", vec![1.0, 2.0, 3.0]),
+                calls: calls.clone(),
+            }),
+        );
+
+        let resolver = CollectionResolver::new(
+            collection_cache,
+            engine_cache,
+            collection_port,
+            wal_manager.clone(),
+        );
+        Ok((
+            VectorReadCoordinator::new(wal_manager, resolver),
+            calls,
+            temp_dir,
+        ))
+    }
+
+    #[tokio::test]
+    async fn wal_miss_routes_to_collection_engine_and_object_store_base_path() {
+        let (coordinator, calls, _temp_dir) = create_test_coordinator().await.unwrap();
+
+        let record = coordinator
+            .vector("recovered-helix", "persisted-record", true, true)
+            .await
+            .unwrap()
+            .expect("configured HELIX engine should serve the recovered record");
+
+        assert_eq!(record.oid, "persisted-record");
+        assert_eq!(record.embeddings.len(), 1);
+        assert_eq!(
+            calls.lock().await.as_slice(),
+            &[(
+                "recovered-helix".to_string(),
+                "adls://proximadb/collections".to_string(),
+                vec!["persisted-record".to_string()],
+                Some(crate::core::stable_id::CollectionIdentity {
+                    account_id: 7,
+                    namespace_id: 11,
+                    collection_id: 13,
+                }),
+            )]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add `VectorReadCoordinator` as the single WAL-first point-read authority
- resolve persisted reads through the collection catalog assignment and configured engine instead of the service-wide SST reader
- carry ADR-031 typed collection identity into the engine-neutral `point_lookup` contract
- converge insert-only existence checks on the same read authority
- extend the real three-process S3/ADLS recovery harness with v2 point GET assertions for SST and HELIX after WAL replay and cold-file recovery
- record the failed live digest and remaining rerun gate in TD-OBJSTORE-2

## Live evidence and root cause

The 2026-07-15 AnvaiOps proof used runtime-full digest `sha256:f4bddeb506186ee572ee1e18469d966f0dbc1f821f31cbedd2cbadae2da64b4a`.

Startup registered HELIX for probe collection 12 and recovered two vectors from two ADLS files. The subsequent v2 GET returned 404 and logged `Failed to list files for collection 12: No such file or directory`. AnvaiOps API-key lookup failed with 401 through the same point-read path.

`VectorOperationsService::vector()` checked WAL, then unconditionally listed/read through its legacy global SST engine. The recovered HELIX data was durable; the service boundary selected the wrong reader.

## Co-design rationale

This change follows the measured boundary trace rather than adding another engine-specific exception:

- one canonical WAL-to-catalog-to-engine read boundary
- existing stable `point_lookup` engine contract; no parallel storage authority
- stable public `VectorOperationsService` surface as a thin delegate while the god object is decomposed
- integrated protocol/server recovery assertion in addition to the component unit test

## Validation

- `cargo fmt --all -- --check`
- `cargo test wal_miss_routes_to_collection_engine_and_object_store_base_path --lib -- --nocapture`
- `cargo test -p proximadb-server --test object_store_restart_recovery --no-run`
- `python3 scripts/check_td_adr_unique.py`
- `python3 scripts/check_td_status_consistency.py`
- `git diff origin/develop...HEAD --check`

## Closure gate

This PR does not close TD-OBJSTORE-2. After merge it must be promoted to QA, published as a new immutable runtime-full digest, deployed to the AnvaiOps test VM, and `scripts/prove_object_store_durability.sh` must pass across the full VM restart.
