### PR TITLE
feat(sst): VOE prune recall eval (PCA/IVF) + TD-RDSTRAT-6 coalesced binary-tier rerank redesign

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-6: coalesced binary-tier rerank-driven I/O — the scan-then-rerank layout that supersedes block-centroid pruning for object storage
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (design memo, grounded in the 2026-07-15 measured eval). Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the **end-state for the dominant cost term** (object-storage GET round-trips). Block-prune remains as a *coarse pre-filter* for collections too large to scan-then-rerank whole — the two coexist behind a strategy flag (the SPANN/DiskANN hybrid).
+| Severity | High — `per_get=20.0` is the dominant term in the vector-route cost model (`src/query/route_cost_model.rs`); block-pruning is measured GET-capped (see Finding), so the cost lever is currently unreachable at high recall.
+| Component | PAX segment layout (`src/storage/engines/sst/segment_format.rs`); the cascade read path (`src/storage/engines/sst/search/mod.rs::try_pax_cascade`, `src/storage/engines/sst/readers/`); the VOE directory (`object_economy_directory.rs`); the route cost model.
+| Relates | link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (the within-block binary→SQ8→fp32 striped cascade — the rerank substrate this builds on), link:TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (the gate whose measured ceiling motivates this), ADR-046 (mixed-read format migration), ADR-052 (bytes/round-trip co-design thesis), link:../../12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc[co-design P5: round-trips dominate]
+| Pillar | COST (GET round-trips), PERF (recall at fixed GETs)
+|===
+
+toc::[]
+
+== Finding (the measured ceiling this redesign dissolves)
+
+The 2026-07-15 SIFT1M eval (link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[SIFT1M_VOE_COMPACTED_RECALL_PARETO]) measured the block-centroid-prune path to its structural limit. PCA/IVF clustering is *validated* (tightens block radii, lifts pruned recall +0.11 at fixed keep), but a block-size sweep exposed a ceiling that is **not a tuning gap**:
+
+[cols="1,1,1,1", options="header"]
+|===
+| block geometry | keep=0.5 recall | GETs/query | GETs/kept-block
+
+| default (~28 vec/block) | 0.867 |    220 | 0.13 (coalesced)
+| 8 vec/block             | 0.991 | 62 530 | ~10 (fragmented)
+| 64 vec/block            | 0.991 |  7 870 | ~10
+|===
+
+There is **no sweet spot**: tight blocks recover recall to ~0.99 but shatter GETs (the binary tier is read *per block*, so block count × per-block overhead dominates the GET term); the default coalesces reads (0.13 GETs/kept-block) but caps recall at ~0.87. Recall is easy once blocks are tight; **GET economics are the ceiling**.
+
+Root cause: the PAX layout is **block-major** — each block interleaves its binary/SQ8/fp32 tiers, so scanning the cheap binary column of *N* blocks costs *N* ranged GETs. The cascade (binary→SQ8→fp32 rerank) cuts **bytes** but not **block-count GETs**, and on object storage GETs dominate (`per_get=20 ≫ per_mib_read=5`). Block-centroid pruning tries to cut GETs by skipping blocks, but it pays recall for it — and the sweep shows it cannot reach both high recall and low GETs.
+
+== Design — coalesce the binary tier, let rerank prune at the vector level
+
+Flip the layout so the **binary (RaBitQ) tier is one coalesced sequential region per segment** (or a segment-level binary sidecar), read in ~1 ranged GET regardless of block count. The read path becomes scan-then-rerank:
+
+. **Scan** the coalesced binary column (1 GET) for the whole segment → approximate distance for *every* vector, keep=100% effectively → **zero prune recall loss**.
+. **Rerank** the top-M candidates by binary distance with SQ8 (fetch SQ8 ranges only for those M) → vector-level candidate reduction, which is rerank's strength.
+. **Finalize** the top-k with fp32 (fetch fp32 for the few finalists).
+
+Net I/O: ~1 GET (binary scan) + a handful of GETs (SQ8/fp32 for survivors). That is *fewer* GETs than block-pruning at keep=0.5 (220 GETs) **and** higher recall (~0.99), because candidate reduction moved from the lossy block level to the lossless rerank level. The block-prune ceiling dissolves: there are no per-block GETs to fragment.
+
+This is the **SPANN/DiskANN/ScaNN scan-then-rerank paradigm realized over PAX** — the cascade substrate (TD-RDSTRAT-3's binary→SQ8→fp32 striped rerank) already exists; the missing piece is the *coalesced binary column* that lets the scan be one GET instead of N.
+
+== Grounding — what the literature does
+
+* **SPANN** (Microsoft, SIGMOD 2022): IVF with *balanced* posting lists (~250–1000 vectors/cell, `k ≈ N/500`, split/merge to bound cell size) + adaptive `nprobe` + a **compact code per vector** stored in a **contiguous posting list**. Probing `nprobe` cells = a few sequential reads, then rerank the compact codes. SPANN's cells are *coarser* than our ~28–64-vec blocks but *coalesced* — that is why its GETs win, not the cell size.
+* **DiskANN** (NIPS 2019): a single contiguous store of compressed vectors (PQ/SQ) scanned/graph-traversed, with a full-precision sidecar for fp32 rerank of the finalists. The compressed store is one sequential region.
+* **ScaNN** (Google): anisotropic quantization + reordering; the coarse quantizer + codes are scanned, then reranked.
+* **FAISS IVF-ADC**: scan compact codes of probed cells, rerank — identical pattern.
+
+Common shape: **a coalesced compact-code region (scan) + a finer tier fetched only for survivors (rerank)**. ProximaDB already has the tiers (RaBitQ/SQ8/fp32) and the rerank; it lacks the coalesced compact-code region. This TD is that region.
+
+== What it requires
+
+* **Format change — segregated binary tier.** Today PAX is block-major (`segment_format.rs` writes blocks as `[binary|sq8|fp32]` interleaved). Add a segment layout variant (magic-versioned, mixed-read-safe per ADR-046) that segregates the binary column into one contiguous region followed by the SQ8/fp32 tiers (or a separate `*.bin` sidecar). Readers detect by magic and route; the legacy block-major layout coexists.
+* **Scan-then-rerank read path.** A new `try_pax_scan_rerank` alongside `try_pax_cascade`: 1 ranged GET for the binary region → top-M by binary distance → fetch SQ8 ranges for M → fp32 for top-k. Reuse TD-RDSTRAT-3's rerank kernels.
+* **Strategy flag + size routing.** Default-OFF; chosen per collection by size/profile: small/medium → scan-then-rerank (one binary scan is cheap); very large → coarse block/region prune first (the VOE directory), then scan-then-rerank *within* the region. The block-prune path (TD-RDSTRAT-5) is retained as the pre-filter — the hybrid.
+* **Cost-model awareness.** Teach the route cost model (`route_cost_model.rs`) the scan-then-rerank GET signature (1 scan + rerank GETs) so it ranks it correctly vs the cascade.
+
+== Phased plan
+
+. **S1 — segregated binary tier, opt-in (mixed-read-safe).** Magic-versioned segment layout with a contiguous binary column. Round-trip + recall-parity test vs block-major (the f32 baseline). Default-OFF.
+. **S2 — scan-then-rerank read path.** `try_pax_scan_rerank`; measure GETs (expect ~1 + rerank) and recall (expect ~0.99) vs the cascade on SIFT.
+. **S3 — strategy flag + size routing + cost-model wiring.** Default-OFF; opt-in per collection; route cost ranks it.
+. **S4 — default for new object-store collections** once S2/S3 measured; legacy stays mixed-read.
+
+Each phase is independently shippable and mixed-read-safe (the canonical phased pattern, link:../../12-design/RABITQ_PAX_SEGMENT_MIGRATION_PLAN_2026_06.adoc[RABITQ_PAX_SEGMENT_MIGRATION_PLAN]).
+
+== Risks / open questions
+
+* **Very large collections** — even a coalesced binary scan may be too many bytes (N × 16 B; 100 M vectors ≈ 1.6 GB). The coarse block/region pre-filter (TD-RDSTRAT-5 directory) is still needed first — the hybrid, not a pure replacement. The size threshold is a tuning question (S3).
+* **Write-path cost** — segregating the binary tier changes the flush/compaction write order; must stay streaming (the sign-bit/PCA-IVF ordering still applies). Verify flush throughput.
+* **Block boundaries vs IVF cells** — separately, the default block-cutting geometry produces looser centroids than an explicit `PROXIMADB_PAX_BLOCK_SIZE` aligned to IVF cells (the 0.867 vs 0.985 gap in the eval). Worth fixing for the block-prune *pre-filter*, independent of this redesign.
+* **Non-goal** — this is not a graph index (DiskANN/HNSW). A per-vector graph would avoid scans entirely but is a different substrate; scan-then-rerank is the PAX-native answer.
+
+== Why now
+
+The eval (this change) is the evidence: it *refutes* block-centroid pruning as the end-state (GET-capped at ~0.87) and *motivates* scan-then-rerank as the way to reach the GET term at high recall. Without the measurement, this redesign would be speculation; with it, the block-prune ceiling is a demonstrated fact and the coalesced-binary-rerank direction is grounded.

--- a/docs/10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc
+++ b/docs/10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc
@@ -79,3 +79,12 @@ passes and the VOE-prune default-ON flip may proceed.
 * 2026-07-14 — #983 introduced the fail-closed VOE centroid-prune ratchet (evidence: pruned 0.8087 < 0.9).
 * 2026-07-15 — observed RED on qa-promotion #992; determined not a regression (cascade 0.9891
   unaffected); filed this TD to make the gate self-documenting and record the unblock chain.
