### PR TITLE
docs(rdstrat): simplify footer v2 rollout

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -112,9 +112,10 @@ Bloom, no false negatives → `vector_by_id`/edge-by-oid skips to the one positi
 
 PR1 implemented the readable footer-v1 **core**: RaBitQ/row/dimension summary, legacy encoding
 summary, block extents, and an empty typed stats slot (`StatsKind::None`). The full schema,
-per-stripe map, per-column stats directory, and auxiliary-region references are additive typed
-sections specified by ADR-062 D4/D5 and TD-RDSTRAT-7. Missing sections use PR1/block-local
-metadata; explicit unknown data encodings fail closed rather than aliasing to SQ8.
+per-stripe map, per-column stats directory, and auxiliary-region references live in the clean
+footer v2 specified by ADR-062 D4/D5 and TD-RDSTRAT-7. New readers retain the footer-v1 parser;
+footer-v2 writes remain default OFF during rollout. Explicit unknown data encodings fail closed
+rather than aliasing to SQ8.
 
 == Self-derived geometry
 
@@ -182,7 +183,7 @@ amendment sanctions.
 == Phased implementation (one coherent PR at a time)
 
 * **PR1 — SHIPPED #1019, layout + scan-then-rerank foundation (the GET win):** header-prefix +
-  RaBitQ-head + footer-v1 core (block table + legacy encoding/schema summary + additive seams) +
+  RaBitQ-head + footer-v1 core (block table + legacy encoding/schema summary) +
   scan-then-rerank read path
   (reuse `plan_selected_block_ranges`/`read_ranges` + unchanged block decoder) + self-derived
   geometry + in-place writer/reader + round-trip/detection tests + SIFT recall + GET measurement.
@@ -190,8 +191,8 @@ amendment sanctions.
 * **PR2 — cost control:** GET-budget compaction trigger (WLP-7 seam) + per-file RaBitQ/footer
   LRU cache (engine `DashMap` vs mmap residency).
 * **PR3 — point-lookup index:** per-block OID bloom (`StatsKind::BloomOid`) + `vector_by_id` fast path.
-* **Bytes phase — TD-RDSTRAT-7:** clustered-residual rerank encoding + additive schema/encoding/
-  stats footer sections; default OFF; end-to-end SIFT bytes + recall gate.
+* **Bytes phase — TD-RDSTRAT-7:** clustered-residual rerank encoding + clean typed footer v2
+  with a footer-v1 read fallback; default OFF; end-to-end SIFT bytes + recall gate.
 * **Deferred (foundation anticipates):** schema-evolution semantics (TD-TBL-4/ADR-047); `MinMax`
   pushdown; within-cell Hilbert; text-as-variable-fetch; coarse
   VOE prune for monster collections; per-collection RaBitQ sidecar only if file-merging proves
@@ -246,4 +247,5 @@ the bytes phase.
   catalog-authority invariant (Q3) are PR2/PR3 follow-ups, not PR1 gates.
 * 2026-07-15 — PR1 #1019 landed and measured recall@10 `0.984`, `20` range GETs/query, and
   `31.7 MB` read/query. Linked the active bytes phase TD-RDSTRAT-7 and reconciled the spec with
-  the shipped footer-v1 core/default-OFF gate; full typed footer sections are additive.
+  the shipped footer-v1 core/default-OFF gate; full typed metadata uses footer v2 while new
+  readers retain the v1 path.

--- a/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
@@ -171,31 +171,33 @@ This follows Parquet's useful separation: file metadata plans physical access;
 column/page-local metadata decodes bytes; optional indexes/Blooms may be ignored.
 It does not copy Parquet Thrift structures into PAX.
 
-=== Additive footer extension envelope
+=== Clean footer v2 with a v1 read fallback
 
