### PR TITLE
feat(storage): Churn working-set observability + soft ceiling (ADR-061 D4, TD-WLP-8a)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -156,7 +156,8 @@ pub use spatial_encoding::{CodeType, SpatialCode, U512};
 pub use storage_error::{ErrorContext, StorageError, StorageErrorKind};
 pub use storage_path::StoragePath;
 pub use storage_profile::{
-    STORAGE_PROFILE_ENV, STORAGE_PROFILE_TAG_PREFIX, StorageProfile, resolve_storage_profile,
+    CHURN_WORKING_SET_MB_ENV, STORAGE_PROFILE_ENV, STORAGE_PROFILE_TAG_PREFIX, StorageProfile,
+    churn_working_set_ceiling_bytes, resolve_storage_profile,
 };
 pub use swift_id_index::{
     BPlusNode, BlockLocation, IdIndex, IndexStats as SwiftIndexStats, RecordLocation,

--- a/crates/storage/proximadb-storage-common/src/storage_profile.rs
+++ b/crates/storage/proximadb-storage-common/src/storage_profile.rs
@@ -23,6 +23,15 @@ pub const STORAGE_PROFILE_TAG_PREFIX: &str = "workload_profile:";
 /// per-collection tag; unset / unrecognized → `AppendBulk`.
 pub const STORAGE_PROFILE_ENV: &str = "PROXIMADB_STORAGE_PROFILE";
 
+/// Soft ceiling (in **megabytes**) on a `Churn` collection's in-memory
+/// working set — the unflushed WAL/memtable delta a `Churn` collection keeps
+/// hot for immediate-freshness reads (ADR-061 D4, TD-WLP-8). It bounds the
+/// assumption that a `Churn` working set is small; crossing it is a soft
+/// signal (gauge + warn), not a hard reject — an over-budget collection
+/// degrades gracefully rather than OOMing. Unset / `0` / unparseable ⇒ no
+/// ceiling (unbounded, default-safe). `AppendBulk` is unaffected.
+pub const CHURN_WORKING_SET_MB_ENV: &str = "PROXIMADB_CHURN_WORKING_SET_MB";
+
 /// Per-collection storage-projection strategy (ADR-061).
 ///
 /// `AppendBulk` (tag values `append` / `bulk`): durable clustered PAX-LSM
@@ -105,6 +114,21 @@ pub fn resolve_storage_profile(tags: &[String]) -> StorageProfile {
     }
 }
 
+/// The `Churn` working-set soft ceiling in **bytes**, from
+/// `PROXIMADB_CHURN_WORKING_SET_MB` (TD-WLP-8). `None` = no ceiling (unset,
+/// `0`, empty, or unparseable — default-safe / unbounded). A positive integer
+/// number of MB is converted to bytes with saturating arithmetic so an absurd
+/// value can't overflow. The ceiling is advisory (observability + warn); it
+/// never rejects a write.
+pub fn churn_working_set_ceiling_bytes() -> Option<u64> {
+    let raw = std::env::var(CHURN_WORKING_SET_MB_ENV).ok()?;
+    let mb: u64 = raw.trim().parse().ok()?;
+    if mb == 0 {
+        return None; // explicit "unbounded"
+    }
+    Some(mb.saturating_mul(1024 * 1024))
+}
+
 /// Read the per-collection `workload_profile:append|bulk|churn` tag from a tag
 /// list. Last matching tag wins; an unrecognized value keeps the prior
 /// resolution (parity with `pax_vector_format_tag`). Absent → `None` (defer to
@@ -158,6 +182,41 @@ mod tests {
             resolve_storage_profile(&tags(&["workload_profile:churn"])).default_radius_k(),
             0.0
         );