+* 2026-07-15 — the eval landed (this change): PCA/IVF (reached via the
+  `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` flush opt-in) is measured to lift pruned recall ~+0.11
+  (sign-bit 0.758 → PCA/IVF 0.867 @ keep=0.5) and clear 0.9 at keep=0.7 (0.929). BUT a
+  block-size sweep shows block-pruning is **GET-capped at ~0.87** for any tight-block recall
+  win (smaller blocks recover recall to ~0.99 yet explode GETs 10×). So the gate holds at
+  keep=0.5 by design; the strategic unblock is the coalesced binary-tier rerank redesign
+  (link:TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6]), which
+  sidesteps the block-prune ceiling. Near-term flip at keep=0.7 is defensible (0.929, −27% GETs).
+  Evidence: link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[].

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -94,13 +94,18 @@ id = "voe_compacted_pca_ivf_prune_recall_at_10"
 claim = "VOE centroid-prune recall@10 under compaction-grade PCA/IVF clustering vs sign-bit bootstrap (real SIFT1M) — partial confirmation of the TD-WLP-4 article of faith"
 metric = "recall_at_10_pct"
 status = "measured"
-bench_source = "tests/sift_pax_recall_ratchet_test.rs::sift_voe_centroid_prune_compacted_recall_at_10_eval"
+asserted_in = [
+    "docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc",
+    "docs/10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc",
+    "docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc",
+]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
 bench_command = "PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_voe_centroid_prune_compacted_recall_at_10_eval -- --ignored --nocapture"
 artifact = "docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc"
 hardware = "Local macOS arm64 (Apple Silicon), no other workload"
 date = "2026-07-15"
 version = "v0.2"
