### PR TITLE
docs(adr): ADR-062/TD-RDSTRAT-6 spec-accuracy fixes + D7 workload-profile scoping

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -8,7 +8,7 @@
 | Field | Value
 | Status | **Spec'd** (full implementation spec, 2026-07-15). The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (Proposed → Accepted on review). This TD is the *what/how* for an implementer/reviewer. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
 | Severity | High — `per_get=20.0` is the dominant vector-route cost-model term; block-pruning is measured GET-capped (link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the eval]), so the GET lever is unreachable until this lands.
-| Component | `src/storage/engines/sst/segment_format.rs` (writer+reader); `crates/storage/proximadb-block-format` (`PaxBlockWriter`/`PaxSegmentScanner`, `stripe.rs::SegmentMeta`); `src/storage/engines/sst/search/mod.rs::try_pax_cascade`; `src/storage/engines/core/coalesce_strategy.rs` + `sst_query_engine.rs::plan_selected_block_ranges`; `src/storage/engines/sst/compaction.rs`; `crates/storage/proximadb-storage-common` (storage-profile IOPS); `crates/storage/proximadb-storage-filesystem-types` (`FileSystem::read_ranges`).
+| Component | `src/storage/engines/sst/segment_format.rs` (writer+reader); `crates/storage/proximadb-block-format/src/writer.rs::PaxBlockWriter` (`:134`) + `crates/storage/proximadb-storage-common/src/pax_block.rs::PaxSegmentScanner` (`:887`) + `stripe.rs::SegmentMeta`; `src/storage/engines/sst/search/mod.rs::try_pax_cascade`; `src/storage/engines/core/coalesce_strategy.rs` + `sst_query_engine.rs::{plan_selected_block_ranges (:733), ObjectRangeCoalescePolicy (:289)}`; `src/storage/engines/sst/compaction.rs`; `crates/storage/proximadb-storage-common` (a NEW per-backend `IopsBudget` — NOT the `StorageProfile` workload enum); `crates/storage/proximadb-storage-filesystem-types` (`FileSystem::read_ranges` — default is a sequential loop; the GET win is the coalesce policy's); `crates/storage/proximadb-object-store/src/lib.rs::put_if_absent` (`:247`, create-only — compaction CAS via Iceberg fresh-name+manifest-swap, ADR-020).
 | Relates | link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (decision), link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (rerank substrate), link:TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (gate), ADR-061 (pre-GA in-place/amend), ADR-046/045 (mixed-read/readability), ADR-036 (storage profile), ADR-020 (WAL authority; footer is advisory), ADR-047 (collection-as-table schema)
 | Pillar | COST (GET round-trips), PERF (recall at fixed GETs)
 |===
@@ -78,10 +78,13 @@ replace predecessors).
    (keep=100%) → approximate distance for every vector.
 2. **Select top-M survivors** (M = adaptive GET-budget; expand until the next survivor crosses a
    block boundary — see <<_self_derived_geometry>>).
