### PR TITLE
docs(adr): ADR-062 Accepted (review-approved) + TD-RDSTRAT-6 PR1-ratchet notes

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Spec'd** (full implementation spec, 2026-07-15). The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (Proposed → Accepted on review). This TD is the *what/how* for an implementer/reviewer. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
+| Status | **Spec'd + review-approved (ADR-062 Accepted, 2026-07-15).** The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (✅ Accepted — code PR1 may proceed). This TD is the *what/how* for an implementer. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
 | Severity | High — `per_get=20.0` is the dominant vector-route cost-model term; block-pruning is measured GET-capped (link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the eval]), so the GET lever is unreachable until this lands.
 | Component | `src/storage/engines/sst/segment_format.rs` (writer+reader); `crates/storage/proximadb-block-format/src/writer.rs::PaxBlockWriter` (`:134`) + `crates/storage/proximadb-storage-common/src/pax_block.rs::PaxSegmentScanner` (`:887`) + `stripe.rs::SegmentMeta`; `src/storage/engines/sst/search/mod.rs::try_pax_cascade`; `src/storage/engines/core/coalesce_strategy.rs` + `sst_query_engine.rs::{plan_selected_block_ranges (:733), ObjectRangeCoalescePolicy (:289)}`; `src/storage/engines/sst/compaction.rs`; `crates/storage/proximadb-storage-common` (a NEW per-backend `IopsBudget` — NOT the `StorageProfile` workload enum); `crates/storage/proximadb-storage-filesystem-types` (`FileSystem::read_ranges` — default is a sequential loop; the GET win is the coalesce policy's); `crates/storage/proximadb-object-store/src/lib.rs::put_if_absent` (`:247`, create-only — compaction CAS via Iceberg fresh-name+manifest-swap, ADR-020).
 | Relates | link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (decision), link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (rerank substrate), link:TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (gate), ADR-061 (pre-GA in-place/amend), ADR-046/045 (mixed-read/readability), ADR-036 (storage profile), ADR-020 (WAL authority; footer is advisory), ADR-047 (collection-as-table schema)
@@ -195,7 +195,14 @@ amendment sanctions.
 * **Recall + GET measurement** (the point): re-run `sift_voe_centroid_prune_compacted_recall_at_10_eval`
   against the new layout — expect recall@10 ≈ 0.99 at the keep=100% scan AND `range_gets`/query ≪
   ~370 (target low tens). Record into `BENCHMARK_EVIDENCE.toml`.
-* Compaction test: N→1 merge → fewer RaBitQ GETs/query + re-clustered tighter locality.
+  **Reviewer ratchet notes (PR1):** (a) run the SIFT GET measurement **with the IVF opt-in ON**
+  (`PROXIMADB_PAX_FLUSH_CLUSTER=ivf`) — D3's rerank-coalescing assumes `cluster_order_pca_ivf`
+  ordering; (b) **isolate the per-file "~1 RaBitQ GET" win on a compacted/single-file collection**
+  so it is not conflated with the PR2 GET-budget compaction win (the flush→compaction scheduler is
+  currently unwired — `segment_format.rs:185`).
+* Compaction test (PR2): N→1 merge → fewer RaBitQ GETs/query + re-clustered tighter locality.
+* PR2/PR3 follow-ups (not PR1 gates): footer-index sizing at scale (Q2); bloom FPP/sizing (Q6);
+  the schema-footer vs catalog-authority invariant (Q3).
 
 == Open questions for review
 
@@ -220,3 +227,10 @@ availability per backend; bloom FPP/sizing; readability during the docs→code w
   applicability + write path (AppendBulk-optimal; Churn = in-memory AXIS hot path + durable-tier
   memtable-buffered; graph edges = ORION epoch-rebuild; the memtable flush threshold is co-designed
   with the file-count/GET-count knob for churn-tolerance). See ADR-062 §Review corrections.
+* 2026-07-15 — **review-approved: ADR-062 → Accepted** (✅ Accept — code PR1 may proceed). The
+  re-review verified all 4 corrections + the 2 stale-checkout retractions against current develop
+  and answered all 7 open questions (header-first write + readability safe; compaction CAS sound).
+  Reviewer's two PR1-ratchet notes folded into §Verification: (a) run the SIFT GET measurement with
+  the IVF opt-in ON; (b) isolate the per-file "~1 RaBitQ GET" win on a compacted/single-file
+  collection so it isn't conflated with the PR2 compaction win. Footer/bloom sizing (Q2/Q6) and the
+  catalog-authority invariant (Q3) are PR2/PR3 follow-ups, not PR1 gates.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 = ADR-062: Coalesced RaBitQ-header + self-describing footer PAX layout — scan-then-rerank over the logical-file unit (TD-RDSTRAT-6)
 
-:status: Proposed (2026-07-15)
+:status: Accepted (2026-07-15, review-approved)
 :date: 2026-07-15
 :deciders: architecture
 :relates-to: ADR-061 (pre-GA "no back-compat, arm defaults" amendment — the in-place writer / readability-preserving reader reconciliation), ADR-052 (round-trips dominate the cost term), ADR-046/045 (PAX durable-core / mixed-read), ADR-036 (per-object access tier / storage profile), ADR-020 (WAL is the durable authority; the segment/footer is advisory), ADR-026 (PAX canonical vector path), link:../../10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6 (full spec)], link:../../10-quality/td/TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (the rerank substrate), link:../../10-quality/td/TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4]/link:../../10-quality/td/TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[5] (block-prune, superseded as the end-state), link:../../10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (the gate), link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the measured eval]