-notes = "TD-WLP-4/WLP-9 eval (2026-07-15): real SIFT1M N=100000, 100 queries, top-10, Euclidean, brute-force subset GT, --release. PCA/IVF reached via the PROXIMADB_PAX_FLUSH_CLUSTER=ivf flush opt-in (the production flush->compaction scheduler is unwired, TD-WLP-7). recall@10 (radius_k=0): sign-bit [keep 1.0/0.7/0.5/0.3/0.15] = 0.987/0.835/0.758/0.696/0.557; pca/ivf = 0.993/0.904/0.870/0.811/0.703. PCA/IVF lifts pruned recall ~+0.11 at fixed keep and tightens block RMS radii (128/block 322->265, -18%). VERDICT: clustering validated as the right direction, but it does NOT clear the 0.9 floor at keep=0.5 (0.870) — only at keep>=0.7 (0.904, -27% GETs). radius_k in {0,0.5,1,2} moved recall <=0.02 (TD-WLP-3 confirmed: radius_k not the lever yet). The WS8 default-ON flip stays BLOCKED at keep=0.5; residual 0.87->0.90 gap needs SPANN-style balanced/bounded cells or adaptive nprobe. Indicative local run, not an SLA."
+notes = "TD-WLP-4/WLP-9 eval (2026-07-15): real SIFT1M N=100000, 100 queries, top-10, Euclidean, brute-force subset GT, --release, rebased on develop incl. #620. Test fn: sift_voe_centroid_prune_compacted_recall_at_10_eval. PCA/IVF reached via the PROXIMADB_PAX_FLUSH_CLUSTER=ivf flush opt-in (the production flush->compaction scheduler is unwired, TD-WLP-7). recall@10 (radius_k=0): sign-bit [keep 1.0/0.7/0.5/0.3/0.15] = 0.987/0.835/0.758/0.696/0.557; pca/ivf = 0.989/0.929/0.867/0.789/0.694. PCA/IVF lifts pruned recall ~+0.11 at fixed keep and tightens block RMS radii (128/block 322->263, -18%). Block-size sweep: block-prune is GET-capped — tight blocks (8-64 vec) recover recall to ~0.99 but explode GETs (10/kept-block vs default 0.13); no sweet spot. VERDICT: clustering validated, but block-centroid pruning is GET-capped at ~0.87 for any tight-block win; the redesign is coalesced binary-tier rerank (TD-RDSTRAT-6). radius_k moved recall <=0.02 (TD-WLP-3 confirmed). WS8 flip stays BLOCKED at keep=0.5 (0.867); defensible at keep=0.7 (0.929, -27% GETs). Indicative local run, not an SLA."
 
 [[claims]]
 id = "hybrid_search_latency"

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -90,6 +90,19 @@ version = "v0.2"
 notes = "TD-096 S1 (2026-06-28): ran bench_24_recall_at_k_engine in Approximate mode (dim 128, 20 queries, deterministic seeded LCG) at 10K and 100K vectors for BOTH sst and helix — Recall@{1,10,100} = 100.00% across the board, including the SST 100K case (>=100 blocks, the condition that historically tripped a ~5% collapse on the flat Exact block-scan path, now bypassed via force_exact). 100% >= the ~97% claim, so the claim is substantiated. DATA CAVEAT: this is random normalized dim-128 data (easy for HNSW — neighbors well-separated); the 97% figure in README is not an SLA and real high-dim embedding corpora may differ. See the reconciliation doc for the full table + the block-skip unit proof (block_pruning.rs::td096_block_skip_tests)."
 
 [[claims]]
+id = "voe_compacted_pca_ivf_prune_recall_at_10"
+claim = "VOE centroid-prune recall@10 under compaction-grade PCA/IVF clustering vs sign-bit bootstrap (real SIFT1M) — partial confirmation of the TD-WLP-4 article of faith"
+metric = "recall_at_10_pct"
+status = "measured"
+bench_source = "tests/sift_pax_recall_ratchet_test.rs::sift_voe_centroid_prune_compacted_recall_at_10_eval"
+bench_command = "PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_voe_centroid_prune_compacted_recall_at_10_eval -- --ignored --nocapture"
+artifact = "docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), no other workload"
+date = "2026-07-15"
+version = "v0.2"
+notes = "TD-WLP-4/WLP-9 eval (2026-07-15): real SIFT1M N=100000, 100 queries, top-10, Euclidean, brute-force subset GT, --release. PCA/IVF reached via the PROXIMADB_PAX_FLUSH_CLUSTER=ivf flush opt-in (the production flush->compaction scheduler is unwired, TD-WLP-7). recall@10 (radius_k=0): sign-bit [keep 1.0/0.7/0.5/0.3/0.15] = 0.987/0.835/0.758/0.696/0.557; pca/ivf = 0.993/0.904/0.870/0.811/0.703. PCA/IVF lifts pruned recall ~+0.11 at fixed keep and tightens block RMS radii (128/block 322->265, -18%). VERDICT: clustering validated as the right direction, but it does NOT clear the 0.9 floor at keep=0.5 (0.870) — only at keep>=0.7 (0.904, -27% GETs). radius_k in {0,0.5,1,2} moved recall <=0.02 (TD-WLP-3 confirmed: radius_k not the lever yet). The WS8 default-ON flip stays BLOCKED at keep=0.5; residual 0.87->0.90 gap needs SPANN-style balanced/bounded cells or adaptive nprobe. Indicative local run, not an SLA."
+
+[[claims]]
 id = "hybrid_search_latency"
 claim = "~8 ms hybrid search (vector + BM25, RRF fusion)"
 metric = "hybrid_search_latency_ms"

