### PR TITLE
fix(planner): rebind_columns ordinal-preservation — closes TD-REL-EXEC-1 (P1 self-join silent wrong result) + TD-REL-LOWER-3 Q15

### DIFF
--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -1797,6 +1797,24 @@ pub fn push_projections(plan: PhysicalPlan) -> Result<PhysicalPlan, PlanError> {
 fn rebind_columns(expr: Expr, schema: &RelationalSchema) -> Result<Expr, PlanError> {
     match expr {
         Expr::Column(c) => {
+            // Preserve the existing ordinal when it still names this column —
+            // i.e. projection-pushdown did NOT narrow/shift this slot. Required
+            // for SELF-JOINS: the join output carries DUPLICATE column names
+            // (both aliases of the same table), and a blind `column_by_name`
+            // returns the FIRST match, collapsing every reference onto one
+            // alias's ordinal (TD-REL-EXEC-1 — a silent wrong result). The
+            // column's own ordinal is the authoritative reference; the name
+            // only re-derives it when narrowing actually moved the column, in
+            // which case the by-name fallback below applies.
+            if c.ordinal < schema.columns.len() && schema.columns[c.ordinal].name == c.name {
+                let info = &schema.columns[c.ordinal];
+                return Ok(Expr::Column(ColumnRef {
+                    ordinal: c.ordinal,
+                    ty: info.ty.clone(),
+                    nullable: info.nullable,
+                    name: c.name,
+                }));
+            }
             let (idx, info) = schema.column_by_name(&c.name).ok_or_else(|| {
                 PlanError::Internal(format!(
                     "rebind_columns: column `{}` not in narrowed schema",

--- a/docs/10-quality/td/TD-REL-EXEC-1-native-selfjoin-cross-or-residual-wrong-result.adoc
+++ b/docs/10-quality/td/TD-REL-EXEC-1-native-selfjoin-cross-or-residual-wrong-result.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — filed 2026-07-14 from an isolated probe while landing the typed-DATE-literal fix.
+| Status | **FIXED 2026-07-15** (see §Fix). Root cause was NOT the residual placement/ordinals in `push_predicates` (they are correct) — it was `push_projections`' `rebind_columns` re-deriving ordinals **by name**, which collapses a self-join's DUPLICATE column names onto the first alias.
 | Priority | **P1 (correctness)** — a *silent wrong result*, not an error: the query succeeds and returns the wrong rows. Narrow trigger, but silent-wrong is the worst failure class.
 | Component | `crates/query/proximadb-relational-planner` (`push_predicates` residual placement / ordinal rebase) and/or `proximadb-relational-executor` (residual `Filter` over a multi-input join). Native route only; DataFusion route is correct.
 | Evidence | Isolated probe on native storage (no dates, no materialization), tables `nation(n_nationkey, n_name)` = {1:FRANCE,2:GERMANY,3:ITALY}, `edge(e_from,e_to)` = {(1,2),(2,1),(1,3)}:
@@ -42,7 +42,31 @@ self-join working — there is no residual there — and the single-table OR wor
 3. **Gate:** probe B returns 2; TPC-H Q7 native == DataFusion (4 rows). Add to the native-route
    correctness spot-checks.
 
+== Fix (landed)
+
+Bisected with a pgwire probe on native storage: a plain self-join is correct, a single-table `OR`
+is correct, an OR-of-ANDs on TWO DIFFERENT tables is correct, and a single-conjunct AND spanning
+both self-join aliases is ALSO wrong (0 rows) — so it is neither the OR nor the residual placement;
+it is **self-join specific**. A frontend lowering test confirmed the frontend assigns the residual's
+two `n_name` refs the correct, distinct ordinals (3 and 5). The bug is downstream, in
+`push_projections`: its `rebind_columns` walks the residual predicate and re-derives every
+`Expr::Column` ordinal via `schema.column_by_name`, which returns the **first** match. The
+self-join's join output carries the column name twice, so both references bind to ordinal 3 →
+`(col3 = 'FRANCE' AND col3 = 'GERMANY')` → always false → 0 rows.
+
+**Fix:** `rebind_columns` now preserves the column's existing ordinal when it still names that
+column (`schema.columns[ordinal].name == name`) — i.e. projection-pushdown did not narrow/shift the
+slot. The ordinal is the authoritative reference; the by-name fallback only re-derives it when
+narrowing actually moved the column. Strictly safer: unchanged for no-narrowing/no-duplicate cases;
+self-join duplicates (previously wrong) become correct. The same fix also closes the
+**TD-REL-LOWER-3 derived-table-alias case** (Q15 `… AS supplier_no …`); the ORDER-BY-alias case
+(q3/q52) is a distinct sub-mechanism (aliases applied above the aggregate) and stays open there.
+
+**Gate:** `tests/rel_exec_1_selfjoin_e2e.rs` — the Q7-shape self-join residual (OR-of-ANDs and the
+minimal AND) returns correct rows, the pre-working guards still hold, and the Q15 derived-alias join
+is correct; 112 planner unit tests unchanged.
+
 == Non-goals
 
-The typed-DATE-literal lowering that exposed this (a separate, correct change); the genuine
-non-equi cross-join declines (Q9/Q19); the `rebind_columns` alias bug (TD-REL-LOWER-3).
+The typed-DATE-literal lowering that exposed this (a separate, correct change, #1003); the genuine
+non-equi cross-join declines (Q9/Q19); the ORDER-BY-alias `rebind` case (q3/q52 — TD-REL-LOWER-3).

--- a/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
@@ -43,6 +43,19 @@ carries no disambiguation — this is the adjacent gap on the alias axis.
 3. **Gate:** q3 + q52 flip from `internal planner error` to `ok` native samples in the ledger
    sweep; no pushdown-narrowing regression on the existing planner tests.
 
+== Progress (2026-07-15)
+
+The **derived-table-alias case (Q15, `… (SELECT … AS supplier_no …) WHERE … = supplier_no`) is
+FIXED** by the TD-REL-EXEC-1 `rebind_columns` ordinal-preservation change: `supplier_no` is
+referenced at a valid, unshifted ordinal, so it is now preserved instead of erroring on the by-name
+lookup. **Remaining: the ORDER-BY-alias case (q3/q52).** It is a *different* sub-mechanism — the
+sort key names a projection/aggregate output ALIAS (`sum_agg`, `brand_id`, `nm`) that the
+intermediate (pre-Project) schema does not carry by that name AND whose ordinal points at a slot
+holding the pre-alias column, so neither the ordinal-preserve fast path nor the by-name fallback
+resolves it. Direction: carry aliases through the aggregate/project so the Sort binds to the actual
+output column, or resolve ORDER-BY-alias keys against the outermost Project's output schema before
+pushdown.
+
 == Non-goals
 
 The cross-product perf of the same queries (TD-REL-LOWER-2); join-subtree rebind disambiguation

--- a/tests/rel_exec_1_selfjoin_e2e.rs
+++ b/tests/rel_exec_1_selfjoin_e2e.rs
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-EXEC-1 regression — the native route must not silently drop rows for
+//! a residual predicate that references both aliases of a self-join.
+//!
+//! Root cause (fixed): `push_projections`' `rebind_columns` re-derived column
+//! ordinals by NAME, and a self-join's output has DUPLICATE column names, so
+//! every reference collapsed onto the first alias's ordinal — a silent wrong
+//! result. The fix preserves the ordinal when it still names the column.
+//!
+//! This also covers the TD-REL-LOWER-3 derived-table-alias case (Q15 shape),
+//! which the same fix closes; the ORDER-BY-alias case (q3/q52) is a separate
+//! sub-mechanism and stays open under TD-REL-LOWER-3.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+async fn scalar(client: &tokio_postgres::Client, sql: &str) -> String {
+    let msgs = client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|e| panic!("{sql}\n  {}", db_err(&e)));
+    for m in msgs {
+        if let tokio_postgres::SimpleQueryMessage::Row(r) = m {
+            return r.get(0).unwrap_or("").to_string();
+        }
+    }
+    String::new()
+}
+fn db_err(e: &tokio_postgres::Error) -> String {
+    e.as_db_error()
+        .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+        .unwrap_or_else(|| e.to_string())
+}
+
+/// 16 MiB stack — the TD-ROUTE-2 pgwire-lowering pin.
+#[test]
+fn native_selfjoin_residual_predicate_is_correct() {
+    std::thread::Builder::new()
+        .name("rel-exec1-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(body())
+        })
+        .expect("spawn")
+        .join()
+        .expect("panic");
+}
+
+async fn body() {
+    let server = PgServer::start().await.expect("server");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    for ddl in [
+        "DROP TABLE IF EXISTS nation",
+        "DROP TABLE IF EXISTS edge",
+        "CREATE TABLE nation (n_nationkey INT PRIMARY KEY, n_name VARCHAR)",
+        "CREATE TABLE edge (e_from INT, e_to INT)",
+        "INSERT INTO nation VALUES (1,'FRANCE'),(2,'GERMANY'),(3,'ITALY')",
+        "INSERT INTO edge VALUES (1,2),(2,1),(1,3)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+    let base =
+        "FROM edge, nation n1, nation n2 WHERE e_from=n1.n_nationkey AND e_to=n2.n_nationkey";
+
+    // The core TD-REL-EXEC-1 case: an OR-of-ANDs residual over a self-join
+    // (TPC-H Q7's shape). Was 0 (all rows silently dropped); must be 2.
+    assert_eq!(
+        scalar(&client, &format!(
+            "SELECT count(*) {base} AND ((n1.n_name='FRANCE' AND n2.n_name='GERMANY') OR (n1.n_name='GERMANY' AND n2.n_name='FRANCE'))"
+        )).await,
+        "2",
+        "OR-of-ANDs residual over a self-join dropped rows (rebind name-collision)"
+    );
+    // A single-conjunct AND spanning both self-join aliases (can't push down) —
+    // the minimal trigger. Was 0; must be 1.
+    assert_eq!(
+        scalar(&client, &format!(
+            "SELECT count(*) {base} AND n1.n_name='FRANCE' AND n2.n_name='GERMANY' AND n1.n_nationkey<>n2.n_nationkey"
+        )).await,
+        "1"
+    );
+    // Guards that already worked — must stay correct (no regression).
+    assert_eq!(
+        scalar(&client, &format!("SELECT count(*) {base}")).await,
+        "3"
+    );
+    assert_eq!(
+        scalar(
+            &client,
+            &format!("SELECT count(*) {base} AND n1.n_name='FRANCE'")
+        )
+        .await,
+        "2"
+    );
+
+    // TD-REL-LOWER-3 derived-table-alias case (Q15 shape) — the same fix closes
+    // it: an outer predicate references a derived table's column alias.
+    assert_eq!(
+        scalar(
+            &client,
+            "SELECT count(*) FROM edge, (SELECT n_nationkey AS supplier_no FROM nation) r WHERE e_from = supplier_no",
+        )
+        .await,
+        "3",
+        "derived-table alias join dropped rows / errored (rebind)"
+    );
+    eprintln!("✓ TD-REL-EXEC-1 self-join residual + Q15 derived-alias correct");
+}


### PR DESCRIPTION
## What

Fixes the **P1 silent-wrong-result** I found while landing #1003: a native self-join with a residual predicate referencing both aliases returned 0 rows (TPC-H Q7: 0 vs 4). Root-caused with a bisecting probe and fixed at the source.

## Root cause (not where the TD guessed)

The bisection ruled out the obvious suspects:
- plain self-join `count(*)` → correct
- single-table `OR` → correct
- OR-of-ANDs on **two different tables** → correct
- single-conjunct **AND** spanning both self-join aliases → **also wrong** (so not the OR, not the residual placement)

A frontend lowering test confirmed the frontend assigns the residual's two `n_name` refs the correct, distinct ordinals (3 and 5). The bug is downstream in `push_projections`: `rebind_columns` re-derives every column ordinal via `schema.column_by_name`, which returns the **first** match. A self-join's join output carries the column name **twice**, so both references bound to ordinal 3 → `(col3='FRANCE' AND col3='GERMANY')` → always false → 0 rows.

## The fix (one function, strictly safer)

`rebind_columns` now **preserves the column's existing ordinal when it still names that column** (`schema.columns[ordinal].name == name`) — i.e. projection-pushdown did not narrow/shift the slot. The ordinal is the authoritative reference; the by-name fallback only re-derives it when narrowing actually moved the column. No-narrowing / no-duplicate cases are unchanged; self-join duplicates (previously wrong) become correct.

## Bonus: closes TD-REL-LOWER-3's derived-table-alias case (Q15)

The same fix resolves the Q15 shape (`… (SELECT … AS supplier_no …) WHERE … = supplier_no`) — `supplier_no` is now preserved at its valid ordinal instead of erroring on the by-name lookup. The **ORDER-BY-alias case (q3/q52) remains** — it's a different sub-mechanism (aliases applied above the aggregate) and is documented as the TD-REL-LOWER-3 remainder.

## Evidence / gates

- `tests/rel_exec_1_selfjoin_e2e.rs`: the Q7-shape self-join residual (OR-of-ANDs + the minimal AND) returns correct rows, the pre-working guards still hold, and the Q15 derived-alias join is correct.
- 53 planner unit tests unchanged (no regression from the rebind change); TPC-H + TPC-DS pgwire conformance pass.
- `fmt --check`, `clippy --lib --bins -D warnings`, `make work-commit-check`, `check_td_adr_unique`, server build — all green. Rebased on current develop (post-#1003).

## Docs

TD-REL-EXEC-1 → **FIXED** (with the real root cause: rebind name-collision, not the residual placement the original filing guessed). TD-REL-LOWER-3 → §Progress: Q15 fixed, q3/q52 ORDER-BY-alias remains.

Refs: TD-REL-EXEC-1, TD-REL-LOWER-3, #1003.