-3. **Rerank:** survivors are cluster-adjacent → they fall in few adjacent blocks → reuse
-   `plan_selected_block_ranges` (`sst_query_engine.rs:733`) + `ObjectRangeCoalescePolicy` +
-   `FileSystem::read_ranges` (batched multi-range) to fetch their SQ8(+metadata) stripes in a
-   few coalesced GETs. Decode with the UNCHANGED block decoder.
+3. **Rerank:** survivors are cluster-adjacent (row order is `cluster_order_pca_ivf`,
+   `block_cluster.rs:198`, shipped #995; reachable at flush via `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`,
+   `block_cluster.rs:54`, shipped #1015) → they fall in few adjacent blocks → the GET reduction
+   comes from `plan_selected_block_ranges` (`sst_query_engine.rs:733`) +
+   `ObjectRangeCoalescePolicy` (`:289`) *planning* merged/coalesced ranges; `FileSystem::read_ranges`
+   (`filesystem-types/lib.rs:507`) only *executes* them (its default impl is a sequential `for`
+   loop — a backend may override to true batched/multipart). Decode with the UNCHANGED block decoder.
 4. **Finalize** top-k with fp32 (fetch fp32 stripe for finalists only).
 5. **OID recovery** unchanged (`segment_format.rs:737-755`).
 
@@ -113,14 +116,16 @@ Block geometry emerges from dim × tier-composition × backend IOPS (replaces st
 
 ```
  per_row_survivor_bytes = sq8(if present)·dim + fp32(if present)·4·dim + fixed_metadata   (RaBitQ excluded — it's in the header)
- block_bytes_target     = storage_profile.iops_target ∈ [iops_min, iops_max]              (backend-derived)
+ block_bytes_target     = iops_budget.target ∈ [iops_budget.min, iops_budget.max]         (backend-derived; NEW IopsBudget — NOT the StorageProfile enum)
  rows_per_block         = clamp( iops_target / per_row_bytes, ceil(iops_min/per_row), floor(iops_max/per_row) )
 ```
 
-`iops_min ≈ 512 KB`, `iops_target ≈ 2 MB`, `iops_max ≈ 8 MB` (S3/ABFS → 4 MB; MinIO/local →
-512 KB-1 MB). The RaBitQ header region is sized separately (one GET = N × rabitq_bytes, cached);
-this governs only the survivor-fetch block. Adaptive survivor M expands until the next survivor
-would cross into a new block (a new GET), then stops — clustering makes this elasticity cheap.
+`IopsBudget { min ≈ 512 KB, target ≈ 2 MB, max ≈ 8 MB }` (S3/ABFS → 4 MB; MinIO/local →
+512 KB-1 MB) is a **NEW per-backend property** on the object-store/storage config — distinct
+from the `StorageProfile {AppendBulk, Churn}` workload enum (`storage_profile.rs:33`, ADR-061).
+The RaBitQ header region is sized separately (one GET = N × rabitq_bytes, cached); this governs
+only the survivor-fetch block. Adaptive survivor M expands until the next survivor would cross
+into a new block (a new GET), then stops — clustering makes this elasticity cheap.
 
 == GET-budget compaction (file-count = GET-count knob)
 
@@ -128,9 +133,34 @@ A collection accumulates files LSM-style (flush → one self-contained file). Co
 on a **query GET-budget**: projected RaBitQ-GETs/query (= file count) exceeds target, or
 file-count > threshold (3-5). Merge N→1: read each file's RaBitQ (cheap), re-cluster the union
 (`cluster_order_pca_ivf`), rewrite one file. Double duty: fewer files (fewer GETs) AND tighter
-survivor locality. Atomicity: single-object conditional replace (S3 `If-None-Match` / ABFS
-`If-None-Match`). This is the WLP-7 compaction-scheduler seam reframed as the vector-query
-GET-cost lever.
+survivor locality. **Atomicity:** the object-store exposes only create-only `put_if_absent`
+(`proximadb-object-store/src/lib.rs:247`; no `if-match` CAS yet) → compaction uses the
+Iceberg-style fresh-name + WAL-authoritative manifest advance (write the new file under a fresh
+content-addressed name, then atomically advance the manifest — ADR-020: WAL is authority, the
+segment is advisory). Native S3/ABFS conditional-replace is a future optimization. This is the
+WLP-7 compaction-scheduler seam reframed as the vector-query GET-cost lever.
+
+== Workload-profile applicability + write path (D7)
+
+The layout is the **durable PAX-LSM segment format** — AppendBulk-optimal, scoped
+per-workload-profile (ADR-061) so it never lands on a hot high-churn write path or a graph-edge
+path:
+
+* **AppendBulk** — direct fit (large-batch flushes → few well-sized files → RaBitQ header amortized).
+* **Churn** (agent code-RAG, high trickle-write churn) — the HOT path is the in-memory mutable
+  AXIS index (ADR-061 D4); this layout is Churn's **durable tier only**, fed batched via the
+  memtable. It does not touch the hot write path.
+* **Graph / ORION** — edges are CSR, epoch-rebuilt (not this layout); node embeddings use the
+  vector layout under AppendBulk/Churn rules.
+
+**Write-path churn-tolerance (the key coupling):** the layout sits behind the existing
+`WAL → memtable → flush` seam (ADR-020). Trickling writes (agent codegraph, Churn) are absorbed
+by the in-memory memtable; a PAX file flushes only when the memtable crosses a threshold
+**co-designed with the file-count/GET-count knob** — flush at a size that amortizes the RaBitQ
+header and bounds file count, *not* on every small write. This prevents per-trickle file
+explosion + compaction thrash; the GET-budget compaction then merges accumulated files.
+PR1/PR2 must (a) confirm the flush threshold is sized for the new layout (not the old static
+block size), and (b) measure write amplification under a Churn/codegraph trickle-write trace.
 
 == Readability preservation
 
@@ -180,3 +210,13 @@ availability per backend; bloom FPP/sizing; readability during the docs→code w
   design refined across the planning iteration (logical-file unit, header-RaBitQ + Parquet
   footer-index, schema-snapshot, OID bloom + extensible StatsKind, self-derived geometry,
   GET-budget compaction, in-place/readability-preserving per ADR-061).
+* 2026-07-15 — spec-accuracy pass after the first review (Request changes): applied #3
+  (`read_ranges` is a sequential loop; GET win is the `ObjectRangeCoalescePolicy` plan),
+  #4 (`IopsBudget` is a new per-backend property, not the `StorageProfile` enum), #5
+  (`PaxSegmentScanner` at `proximadb-storage-common/src/pax_block.rs:887`), #6 (compaction CAS =
+  Iceberg fresh-name+manifest-swap via `put_if_absent`, ADR-020; no `if-match` yet). Refuted #1/#2
+  as stale-checkout false alarms (`cluster_order_pca_ivf`@`block_cluster.rs:198` + the
+  `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in are shipped #995/#1015). Added **D7** — workload-profile
+  applicability + write path (AppendBulk-optimal; Churn = in-memory AXIS hot path + durable-tier
+  memtable-buffered; graph edges = ORION epoch-rebuild; the memtable flush threshold is co-designed
+  with the file-count/GET-count knob for churn-tolerance). See ADR-062 §Review corrections.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -67,10 +67,10 @@ file-level header region. Six decisions:
 === D1 — The file is the atomic logical unit (no sidecar)
 
 One self-contained object per segment: RaBitQ region + data blocks + footer-index + magic.
-Object-store mechanisms (DR replication, lifecycle tiering, point-in-time versioning,
-conditional replace) all operate per-object, so a single logical file is operationally simpler
-than a 2-object RaBitQ sidecar and makes compaction/delete atomic (write-new + conditional
-swap). A collection accumulates 3-5 files LSM-style.
+Object-store mechanisms (DR replication, lifecycle tiering, point-in-time versioning, lifecycle
+delete) all operate per-object, so a single logical file is operationally simpler than a 2-object
+RaBitQ sidecar and makes compaction/delete a single-object operation (atomicity mechanics in D6).
+A collection accumulates 3-5 files LSM-style.
 
 === D2 — RaBitQ hoisted to a coalesced header region at offset 0; scan at keep=100%
 
@@ -99,12 +99,23 @@ SQ8/fp32/metadata/text is reused verbatim; only the RaBitQ stripe leaves the blo
 === D3 — Rerank does the candidate reduction (vector-level), reusing existing infra
 
 After the RaBitQ scan, select top-M survivors and fetch their SQ8(+metadata) block-stripes.
-Because survivors are **cluster-adjacent** (`cluster_order_pca_ivf` orders rows by
-IVF-cell-then-Hilbert/PC1), they fall in a handful of adjacent blocks → reuse the **existing**
-cross-block range planner `plan_selected_block_ranges` (`sst_query_engine.rs:733`) +
-`ObjectRangeCoalescePolicy` + `FileSystem::read_ranges` (`filesystem-types/lib.rs:507`,
-batched multi-range) → **few coalesced GETs**, not M scattered. fp32 finalized for top-k only.
-Net: ~1 RaBitQ GET/file (cached) + a few survivor GETs, vs today's ~4-5 × every selected block.
+Because survivors are **cluster-adjacent** — the row order is the compaction-grade PCA/IVF
+re-cluster `cluster_order_pca_ivf` (`src/storage/engines/sst/block_cluster.rs:198`, shipped
+#995; reachable at *flush* via the `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in, `block_cluster.rs:54`
++ the `write_pax_segment_full` branch at `segment_format.rs:183`, shipped #1015; measured in
+the 2026-07-15 eval) — they fall in a handful of adjacent blocks. D3's rerank-coalescing GET-win
+**depends on this clustered ordering being in effect**; PR1 therefore measures GETs *with the
+flush opt-in ON* (the shipped `cluster_order_pca_ivf`), and names S4 (calibrated IVF
+nlist/nprobe) a co-requisite if PR1's survivor locality is insufficient.
+
+The GET reduction itself comes from the **existing cross-block range planner**
+`plan_selected_block_ranges` (`sst_query_engine.rs:733`) + `ObjectRangeCoalescePolicy`
+(`sst_query_engine.rs:289`), which *plan* merged/coalesced ranges (fewer, larger reads) before
+any fetch. `FileSystem::read_ranges` (`filesystem-types/lib.rs:507`) only *executes* those
+planned ranges — its default impl is a sequential `for range { read_range }` loop, so the
+coalescing win is the policy's, not `read_ranges`' (a backend may override `read_ranges` to
+true batched/multipart as a follow-on). fp32 finalized for top-k only. Net: ~1 RaBitQ GET/file
+(cached) + a few coalesced survivor GETs, vs today's ~4-5 × every selected block.
 
 === D4 — Parquet-style self-describing footer-index; schema snapshot in v1
 
@@ -136,19 +147,56 @@ Block geometry **emerges** from dim × tier-composition × backend IOPS, not a s
 
 ```
  per_row_survivor_bytes = sq8(if present)·dim + fp32(if present)·4·dim + fixed_metadata   (RaBitQ excluded — it's in the header)
- block_bytes_target     = storage_profile.iops_target ∈ [iops_min, iops_max]              (backend-derived)
+ block_bytes_target     = iops_budget.target ∈ [iops_budget.min, iops_budget.max]         (backend-derived; see below)
  rows_per_block         = clamp( iops_target / per_row_bytes, ceil(iops_min/per_row), floor(iops_max/per_row) )
 ```
 
-`iops_min ≈ 512 KB`, `iops_target ≈ 2 MB`, `iops_max ≈ 8 MB` (S3/ABFS lean to 4 MB; MinIO/local
-to 512 KB-1 MB). A collection accumulates files LSM-style; **compaction triggers on a query
-GET-budget** (projected RaBitQ-GETs/query = file count, or file-count threshold 3-5). Compaction
-merges N→1: reads each file's RaBitQ (cheap), **re-clusters** the union, rewrites one file —
-**double duty**: fewer files (fewer GETs) AND tighter survivor locality. This reframes the WLP-7
-compaction scheduler as *the* vector-query GET-cost lever. Atomicity via single-object
-conditional replace (S3 `If-None-Match` / ABFS `If-None-Match`). Block-centroid pruning
-(TD-RDSTRAT-4/5) is retained only as an optional coarse pre-filter for monster collections where
-a cached RaBitQ scan would exceed RAM.
+The IOPS budgets (`iops_min ≈ 512 KB`, `iops_target ≈ 2 MB`, `iops_max ≈ 8 MB`; S3/ABFS lean
+to 4 MB, MinIO/local to 512 KB-1 MB) are a **NEW per-backend `IopsBudget` property** on the
+object-store/storage configuration — **not** the `StorageProfile` enum (`{AppendBulk, Churn}`,
+`storage_profile.rs:33`, which is a per-collection *workload* tag, ADR-061). PR1 introduces
+`IopsBudget` (the storage-profile crate is a reasonable home) keyed by backend; it is distinct
+from and does not modify the workload enum.
+
+A collection accumulates files LSM-style; **compaction triggers on a query GET-budget**
+(projected RaBitQ-GETs/query = file count, or file-count threshold 3-5). Compaction merges N→1:
+reads each file's RaBitQ (cheap), **re-clusters** the union, rewrites one file — **double duty**:
+fewer files (fewer GETs) AND tighter survivor locality. This reframes the WLP-7 compaction
+scheduler as *the* vector-query GET-cost lever. **Atomicity:** the object-store abstraction
+exposes only create-only `put_if_absent` today (`proximadb-object-store/src/lib.rs:247`; no
+`if-match`/`if-none-match` conditional replace yet), so compaction uses the **Iceberg-style
+fresh-name + atomic pointer/manifest advance** — write the new file under a fresh
+content-addressed name via `put_if_absent`, then atomically advance the WAL-authoritative
+manifest/pointer (ADR-020: the segment/footer is advisory, the WAL is authority). Native S3/ABFS
+conditional-replace (`if-match`) is a future optimization once the abstraction gains it.
+Block-centroid pruning (TD-RDSTRAT-4/5) is retained only as an optional coarse pre-filter for
+monster collections where a cached RaBitQ scan would exceed RAM.
+
+=== D7 — Workload-profile applicability + write path (AppendBulk-optimal; Churn/graph scoped)
+
+This layout is the **durable PAX-LSM segment format** — AppendBulk-optimal, applied
+per-workload-profile (ADR-061), so it never lands on a hot high-churn write path or a graph-edge
+path:
+
+* **AppendBulk** (bulk vector loads, RAG corpora) — direct fit: large-batch flushes → few,
+  well-sized files → RaBitQ header amortized; compaction merges occasionally.
+* **Churn** (agent code-RAG, high trickle-write churn) — the HOT read/write path is the
+  in-memory mutable AXIS index (ADR-061 D4) for immediate freshness; this layout is Churn's
+  **durable tier only**, fed batched. It does not touch the hot write path.
+* **Graph / ORION** — graph EDGES are CSR, epoch-rebuilt (not this layout); node EMBEDDINGS use
+  the vector layout under AppendBulk/Churn rules.
+
+**Write-path churn-tolerance:** the layout sits behind the existing **WAL → memtable → flush**
+seam (ADR-020: WAL is durable authority; the memtable buffers before flush). Trickling writes
+(agent codegraph, Churn) are absorbed by the in-memory memtable; a PAX file flushes only when
+the memtable crosses a threshold. That threshold is **co-designed with the file-count/GET-count
+knob** (D6): flush at a size that amortizes the RaBitQ header and bounds file count — *not* on
+every small write. This prevents per-trickle file explosion + compaction thrash; the GET-budget
+compaction (D6) then merges accumulated files. Graph-edge churn is ORION epoch-rebuild, separate.
+
+**Net:** SEARCH is served identically across profiles (the layout helps reads everywhere); the
+WRITE path is churn-tolerant via the memtable buffer + GET-budget compaction, and the layout is
+scoped so it is never on a per-trickle-write or per-graph-edge path.
 
 == First principles / rationale
 
@@ -226,8 +274,37 @@ bytes once the layout is in and measured; not v1.
    assumes catalog-only schema (ADR-047/048 interaction).
 . **GET-budget compaction trigger** — file-count threshold vs projected-GETs vs hybrid; tuning;
    write-amplification bounds.
-. **Conditional-write availability** — S3 `If-None-Match` (GA 2024) / ABFS for the compaction
-   CAS; fallback where unavailable.
+. **Compaction atomicity** — the object-store exposes only create-only `put_if_absent` today
+   (no `if-match` CAS); D6 specifies the Iceberg fresh-name + manifest-advance fallback
+   (ADR-020). Confirm that path is sound and that no compaction step assumes an object-level
+   conditional replace. (Native S3/ABFS `if-match` is a future optimization.)
 . **Bloom sizing** — FPP target + bits/elt for OID; per-block vs per-file; cost in the cached footer.
 . **Readability during the docs→code window** — in-place change is atomic per PR; the footer
    presence-field preserves legacy readability (ADR-061 amendment).
+
+== Review corrections (2026-07-15)
+
+Spec-accuracy pass after the first review (verdict: Request changes — decision sound, references
+to fix). Applied against **current** `develop` (which includes #995 `cluster_order_pca_ivf` and
+#1015 the `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in):
+
+* **#3 read_ranges attribution** — clarified that the GET win is the `ObjectRangeCoalescePolicy`
+  *planning* merged ranges; `FileSystem::read_ranges`'s default impl is a sequential loop that
+  only executes them (D3).
+* **#4 IOPS budget** — `iops_min/target/max` are a **new per-backend `IopsBudget`**, not the
+  `StorageProfile` `{AppendBulk, Churn}` workload enum (D6).
+* **#5 PaxSegmentScanner path** — corrected to `proximadb-storage-common/src/pax_block.rs:887`
+  (`PaxBlockWriter` remains in `proximadb-block-format/src/writer.rs:134`).
+* **#6 compaction atomicity** — the object-store has only create-only `put_if_absent` (no
+  `if-match` CAS); compaction uses Iceberg fresh-name + WAL-authoritative manifest advance
+  (ADR-020); native conditional-replace is future (D1, D6, open-question).
+
+Two review findings were **stale-checkout false alarms** (the review's own meta-note flagged its
+Explore agent read a pre-#995/#1015 checkout), verified present on current `develop`:
+* `cluster_order_pca_ivf` **exists** at `block_cluster.rs:198` (shipped #995) — not hallucinated.
+* `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` **exists** at `block_cluster.rs:54/56` + the
+  `write_pax_segment_full` branch at `segment_format.rs:183` (shipped #1015); the 2026-07-15
+  eval measured it. D3 now states the precise refs + that PR1 measures GETs with the opt-in ON.
+(Note: `block_cluster.rs:8-10` still calls IVF "the S4 upgrade" in the *module doc* while
+:16-17 references `cluster_order_pca_ivf` as shipped for compaction — a pre-existing source-doc
+inconsistency, separate cleanup, not a spec error.)


### PR DESCRIPTION
Follow-up to #1016 (the merged spec). Applies the spec-accuracy fixes from the first review (verdict: Request changes — decision sound) + a new D7 (workload-profile/write-path scoping raised in review). All verified against CURRENT develop.

## Applied (4 valid corrections, each verified in the code)
- **#3 `read_ranges` attribution** — the GET win is the `ObjectRangeCoalescePolicy` *planning* merged ranges; `FileSystem::read_ranges`'s default impl is a sequential `for` loop that only executes them (`filesystem-types/lib.rs:507`).
- **#4 IOPS budget** — `iops_min/target/max` are a **new per-backend `IopsBudget`**, NOT the `StorageProfile {AppendBulk,Churn}` workload enum (`storage_profile.rs:33`).
- **#5 `PaxSegmentScanner` path** — corrected to `proximadb-storage-common/src/pax_block.rs:887` (`PaxBlockWriter` stays in `proximadb-block-format/src/writer.rs:134`).
- **#6 compaction atomicity** — object-store has only create-only `put_if_absent` (`proximadb-object-store/src/lib.rs:247`), no `if-match` CAS; compaction uses Iceberg fresh-name + WAL-authoritative manifest advance (ADR-020); native conditional-replace is future.

## Refuted as stale-checkout false alarms
The review's own meta-note flagged its Explore agent read a **pre-#995/#1015 checkout**. Verified present on current develop:
- `cluster_order_pca_ivf` **@block_cluster.rs:198** (shipped #995).
- `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in **@block_cluster.rs:54** + the `write_pax_segment_full` branch **@segment_format.rs:183** (shipped #1015; measured by the 2026-07-15 eval).
D3 now states the precise refs + that PR1 measures GETs with the opt-in ON.

## Added D7 — workload-profile applicability + write path
The layout is **AppendBulk-optimal** and scoped per profile: **Churn**'s hot path is the in-memory AXIS index (this layout is Churn's durable tier only, memtable-buffered); **graph edges** are ORION epoch-rebuild (not this layout). The **memtable flush threshold is co-designed with the file-count/GET-count knob** so high-churn trickle writes (agent codegraph) don't cause per-write file explosion. PR1/PR2 must confirm the flush threshold is sized for the new layout + measure write-amp under a Churn/codegraph trace.

## Validation
`check_td_adr_unique.py` 0 errors · `check_td_status_consistency.py` pass · fmt clean · docs-only.