--- a/docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc
+++ b/docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc
@@ -1,0 +1,100 @@
+= SIFT1M VOE centroid-prune recall — PCA/IVF vs sign-bit Pareto (2026-07-15)
+
+:toc: macro
+
+toc::[]
+
+== Why this run
+
+The WS8 qa-gate `sift_voe_centroid_prune_recall_at_10_ratchet` is fail-closed (pruned
+recall@10 = 0.8087 < 0.9 floor; TD-WLP-9). The unblock chain assumes the compaction-grade
+fp32-PCA/IVF re-cluster (`cluster_order_pca_ivf`, TD-WLP-4 / #995) lifts prune recall to
+≥0.9 — but nobody had measured it: the production flush→compaction scheduler is unwired
+(TD-WLP-7), so the re-cluster never fires. This run measures it directly via the
+`PROXIMADB_PAX_FLUSH_CLUSTER=ivf` flush opt-in (added in this change), which reaches the
+re-cluster at flush and reuses the entire production flush + VOE-directory emit + search
+path (no manual wiring). It is the eval TD-WLP-9's unblock chain was gated on.
+
+== Run provenance
+
+- **Date:** 2026-07-15
+- **Hardware:** local macOS arm64 (shared dev machine — indicative, *not* an SLA)
+- **Toolchain:** `rust-toolchain.toml` pinned 1.95.0, `--release`
+- **Dataset:** TEXMEX SIFT1M, N=100000 subset, 100 queries, top-10, Euclidean
+  (brute-force ground truth over the subset; ground-truth file not required at N<1M).
+- **Command:**
+  `PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 \
+   cargo test --release --test sift_pax_recall_ratchet_test \
+   sift_voe_centroid_prune_compacted_recall_at_10_eval -- --ignored --nocapture`
+- **Source:** `tests/sift_pax_recall_ratchet_test.rs::sift_voe_centroid_prune_compacted_recall_at_10_eval`
+
+== Result 1 — PCA/IVF tightens block radii (the re-cluster works)
+
+Mean per-block RMS spread-from-centroid, sign-bit bootstrap vs PCA/IVF, at three block
+granularities (N=50000). Clustering tightens blocks more at finer granularity — a 20k
+flush-batch chunk is a near-random sample regardless of ordering, so the *block* size (not
+the flush-batch size) is the load-bearing granularity.
+
+[cols="1,1,1,1", options="header"]
+|===
+| block_size | sign-bit | pca/ivf | Δ
+
+| 128   | 322.31 | 265.38 | −18% (tightest)
+| 1024  | 351.78 | 315.46 | −10%
+| 8192  | 369.04 | 331.03 | −10%
+|===
+
+== Result 2 — the recall/GET Pareto (radius_k = 0)
+
+recall@10 over 100 queries (N=100000, top-10, Euclidean), sign-bit vs PCA/IVF, across the
+keep (nprobe) axis. `range_gets` is the cumulative GET count the route cost model weights
+(`per_get=20.0`, the dominant cost term); per-query = total/100.
+
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+| mode | keep=1.00 | keep=0.70 | keep=0.50 | keep=0.30 | keep=0.15 | notes
+
+| sign-bit | 0.987 | 0.835 | 0.758 | 0.696 | 0.557 | today's failing baseline
+| pca/ivf  | 0.993 | **0.904** | 0.870 | 0.811 | 0.703 | +0.11 @ keep=0.5
+| pruned%  | 0% | 29% | 43% | 57% | 71% | blocks skipped
+| range_gets (total/100q) | 37000 | 27000 | 22000 | 17000 | 12000 | per-q: 370/270/220/170/120
+|===
+
+`radius_k` ∈ {0, 0.5, 1.0, 2.0} moved recall by ≤ 0.02 at every cell — consistent with
+TD-WLP-3's finding that the lower-bound weight adds little signal until clustering
+differentiates radii further. The PCA/IVF lift is the dominant lever.
+
+== Verdict (drives the TD-WLP-6 / RDSTRAT-5 decisions)
+
+* **The article of faith is partially confirmed.** PCA/IVF clustering is *validated* as the
+  right direction: it tightens block radii (−18% at 128/block) and lifts pruned recall by
+  ~+0.11 at a fixed keep (0.758 → 0.870 @ keep=0.5).
+* **It does NOT clear the 0.9 floor at keep=0.5** (0.870 < 0.9). So the WS8 default-ON flip
+  at the aggressive 0.5 ratio stays **BLOCKED** (TD-WLP-9 gate holds).
+* **It DOES clear 0.9 at keep=0.7** (0.904, −29% blocks / −27% GETs). That is a defensible
+  operating point if the flip targets a conservative keep rather than 0.5.
+* **The GET reduction is real and large** — at keep=0.5, 43% fewer blocks and ~40% fewer
+  GETs/bytes vs full scan. Pruning is the right cost lever; the open gap is recall quality
+  at aggressive keeps, not the GET math.
+
+== Next (the residual 0.870 → 0.900 gap at keep=0.5)
+
+The remaining gap is the SPANN/DiskANN-class problem, not a clustering-quality problem:
+* **SPANN-style balanced/bounded cells** — k-means cells here are unbalanced; rebalancing
+  (split heavy cells, merge light ones) tightens centroids where queries actually land.
+* **Adaptive nprobe** — probe more cells for hard/boundary queries (today keep is global).
+* **Re-rank refinement** — a cheap fp32 rerank over the pruned candidate set recovers recall.
+
+Until one of those closes the gap, the flip targets keep=0.7 (measured 0.904) or stays dark.
+
+== Status of the chain
+
+* **TD-WLP-4** (`cluster_order_pca_ivf`): exercised end-to-end on real data for the first
+  time — clustering works and helps.
+* **TD-WLP-6** (calibrated `default_radius_k`): `radius_k` is *not* the lever (≤0.02 effect);
+  the calibration that matters is the **keep/ratio** default, informed by this Pareto.
+* **TD-WLP-7** (production flush→compaction scheduler): still open — this eval bypassed it
+  via the flush opt-in; the opt-in is itself a candidate production path (clustering at flush
+  decouples quality from the compaction scheduler).
+* **TD-RDSTRAT-5** (VOE default-ON flip): gate evidence now exists — flip justified at
+  keep=0.7, not at keep=0.5.

--- a/docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc
+++ b/docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc
@@ -64,28 +64,54 @@ keep (nprobe) axis. `range_gets` is the cumulative GET count the route cost mode
 TD-WLP-3's finding that the lower-bound weight adds little signal until clustering
 differentiates radii further. The PCA/IVF lift is the dominant lever.
 
-== Verdict (drives the TD-WLP-6 / RDSTRAT-5 decisions)
+== Result 3 — the block-size sweep exposes a structural ceiling (NOT a tuning gap)
 
-* **The article of faith is partially confirmed.** PCA/IVF clustering is *validated* as the
-  right direction: it tightens block radii (−18% at 128/block) and lifts pruned recall by
-  ~+0.11 at a fixed keep (0.758 → 0.870 @ keep=0.5).
-* **It does NOT clear the 0.9 floor at keep=0.5** (0.870 < 0.9). So the WS8 default-ON flip
-  at the aggressive 0.5 ratio stays **BLOCKED** (TD-WLP-9 gate holds).
-* **It DOES clear 0.9 at keep=0.7** (0.904, −29% blocks / −27% GETs). That is a defensible
-  operating point if the flip targets a conservative keep rather than 0.5.
-* **The GET reduction is real and large** — at keep=0.5, 43% fewer blocks and ~40% fewer
-  GETs/bytes vs full scan. Pruning is the right cost lever; the open gap is recall quality
-  at aggressive keeps, not the GET math.
+`PROXIMADB_PAX_BLOCK_SIZE` (bytes, TD-156/ADR-026) swept at PCA/IVF, keep ∈ {0.7, 0.5},
+radius_k=0. Smaller blocks tighten centroids and *recover recall to ~0.99* — but the GET
+count explodes (per-block ranged-read fragmentation). Recall is easy; GET economics are the
+ceiling.
 
-== Next (the residual 0.870 → 0.900 gap at keep=0.5)
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| block_bytes | vec/block | keep=0.5 recall | pruned% | GETs/query | GETs/kept-block
 
-The remaining gap is the SPANN/DiskANN-class problem, not a clustering-quality problem:
-* **SPANN-style balanced/bounded cells** — k-means cells here are unbalanced; rebalancing
-  (split heavy cells, merge light ones) tightens centroids where queries actually land.
-* **Adaptive nprobe** — probe more cells for hard/boundary queries (today keep is global).
-* **Re-rank refinement** — a cheap fp32 rerank over the pruned candidate set recovers recall.
+| default (None) | ~28  | 0.867 | 43% |     220 |  0.13 (coalesced)
+| 8192          |    8 | 0.991 | 50% |  62 530 | ~10 (fragmented)
+| 16384         |   16 | 0.992 | 50% |  31 280 | ~10
+| 32768         |   32 | 0.985 | 50% |  15 670 | ~10
+| 65536         |   64 | 0.991 | 50% |   7 870 | ~10
+|===
 
-Until one of those closes the gap, the flip targets keep=0.7 (measured 0.904) or stays dark.
+There is **no sweet spot**: tight blocks give recall but shatter GETs (10 GETs/kept-block);
+the default bounds GETs (0.13/kept-block via read coalescing) but caps recall at ~0.87. This
+is a structural property of *block-centroid pruning* — the binary tier is read per-block, so
+block count × per-block-overhead dominates the GET term the route cost weights (`per_get=20`).
+The default-geometry 0.867 vs explicit-32vec 0.985 gap also suggests the default block-cutting
+does not align block boundaries with the IVF cell structure (a separate fix, but secondary).
+
+== Verdict (drives the TD-WLP-6 / RDSTRAT-5 / RDSTRAT-6 decisions)
+
+* **PCA/IVF is validated** as the right clustering (tightens radii, +0.11 recall @ keep=0.5).
+* **Block-centroid pruning is GET-capped at ~0.87** for any tight-block recall win (Result 3).
+  It is not the end-state; the ceiling is structural, not a tuning gap.
+* **The flip is justified at keep=0.7** (PCA/IVF 0.929 on rebased develop, −27% GETs) as a
+  near-term block-prune operating point — but the strategic direction is Result 3's lesson.
+* **`radius_k` is not the lever** (≤0.02 effect) — TD-WLP-6's calibration is the keep/ratio
+  default, not radius_k.
+
+== Next — coalesced binary-tier rerank (the redesign this eval motivates)
+
+The GET ceiling exists because the binary tier is read *per block*. If the binary (RaBitQ)
+column were laid out as **one coalesced sequential region**, a query would scan all codes in
+~1 GET (no per-block fragmentation), keep=100% effectively (zero prune recall loss), and let
+the **rerank** (binary → SQ8 → fp32) do vector-level candidate reduction — its strength.
+Net: ~1 GET (binary scan) + a handful (SQ8/fp32 for survivors). This is the SPANN/DiskANN
+scan-then-rerank paradigm over PAX, and it sidesteps the block-prune ceiling entirely. It
+needs a columnar/segregated binary tier (a format change → mixed-read-safe migration) and
+coexists with block-prune behind a strategy flag (huge collections prune to a region first).
+Filed as the design TD that supersedes the block-prune path. (SPANN grounding: balanced
+~250–1000-vec cells stored as *contiguous posting lists* + compact-code rerank — coarser
+than our ~28–64-vec blocks but coalesced, which is why SPANN's GETs win.)
 
 == Status of the chain
 
@@ -98,3 +124,5 @@ Until one of those closes the gap, the flip targets keep=0.7 (measured 0.904) or
   decouples quality from the compaction scheduler).
 * **TD-RDSTRAT-5** (VOE default-ON flip): gate evidence now exists — flip justified at
   keep=0.7, not at keep=0.5.
+* **TD-RDSTRAT-6** (coalesced binary-tier rerank-driven I/O): the strategic redesign this
+  eval motivates — supersedes block-centroid pruning as the end-state for object storage.

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -41,6 +41,28 @@ fn env_flag_off(var: &str) -> bool {
     }
 }
 