+    }
+
+    /// TD-WLP-8: the `Churn` working-set soft ceiling parses MB→bytes, and
+    /// unset / `0` / garbage ⇒ unbounded (`None`, default-safe). Serialized on
+    /// the shared env var; brackets its own mutation.
+    #[test]
+    fn test_churn_working_set_ceiling_bytes() {
+        unsafe {
+            std::env::remove_var(CHURN_WORKING_SET_MB_ENV);
+        }
+        // unset → unbounded
+        assert_eq!(churn_working_set_ceiling_bytes(), None);
+        // positive MB → bytes
+        unsafe {
+            std::env::set_var(CHURN_WORKING_SET_MB_ENV, "256");
+        }
+        assert_eq!(churn_working_set_ceiling_bytes(), Some(256 * 1024 * 1024));
+        // whitespace tolerated
+        unsafe {
+            std::env::set_var(CHURN_WORKING_SET_MB_ENV, "  8 ");
+        }
+        assert_eq!(churn_working_set_ceiling_bytes(), Some(8 * 1024 * 1024));
+        // explicit 0 → unbounded (not a zero-byte ceiling that rejects everything)
+        unsafe {
+            std::env::set_var(CHURN_WORKING_SET_MB_ENV, "0");
+        }
+        assert_eq!(churn_working_set_ceiling_bytes(), None);
+        // unparseable → unbounded (default-safe)
+        unsafe {
+            std::env::set_var(CHURN_WORKING_SET_MB_ENV, "lots");
+        }
+        assert_eq!(churn_working_set_ceiling_bytes(), None);
+        unsafe {
+            std::env::remove_var(CHURN_WORKING_SET_MB_ENV);
+        }
     }
 
     /// TD-WLP-1 TDD gate: the tag > env > default cascade, mirroring

--- a/docs/10-quality/td/TD-WLP-8-churn-mutable-index-orion-fusion-memory-guard.adoc
+++ b/docs/10-quality/td/TD-WLP-8-churn-mutable-index-orion-fusion-memory-guard.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — filed 2026-07-14 as the TD-WLP-5 descope. Not started.
+| Status | In progress (sliced). **Part 8a (working-set observability + soft ceiling) — Implemented 2026-07-15:** per-collection resident working-set gauge `proximadb_churn_collection_working_set_bytes{tenant_id,collection_id}` + the `PROXIMADB_CHURN_WORKING_SET_MB` soft ceiling (`churn_working_set_ceiling_bytes()`, unset/`0`/garbage ⇒ unbounded/default-safe), sampled at the existing `Churn` read seam (`unified_search_with_tenant_context`, alongside the TD-WLP-5 freshness override + TD-WLP-6 io_trace stamp) via a thin `WriteAheadLogManager::get_collection_working_set_bytes` accessor; over-ceiling emits an **edge-triggered** `warn!` (deduped per collection, re-arms when it drops back). Best-effort — never fails a search; `AppendBulk` never samples. Deliberately **disjoint** from the concurrent ADR-062/TD-RDSTRAT-6 PAX-layout work (no `sst/{flush,search,segment_format}`, no `block-format`/`pax_block` touch). **Part 8b (open, not started):** the AXIS dedicated in-memory mutable index over UNFLUSHED inserts + ORION `oid` fusion + write-path enforcement — see Scope. Original filing: 2026-07-14 as the TD-WLP-5 descope.
 | Priority | P2 — the Churn projection's performance + graph-RAG payoff; the read-correctness core (Strong-override) already shipped in TD-WLP-5.
 | Severity | Medium — adds a bounded in-memory surface (OOM risk, guarded) + a graph-fusion read path; no durability change (WAL stays authority, ADR-061 D2).
 | Component | `src/index/axis/` (mutable ANN index that also indexes UNFLUSHED inserts, not just flushed segments — today `handle_flushed_vectors` is post-flush only); `src/graph/engines/orion/` (`oid`-keyed match-then-traverse fusion, ADR-044); a per-collection working-set memory gauge (telemetry) + guard in the Churn write path
