### PR TITLE
docs(rdstrat): specify clustered residual bytes phase

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Spec'd + review-approved (ADR-062 Accepted, 2026-07-15).** The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (✅ Accepted — code PR1 may proceed). This TD is the *what/how* for an implementer. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
+| Status | **PR1 shipped (#1019, 2026-07-15); phased program remains active.** PR1 measured recall@10 `0.984`, `20` range GETs/query, and `31.7 MB` read/query. The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]. The deferred bytes phase is now specified by link:TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7]. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
 | Severity | High — `per_get=20.0` is the dominant vector-route cost-model term; block-pruning is measured GET-capped (link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the eval]), so the GET lever is unreachable until this lands.
 | Component | `src/storage/engines/sst/segment_format.rs` (writer+reader); `crates/storage/proximadb-block-format/src/writer.rs::PaxBlockWriter` (`:134`) + `crates/storage/proximadb-storage-common/src/pax_block.rs::PaxSegmentScanner` (`:887`) + `stripe.rs::SegmentMeta`; `src/storage/engines/sst/search/mod.rs::try_pax_cascade`; `src/storage/engines/core/coalesce_strategy.rs` + `sst_query_engine.rs::{plan_selected_block_ranges (:733), ObjectRangeCoalescePolicy (:289)}`; `src/storage/engines/sst/compaction.rs`; `crates/storage/proximadb-storage-common` (a NEW per-backend `IopsBudget` — NOT the `StorageProfile` workload enum); `crates/storage/proximadb-storage-filesystem-types` (`FileSystem::read_ranges` — default is a sequential loop; the GET win is the coalesce policy's); `crates/storage/proximadb-object-store/src/lib.rs::put_if_absent` (`:247`, create-only — compaction CAS via Iceberg fresh-name+manifest-swap, ADR-020).
 | Relates | link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (decision), link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (rerank substrate), link:TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (gate), ADR-061 (pre-GA in-place/amend), ADR-046/045 (mixed-read/readability), ADR-036 (storage profile), ADR-020 (WAL authority; footer is advisory), ADR-047 (collection-as-table schema)
@@ -67,8 +67,9 @@ Same segment magic/version as today; in-place writer + readability-preserving re
 4. `SegmentMeta` gains `rabitq_off/rabitq_len`; `pax_write_outcome` (`flush/mod.rs:970`) threads
    them into the VOE `IndexEntry`/footer so the read path finds the region.
 
-Same magic/version. Default-ON for new writes (ADR-061 pre-GA amendment: write-time internals
-replace predecessors).
+Same magic/version. PR1 shipped behind `PROXIMADB_PAX_COALESCED_RABITQ=1`, default OFF; readers
+remain mixed-read-safe. Later on-disk encodings stay independently default OFF until their
+recall/cost and readability ratchets pass.
 
 == Reader changes — scan-then-rerank
 
@@ -105,9 +106,15 @@ selected block.
 stats: [ per-column: { col_id, stats_kind: StatsKind, payload } ]
 enum StatsKind { None, BloomOid, MinMax, BloomOid_MinMax, … }   // add kinds, no format change
 ```
-v1: `BloomOid` (per-block OID bloom, no false negatives → `vector_by_id`/edge-by-oid skips to the
-one positive block — the point-lookup index). `MinMax` pushdown + bloom on other columns deferred
-(forward-compatible; unknown kinds skipped).
+PR1/v1 emits `StatsKind::None` with an empty payload. PR3 activates `BloomOid` (per-block OID
+Bloom, no false negatives → `vector_by_id`/edge-by-oid skips to the one positive block).
+`MinMax` pushdown + Bloom on other columns remain deferred.
+
+PR1 implemented the readable footer-v1 **core**: RaBitQ/row/dimension summary, legacy encoding
+summary, block extents, and an empty typed stats slot (`StatsKind::None`). The full schema,
+per-stripe map, per-column stats directory, and auxiliary-region references are additive typed
+sections specified by ADR-062 D4/D5 and TD-RDSTRAT-7. Missing sections use PR1/block-local
+metadata; explicit unknown data encodings fail closed rather than aliasing to SQ8.
 
 == Self-derived geometry
 
@@ -174,16 +181,19 @@ amendment sanctions.
 
 == Phased implementation (one coherent PR at a time)
 
-* **PR1 — layout + scan-then-rerank foundation (the GET win):** header-prefix + RaBitQ-head +
-  footer-index (block table + encoding map + schema snapshot) + scan-then-rerank read path
+* **PR1 — SHIPPED #1019, layout + scan-then-rerank foundation (the GET win):** header-prefix +
+  RaBitQ-head + footer-v1 core (block table + legacy encoding/schema summary + additive seams) +
+  scan-then-rerank read path
   (reuse `plan_selected_block_ranges`/`read_ranges` + unchanged block decoder) + self-derived
   geometry + in-place writer/reader + round-trip/detection tests + SIFT recall + GET measurement.
   Indivisible core.
 * **PR2 — cost control:** GET-budget compaction trigger (WLP-7 seam) + per-file RaBitQ/footer
   LRU cache (engine `DashMap` vs mmap residency).
 * **PR3 — point-lookup index:** per-block OID bloom (`StatsKind::BloomOid`) + `vector_by_id` fast path.
+* **Bytes phase — TD-RDSTRAT-7:** clustered-residual rerank encoding + additive schema/encoding/
+  stats footer sections; default OFF; end-to-end SIFT bytes + recall gate.
 * **Deferred (foundation anticipates):** schema-evolution semantics (TD-TBL-4/ADR-047); `MinMax`
-  pushdown; clustered SQ8/fp32 compression; within-cell Hilbert; text-as-variable-fetch; coarse
+  pushdown; within-cell Hilbert; text-as-variable-fetch; coarse
   VOE prune for monster collections; per-collection RaBitQ sidecar only if file-merging proves
   insufficient at extreme scale.
 
@@ -192,9 +202,9 @@ amendment sanctions.
 * Round-trip + format-detection tests (mirror `write_pax_segment_round_trips_through_reader`,
   `detection_defaults_to_legacy_and_guards_false_positives` in `segment_format.rs`).
 * `check_td_adr_unique.py` + `check_td_status_consistency.py`; `cargo check --lib` + clippy + fmt.
-* **Recall + GET measurement** (the point): re-run `sift_voe_centroid_prune_compacted_recall_at_10_eval`
-  against the new layout — expect recall@10 ≈ 0.99 at the keep=100% scan AND `range_gets`/query ≪
-  ~370 (target low tens). Record into `BENCHMARK_EVIDENCE.toml`.
+* **Recall + GET measurement — measured by PR1:** SIFT1M N=100k, single-file, IVF-ON reached
+  recall@10 `0.984`, `20` range GETs/query, and `31.7 MB` read/query; recorded in the dated
+  status artifact and `BENCHMARK_EVIDENCE.toml`.
   **Reviewer ratchet notes (PR1):** (a) run the SIFT GET measurement **with the IVF opt-in ON**
   (`PROXIMADB_PAX_FLUSH_CLUSTER=ivf`) — D3's rerank-coalescing assumes `cluster_order_pca_ivf`
   ordering; (b) **isolate the per-file "~1 RaBitQ GET" win on a compacted/single-file collection**
@@ -204,11 +214,11 @@ amendment sanctions.
 * PR2/PR3 follow-ups (not PR1 gates): footer-index sizing at scale (Q2); bloom FPP/sizing (Q6);
   the schema-footer vs catalog-authority invariant (Q3).
 
-== Open questions for review
+== Remaining questions
 
-(see ADR-062 §Open questions) — header-first write correctness; footer-index size at scale;
-schema-footer vs catalog authority; GET-budget compaction trigger tuning; conditional-write
-availability per backend; bloom FPP/sizing; readability during the docs→code window.
+See ADR-062 §Initial open questions and resolution. PR2 still owns GET-budget compaction tuning;
+PR3 owns measured Bloom sizing/FPP. TD-RDSTRAT-7 resolves the footer/schema/encoding seams for
+the bytes phase.
 
 == History
 
@@ -234,3 +244,6 @@ availability per backend; bloom FPP/sizing; readability during the docs→code w
   the IVF opt-in ON; (b) isolate the per-file "~1 RaBitQ GET" win on a compacted/single-file
   collection so it isn't conflated with the PR2 compaction win. Footer/bloom sizing (Q2/Q6) and the
   catalog-authority invariant (Q3) are PR2/PR3 follow-ups, not PR1 gates.
+* 2026-07-15 — PR1 #1019 landed and measured recall@10 `0.984`, `20` range GETs/query, and
+  `31.7 MB` read/query. Linked the active bytes phase TD-RDSTRAT-7 and reconciled the spec with
+  the shipped footer-v1 core/default-OFF gate; full typed footer sections are additive.

--- a/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
@@ -1,0 +1,442 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-7: clustered-residual PAX encoding — move the deferred bytes term
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+
+| Status
+| **Proposed implementation design (2026-07-15).** This is the deferred BYTES
+  phase of link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]
+  after PR1 (#1019) moved GETs. This document is the required codec/layout audit
+  and implementation contract; code follows in a separate TDD PR after this
+  design lands.
+
+| Severity
+| High — PR1 measured `bytes_read/query = 31.7 MB` at recall@10 `0.984` and
+  `range_gets/query = 20`. GETs moved 18.5x; bytes now carry the remaining
+  `per_mib_read=5` route-cost term.
+
+| Component
+| `crates/horizontal/proximadb-codec` (shared statistical codec);
+  `crates/storage/proximadb-block-format` (PAX stripes, `ColumnMeta`,
+  `VectorParamBlock`); `crates/storage/proximadb-storage-common/src/segment_layout.rs`
+  (segment footer-index); `src/storage/engines/sst/{block_cluster,segment_format}.rs`
+  (cluster producer and segment wiring); ProximaBlocks under
+  `src/storage/engines/core/formats/proximablocks/` (reuse audit/prior art only).
+
+| Relates
+| ADR-062 D2-D5; link:TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6]
+  PR1; ADR-047 (stable physical field IDs and catalog/footer authority);
+  ADR-061 (mixed-read and pre-GA default policy); TD-TBL-4 (full schema
+  evolution); TD-RDSTRAT-6 PR3 (OID Bloom activation).
+
+| Pillar
+| COST (bytes read), PERF (recall at fixed GETs), RELIABILITY (mixed-read-safe
+  storage format)
+|===
+
+toc::[]
+
+== Measured baseline and gate
+
+The SIFT1M N=100k, 100-query, single-file run with IVF ordering ON measured:
+
+[cols="1,1,1", options="header"]
+|===
+| Metric | PR1 baseline | This phase's gate
+
+| recall@10 | `0.984` | `>= 0.98`; ratchet only moves upward
+| range GETs/query | `20` | no material regression; bytes work must not undo PR1
+| bytes read/query | `31.7 MB` | **materially below 31.7 MB** at the recall gate
+|===
+
+The dated source is
+link:../../_internal/status/SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc[SIFT1M coalesced-RaBitQ evidence]
+and claim `coalesced_rabitq_scan_rerank_sift` in
+`docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml`.
+
+Kernel compression ratios and codec microbenchmarks are diagnostic only. The
+headline is the end-to-end query counter under the same single-file, IVF-ON
+protocol because range over-read, codebook bytes, footer bytes, and survivor
+locality all contribute to the actual route-cost term.
+
+== Settled constraints inherited from ADR-062
+
+* Keep the coalesced RaBitQ region at the fixed header offset. It is the first,
+  unconditional, self-sufficient query step; moving it behind the footer adds a
+  serialized object-store GET.
+* Clustering reduces GETs through survivor locality but does not compress SQ8 or
+  RaBitQ codes by itself. Bytes move only through a statistical encoding whose
+  model is fitted to the clustered distribution.
+* Object-store-first remains the durable cost spine (`per_get` remains greater
+  than `per_mib_read`). This phase must preserve the PR1 GET win.
+* The survivor-fetch block is sized by `IopsBudget`; the cached RaBitQ region is
+  sized by `dimension * file_rows`. They are independent controls.
+* Storage-format additions are mixed-read-safe and default OFF. The reader never
+  assumes that a new encoding is present.
+
+== Audit: one codec engine, two physical layouts
+
+ProximaBlocks and PAX are not the same block format. Reuse occurs below their
+layout boundary.
+
+[cols="1,2,2,2", options="header"]
+|===
+| Area | Already implemented | Reuse decision | Not reused as-is
+
+| Shared codec (`proximadb-codec`)
+| Stable `ProximaScheme` markers; SQ8 fitting/encode/decode; RaBitQ;
+  bit-packing; frame-of-reference; PFor-delta; delta/RLE/dictionary and
+  vector-base-XOR primitives
+| Implement clustered-residual quantization here. Register one canonical
+  scheme marker and expose explicit parameter-bearing APIs, as SQ8/RaBitQ do.
+| The generic scalar dispatcher deliberately rejects SQ8/RaBitQ because their
+  parameters belong to the surrounding vector layout. Clustered residuals use
+  the same explicit-parameter pattern.
+
+| ProximaBlocks (row/legacy layout)
+| Row/block compression configuration; block and per-dimension compression;
+  byte-compression algorithms and markers; metadata dictionary/delta/RLE prior
+  art
+| Mine policy and codec-composition prior art. A later ProximaBlocks consumer
+  may call the shared clustered-residual codec without sharing PAX bytes.
+| Do not import ProximaBlocks wire markers or revive layout-specific compression
+  branches in the PAX PR. Its outer byte compression is not a residual vector
+  codebook.
+
+| PAX block format
+| `ColumnMeta { column_id, role, data_type_id, encoding_id, min/max,
+  distinct_hint, bloom offset/len }`; stable codec marker per stripe;
+  `VectorParamBlock` for block-local vector parameters; optional footer-resident
+  Bloom bytes; fixed-stride vector stripes
+| Extend the PAX quantization kind and the versioned parameter side-region for
+  residual run directories/codebooks. Lift existing `ColumnMeta` into the
+  segment footer index instead of recomputing statistics.
+| Do not place centroids/scales in the segment encoding map: that would make a
+  block decode depend on the segment tail and duplicate block-local authority.
+
+| Foundation Bloom crate
+| Sized Bloom strategies, serialization, approximately 10 bits/key defaults,
+  and membership APIs
+| Reuse its sizing/hash concepts after making the chosen durable Bloom payload
+  deterministic and explicitly versioned.
+| Current factory creation always selects `ByteAligned` regardless of requested
+  strategy, and `BitPacked` chooses a random seed. Do not silently adopt either
+  behavior as the PAX durable contract.
+
+| Current PAX string Bloom
+| Deterministic small footer Bloom and reader membership check
+| Reuse the block-local `ColumnMeta` pointer seam and conservative no-false-
+  negative behavior.
+| Its fixed 32-byte payload saturates at useful OID block cardinalities; it is
+  not the scalable OID Bloom specified by ADR-062 D5.
+|===
+
+Conclusion: no existing clustered-residual vector codec is available to revive.
+The implementation adds the missing statistical codec once in
+`proximadb-codec`; PAX is its first physical-layout consumer.
+
+== Footer model: schema, encoding, statistics, and parameters have distinct roles
+
+The segment remains four-layered:
+
+[cols="1,3", options="header"]
+|===
+| Layer | Authority and contents
+
+| Header prefix
+| Offsets required to scan RaBitQ with zero metadata dependency. No schema,
+  encoding parameters, or Bloom payloads.
+
+| Segment footer-index
+| Immutable physical snapshot for this file: schema snapshot, block extents,
+  stripe encoding declarations, typed statistics descriptors, and auxiliary
+  region references. It lets a reader plan reads without decoding every block.
+
+| PAX block footer/side regions
+| `ColumnMeta` and codec parameters required to decode that block, including
+  residual run boundaries, centroids, and scales. A fetched block remains
+  independently decodable.
+
+| Catalog
+| Logical schema and write authority. Defaults, comments, indexes, catalog
+  object IDs, and mutable properties stay here; they are not copied into every
+  segment.
+|===
+
+This follows Parquet's useful separation: file metadata plans physical access;
+column/page-local metadata decodes bytes; optional indexes/Blooms may be ignored.
+It does not copy Parquet Thrift structures into PAX.
+
+=== Additive footer extension envelope
+
+PR1 footer v1 emits a fixed core and its parser stops after the declared block
+entries. It intentionally tolerates trailing bytes. Preserve that readable core
+and append an independently framed extension:
+
+```
+[PR1 footer-v1 core]
+[extension payload:
+   ext_version:u8
+   section_count:u16
+   repeated { section_tag:u8, section_version:u8, section_len:u32, bytes[] }]
+[extension_len:u32]
+[PXE1:4B]
+```
+
+Rules:
+
+* No segment-magic, header-layout, or footer-version bump for these additive
+  sections. `PXE1` frames only the optional footer extension.
+* An old PR1 reader parses the v1 core and ignores the trailing extension.
+* A new reader first parses the v1 core, then recognizes `PXE1`, validates all
+  lengths with checked arithmetic, and skips unknown section tags/versions.
+* Missing extension means the exact PR1 interpretation. A malformed recognized
+  extension is an error, not a legacy fallback.
+* Section order is deterministic on write; readers do not depend on order.
+
+Initial section tags are `SchemaSnapshot`, `StripeEncodingMap`,
+`BlockColumnStats`, and `AuxRegionDirectory`. Tags are stable; each section owns
+its own version.
+
+=== SchemaSnapshot section
+
+The snapshot is the minimum physical schema needed to interpret the segment:
+
+```
+schema_fingerprint:u64
+schema_version:u32
+fields[] {
+  field_id:i32, physical_column_id:i32, ordinal:u32,
+  name:utf8, physical_type:u8, logical_type:versioned-bytes,
+  nullable:bool, role:u8
+}
+```
+
+`CatalogColumn.id` is the stable Parquet/PAX physical field identity and is the
+reconciliation key across rename/reorder. `object_id` is a catalog surrogate and
+must not be serialized as the PAX field ID. The footer excludes defaults,
+comments, indexes, and arbitrary properties. Unknown logical-type annotations
+do not change the physical decoder; unknown physical types fail closed.
+
+RaBitQ, residual-rerank, and exact-f32 are physical tiers of one logical vector
+field. They are entries in the encoding map, not three logical schema fields.
+Full multi-version schema reconciliation remains TD-TBL-4/ADR-047.
+
+=== StripeEncodingMap section
+
+Replace the singular PR1 `embed_quant_tag` as the new reader's control plane;
+retain that byte in the v1 core as the legacy/default summary.
+
+```
+entries[] {
+  logical_field_id:i32,
+  physical_column_id:i32,
+  tier_role:u8,              // index | rerank | exact | metadata
+  codec_tag:u8,              // stable ProximaScheme marker
+  codec_version:u8,
+  compression_tag:u8,
+  parameter_scope:u8,        // none | segment | block | cluster-run
+  flags:u16
+}
+```
+
+Compatibility is asymmetric by design:
+
+* Extension/map absent: use the PR1/block-local `VectorParamBlock` path; legacy
+  SQ8 remains readable.
+* Known codec tag: dispatch the declared decoder and validate its version/scope.
+* Explicit unknown codec tag/version: never reinterpret its bytes as SQ8.
+  Either use an independently declared exact tier when the caller permits that
+  fallback, or return an unsupported-encoding error.
+* Unknown compression tag on a required stripe also fails closed.
+
+Optional metadata is skippable; an unknown data encoding is not. This is the
+same compatibility distinction that keeps Parquet Bloom additions benign while
+new encodings require reader support.
+
+=== BlockColumnStats and optional Bloom payloads
+
+The segment footer indexes existing block-local statistics by stable column ID:
+
+```
+stats[] {
+  block_ordinal:u32,
+  column_id:i32,
+  stats_kind:u8,
+  stats_version:u8,
+  payload_ref:{ region_id:u16, offset:u32, len:u32 }
+}
+```
+
+`ColumnMeta` remains the producer of min/max, null count, distinct hint, and
+Bloom presence. The segment writer lifts these values; it does not run a second
+statistics implementation.
+
+Large Bloom/statistics bytes live in a contiguous auxiliary metadata region and
+are addressed through `AuxRegionDirectory`, analogous to Parquet column-chunk
+Bloom `offset + length`. Small fixed stats may be inline in a later section
+version. The core footer stays bounded and cacheable.
+
+The OID Bloom payload contract, when activated by TD-RDSTRAT-6 PR3, is
+deterministic and self-describing:
+
+```
+bloom_version:u8 | hash_algorithm:u8 | hash_seed:u64 |
+num_hashes:u8 | bit_count:u32 | inserted_count:u32 | bits[]
+```
+
+Target sizing starts near 10 bits/key (approximately 1% false-positive rate) and
+is measured by block cardinality. A missing/unknown Bloom or a failed optional
+Bloom decode means "may contain"; no point lookup may be skipped unless a known,
+valid filter proves absence. Bloom activation is not required for the BYTES
+headline, but the typed slot and auxiliary-region framing land now so PR3 does
+not redesign the footer.
+
+== Clustered-residual rerank encoding
+
+=== Tier composition
+
+Under the opt-in, clustered residual **replaces** the flat SQ8 rerank stripe:
+
+```
+RaBitQ header index -> clustered-residual rerank -> optional exact f32
+```
+
+Keeping both residual and flat SQ8 would spend additional bytes without adding
+a new accuracy level. Flat SQ8 remains a per-block fallback encoding and the
+only encoding for legacy/default-OFF writes.
+
+=== Producer and granularity
+
+Refactor `cluster_order_pca_ivf` to expose the fitted plan instead of discarding
+assignments after returning a permutation:
+
+```
+ClusterPlan { order, runs[] { cluster_id, ordered_start, row_count } }
+```
+
+The existing permutation-only function remains as a compatibility wrapper.
+Writer and codec consume the same plan, so row order and codebook boundaries
+cannot drift.
+
+Granularity is **one codebook per contiguous IVF cluster-run intersecting a PAX
+block**. A PAX block remains the survivor-fetch/IopsBudget unit; an IVF cluster
+is the statistical model. Neither is forced to equal the other. A block may
+contain several run fragments, and a cluster may cross blocks. Each block stores
+the codebook needed for its local fragment, preserving independent decoding.
+
+=== Initial codec contract
+
+The first implementation is versioned `ClusteredResidualSq4/v1`:
+
+* fit a full-dimensional f32 centroid per local cluster-run;
+* compute residual `x - centroid`;
+* fit a symmetric f32 scale per dimension from the local absolute residual
+  range;
+* quantize each residual to signed 4-bit values and pack two nibbles per byte;
+* reconstruct `centroid + code * scale` for rerank distance.
+
+The shared codec API accepts vectors plus explicit run boundaries and returns
+codes plus codebooks. It validates dimension, row/run coverage, finite inputs,
+and packed lengths with `Result`; it does not infer clusters independently.
+
+For 128 dimensions, codes cost 64 bytes/row. A centroid plus per-dimension scale
+costs 1024 bytes/run; at 128 rows/run this amortizes to 8 bytes/row, for an
+estimated 72 bytes/row versus flat SQ8's 128 bytes/row (about 44% smaller before
+headers). This estimate is not evidence. Runs that are too small or fail a
+minimum realized-saving threshold fall back to flat SQ8 for that block.
+
+The encoding map declares the block's chosen codec; block-local parameters live
+in a versioned `VectorParamBlock` extension. Mixed codec blocks in one segment
+are permitted.
+
+=== Opt-in and fallback
+
+Writer gate: `PROXIMADB_PAX_CLUSTERED_RESIDUAL_SQ4=1`, default OFF. It is
+effective only when the coalesced RaBitQ layout and IVF cluster plan are present.
+Otherwise the writer emits flat SQ8 and declares SQ8 in the encoding map.
+
+Fallback is selected at write time for missing plans, inconsistent dimensions,
+non-finite training values, undersized runs, or insufficient realized savings.
+Once a block explicitly declares residual bytes, decode errors fail closed; the
+reader does not guess that the payload was SQ8.
+
+The PR1 coalesced-RaBitQ default flip, if desired, is a sibling change. Keeping
+it separate isolates the bytes A/B result; the residual encoding itself remains
+OFF until its recall and bytes gates are accepted.
+
+== TDD implementation sequence
+
+The code PR proceeds in this order; each production slice starts from a failing
+test.
+
+. Footer extension tests: legacy PR1 body/no extension; full section round-trip;
+  unknown optional section skip; malformed/truncated extension fail; explicit
+  unknown required codec fail.
+. Shared codec tests: deterministic encode; exact wire round-trip; dimension/run
+  validation; odd nibble count; error bound; clustered recall-tolerance fixture;
+  realized-size accounting and flat-SQ8 fallback threshold.
+. PAX block tests: residual parameter side-region round-trip; block independent
+  decode; mixed SQ8/residual blocks; ranged reader parity; unknown quant kind
+  fail closed.
+. Segment tests: schema/encoding/stats sections are emitted from actual block
+  metadata; missing extension reads PR1; gate OFF writes SQ8; gate ON with IVF
+  writes residual; legacy and new segments coexist in one query.
+. SIFT eval: same N=100k, 100-query, single-file, IVF-ON protocol; compare OFF
+  and ON in one run; assert recall floor `>= 0.98`, GET non-regression, and a
+  ratcheted bytes/query ceiling materially below `31.7 MB`.
+
+Lossy recall is an evaluation gate, not a unit test disguised as correctness.
+Unit tests constrain codec error and deterministic behavior; the ignored SIFT
+evaluation validates ranking quality against f32 ground truth.
+
+== Scope boundaries and follow-ons
+
+Included in the implementation PR:
+
+* shared clustered-residual codec and stable tag;
+* cluster-plan reuse;
+* PAX writer/reader and block-local codebooks;
+* additive footer sections for schema, encodings, stats descriptors, and aux
+  region references;
+* default-OFF mixed-read gate, tests, SIFT evidence, and ledger claim.
+
+Not included:
+
+* actual OID Bloom population/query routing (TD-RDSTRAT-6 PR3);
+* metadata delta/RLE activation beyond registering the compression field;
+* ProximaBlocks wire-format conversion;
+* GET-budget compaction and per-file RaBitQ region-cache feedback (PR2);
+* full schema-evolution reconciliation (TD-TBL-4).
+
+The per-file RaBitQ cache cap may later feed the compaction controller as the
+upper bound on file size, while the query GET budget supplies the lower bound on
+file size. This file-count/region-size band is real but orthogonal to the
+survivor-block codec and is not tuned in the bytes PR.
+
+== Definition of done
+
+* This audit/design and the ADR-062 D4/D5 amendment land before code.
+* A canonical clustered-residual codec tag is registered; no segment magic bump.
+* Footer schema/encoding/stats sections round-trip and old PR1 readers can ignore
+  them.
+* Missing map reads legacy SQ8; explicit unknown data encoding never aliases to
+  SQ8.
+* Encoding is default OFF and mixed-read-safe.
+* Unit, block, segment, ranged-read, and recall-tolerance coverage passes.
+* SIFT1M N=100k single-file IVF-ON records recall@10 `>= 0.98`, GET
+  non-regression, and bytes/query materially below `31.7 MB` in a dated artifact
+  and `BENCHMARK_EVIDENCE.toml`.
+* All repository format, clippy/check, server-binary, TD uniqueness, attribution,
+  and work-commit guards pass before the implementation PR targets `develop`.
+
+== History
+
+* 2026-07-15 — filed after PR1 #1019 landed. Audit established one shared codec
+  engine/two layouts; selected residual-as-rerank-replacement, per-cluster-run
+  codebooks local to each PAX block, additive footer TLV sections, typed optional
+  Bloom references, and fail-closed unknown encoding behavior.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -5,7 +5,7 @@
 :status: Accepted (2026-07-15, review-approved)
 :date: 2026-07-15
 :deciders: architecture
-:relates-to: ADR-061 (pre-GA "no back-compat, arm defaults" amendment — the in-place writer / readability-preserving reader reconciliation), ADR-052 (round-trips dominate the cost term), ADR-046/045 (PAX durable-core / mixed-read), ADR-036 (per-object access tier / storage profile), ADR-020 (WAL is the durable authority; the segment/footer is advisory), ADR-026 (PAX canonical vector path), link:../../10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6 (full spec)], link:../../10-quality/td/TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (the rerank substrate), link:../../10-quality/td/TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4]/link:../../10-quality/td/TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[5] (block-prune, superseded as the end-state), link:../../10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (the gate), link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the measured eval]
+:relates-to: ADR-061 (pre-GA mixed-read/default policy), ADR-052 (round-trips dominate the cost term), ADR-047/046/045 (schema authority / PAX durable-core / mixed-read), ADR-036 (per-object access tier / storage profile), ADR-020 (WAL is the durable authority; the segment/footer is advisory), ADR-026 (PAX canonical vector path), link:../../10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6 (GET phase)], link:../../10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7 (bytes/footer phase)], link:../../10-quality/td/TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (the rerank substrate), link:../../10-quality/td/TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4]/link:../../10-quality/td/TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[5] (block-prune, superseded as the end-state), link:../../10-quality/td/TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (the gate), link:../../_internal/status/SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc[the PR1 measured eval]
 :supersedes: the *block-centroid-prune* path (TD-RDSTRAT-4 Lever B / TD-RDSTRAT-5) as the **end-state for the dominant object-storage cost term** (GET round-trips). Block-prune is retained only as an optional coarse pre-filter for monster collections (§Decision D6).
 
 == Status
@@ -16,11 +16,11 @@ proceed**, after a Request-changes round whose 4 spec-accuracy fixes (#3 `read_r
 attribution, #4 `IopsBudget` ≠ `StorageProfile`, #5 `PaxSegmentScanner` path, #6 compaction CAS
 via `put_if_absent`+Iceberg) were applied and verified; 2 stale-checkout false alarms
 (`cluster_order_pca_ivf`, `PROXIMADB_PAX_FLUSH_CLUSTER`) were retracted (both shipped #995/#1015).
-All 7 open questions answered (header-first write + readability confirmed safe; compaction
-atomicity sound). Implementation is a phased program (PR1 layout+read-path, PR2 cost-control,
-PR3 point-lookup); each slice default-ON for new writes, readability-preserving for already-written
-segments (per the ADR-061 pre-GA amendment). Reviewer's two PR1-ratchet notes folded into
-TD-RDSTRAT-6 §Verification.
+All 7 initial open questions were answered (header-first write + readability confirmed safe;
+compaction atomicity sound). Implementation is a phased program: PR1 (#1019) shipped the
+layout+read-path behind an opt-in and measured the GET win; PR2 is cost-control; PR3 is
+point-lookup. New on-disk encodings remain default-OFF until their mixed-read + recall/cost
+ratchets pass. Reviewer's two PR1-ratchet notes are folded into TD-RDSTRAT-6 §Verification.
 
 == Context
 
@@ -123,17 +123,50 @@ coalescing win is the policy's, not `read_ranges`' (a backend may override `read
 true batched/multipart as a follow-on). fp32 finalized for top-k only. Net: ~1 RaBitQ GET/file
 (cached) + a few coalesced survivor GETs, vs today's ~4-5 × every selected block.
 
-=== D4 — Parquet-style self-describing footer-index; schema snapshot in v1
+=== D4 — Parquet-style self-describing footer-index; additive typed sections
 
 The footer-index is the metadata hub: **schema snapshot** (field-ids, types, column order —
 self-describing; catalog stays the write authority, footer is the segment's physical
 self-description), block offset table, per-block per-column **stats**, per-stripe **encoding
 map**, rabitq_off/len, row_count. **Encoding control lives in the footer** (Parquet-style),
-not in magic bytes — magic stays format-family-only. Full schema-*evolution* (field-ID
-reconciliation, complex types) is the follow-on (TD-TBL-4 / ADR-047); v1 embeds the snapshot so
-that follow-on is additive.
+not in segment magic — magic stays format-family-only.
 
-=== D5 — Per-block stats: OID bloom in v1, extensible `StatsKind` (min/max deferred)
+PR1's footer-v1 core is the readability base: RaBitQ extent mirror, row/dimension summary,
+legacy `embed_quant_tag`, f32-presence flag, and block extents. Its parser stops after the
+declared block entries and tolerates trailing bytes. Later phases append a framed, versioned
+section envelope after that core:
+
+```
+[footer-v1 core][typed sections][extension_len:u32][PXE1]
+section = { tag:u8, version:u8, len:u32, payload }
+```
+
+Initial sections are `SchemaSnapshot`, `StripeEncodingMap`, `BlockColumnStats`, and
+`AuxRegionDirectory`. Old PR1 readers ignore the envelope; new readers skip unknown optional
+sections after validating lengths. A malformed recognized envelope fails closed. This is an
+additive footer extension, not a segment-magic/header/footer-version bump.
+
+The schema snapshot contains the immutable physical facts required to interpret the file:
+schema fingerprint/version and ordered fields `{ CatalogColumn.id (stable physical field-id),
+physical_column_id, name, physical/logical type, nullable, role }`. Catalog `object_id`,
+defaults, comments, indexes, and mutable properties remain catalog-only. Tier stripes
+(RaBitQ index, residual/SQ8 rerank, exact f32) are physical representations of one logical
+vector field and therefore belong in the encoding map, not as duplicate logical schema
+fields. Full schema-*evolution* reconciliation remains TD-TBL-4 / ADR-047.
+
+The footer encoding map declares `{ logical_field_id, physical_column_id, tier_role,
+codec_tag, codec_version, compression_tag, parameter_scope }`. `codec_tag` is the stable
+shared `ProximaScheme` marker. Codec parameters needed to decode one PAX block remain in that
+block's `VectorParamBlock`, so a fetched block is self-sufficient and the segment footer does
+not duplicate codebooks.
+
+Compatibility distinguishes absent metadata from unknown data bytes: a missing extension/map
+uses the PR1 block-local SQ8 path, but an explicitly unknown codec/version is never
+reinterpreted as SQ8. The reader may use an independently declared exact tier when the caller
+permits it; otherwise it returns unsupported-encoding. Unknown optional metadata sections may
+be ignored.
+
+=== D5 — Per-block stats: typed slot in v1; optional OID Bloom activation in PR3
 
 The footer block-table carries an optional, tagged, per-block per-column stats entry:
 
@@ -142,10 +175,22 @@ The footer block-table carries an optional, tagged, per-block per-column stats e
  enum StatsKind { None, BloomOid, MinMax, BloomOid_MinMax, … }   // extensible, no format change
 ```
 
-v1: `BloomOid` (per-block OID bloom, no false negatives → `vector_by_id`/edge-by-oid skips to
-the one positive block — the *point-lookup* index, complementary to the RaBitQ *vector-search*
-index). `MinMax` zone-map pushdown and bloom on other columns are deferred, added as new
-`StatsKind` values (forward-compatible; unknown kinds skipped).
+PR1 emits `StatsKind::None` and zero payload length; it reserves the typed slot. PR3 activates
+`BloomOid` (per-block OID Bloom, no false negatives → `vector_by_id`/edge-by-oid skips to the
+one positive block — the *point-lookup* index, complementary to the RaBitQ *vector-search*
+index). `MinMax` zone-map pushdown and Bloom on other columns are deferred, added as new
+`StatsKind` values.
+
+The segment-level stats directory is keyed by `{block_ordinal, stable column_id}` and is lifted
+from the existing PAX block `ColumnMeta`; it does not run a second stats producer. Large Bloom
+and statistics payloads live in a contiguous auxiliary metadata region referenced by
+`{region_id, offset, length}`, analogous to Parquet's optional column-chunk Bloom
+offset+length. This bounds the cache-hot footer control plane. Bloom payloads carry their own
+version, hash algorithm/seed, hash count, bit count, inserted count, and bits. Start sizing at
+approximately 10 bits/key (~1% target false-positive rate), then measure by block cardinality.
+Unknown/missing/corrupt optional Bloom metadata degrades conservatively to "may contain"; it
+must never create a false-negative skip. TD-RDSTRAT-7 lands the directory/envelope; PR3 owns
+population and point-lookup routing.
 
 === D6 — Self-derived block geometry; GET-budget compaction (file-count = GET-count knob)
 
@@ -204,6 +249,28 @@ compaction (D6) then merges accumulated files. Graph-edge churn is ORION epoch-r
 WRITE path is churn-tolerant via the memtable buffer + GET-budget compaction, and the layout is
 scoped so it is never on a per-trickle-write or per-graph-edge path.
 
+=== D8 — Clustered statistical encoding moves bytes; clustering alone does not
+
+PR1 (#1019) validates the separation of levers: SIFT1M N=100k, single-file, IVF-ON measured
+recall@10 `0.984`, `20` range GETs/query (18.5x fewer), but `31.7 MB` read/query. Reordering
+near-max-entropy SQ8/RaBitQ codes makes survivors contiguous but does not compress those codes.
+The bytes term moves through link:../../10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7]:
+a per-IVF-cluster-run residual model, encoded by the shared codec and consumed first by PAX.
+
+Under the default-OFF gate, clustered-residual rerank **replaces** flat SQ8 for an eligible
+block; it does not sit beside SQ8 as another permanently fetched tier. The pipeline is
+`RaBitQ header index -> residual rerank -> optional exact f32`. Flat SQ8 remains the legacy and
+write-time fallback. Codebook granularity follows contiguous IVF cluster-runs intersecting a
+PAX block: cluster is the statistical model, block is the IOPS/range-read unit. Each block
+stores the parameters needed for its local run fragments, preserving independent decode.
+
+The initial implementation is versioned four-bit symmetric per-dimension residual
+quantization (centroid + per-dimension scale per run). Small runs, missing IVF plans,
+inconsistent dimensions, non-finite inputs, or insufficient realized byte savings fall back
+to flat SQ8 and are declared as such in the encoding map. Lossy activation requires an
+end-to-end SIFT gate: bytes/query materially below `31.7 MB`, recall@10 `>= 0.98`, and no
+material regression from PR1's GET result. Codec microbenchmarks are not headline evidence.
+
 == First principles / rationale
 
 * **Move the dominant cost term.** On object storage GET round-trips dominate (`per_get=20 ≫
@@ -233,15 +300,16 @@ segments (DR, external-tool inspection, debugging); a point-lookup index (OID bl
 in the same footer; block geometry self-tunes to dim/composition/backend; the compaction
 scheduler becomes the query-cost knob.
 
-*Negative / costs:* a format change (in-place per ADR-061's pre-GA amendment — writer changes
-default-on; reader retains a footer presence-field fallback to read legacy RaBitQ-in-block
-segments, so on-disk *readability* is preserved); footer-index grows with block count +
-blooms (cap/region layout needed at scale — open question); LSM write-amplification from
-file-merging compaction; a cold query pays one footer-index GET before the scan (cached after).
+*Negative / costs:* a format change behind an opt-in; the reader retains a footer
+presence-field fallback for legacy RaBitQ-in-block segments, so on-disk *readability* is
+preserved. Footer metadata grows with block/column count, hence large optional payloads use a
+separate referenced auxiliary region. LSM file-merging adds write amplification. A cold query
+may pay a footer-index GET to plan survivor data reads, but the fixed-offset RaBitQ scan never
+depends on that footer GET and can proceed independently.
 
-*Co-design cost-term note:* this moves GETs (dominant). Bytes move secondarily and are the
-deferred lever — clustered SQ8/fp32 statistical compression (per-block residual/codebook) cuts
-bytes once the layout is in and measured; not v1.
+*Co-design cost-term note:* PR1 moved GETs (dominant). TD-RDSTRAT-7 is the separately gated
+bytes lever; it reuses the same IVF producer for per-cluster-run residual codebooks while
+leaving RaBitQ at the header.
 
 == Alternatives considered
 
@@ -257,6 +325,12 @@ bytes once the layout is in and measured; not v1.
   Rejected; RaBitQ pinned at head (D2).
 * **Per-encoding magic/version bumps** — rejected; encoding control lives in the footer's
   per-stripe encoding map + extensible `StatsKind` (Parquet-style).
+* **Unknown encoding -> assume SQ8** — rejected. Absence of the new map means the legacy SQ8
+  path; an explicit unknown codec describes bytes the reader cannot safely interpret and must
+  fail closed (or use an independently declared exact tier).
+* **Residual beside flat SQ8** — rejected for the normal rerank path because both would be
+  fetched for the same accuracy stage. Eligible blocks replace SQ8; ineligible blocks declare
+  SQ8 as their write-time fallback.
 * **Cap files at 1 (force compaction)** — rejected; LSM-accumulate 3-5, compact on a GET-budget
   (D6), so file-count = the GET-count knob without over-compacting.
 
@@ -264,29 +338,32 @@ bytes once the layout is in and measured; not v1.
 
 * Round-trip + format-detection unit tests (mirror `write_pax_segment_round_trips_through_reader`).
 * `check_td_adr_unique.py` + `check_td_status_consistency.py`.
-* **Recall + GET measurement** (the point): re-run
-  `sift_voe_centroid_prune_compacted_recall_at_10_eval` against the new layout — expect
-  recall@10 ≈ 0.99 at the keep=100% scan AND `range_gets`/query ≪ ~370. Record into
-  `BENCHMARK_EVIDENCE.toml`.
+* **PR1 result (measured):** SIFT1M N=100k, single-file, IVF-ON reached recall@10 `0.984`,
+  `20` range GETs/query, and `31.7 MB` read/query; recorded in
+  `SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc` and `BENCHMARK_EVIDENCE.toml`.
+* **TD-RDSTRAT-7 bytes ratchet:** same end-to-end protocol, recall@10 `>= 0.98`, no material
+  GET regression, and bytes/query materially below `31.7 MB`. Codec-only ratios are diagnostic.
 * Compaction test: N→1 merge yields fewer RaBitQ GETs/query + re-clustered tighter locality.
 
-== Open questions for review
+== Initial open questions and resolution
 
-. **Header-first write correctness** — flush buffers the batch in RAM; confirm no
-   single-row streaming path bypasses the buffer.
-. **Footer-index size at scale** — OID bloom + block table for thousands of blocks; cap/region
-   layout so the cached footer stays small.
-. **Schema-footer vs catalog authority** — v1 footer = write-time snapshot; confirm no read-path
-   assumes catalog-only schema (ADR-047/048 interaction).
-. **GET-budget compaction trigger** — file-count threshold vs projected-GETs vs hybrid; tuning;
-   write-amplification bounds.
-. **Compaction atomicity** — the object-store exposes only create-only `put_if_absent` today
-   (no `if-match` CAS); D6 specifies the Iceberg fresh-name + manifest-advance fallback
-   (ADR-020). Confirm that path is sound and that no compaction step assumes an object-level
-   conditional replace. (Native S3/ABFS `if-match` is a future optimization.)
-. **Bloom sizing** — FPP target + bits/elt for OID; per-block vs per-file; cost in the cached footer.
-. **Readability during the docs→code window** — in-place change is atomic per PR; the footer
-   presence-field preserves legacy readability (ADR-061 amendment).
+. **Header-first write correctness — resolved by PR1.** Flush buffers the batch; #1019 shipped
+  the fixed-offset header/RaBitQ writer and mixed reader.
+. **Footer-index size at scale — structure resolved, measurement remains.** Keep typed
+  descriptors in the cache-hot footer and place large Bloom/statistics bytes in referenced
+  auxiliary regions (D4/D5). PR3 measures actual size/FPP.
+. **Schema-footer vs catalog authority — resolved.** Catalog is logical/write authority;
+  footer is the immutable physical snapshot keyed by `CatalogColumn.id`; block metadata owns
+  local decode parameters. TD-TBL-4 owns evolution reconciliation.
+. **GET-budget compaction trigger — open for PR2.** File-count threshold versus projected GETs
+  versus a hybrid still requires workload/write-amplification evidence.
+. **Compaction atomicity — resolved in design.** Use Iceberg fresh-name + manifest advance via
+  create-only `put_if_absent` (ADR-020); native `if-match` remains an optimization.
+. **Bloom sizing — initial policy resolved, activation evidence remains.** Per-block,
+  approximately 10 bits/key and ~1% target FPP, deterministic versioned payload; PR3 ratchets
+  it from measured cardinality and footer/aux bytes.
+. **Readability — resolved by PR1 and D4.** Header/footer presence selects the legacy path;
+  old PR1 readers ignore additive footer sections; explicit unknown data encodings fail closed.
 
 == Review corrections (2026-07-15)
 
@@ -314,3 +391,14 @@ Explore agent read a pre-#995/#1015 checkout), verified present on current `deve
 (Note: `block_cluster.rs:8-10` still calls IVF "the S4 upgrade" in the *module doc* while
 :16-17 references `cluster_order_pca_ivf` as shipped for compaction — a pre-existing source-doc
 inconsistency, separate cleanup, not a spec error.)
+
+== Footer/bytes implementation amendment (2026-07-15)
+
+After PR1 #1019 landed and measured recall `0.984`, `20` range GETs/query, and `31.7 MB`
+read/query, link:../../10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7]
+audited the shared codec, ProximaBlocks prior art, PAX `ColumnMeta`/`VectorParamBlock`, and Bloom
+implementations. D4/D5/D8 now fix the implementation seams: additive typed footer sections;
+stable physical field IDs with catalog/footer/block authority separation; skippable optional
+metadata but fail-closed unknown data encodings; auxiliary-region Bloom references; and a
+default-OFF clustered-residual SQ4 rerank encoding that replaces flat SQ8 only for eligible
+blocks. The RaBitQ header decision is unchanged.


### PR DESCRIPTION
## Summary

- file TD-RDSTRAT-7 with the shared-codec/ProximaBlocks/PAX/Bloom audit
- amend ADR-062 D4/D5 with additive typed footer sections, stable field identity, and auxiliary metadata regions
- accept D8 clustered-residual SQ4 as the default-off bytes lever, replacing flat SQ8 only for eligible blocks
- reconcile TD-RDSTRAT-6 with shipped PR1 behavior and measured baseline

## Key compatibility rules

- no segment magic or footer-v1 core version bump
- missing extension uses the PR1 block-local path
- unknown optional metadata is skippable
- explicit unknown data encodings fail closed and never alias to SQ8
- block-local VectorParamBlock remains decode-parameter authority

## Validation

- cargo clippy --lib --bins -- -D warnings
- cargo check --lib --tests
- cargo check -p proximadb-server
- make work-commit-check
- scripts/check_td_adr_unique.py
- scripts/check_td_status_consistency.py
- scripts/check_no_agent_attribution.py --range origin/develop..HEAD
- scripts/worktree.sh guard

The broad validate_docs.sh script also reports a pre-existing missing src/storage/engines/impls/sst/README.adoc; focused doc authority and TD guards pass.