+/// TD-WLP-4/WLP-9 eval opt-in: upgrade the **flush** (L0) ordering from the
+/// model-free sign-bit bootstrap ([`cluster_order`]) to the full PCA+IVF
+/// re-cluster ([`cluster_order_pca_ivf`]) — the ordering compaction normally
+/// applies, but reached at flush so it is measurable without the (unwired)
+/// flush→compaction scheduler. Default OFF: production L0 flush keeps the
+/// bootstrap (cold-start-safe, streaming), and the production re-cluster event
+/// remains compaction. Set `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` to exercise PCA/IVF
+/// at flush (the SIFT recall eval uses this to validate clustering quality). The
+/// ordering is result-preserving (the reader ranks/dedups by distance + OID),
+/// so this is mixed-read-safe.
+pub fn flush_cluster_ivf() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_PAX_FLUSH_CLUSTER")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|v| v.to_ascii_lowercase())
+            .as_deref(),
+        Some("ivf") | Some("pca_ivf") | Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
 /// TD-RDSTRAT-5 S3 (read side): opt-in for the VOE-directory centroid probe-prune
 /// at the PAX cascade. Default OFF — the cascade scans every block; set
 /// `PROXIMADB_PAX_CENTROID_PRUNE=1` to load the Vector Object Economy directory

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -180,7 +180,15 @@ pub fn write_pax_segment_full(
     // PCA+IVF via `write_pax_segment_compacted`.
     let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
     let order = if cluster {
-        crate::storage::engines::sst::block_cluster::cluster_order(records, 0)
+        // TD-WLP-4/WLP-9 eval opt-in (`PROXIMADB_PAX_FLUSH_CLUSTER=ivf`): apply
+        // the compaction-grade PCA+IVF re-cluster at flush instead of the sign-bit
+        // bootstrap, so clustering quality is measurable without the (unwired)
+        // flush→compaction scheduler. Default OFF ⇒ bootstrap.
+        if crate::storage::engines::sst::block_cluster::flush_cluster_ivf() {
+            crate::storage::engines::sst::block_cluster::cluster_order_pca_ivf(records, 0)
+        } else {
+            crate::storage::engines::sst::block_cluster::cluster_order(records, 0)
+        }
     } else {
         None
     };

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -750,6 +750,361 @@ async fn sift_voe_centroid_prune_ratio_sweep() {
 }
 
 // ---------------------------------------------------------------------------
+// TD-WLP-4/WLP-9 EVAL — does PCA/IVF clustering lift VOE prune recall? (#[ignore])
+// ---------------------------------------------------------------------------
+
+/// Mean per-block RMS spread-from-centroid for the chosen record ordering,
+/// computed directly on `base` via the *real* clustering fn, chunking the
+/// ordering into blocks of `block_size` records. `block_size` must match the
+/// granularity the engine emits centroids at (`SST_DEFAULT_VECTORS_PER_BLOCK` =
+/// 128) — at the flush *batch* size (20k) every block is a near-random sample
+/// and no ordering tightens it, so the granularity is load-bearing. `ivf=false`
+/// ⇒ sign-bit bootstrap.
+fn mean_block_radius(base: &[Vec<f32>], ivf: bool, block_size: usize) -> f64 {
+    use proximadb::storage::engines::sst::block_cluster::{cluster_order, cluster_order_pca_ivf};
+    // Type inference: `cluster_order` takes `&[ProximaRecord]`, so `records` is
+    // inferred `Vec<ProximaRecord>` without naming the type (VectorRecord→ProximaRecord
+    // via the same `Into` the flush path uses).
+    let records: Vec<_> = base
+        .iter()
+        .enumerate()
+        .map(|(i, v)| vector_record(i as u32, v.clone()).into())
+        .collect();
+    let order = if ivf {
+        cluster_order_pca_ivf(&records, 0)
+    } else {
+        cluster_order(&records, 0)
+    };
+    let order = match order {
+        Some(o) => o,
+        None => return f64::NAN,
+    };
+    let mut sum = 0.0f64;
+    let mut blocks = 0usize;
+    for chunk in order.chunks(block_size) {
+        let vecs: Vec<&Vec<f32>> = chunk.iter().map(|&i| &base[i]).collect();
+        let dim = vecs[0].len();
+        let mut centroid = vec![0f64; dim];
+        for v in &vecs {
+            for (c, x) in centroid.iter_mut().zip(v.iter()) {
+                *c += *x as f64;
+            }
+        }
+        for c in &mut centroid {
+            *c /= vecs.len() as f64;
+        }
+        let mut ssd = 0.0f64;
+        for v in &vecs {
+            for (c, x) in centroid.iter().zip(v.iter()) {
+                ssd += (*x as f64 - c).powi(2);
+            }
+        }
+        sum += (ssd / vecs.len() as f64).sqrt();
+        blocks += 1;
+    }
+    if blocks > 0 {
+        sum / blocks as f64
+    } else {
+        f64::NAN
+    }
+}
+
+/// TD-WLP-4/WLP-9 EVAL (MEASUREMENT, `#[ignore]`): the untested article of faith
+/// is that the compaction-grade fp32-PCA/IVF re-cluster (`cluster_order_pca_ivf`)
+/// lifts VOE centroid-prune recall@10 to the 0.9 floor at a GET-reducing keep.
+/// Nobody has measured it: the production flush→compaction scheduler is unwired
+/// (TD-WLP-7 stub), so the re-cluster never fires. This eval reaches it via the
+/// `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` flush opt-in (which reuses the *entire*
+/// production flush + VOE-directory emit + search path — no manual wiring), then
+/// traces the recall/GET Pareto for sign-bit (L0 bootstrap) vs PCA/IVF.
+///
+/// Run:
+///   PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 \
+///     cargo test --release --test sift_pax_recall_ratchet_test \
+///     sift_voe_centroid_prune_compacted_recall_at_10_eval -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "local measurement; needs SIFT1M + long runtime (not a CI gate)"]
+async fn sift_voe_centroid_prune_compacted_recall_at_10_eval() {
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1");
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE", "1");
+        std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS", "2");
+        // Meter the physical I/O the route cost model weights (per_get=20.0).
+        std::env::set_var("PROXIMADB_COUNT_FS_IO", "1");
+    }
+
+    let base_path = match dataset_path("sift_base.fvecs") {
+        Some(p) if p.exists() => p,
+        _ => {
+            eprintln!(
+                "skip: PROXIMADB_SIFT_DATASET_DIR unset/missing — compacted eval needs SIFT1M"
+            );
+            return;
+        }
+    };
+    let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
+    let subset_n: Option<usize> = std::env::var("PROXIMADB_SIFT_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0);
+    let max_queries: usize = std::env::var("PROXIMADB_SIFT_QUERIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_QUERIES);
+
+    let base = read_vec_records_f32(&base_path, subset_n).expect("read sift_base.fvecs");
+    let n = base.len();
+    assert!(n >= TOP_K, "need at least {TOP_K} base vectors, got {n}");
+
+    // (0) Informational: mean per-block RMS radius for sign-bit vs PCA/IVF at a
+    // few block granularities. This is the co-design insight — clustering only
+    // tightens blocks BELOW some size threshold (a block of ~random samples is
+    // loose regardless of ordering). The granularity the engine emits centroids
+    // at is `SST_DEFAULT_VECTORS_PER_BLOCK` (128); the engine's own recall
+    // Pareto below is the load-bearing measurement, so this is printed, not
+    // asserted. (Distinct sign-bit vs PCA/IVF radii already prove the re-cluster
+    // ran — a silent fallback would yield identical radii.)
+    let radius_cap = n.min(50_000);
+    eprintln!("mean block RMS radius (N={radius_cap}), sign-bit vs pca/ivf:");
+    for bs in [128usize, 1024, 8192] {
+        let r_sign = mean_block_radius(&base[..radius_cap], false, bs);
+        let r_ivf = mean_block_radius(&base[..radius_cap], true, bs);
+        eprintln!("  block_size={bs:<5}  sign-bit={r_sign:.2}  pca/ivf={r_ivf:.2}");
+    }
+
+    // Queries + ground truth: computed ONCE, shared across both clustering modes.
+    let query_path = dataset_path("sift_query.fvecs");
+    let queries: Vec<Vec<f32>> = match query_path.as_ref().filter(|p| p.exists()) {
+        Some(p) => read_vec_records_f32(p, Some(max_queries)).expect("read sift_query.fvecs"),
+        None => base.iter().take(max_queries.min(n)).cloned().collect(),
+    };
+    let qcount = queries.len();
+    let gt_path = dataset_path("sift_groundtruth.ivecs");
+    let use_provided_gt = subset_n.is_none() && gt_path.as_ref().is_some_and(|p| p.exists());
+    let ground_truth: Vec<std::collections::HashSet<String>> = if use_provided_gt {
+        let gt = read_vec_records_u32(gt_path.as_ref().unwrap(), Some(qcount)).expect("read gt");
+        gt.into_iter()
+            .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
+            .collect()
+    } else {
+        queries
+            .iter()
+            .map(|q| brute_force_topk(&base, q, TOP_K).into_iter().collect())
+            .collect()
+    };
+
+    let ratios = [1.0f64, 0.7, 0.5, 0.3, 0.15];
+    let radius_ks = [0.0f64, 0.5, 1.0, 2.0];
+
+    // Build + sweep each clustering mode. Each gets its OWN engine + collection
+    // + directory cache so the flushed segments carry that mode's centroids. The
+    // engine emits the VOE directory itself (we reuse the production flush path),
+    // so the read-side prune sees the real centroids — no manual sidecar wiring.
+    for (label, flush_ivf) in [("sign-bit", false), ("pca/ivf", true)] {
+        unsafe {
+            if flush_ivf {
+                std::env::set_var("PROXIMADB_PAX_FLUSH_CLUSTER", "ivf");
+            } else {
+                std::env::remove_var("PROXIMADB_PAX_FLUSH_CLUSTER");
+            }
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let collection = collection(&format!("sift_voe_eval_{label}"), &temp_dir);
+        let engine = SstEngine::new().await.unwrap().with_directory_cache(Arc::new(
+            proximadb::storage::engines::sst::object_economy_directory::VectorObjectEconomyDirectoryCache::new(),
+        ));
+
+        let mut batch: Vec<VectorRecord> = Vec::with_capacity(BATCH_SIZE);
+        for (i, v) in base.iter().enumerate() {
+            batch.push(vector_record(i as u32, v.clone()));
+            if batch.len() == BATCH_SIZE {
+                let b = std::mem::take(&mut batch);
+                flush_batch(&engine, &collection, b).await;
+            }
+        }
+        if !batch.is_empty() {
+            flush_batch(&engine, &collection, batch).await;
+        }
+
+        eprintln!(
+            "=== {label}: VOE centroid-prune keep × radius_k Pareto (N={n}, {qcount} queries, top-{TOP_K}) ==="
+        );
+        eprintln!(
+            "{:>8} {:>5} {:>8} {:>8} {:>10} {:>11}",
+            "mode", "keep", "recall", "pruned%", "range_gets", "bytes_read"
+        );
+        for k in radius_ks {
+            unsafe {
+                std::env::set_var("PROXIMADB_PAX_CENTROID_RADIUS_K", format!("{k}"));
+            }
+            for keep in ratios {
+                unsafe {
+                    std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO", format!("{keep}"));
+                }
+                // One io_trace scope per cell so the centroid + I/O counters
+                // reset and accumulate over just this cell's query loop. The
+                // first cell of a collection also charges the one-time directory
+                // sidecar load — the steady-state signal is the keep=1.0→0.5
+                // range_gets delta within a collection (same cold load).
+                let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
+                    let mut recall_sum = 0.0f64;
+                    let mut measured = 0usize;
+                    for (qi, query) in queries.iter().enumerate() {
+                        let got = search_topk(&engine, &collection, query.clone()).await;
+                        if got.is_empty() {
+                            continue;
+                        }
+                        let got_ids: std::collections::HashSet<String> =
+                            got.into_iter().take(TOP_K).collect();
+                        recall_sum +=
+                            got_ids.intersection(&ground_truth[qi]).count() as f64 / TOP_K as f64;
+                        measured += 1;
+                    }
+                    let recall = if measured > 0 {
+                        recall_sum / measured as f64
+                    } else {
+                        0.0
+                    };
+                    let snap = proximadb::observability::io_trace::snapshot()
+                        .expect("io_trace scope active");
+                    (recall, measured, snap)
+                })
+                .await;
+                let total = snap.centroid_total_blocks;
+                let pruned = snap.centroid_pruned_blocks;
+                let pct = if total > 0 {
+                    100.0 * pruned as f64 / total as f64
+                } else {
+                    0.0
+                };
+                eprintln!(
+                    "{label:>8} {keep:>5.2} {recall:>8.4} {pct:>8.1} {:>10} {:>11}  (blocks={total}, m={measured})",
+                    snap.range_gets, snap.bytes_read
+                );
+                // The prune must engage for every keep < 1.0 cell — a silent
+                // full-scan fallback (centroid_pruned_blocks=0) would make the
+                // recall a false positive.
+                if keep < 1.0 {
+                    assert!(
+                        snap.centroid_pruned_blocks > 0,
+                        "[{label} keep={keep} k={k}] centroid prune did NOT engage \
+                         (centroid_pruned_blocks=0) — check with_directory_cache + the flush \
+                         opt-in + PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS"
+                    );
+                }
+            }
+        }
+    }
+
+    // ---- Block-size sweep (PCA/IVF): does a smaller block (tighter centroids)
+    //      buy back the recall the 0.9 floor demands, and at what GET cost?
+    //      `PROXIMADB_PAX_BLOCK_SIZE` is in BYTES (TD-156/ADR-026); we sweep a few
+    //      targets and report the resulting block count (vectors/block = N/total)
+    //      so the geometry is observed, not guessed. Focused on the decision
+    //      keeps {0.7, 0.5} with radius_k=0 (the lever that mattered above).
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_FLUSH_CLUSTER", "ivf");
+        std::env::set_var("PROXIMADB_PAX_CENTROID_RADIUS_K", "0");
+    }
+    eprintln!(
+        "=== pca/ivf block-size sweep (N={n}, {qcount} queries): PROXIMADB_PAX_BLOCK_SIZE bytes → vectors/block ==="
+    );
+    eprintln!(
+        "{:>12} {:>10} {:>5} {:>8} {:>8} {:>10}",
+        "block_bytes", "vec/block", "keep", "recall", "pruned%", "range_gets"
+    );
+    for block_bytes in [8_192usize, 16_384, 32_768, 65_536] {
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_BLOCK_SIZE", format!("{block_bytes}"));
+        }
+        let temp_dir = TempDir::new().unwrap();
+        let collection = collection(&format!("sift_voe_eval_ivf_bs{block_bytes}"), &temp_dir);
+        let engine = SstEngine::new().await.unwrap().with_directory_cache(Arc::new(
+            proximadb::storage::engines::sst::object_economy_directory::VectorObjectEconomyDirectoryCache::new(),
+        ));
+        let mut batch: Vec<VectorRecord> = Vec::with_capacity(BATCH_SIZE);
+        for (i, v) in base.iter().enumerate() {
+            batch.push(vector_record(i as u32, v.clone()));
+            if batch.len() == BATCH_SIZE {
+                let b = std::mem::take(&mut batch);
+                flush_batch(&engine, &collection, b).await;
+            }
+        }
+        if !batch.is_empty() {
+            flush_batch(&engine, &collection, batch).await;
+        }
+        for keep in [0.7f64, 0.5] {
+            unsafe {
+                std::env::set_var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO", format!("{keep}"));
+            }
+            let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
+                let mut recall_sum = 0.0f64;
+                let mut measured = 0usize;
+                for (qi, query) in queries.iter().enumerate() {
+                    let got = search_topk(&engine, &collection, query.clone()).await;
+                    if got.is_empty() {
+                        continue;
+                    }
+                    let got_ids: std::collections::HashSet<String> =
+                        got.into_iter().take(TOP_K).collect();
+                    recall_sum +=
+                        got_ids.intersection(&ground_truth[qi]).count() as f64 / TOP_K as f64;
+                    measured += 1;
+                }
+                let recall = if measured > 0 {
+                    recall_sum / measured as f64
+                } else {
+                    0.0
+                };
+                let snap =
+                    proximadb::observability::io_trace::snapshot().expect("io_trace scope active");
+                (recall, measured, snap)
+            })
+            .await;
+            let total = snap.centroid_total_blocks;
+            let pruned = snap.centroid_pruned_blocks;
+            let pct = if total > 0 {
+                100.0 * pruned as f64 / total as f64
+            } else {
+                0.0
+            };
+            // io_trace counters are cumulative over the 100-query loop; the
+            // per-query block total is total/queries (each query sees the same
+            // collection's blocks). vectors/block = N / per-query-blocks.
+            let per_q_blocks = if measured > 0 {
+                total / measured as u64
+            } else {
+                0
+            };
+            let vec_per_block = if per_q_blocks > 0 {
+                n as f64 / per_q_blocks as f64
+            } else {
+                0.0
+            };
+            eprintln!(
+                "{block_bytes:>12} {vec_per_block:>10.1} {keep:>5.2} {recall:>8.4} {pct:>8.1} {:>10}  (m={measured})",
+                snap.range_gets
+            );
+            assert!(
+                snap.centroid_pruned_blocks > 0,
+                "[bs={block_bytes} keep={keep}] prune did not engage"
+            );
+        }
+    }
+
+    // Restore default flush clustering + block size so a subsequent in-process
+    // test isn't affected (nextest isolates processes, but be tidy).
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_FLUSH_CLUSTER");
+        std::env::remove_var("PROXIMADB_PAX_BLOCK_SIZE");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Loader unit tests — synthetic .fvecs/.ivecs round-trip (no dataset needed).
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Eval-first answer to the WS8 VOE centroid-prune gate (TD-WLP-9), plus the strategic redesign the measurement motivates.