@@ -37,11 +37,20 @@ correctness, and were deferred to keep WLP-5 focused and low-risk:
 
 == Scope
 
-* AXIS mutable index that indexes unflushed inserts for `Churn` collections; read path prefers it
+Sliced into **8a** (observability + soft ceiling — shipped) and **8b** (mutable index + fusion +
+write-path enforcement — open):
+
+* *(8b)* AXIS mutable index that indexes unflushed inserts for `Churn` collections; read path prefers it
   for the bounded set, still dead-filtered (`is_dead`/`valid_to_ns`).
-* ORION `oid`-keyed match-then-traverse fusion behind the Churn read path.
-* Per-collection working-set gauge + guard; emit on the Churn write/flush boundary.
-* Full-server pre-flush freshness e2e (`tests/storage_wlp_churn_freshness.rs`) exercising the real
+* *(8b)* ORION `oid`-keyed match-then-traverse fusion behind the Churn read path. **Gate before starting:**
+  confirm ADR-044 symbol-`oid` minting is production-wired (still "Decision" phase at filing) — else the
+  fusion strands on an unpopulated key.
+* *(8a — done, read-seam variant)* Per-collection working-set gauge + soft ceiling. 8a samples + emits at
+  the `Churn` *read* seam (where the profile is already resolved and WLP-5/6 live, keeping it disjoint
+  from the concurrent TD-RDSTRAT-6 flush path) and warns on breach. *(8b)* adds the **write/flush-boundary
+  emission + actual enforcement** (backpressure / forced flush) once the mutable index — which is what
+  holds the RAM — exists to enforce against.
+* *(8b)* Full-server pre-flush freshness e2e (`tests/storage_wlp_churn_freshness.rs`) exercising the real
   REST/pgwire path: insert → search pre-flush sees it; re-embed same `oid` → search pre-flush sees
   the new neighbours; restart + WAL replay reconstructs identical state; an `AppendBulk` collection
   in the same process is unaffected.

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -97,6 +97,18 @@ lazy_static! {
         "Bytes written to object storage per tenant by access tier (write-time; the cold-tier cost lever)",
         &["tenant_id", "tier"]
     );
+    /// TD-WLP-8 (ADR-061 D4): resident in-memory **working-set** bytes of a
+    /// `Churn` collection — the unflushed WAL/memtable delta it keeps hot for
+    /// immediate-freshness reads. A level gauge (current resident bytes),
+    /// sampled at the `Churn` read seam; the companion soft ceiling
+    /// (`PROXIMADB_CHURN_WORKING_SET_MB`) makes an over-budget collection
+    /// observable so it degrades gracefully instead of silently OOMing.
+    /// Emitted only for `Churn` collections (`AppendBulk` never samples).
+    pub static ref CHURN_WORKING_SET_BYTES: GaugeVec = registered_gauge_vec(
+        "proximadb_churn_collection_working_set_bytes",
+        "Resident in-memory working-set bytes of a Churn collection (unflushed WAL/memtable delta)",
+        &["tenant_id", "collection_id"]
+    );
 }
 
 /// Cloud provider hosting the object store — the multi-cloud axis for egress
@@ -574,6 +586,17 @@ pub fn record_storage_bytes(tenant_id: Option<&str>, storage_type: &str, bytes: 
         .set(bytes);
 }
 
+/// TD-WLP-8: set the `Churn` collection working-set level gauge. Called from
+/// the `Churn` read seam with the collection's current unflushed byte count;
+/// pure gauge `.set()` (the soft-ceiling decision lives at the call site,
+/// which owns the env). An absent/empty tenant is attributed to `"default"`.
+pub fn record_churn_working_set_bytes(tenant_id: Option<&str>, collection_id: &str, bytes: u64) {
+    let t_id = tenant_id.unwrap_or("default");
+    CHURN_WORKING_SET_BYTES
+        .with_label_values(&[t_id, collection_id])
+        .set(bytes as f64);
+}
+
 /// ADR-030 **KSU**: snapshot per-tenant *resident* storage bytes from the live
 /// collection set and `.set()` the `STORAGE_BYTES_SECONDS` **level** gauge
 /// (Prometheus integrates the level to byte-seconds downstream — KSU is an