-PR1 footer v1 emits a fixed core and its parser stops after the declared block
-entries. It intentionally tolerates trailing bytes. Preserve that readable core
-and append an independently framed extension:
+PR1 footer v1 is an input compatibility case, not a byte-layout constraint on
+this unreleased follow-on writer. Footer v2 removes the v1 summary fields that
+the typed sections supersede:
 
 ```
-[PR1 footer-v1 core]
-[extension payload:
-   ext_version:u8
-   section_count:u16
-   repeated { section_tag:u8, section_version:u8, section_len:u32, bytes[] }]
-[extension_len:u32]
-[PXE1:4B]
+[footer_version:u8 = 2]
+[row_count:u64 | rabitq_off:u64 | rabitq_len:u64]
+[embed_dim:u32 | embed_count:u32]
+[block_count:u32 | required block entries]
+[section_count:u16]
+[repeated { section_tag:u8, section_version:u8, section_len:u32, bytes[] }]
 ```
 
 Rules:
 
-* No segment-magic, header-layout, or footer-version bump for these additive
-  sections. `PXE1` frames only the optional footer extension.
-* An old PR1 reader parses the v1 core and ignores the trailing extension.
-* A new reader first parses the v1 core, then recognizes `PXE1`, validates all
-  lengths with checked arithmetic, and skips unknown section tags/versions.
-* Missing extension means the exact PR1 interpretation. A malformed recognized
-  extension is an error, not a legacy fallback.
+* No segment-magic or header-layout bump. Footer version changes because its
+  byte layout changes; the new residual encoding remains a codec tag, not a
+  format magic.
+* A new reader dispatches footer v1 to the PR1 parser and footer v2 to the typed
+  parser. New-reader -> old-file readability is required.
+* Old PR1 binaries are not required to read footer v2. Footer-v2 writes remain
+  default OFF until the new reader is deployed.
+* Footer v2 validates all lengths with checked arithmetic and skips unknown
+  optional section tags/versions.
+* A malformed recognized v2 section is an error, not a v1 fallback.
 * Section order is deterministic on write; readers do not depend on order.
 
 Initial section tags are `SchemaSnapshot`, `StripeEncodingMap`,