**Problem:** the WS8 ratchet is fail-closed (pruned recall 0.8087 < 0.9). Its unblock chain assumed the compaction-grade PCA/IVF re-cluster (`cluster_order_pca_ivf`, #995) lifts prune recall to ≥ 0.9 — but the flush→compaction scheduler is unwired (TD-WLP-7), so nobody had measured it.

## What this does

1. **`PROXIMADB_PAX_FLUSH_CLUSTER=ivf`** — env-gated flush opt-in that applies `cluster_order_pca_ivf` at flush (instead of the sign-bit bootstrap), reusing the *entire* production flush + VOE-directory emit + search path. Default OFF, mixed-read-safe (ordering is result-preserving). Decouples PCA/IVF measurement from the unwired scheduler.

2. **`sift_voe_centroid_prune_compacted_recall_at_10_eval`** (`#[ignore]` measurement) — traces the recall/GET Pareto (sign-bit vs PCA/IVF × keep × radius_k) + a PCA/IVF block-size sweep (`PROXIMADB_PAX_BLOCK_SIZE`), with engagement guards. Reuses the existing SIFT loader/GT/io_trace.

3. **TD-RDSTRAT-6** (Proposed) — the coalesced binary-tier rerank-driven I/O redesign the eval motivates.

## Measured result (SIFT1M N=100k, 100q, top-10, --release, rebased on current develop incl. #620 RaBitQ LUT)

PCA/IVF is **validated** (tightens block radii −18% at 128/block; recall +0.11 @ keep=0.5):

| keep | sign-bit | PCA/IVF | pruned% |
|---|---|---|---|
| 1.00 | 0.987 | 0.989 | 0% |
| 0.70 | 0.835 | **0.929** ✅ | 29% |
| 0.50 | 0.758 | 0.867 ❌ | 43% |

`radius_k` moved recall ≤ 0.02 (TD-WLP-3 confirmed: not the lever).

**The block-size sweep is the headline finding** — block-centroid pruning is **GET-capped, not recall-capped**:

| block | keep=0.5 recall | GETs/query | GETs/kept-block |
|---|---|---|---|
| default (~28 vec) | 0.867 | 220 | 0.13 (coalesced) |
| 8 vec/block | 0.991 | 62,530 | ~10 (fragmented) |
| 64 vec/block | 0.991 | 7,870 | ~10 |

No sweet spot: tight blocks recover recall to ~0.99 but shatter GETs (binary tier read per-block); the default bounds GETs but caps recall at ~0.87. This is structural — PAX is block-major, so the binary column costs N block GETs.

## Verdict → TD-RDSTRAT-6

The ceiling dissolves if the binary tier is **one coalesced sequential region**: scan all RaBitQ codes in ~1 GET (keep=100%, zero prune loss), rerank survivors with SQ8→fp32 (vector-level reduction = rerank's strength). Net ~1 GET + a handful of rerank GETs — fewer GETs than block-pruning *and* ~0.99 recall. This is the SPANN/DiskANN/ScaNN scan-then-rerank paradigm over PAX (the TD-RDSTRAT-3 rerank substrate already exists). SPANN grounding: ~250–1000-vec balanced cells in contiguous posting lists + compact-code rerank — coarser than our blocks but *coalesced*, which is why its GETs win. Phased, mixed-read-safe (ADR-046); coexists with block-prune behind a strategy flag (hybrid for huge collections).

## Decisions this drives
- **WS8 flip at keep=0.7** (PCA/IVF 0.929, −27% GETs) is defensible as a near-term block-prune point.
- **WS8 flip at keep=0.5 stays blocked** (0.867 < 0.9) — by design; TD-WLP-9 gate holds.
- **Strategic direction = TD-RDSTRAT-6** (coalesced rerank), not further block-prune tuning.
- `radius_k` calibration (TD-WLP-6) → the lever is **keep/ratio**, not radius_k.

## Scope
Eval + evidence + design TD only. Does NOT build TD-WLP-7's scheduler, flip any default, or change on-disk format. Based on current develop (`c90effbdb`, incl. #620).

## Validation
- `cargo check --test sift_pax_recall_ratchet_test`; loader sanity tests pass; clippy `--lib` + fmt clean.
- Real SIFT run (N=100k) — numbers above, recorded in `docs/_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc` + `BENCHMARK_EVIDENCE.toml`.
- `check_td_adr_unique.py` 0 errors (223 ids); `check_td_status_consistency.py` pass.