@@ -809,6 +832,35 @@ mod tests {
                 .get(),
             7.0,
             "unowned bytes attributed to default (fail-closed)"
+        );
+    }
+
+    /// TD-WLP-8: the Churn working-set gauge round-trips per (tenant, collection)
+    /// and attributes an absent tenant to "default" (fail-closed).
+    #[test]
+    fn churn_working_set_gauge_round_trips() {
+        record_churn_working_set_bytes(Some("ksu_wlp8"), "col_hot", 4096);
+        assert_eq!(
+            CHURN_WORKING_SET_BYTES
+                .with_label_values(&["ksu_wlp8", "col_hot"])
+                .get(),
+            4096.0
+        );
+        // A later sample overwrites the level (gauge, not counter).
+        record_churn_working_set_bytes(Some("ksu_wlp8"), "col_hot", 2048);
+        assert_eq!(
+            CHURN_WORKING_SET_BYTES
+                .with_label_values(&["ksu_wlp8", "col_hot"])
+                .get(),
+            2048.0
+        );
+        // Absent tenant → "default".
+        record_churn_working_set_bytes(None, "col_unowned", 512);
+        assert_eq!(
+            CHURN_WORKING_SET_BYTES
+                .with_label_values(&["default", "col_unowned"])
+                .get(),
+            512.0
         );
     }
 

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -110,6 +110,53 @@ fn churn_effective_freshness(
         .unwrap_or_default()
 }
 
+/// TD-WLP-8 (ADR-061 D4): sample a `Churn` collection's resident working-set
+/// bytes (the unflushed WAL/memtable delta) onto the per-collection gauge and
+/// edge-trigger a `warn!` when it crosses the soft ceiling
+/// (`PROXIMADB_CHURN_WORKING_SET_MB`). Best-effort observability: a sampling
+/// error is swallowed (it must never fail a search), and the warn is deduped
+/// per collection so a hot over-budget collection doesn't spam the log — it
+/// fires once on breach and re-arms only after the working set drops back under
+/// the ceiling. `AppendBulk` never calls this (gated at the call site).
+async fn sample_churn_working_set(
+    wal_manager: &crate::storage::persistence::write_ahead_log::WriteAheadLogManager,
+    tenant_id: Option<&str>,
+    collection_id: &str,
+) {
+    let bytes = match wal_manager
+        .get_collection_working_set_bytes(collection_id)
+        .await
+    {
+        Ok(b) => b,
+        Err(_) => return, // observability must never fail the read
+    };
+    crate::metrics::consumption_metrics::record_churn_working_set_bytes(
+        tenant_id,
+        collection_id,
+        bytes,
+    );
+    let Some(ceiling) = proximadb_storage_common::churn_working_set_ceiling_bytes() else {
+        return; // unbounded (default) — gauge only, no ceiling to breach
+    };
+    static WARNED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        std::sync::OnceLock::new();
+    let warned = WARNED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+    if let Ok(mut set) = warned.lock() {
+        if bytes > ceiling {
+            if set.insert(collection_id.to_string()) {
+                warn!(
+                    "Churn collection '{}' working set {} B exceeds soft ceiling {} B \
+                     (PROXIMADB_CHURN_WORKING_SET_MB): reads stay correct but the in-memory \
+                     working set is unbounded — flush/compact or raise the ceiling",
+                    collection_id, bytes, ceiling
+                );
+            }
+        } else {
+            set.remove(collection_id); // dropped back under → re-arm the warn
+        }
+    }
+}
+
 fn filter_fail_loud_enabled() -> bool {
     let value = std::env::var(FILTER_FAIL_LOUD_ENV).ok();
     filter_fail_loud_for_value(value.as_deref())
@@ -2167,6 +2214,27 @@ impl VectorOperationsService {
         // no-op there. Computed once and reused at the cache gate and the
         // execute path below so both honor the override.
         let freshness_mode = churn_effective_freshness(&collection, config.as_ref());
+
+        // TD-WLP-8 (ADR-061 D4): for `Churn` collections, sample the resident
+        // in-memory working-set bytes onto the per-collection gauge and warn if
+        // it crosses the soft ceiling. Gated on the profile (not the effective
+        // freshness — an `AppendBulk` request may also ask Strong). Best-effort;
+        // never fails the search. `AppendBulk` is skipped entirely.
+        {
+            let tags = collection
+                .config
+                .as_ref()
+                .map(|c| c.tags.as_slice())
+                .unwrap_or(&[]);
+            if proximadb_storage_common::resolve_storage_profile(tags).forces_strong_reads() {
+                sample_churn_working_set(
+                    &self.wal_manager,
+                    tenant_context.map(|t| t.tenant_id.as_str()),
+                    collection_id,
+                )
+                .await;
+            }
+        }
 
         // Create cache key for unified result caching
         let filter_str = filter.as_ref().map(|f| format!("{:?}", f));

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -2391,6 +2391,20 @@ impl WriteAheadLogManager {
                 .collect())
         }
     }
