### PR TITLE
fix(frontend): group-key projection alias must not rename the inner ColumnRef — closes TD-REL-LOWER-3 (q3/q52)

### DIFF
--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -1626,8 +1626,18 @@ fn lower_projection_with_aggregates(
                 // isn't the table's first column.
                 let ty = expr.result_type();
                 let output_expr = match group_by.iter().position(|g| g.expr == expr) {
+                    // Reference the group-key slot by the AGGREGATE OUTPUT's
+                    // declared name (the group-by key's name), NOT the projection
+                    // ALIAS. The alias belongs only on the enclosing `NamedExpr`
+                    // (the Project renames the column); the inner `ColumnRef` must
+                    // name the slot it indexes so name-based rebind in
+                    // `push_projections` resolves it. With the alias on the inner
+                    // ref, `SELECT g AS a … ORDER BY a` produced a `ColumnRef`
+                    // named `a` over an Aggregate output named `g`, and the
+                    // planner rebind failed (`column 'a' not in narrowed schema`,
+                    // TD-REL-LOWER-3 q3/q52).
                     Some(slot) => Expr::column(ColumnRef {
-                        name: name.clone(),
+                        name: group_by[slot].name.clone(),
                         ordinal: slot,
                         ty,
                         nullable: true,

--- a/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-3-pushdown-rebind-alias-sort-key.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — filed 2026-07-14 from the post-#953 ledger native sweep (SF 0.01 release).
+| Status | **FIXED 2026-07-15** — both cases: the derived-table-alias case (Q15) by #1011's `rebind_columns` ordinal-preservation, and the ORDER-BY-alias case (q3/q52) by the frontend fix in this PR (see §Progress). Filed 2026-07-14 from the post-#953 ledger native sweep.
 | Priority | P2 — hard error on valid ANSI SQL (`[XX000] plan: internal planner error`); ≥3 TPC queries (TPC-DS q3/q52, TPC-H Q15); pre-existing planner bug newly *reachable* as upstream lowering gaps close.
 | Component | `crates/query/proximadb-relational-planner` — `push_projections_inner` / `rebind_columns` (name-keyed ordinal rebind).
 | Evidence | TPC-DS q3/q52: `rebind_columns: column `brand_id` not in narrowed schema` — a projection alias used as an ORDER BY key. **TPC-H Q15 (reachable after this PR's DATE fix): `column `supplier_no` not in narrowed schema`** — a DERIVED-TABLE alias (`select l_suppkey as supplier_no … ) as revenue0 where s_suppkey = supplier_no`) referenced by the outer join/filter. So the bug is broader than ORDER BY keys: `rebind_columns` re-derives ordinals by NAME against a narrowed child schema, but an ALIAS name (ORDER-BY output alias OR derived-table column alias) does not appear in the schema at the level rebind runs, so it errors. Repro needs a planner-crate harness that can lower SQL (add `proximadb-relational-frontend` + `sqlparser` as dev-deps, or drive via a pgwire e2e).
@@ -48,13 +48,20 @@ carries no disambiguation — this is the adjacent gap on the alias axis.
 The **derived-table-alias case (Q15, `… (SELECT … AS supplier_no …) WHERE … = supplier_no`) is
 FIXED** by the TD-REL-EXEC-1 `rebind_columns` ordinal-preservation change: `supplier_no` is
 referenced at a valid, unshifted ordinal, so it is now preserved instead of erroring on the by-name
-lookup. **Remaining: the ORDER-BY-alias case (q3/q52).** It is a *different* sub-mechanism — the
-sort key names a projection/aggregate output ALIAS (`sum_agg`, `brand_id`, `nm`) that the
-intermediate (pre-Project) schema does not carry by that name AND whose ordinal points at a slot
-holding the pre-alias column, so neither the ordinal-preserve fast path nor the by-name fallback
-resolves it. Direction: carry aliases through the aggregate/project so the Sort binds to the actual
-output column, or resolve ORDER-BY-alias keys against the outermost Project's output schema before
-pushdown.
+lookup.
+
+The **ORDER-BY-alias case (q3/q52) is now also FIXED** — and its true root cause was upstream of
+the planner rebind, in the FRONTEND. A GROUP BY key projected with an alias
+(`SELECT g AS a … GROUP BY g`) built its Project output as
+`NamedExpr{ name:"a", expr: Column{ name:"a", ordinal: slot } }` — the inner `ColumnRef` wrongly
+adopted the projection ALIAS, while the Aggregate output slot it indexes is named by the group KEY
+(`g`). So the sort key resolving to that output carried the name `a`, and the planner's name-based
+rebind against an Aggregate schema named `g` failed. Fix: the inner `ColumnRef` of a grouped-key
+output references the group-by key's SOURCE name (its aggregate-output slot name); the alias lives
+only on the enclosing `NamedExpr` (the Project renames the column) — mirroring the aggregate-slot
+path, whose ref name already matched its slot. Verified: `tests/rel_lower_3_orderby_e2e.rs`
+(`SELECT brand AS b, sum(amt) AS total … GROUP BY brand ORDER BY total DESC, b`) executes with
+correct rows + order (was an internal planner error).
 
 == Non-goals
 

--- a/tests/rel_lower_3_orderby_e2e.rs
+++ b/tests/rel_lower_3_orderby_e2e.rs
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-LOWER-3 (ORDER-BY-alias case, q3/q52) — a GROUP BY key projected with
+//! an alias and used as an ORDER BY key must execute on the native route, not
+//! error `rebind_columns: column '<alias>' not in narrowed schema`.
+//!
+//! Root cause (fixed): the frontend put the projection ALIAS on the inner
+//! `ColumnRef` of a grouped-key output instead of the group-key's source name,
+//! so the planner's name-based rebind could not resolve it.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+async fn rows(client: &tokio_postgres::Client, sql: &str) -> Vec<String> {
+    let msgs = client.simple_query(sql).await.unwrap_or_else(|e| {
+        panic!(
+            "{sql}\n  {}",
+            e.as_db_error()
+                .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+                .unwrap_or_else(|| e.to_string())
+        )
+    });
+    msgs.iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                (0..r.len())
+                    .map(|i| r.get(i).unwrap_or("").to_string())
+                    .collect::<Vec<_>>()
+                    .join("|"),
+            ),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn native_orderby_alias_of_group_key() {
+    std::thread::Builder::new()
+        .name("rel-lower3-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(body())
+        })
+        .expect("spawn")
+        .join()
+        .expect("panic");
+}
+
+async fn body() {
+    let server = PgServer::start().await.expect("server");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    for ddl in [
+        "DROP TABLE IF EXISTS sales",
+        "CREATE TABLE sales (id INT PRIMARY KEY, brand VARCHAR, amt INT)",
+        "INSERT INTO sales VALUES (1,'A',10),(2,'A',20),(3,'B',5),(4,'C',30),(5,'C',30)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+
+    // GROUP-BY key aliased AND used as an ORDER BY key (q3/q52 shape). Ordered
+    // by the alias, so the result order is deterministic.
+    let got = rows(
+        &client,
+        "SELECT brand AS b, sum(amt) AS total FROM sales GROUP BY brand ORDER BY total DESC, b",
+    )
+    .await;
+    // total DESC: C=60, A=30, B=5.
+    assert_eq!(
+        got,
+        vec!["C|60".to_string(), "A|30".to_string(), "B|5".to_string()],
+        "ORDER BY on a group-key alias returned wrong/erroring result"
+    );
+
+    // The pure alias-as-only-sort-key form.
+    let got2 = rows(
+        &client,
+        "SELECT brand AS b, count(*) AS c FROM sales GROUP BY brand ORDER BY b",
+    )
+    .await;
+    assert_eq!(
+        got2,
+        vec!["A|2".to_string(), "B|1".to_string(), "C|2".to_string()]
+    );
+    eprintln!("✓ TD-REL-LOWER-3 ORDER-BY-alias of a group key executes correctly");
+}


### PR DESCRIPTION
## What

Closes the remaining TD-REL-LOWER-3 case (the ORDER-BY-alias, TPC-DS q3/q52) — the third and final piece of the native-route relational-coverage arc (after #1003 DATE literals and #1011 rebind ordinal-preservation).

## Root cause (frontend, upstream of the planner rebind)

A GROUP BY key projected with an alias (`SELECT g AS a … GROUP BY g`) built its Project output as:
```
NamedExpr{ name: "a", expr: Column{ name: "a", ordinal: slot } }
```
The inner `ColumnRef` wrongly adopted the projection **alias** (`a`), while the Aggregate output slot it indexes is named by the group **key** (`g`). So an `ORDER BY a` key resolving to that output carried the name `a`, and the planner's name-based rebind — looking it up against an Aggregate schema named `g` — failed with `rebind_columns: column 'a' not in narrowed schema`.

Found by dumping the lowered plan for the minimal shape; the fix is one branch in `lower_projection_with_aggregates`.

## Fix

The inner `ColumnRef` of a grouped-key output references the **group-by key's source name** (its aggregate-output slot name); the alias lives only on the enclosing `NamedExpr` (the Project renames the column). This mirrors the aggregate-slot path, whose ref name already matched its slot. Independent of #1011 (frontend vs planner) — both improve rebind correctness in complementary ways.

## Evidence / gates

- `tests/rel_lower_3_orderby_e2e.rs`: `SELECT brand AS b, sum(amt) AS total FROM sales GROUP BY brand ORDER BY total DESC, b` (and the pure alias-sort-key form) execute with correct rows + order — was an internal planner error.
- 113 frontend+planner unit tests unchanged; TPC-H + TPC-DS pgwire conformance pass.
- `fmt --check`, `clippy --lib --bins -D warnings`, `make work-commit-check`, `check_td_adr_unique`, server build — all green. Rebased on current develop (post-#1011).

## Docs

TD-REL-LOWER-3 → **FIXED** (both cases: Q15 derived-table alias via #1011, q3/q52 ORDER-BY alias via this — with the true frontend root cause recorded).

Refs: TD-REL-LOWER-3, #1003, #1011.