@@ -10,11 +10,17 @@
 
 == Status
 
-**Proposed** (2026-07-15), filed for comprehensive review (docs-only PR) before any code. On
-review sign-off → Accepted, and link:../../10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6]
-moves from Proposed to the full implementation spec. Implementation is a phased program
-(PR1 layout+read-path, PR2 cost-control, PR3 point-lookup); each slice default-ON for new
-writes, readability-preserving for already-written segments (per the ADR-061 pre-GA amendment).
+**Accepted** (2026-07-15, review-approved). A comprehensive review (against current `develop`,
+commits `f1075d46f` spec + `df8c0e591` spec-accuracy fixes) returned **✅ Accept — code PR1 may
+proceed**, after a Request-changes round whose 4 spec-accuracy fixes (#3 `read_ranges`
+attribution, #4 `IopsBudget` ≠ `StorageProfile`, #5 `PaxSegmentScanner` path, #6 compaction CAS
+via `put_if_absent`+Iceberg) were applied and verified; 2 stale-checkout false alarms
+(`cluster_order_pca_ivf`, `PROXIMADB_PAX_FLUSH_CLUSTER`) were retracted (both shipped #995/#1015).
+All 7 open questions answered (header-first write + readability confirmed safe; compaction
+atomicity sound). Implementation is a phased program (PR1 layout+read-path, PR2 cost-control,
+PR3 point-lookup); each slice default-ON for new writes, readability-preserving for already-written
+segments (per the ADR-061 pre-GA amendment). Reviewer's two PR1-ratchet notes folded into
+TD-RDSTRAT-6 §Verification.
 
 == Context
 

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -241,7 +241,7 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 
 | link:ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]
 | Coalesced RaBitQ-header + self-describing footer PAX layout — scan-then-rerank over the logical-file unit
-| Proposed (2026-07-15)
+| Accepted (2026-07-15, review-approved)
 | Dissolves the measured block-centroid-prune GET ceiling (TD-WLP-9 / the 2026-07-15 SIFT eval: block-prune is GET-capped at ~0.87 recall, not tunable). **D1** the file is the atomic logical unit (no RaBitQ sidecar — per-object DR/lifecycle/versioning/conditional-write stay atomic); **D2** RaBitQ hoisted to a coalesced header region @0, scanned at keep=100% (~0.99 recall, zero prune loss, cached/file) while SQ8/fp32/metadata/text blocks stay unchanged; **D3** rerank reuses the existing `plan_selected_block_ranges` + `read_ranges` (clustered survivors → few coalesced GETs); **D4** Parquet-style self-describing footer-index (schema snapshot + block table + per-stripe encoding map; encoding control in the footer, magic stays format-family); **D5** per-block OID bloom in v1 via an extensible `StatsKind` (point-lookup index; `MinMax` pushdown deferred, no format change); **D6** self-derived block geometry (dim × tier-composition × backend IOPS) + GET-budget compaction (file-count = query GET-count knob; the WLP-7 seam reframed). In-place writer + readability-preserving reader (footer presence-field) per the ADR-061 pre-GA amendment. Supersedes block-prune (TD-RDSTRAT-4/5) as the object-storage end-state; block-prune retained as optional coarse pre-filter. Implemented by TD-RDSTRAT-6; phased PR1 (layout+read-path) / PR2 (cost-control) / PR3 (point-lookup).
 |===
 


### PR DESCRIPTION
Records the spec review verdict. Re-review of the corrected spec (current develop df8c0e591) returned ✅ Accept — code PR1 may proceed: all 4 spec-accuracy fixes verified, the 2 stale-checkout false alarms retracted (cluster_order_pca_ivf + PROXIMADB_PAX_FLUSH_CLUSTER shipped #995/#1015), all 7 open questions answered (header-first write + readability safe; compaction CAS sound).

Bumps ADR-062 Proposed→Accepted (frontmatter, Status, README index). Folds the reviewer's two PR1-ratchet notes into TD-RDSTRAT-6 §Verification: (a) run the SIFT GET measurement with the IVF opt-in ON; (b) isolate the per-file ~1-RaBitQ-GET win on a compacted/single-file collection so it isn't conflated with the PR2 compaction win. Q2/Q6/Q3 are PR2/PR3 follow-ups, not PR1 gates.

Docs-only. Guards: td-adr-unique 0 errors; td-status-consistency pass; fmt clean.