+    /// TD-WLP-8 (ADR-061 D4): current resident **working-set bytes** for a
+    /// collection — the sum of its unflushed WAL/memtable batch sizes. This is
+    /// the same quantity `MemtableManager::get_collection_memory_usage` reports
+    /// via the shared behavior; exposed here so the `Churn` read seam can sample
+    /// it for the working-set gauge/soft-ceiling without reaching a
+    /// `MemtableManager` handle it doesn't hold. Best-effort: `0` for an unknown
+    /// collection (no unflushed delta).
+    pub async fn get_collection_working_set_bytes(&self, collection_id: &str) -> Result<u64> {
+        let memtable_config = crate::storage::memtable::core::MemtableConfig::default();
+        let wal_behavior = self.shared_wal_behavior.get_or_init(&memtable_config);
+        let batches = wal_behavior.get_unflushed_batches(collection_id).await?;
+        Ok(batches.iter().map(|b| b.total_size_bytes as u64).sum())
+    }
+
     /// Enhanced search with bloom filter optimization for WAL/memtable data
     /// This is the PREFERRED method for searching unflushed vectors with metadata filtering
     pub async fn search_unflushed_vectors(
@@ -3368,6 +3382,58 @@ mod wal_manager_infra_tests {
 
         let stats = manager.stats().await.expect("stats should succeed");
         assert_eq!(stats.total_entries, 0);
+    }
+
+    /// TD-WLP-8: the working-set-bytes accessor is `0` before any insert and
+    /// reflects the unflushed batch size after — the quantity the `Churn`
+    /// read seam samples onto the working-set gauge. `MemoryOnly` sync keeps
+    /// the batch resident (no disk dependency) so the assertion is exact.
+    #[tokio::test]
+    async fn test_get_collection_working_set_bytes_reflects_unflushed() {
+        let mut config = WALConfig::default();
+        config.performance.sync_mode = config::SyncMode::MemoryOnly;
+        let manager =
+            WriteAheadLogManager::new_for_collection(config, "wlp8_ws_collection".to_string())
+                .await
+                .expect("manager creation should succeed");
+
+        // No inserts yet → zero working set (accessor never errors).
+        let empty = manager
+            .get_collection_working_set_bytes("wlp8_ws_collection")
+            .await
+            .expect("accessor should not error on an empty collection");
+        assert_eq!(empty, 0, "no unflushed delta yet → zero working-set bytes");
+
+        // Insert a handful of fp32 records; insert_vectors sizes each record as
+        // dim*4 + 256 bytes into the batch's total_size_bytes.
+        let dim = 8u32;
+        let records: Vec<ProximaRecord> = (0..4)
+            .map(|i| ProximaRecord {
+                oid: format!("wlp8-rec-{i}"),
+                embeddings: vec![EmbeddingCell {
+                    model_id: "wlp8".to_string(),
+                    modality: "dense_vector".to_string(),
+                    dim,
+                    values: proximadb_records::EmbeddingValues::Fp32(vec![i as f32; dim as usize]),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+            .collect();
+        manager
+            .insert_vectors("wlp8_ws_collection".to_string(), records)
+            .await
+            .expect("insert should succeed under MemoryOnly sync");
+
+        let after = manager
+            .get_collection_working_set_bytes("wlp8_ws_collection")
+            .await
+            .expect("accessor should not error after inserts");
+        let expected = 4 * (dim as u64 * 4 + 256);
+        assert_eq!(
+            after, expected,
+            "working-set bytes must reflect the unflushed batch total_size_bytes"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

**TD-WLP-8a** — the first, low-risk slice of TD-WLP-8. Ships the `Churn` working-set **safety rail** (observability + soft ceiling) ahead of **8b** (the dedicated mutable AXIS index + ORION `oid` fusion + write-path enforcement).

A `Churn` collection keeps its unflushed WAL/memtable delta hot in RAM for immediate-freshness reads (ADR-061 D4, shipped in TD-WLP-5). This makes that resident working set **observable** and bounds the "small working set" assumption so an over-budget collection degrades gracefully instead of silently OOMing.

## Changes

- **Gauge** `proximadb_churn_collection_working_set_bytes{tenant_id,collection_id}` (level) — `consumption_metrics.rs`.
- **Soft ceiling** `PROXIMADB_CHURN_WORKING_SET_MB` via `churn_working_set_ceiling_bytes()` — unset / `0` / unparseable ⇒ unbounded (default-safe). Advisory only; **never rejects a write**.
- **`WriteAheadLogManager::get_collection_working_set_bytes`** — thin accessor summing unflushed batch sizes (same quantity `MemtableManager::get_collection_memory_usage` reports), so the read seam can sample without a `MemtableManager` handle it doesn't hold.
- **Wiring** at the existing `Churn` read seam (`unified_search_with_tenant_context`, beside the TD-WLP-5 freshness override + TD-WLP-6 io_trace stamp): sets the gauge and **edge-triggers** a `warn!` on breach (deduped per collection, re-arms after it drops back). Best-effort — never fails the search; `AppendBulk` never samples.

## Design notes

- **Sampled at the read seam, not the flush boundary** — keeps 8a **100% disjoint** from the concurrent ADR-062/TD-RDSTRAT-6 PAX-layout work (which merged #1019 touching `sst/{flush,search}`). No `block-format`/`pax_block`/`segment_format` touch. Zero file overlap → no merge contention with that track.
- **Write-path enforcement** (backpressure/forced flush) and the **mutable index** it enforces against are **8b** — the index is what actually holds the RAM.

## Tests (all merge-gated in the unit job)

- `churn_working_set_ceiling_bytes` MB→bytes + unbounded defaults (storage-common) ✅
- gauge round-trip + default-tenant attribution (consumption_metrics) ✅
- WAL accessor: `0` pre-insert, reflects the unflushed batch bytes after (MemoryOnly sync, exact) ✅

Full-path e2e is folded into **8b**'s `storage_wlp_churn_freshness.rs` (the service-level seam isn't reachable from the engine-level test harness; noted, not a silent gap).

Local gates: `cargo fmt --check` ✅, `cargo clippy --lib --bins -- -D warnings` ✅, targeted `nextest` ✅, `check_td_adr_unique.py` 0 errors. Rebased onto latest develop.

Refs ADR-061 D4, TD-WLP-8 (status updated for the 8a/8b split).