@@ -246,8 +248,9 @@ entries[] {
 
 Compatibility is asymmetric by design:
 
-* Extension/map absent: use the PR1/block-local `VectorParamBlock` path; legacy
-  SQ8 remains readable.
+* Footer v1: use the PR1/block-local `VectorParamBlock` path; legacy SQ8 remains
+  readable.
+* Footer v2 with no encoding map: reject the malformed self-description.
 * Known codec tag: dispatch the declared decoder and validate its version/scope.
 * Explicit unknown codec tag/version: never reinterpret its bytes as SQ8.
   Either use an independently declared exact tier when the caller permits that
@@ -374,8 +377,8 @@ OFF until its recall and bytes gates are accepted.
 The code PR proceeds in this order; each production slice starts from a failing
 test.
 
-. Footer extension tests: legacy PR1 body/no extension; full section round-trip;
-  unknown optional section skip; malformed/truncated extension fail; explicit
+. Footer tests: legacy footer-v1 parse; footer-v2 full section round-trip;
+  unknown optional v2 section skip; malformed/truncated v2 fail; explicit
   unknown required codec fail.
 . Shared codec tests: deterministic encode; exact wire round-trip; dimension/run
   validation; odd nibble count; error bound; clustered recall-tolerance fixture;
@@ -384,7 +387,8 @@ test.
   decode; mixed SQ8/residual blocks; ranged reader parity; unknown quant kind
   fail closed.
 . Segment tests: schema/encoding/stats sections are emitted from actual block
-  metadata; missing extension reads PR1; gate OFF writes SQ8; gate ON with IVF
+  metadata; footer v1 reads through the PR1 path; gate OFF writes footer v1/SQ8;
+  gate ON with IVF
   writes residual; legacy and new segments coexist in one query.
 . SIFT eval: same N=100k, 100-query, single-file, IVF-ON protocol; compare OFF
   and ON in one run; assert recall floor `>= 0.98`, GET non-regression, and a
@@ -401,8 +405,8 @@ Included in the implementation PR:
 * shared clustered-residual codec and stable tag;
 * cluster-plan reuse;
 * PAX writer/reader and block-local codebooks;
-* additive footer sections for schema, encodings, stats descriptors, and aux
-  region references;
+* clean footer-v2 sections for schema, encodings, stats descriptors, and aux
+  region references, plus the footer-v1 read path;
 * default-OFF mixed-read gate, tests, SIFT evidence, and ledger claim.
 
 Not included:
@@ -422,10 +426,10 @@ survivor-block codec and is not tuned in the bytes PR.
 
 * This audit/design and the ADR-062 D4/D5 amendment land before code.
 * A canonical clustered-residual codec tag is registered; no segment magic bump.
-* Footer schema/encoding/stats sections round-trip and old PR1 readers can ignore
-  them.
-* Missing map reads legacy SQ8; explicit unknown data encoding never aliases to
-  SQ8.
+* Footer-v2 schema/encoding/stats sections round-trip; the new reader also reads
+  footer v1.
+* Footer v1 reads legacy SQ8; footer v2 requires an encoding map; explicit
+  unknown data encoding never aliases to SQ8.
 * Encoding is default OFF and mixed-read-safe.
 * Unit, block, segment, ranged-read, and recall-tolerance coverage passes.
 * SIFT1M N=100k single-file IVF-ON records recall@10 `>= 0.98`, GET
@@ -438,5 +442,6 @@ survivor-block codec and is not tuned in the bytes PR.
 
 * 2026-07-15 — filed after PR1 #1019 landed. Audit established one shared codec
   engine/two layouts; selected residual-as-rerank-replacement, per-cluster-run
-  codebooks local to each PAX block, additive footer TLV sections, typed optional
+  codebooks local to each PAX block, a clean footer-v2 section layout with v1
+  read fallback, typed optional
   Bloom references, and fail-closed unknown encoding behavior.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -123,7 +123,7 @@ coalescing win is the policy's, not `read_ranges`' (a backend may override `read
 true batched/multipart as a follow-on). fp32 finalized for top-k only. Net: ~1 RaBitQ GET/file
 (cached) + a few coalesced survivor GETs, vs today's ~4-5 × every selected block.
 
-=== D4 — Parquet-style self-describing footer-index; additive typed sections
+=== D4 — Parquet-style self-describing footer-index; clean footer v2
 
 The footer-index is the metadata hub: **schema snapshot** (field-ids, types, column order —
 self-describing; catalog stays the write authority, footer is the segment's physical
@@ -131,20 +131,25 @@ self-description), block offset table, per-block per-column **stats**, per-strip
 map**, rabitq_off/len, row_count. **Encoding control lives in the footer** (Parquet-style),
 not in segment magic — magic stays format-family-only.
 
-PR1's footer-v1 core is the readability base: RaBitQ extent mirror, row/dimension summary,
-legacy `embed_quant_tag`, f32-presence flag, and block extents. Its parser stops after the
-declared block entries and tolerates trailing bytes. Later phases append a framed, versioned
-section envelope after that core:
+PR1's footer v1 is readable input, not the byte-layout base for unreleased follow-on writers.
+It contains the RaBitQ extent mirror, row/dimension summary, legacy `embed_quant_tag`,
+f32-presence flag, and block extents. The bytes phase introduces a clean footer v2:
 
 ```
-[footer-v1 core][typed sections][extension_len:u32][PXE1]
+[footer_version:u8 = 2]
+[row_count | rabitq_off/len | embed_dim/count]
+[required block table]
+[section_count:u16][typed sections]
 section = { tag:u8, version:u8, len:u32, payload }
 ```
 
 Initial sections are `SchemaSnapshot`, `StripeEncodingMap`, `BlockColumnStats`, and
-`AuxRegionDirectory`. Old PR1 readers ignore the envelope; new readers skip unknown optional
-sections after validating lengths. A malformed recognized envelope fails closed. This is an
-additive footer extension, not a segment-magic/header/footer-version bump.
+`AuxRegionDirectory`. The existing footer tail already supplies the total footer length, so v2
+does not add a second extension length/magic. New readers dispatch on footer version: v1 parses
+the PR1 core and synthesizes its legacy interpretation; v2 parses typed sections and skips
+unknown optional section tags/versions after validating lengths. A malformed recognized
+section fails closed. The segment/header magic is unchanged; the footer version changes because
+the footer layout changes.
 
 The schema snapshot contains the immutable physical facts required to interpret the file:
 schema fingerprint/version and ordered fields `{ CatalogColumn.id (stable physical field-id),
@@ -160,11 +165,13 @@ shared `ProximaScheme` marker. Codec parameters needed to decode one PAX block r
 block's `VectorParamBlock`, so a fetched block is self-sufficient and the segment footer does
 not duplicate codebooks.
 
-Compatibility distinguishes absent metadata from unknown data bytes: a missing extension/map
-uses the PR1 block-local SQ8 path, but an explicitly unknown codec/version is never
+Compatibility distinguishes legacy metadata from unknown data bytes: a v1 footer uses the PR1
+block-local SQ8 path, but a v2 footer requires its encoding map. An explicitly unknown
+codec/version is never
 reinterpreted as SQ8. The reader may use an independently declared exact tier when the caller
 permits it; otherwise it returns unsupported-encoding. Unknown optional metadata sections may
-be ignored.
+be ignored. Because this phase is unreleased, old PR1 binaries are not required to read v2;
+footer-v2 writes stay default-OFF until new readers are deployed.
 
 === D5 — Per-block stats: typed slot in v1; optional OID Bloom activation in PR3
 
@@ -362,8 +369,9 @@ leaving RaBitQ at the header.
 . **Bloom sizing — initial policy resolved, activation evidence remains.** Per-block,
   approximately 10 bits/key and ~1% target FPP, deterministic versioned payload; PR3 ratchets
   it from measured cardinality and footer/aux bytes.
-. **Readability — resolved by PR1 and D4.** Header/footer presence selects the legacy path;
-  old PR1 readers ignore additive footer sections; explicit unknown data encodings fail closed.
+. **Readability — resolved by PR1 and D4.** New readers parse both footer v1 and v2; v2 writes
+  stay default-OFF during reader rollout. Explicit unknown data encodings fail closed. Old PR1
+  binaries reading v2 is not a pre-release requirement.
 
 == Review corrections (2026-07-15)
 
@@ -397,7 +405,8 @@ inconsistency, separate cleanup, not a spec error.)
 After PR1 #1019 landed and measured recall `0.984`, `20` range GETs/query, and `31.7 MB`
 read/query, link:../../10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7]
 audited the shared codec, ProximaBlocks prior art, PAX `ColumnMeta`/`VectorParamBlock`, and Bloom
-implementations. D4/D5/D8 now fix the implementation seams: additive typed footer sections;
+implementations. D4/D5/D8 now fix the implementation seams: a clean typed footer v2 with a v1
+read fallback;
 stable physical field IDs with catalog/footer/block authority separation; skippable optional
 metadata but fail-closed unknown data encodings; auxiliary-region Bloom references; and a
 default-OFF clustered-residual SQ4 rerank encoding that replaces flat SQ8 only for eligible


### PR DESCRIPTION
## Summary
- replace the additive PXE1 footer-extension design with a clean typed footer v2
- require new readers to parse footer v1 and v2, without requiring old PR1 binaries to parse v2
- keep footer-v2/residual writes default OFF during rollout

## Validation
- make work-commit-check
- python3 scripts/check_td_adr_unique.py
- python3 scripts/check_td_status_consistency.py
- python3 scripts/check_doc_authority.py
- scripts/worktree.sh guard