### PR TITLE
fix(planner): factor shared equi-key out of OR-of-ANDs comma join — TD-REL-LOWER-6 (TPC-H Q19)

### DIFF
--- a/crates/query/proximadb-relational-planner/src/lib.rs
+++ b/crates/query/proximadb-relational-planner/src/lib.rs
@@ -1079,6 +1079,23 @@ pub fn push_predicates<R: CapabilityResolver>(plan: PhysicalPlan, resolver: &R) 
                             implicit_join_bucket.push(conj);
                             continue;
                         }
+                        // Factor a cross-side equi-key shared by EVERY branch of a
+                        // top-level disjunction out of the OR, so a comma-join whose
+                        // join key only appears inside an `OR` of range predicates
+                        // (TPC-H Q19) still normalizes to an equi-join instead of a
+                        // raw cross product. `(A=B ∧ p1) ∨ (A=B ∧ p2)` ≡
+                        // `A=B ∧ (p1 ∨ p2)`: A=B becomes the join key, the reduced
+                        // disjunction the residual filter.
+                        if kind == JoinKind::Cross
+                            && let Some((commons, reduced)) =
+                                factor_common_cross_equalities(&conj, left_width)
+                        {
+                            implicit_join_bucket.extend(commons);
+                            if let Some(r) = reduced {
+                                residual.push(r);
+                            }
+                            continue;
+                        }
                         let mut ords = Vec::new();
                         collect_column_ordinals(&conj, &mut ords);
                         if ords.is_empty() {
@@ -1525,6 +1542,95 @@ fn is_cross_side_equality(expr: &Expr, left_width: usize) -> bool {
         return false;
     };
     (left.ordinal < left_width) != (right.ordinal < left_width)
+}
+
+/// Flatten a top-level disjunction into its OR-branches (descending only through
+/// `Or` nodes, mirroring [`flatten_and`]). A non-`Or` expression yields one branch.
+fn flatten_or(expr: &Expr) -> Vec<&Expr> {
+    let mut out = Vec::new();
+    flatten_or_into(expr, &mut out);
+    out
+}
+
+fn flatten_or_into<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+    match expr {
+        Expr::BinaryOp {
+            op: BinaryOp::Or,
+            left,
+            right,
+        } => {
+            flatten_or_into(left, out);
+            flatten_or_into(right, out);
+        }
+        other => out.push(other),
+    }
+}
+
+/// Combine predicates with `OR` (the disjunctive mirror of [`combine_all`]).
+fn combine_any(preds: Vec<Expr>) -> Option<Expr> {
+    preds.into_iter().fold(None, |acc, p| match acc {
+        None => Some(p),
+        Some(l) => Some(Expr::BinaryOp {
+            op: BinaryOp::Or,
+            left: Box::new(l),
+            right: Box::new(p),
+        }),
+    })
+}
+
+/// Factor cross-side equi-join keys shared by EVERY branch of a top-level
+/// disjunction out of that disjunction. `(A=B ∧ p1) ∨ (A=B ∧ p2) ∨ …` is
+/// logically `A=B ∧ (p1 ∨ p2 ∨ …)` — A=B distributes over the OR because it
+/// appears in every branch — so a comma-join whose join key only lives inside an
+/// `OR` of range predicates (TPC-H Q19) still normalizes to an equi-join rather
+/// than a raw cross product.
+///
+/// Returns the extracted equi-terms plus the reduced disjunction (the residual to
+/// keep as a `Filter`), or `None` if `conj` is not a real (≥2-branch) disjunction
+/// or shares no cross-side equality across all branches. If stripping the common
+/// terms empties any branch — that branch was exactly `A=B`, so the disjunction
+/// collapses to `A=B` by absorption — the residual is `None`.
+fn factor_common_cross_equalities(
+    conj: &Expr,
+    left_width: usize,
+) -> Option<(Vec<Expr>, Option<Expr>)> {
+    let branches = flatten_or(conj);
+    if branches.len() < 2 {
+        return None;
+    }
+    let branch_terms: Vec<Vec<&Expr>> = branches.iter().map(|b| flatten_and(b)).collect();
+    // Common cross-side equalities = those in the first branch present (structurally)
+    // in every branch.
+    let mut commons: Vec<Expr> = Vec::new();
+    for t in &branch_terms[0] {
+        if is_cross_side_equality(t, left_width)
+            && !commons.contains(*t)
+            && branch_terms.iter().all(|terms| terms.contains(t))
+        {
+            commons.push((*t).clone());
+        }
+    }
+    if commons.is_empty() {
+        return None;
+    }
+    // Rebuild each branch without the common terms; an emptied branch means the
+    // whole disjunction reduces to the common terms (no residual filter).
+    let mut reduced_branches: Vec<Expr> = Vec::with_capacity(branch_terms.len());
+    for terms in &branch_terms {
+        let remaining: Vec<Expr> = terms
+            .iter()
+            .filter(|t| !commons.contains(**t))
+            .map(|t| (*t).clone())
+            .collect();
+        if remaining.is_empty() {
+            return Some((commons, None));
+        }
+        if let Some(b) = combine_all(remaining) {
+            reduced_branches.push(b);
+        }
+    }
+    let reduced = combine_any(reduced_branches);
+    Some((commons, reduced))
 }
 
 fn expression_references_columns(expr: &Expr) -> bool {
@@ -3397,6 +3503,78 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn comma_join_disjunction_factors_shared_equi_key() {
+        // TD-REL-LOWER-6 (Q19 shape): the join key `id = user_id` appears inside
+        // EVERY branch of a top-level OR of range predicates. It must be factored
+        // out to an equi-join, leaving the disjunction of residuals as a Filter
+        // above the join — not left as a raw cross product.
+        let join_key = || {
+            Expr::bin(
+                BinaryOp::Eq,
+                col_at(0, "id", ProximaType::Int64),
+                col_at(4, "user_id", ProximaType::Int64),
+            )
+        };
+        let hi = Expr::bin(
+            BinaryOp::Gt,
+            col_at(5, "total", ProximaType::Float64),
+            Expr::literal(ProximaValue::Float64(100.0)),
+        );
+        let lo = Expr::bin(
+            BinaryOp::Lt,
+            col_at(5, "total", ProximaType::Float64),
+            Expr::literal(ProximaValue::Float64(5.0)),
+        );
+        let predicate = Expr::bin(
+            BinaryOp::Or,
+            Expr::bin(BinaryOp::And, join_key(), hi),
+            Expr::bin(BinaryOp::And, join_key(), lo),
+        );
+        let physical = PhysicalPlan::Filter {
+            input: Box::new(PhysicalPlan::Join {
+                left: Box::new(lower_to_physical(users_scan())),
+                right: Box::new(lower_to_physical(orders_scan())),
+                kind: JoinKind::Cross,
+                on: None,
+                strategy: JoinStrategy::NestedLoop,
+            }),
+            predicate,
+        };
+
+        let result = push_predicates(physical, &cap_full(Vec::new()));
+        // Residual disjunction sits as a Filter above the normalized equi-join.
+        let PhysicalPlan::Filter {
+            input,
+            predicate: resid,
+        } = result
+        else {
+            panic!("expected residual Filter over the normalized join");
+        };
+        assert!(
+            matches!(
+                resid,
+                Expr::BinaryOp {
+                    op: BinaryOp::Or,
+                    ..
+                }
+            ),
+            "residual is the reduced disjunction (total>100 OR total<5)"
+        );
+        let PhysicalPlan::Join {
+            kind, on, strategy, ..
+        } = *input
+        else {
+            panic!("expected a normalized equi-join under the residual filter");
+        };
+        assert_eq!(kind, JoinKind::Inner, "shared equi-key normalizes to Inner");
+        assert!(
+            on.is_some(),
+            "the shared cross-side equality becomes the ON key"
+        );
+        assert!(matches!(strategy, JoinStrategy::Hash { .. }));
     }
 
     #[test]

--- a/docs/10-quality/td/TD-REL-LOWER-6-disjunction-shared-equi-key-cross-join.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-6-disjunction-shared-equi-key-cross-join.adoc
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-6: Comma-join equi-key hidden inside an OR-of-ANDs declines as an unnormalized cross join (TPC-H Q19)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **FIXED 2026-07-15** — the planner's `push_predicates` cross→equi normalization now factors a cross-side equi-key shared by *every* branch of a top-level disjunction out of the `OR`, so the comma-join normalizes to an equi-join. Filed + fixed in one PR from the post-#1026 native ledger taxonomy.
+| Priority | P2 — the "revenue for these N (brand, container, quantity, size) combinations" shape (a disjunction of range predicates sharing one join key) is common ANSI SQL; it declined the native route as a raw cross product (`0A000 … unnormalized cross join`). TPC-H **Q19**. Distinct mechanism from the base equi-extraction (TD-REL-LOWER-2, already landed).
+| Component | `crates/query/proximadb-relational-planner` — `push_predicates` filter-over-cross-join classification + the new `factor_common_cross_equalities` / `flatten_or` / `combine_any` helpers.
+| Evidence | Native ledger sweep: Q19 → `0A000: native execution declined an unnormalized cross join`. The query lowers fine; the decline is at the planner. `flatten_and` treats the top-level `OR` as one opaque residual conjunct, so the join key `p_partkey = l_partkey` — repeated inside *every* `OR` branch — is never seen by `is_cross_side_equality`, and the `CrossJoin` survives to `plan_has_raw_cross_join` (relational_pipeline.rs).
+|===
+
+== The finding
+
+A comma-join `FROM a, b` lowers to `CrossJoin(a, b)` + a WHERE `Filter`; the planner normalizes it to an equi-join by pulling cross-side equalities out of the filter's **AND**-conjuncts. Q19's join key lives inside a **disjunction** instead:
+
+[source,sql]
+----
+FROM lineitem, part
+WHERE (p_partkey = l_partkey AND p_brand = 'Brand#12' AND l_quantity >= 1  AND ...)
+   OR (p_partkey = l_partkey AND p_brand = 'Brand#23' AND l_quantity >= 10 AND ...)
+   OR (p_partkey = l_partkey AND ...)
+----
+
+`flatten_and` stops at the top-level `OR`, so `p_partkey = l_partkey` is never extracted and the cross product is left raw — which `plan_has_raw_cross_join` then declines.
+
+== The fix
+
+`(A=B ∧ p1) ∨ (A=B ∧ p2) ∨ …` is logically `A=B ∧ (p1 ∨ p2 ∨ …)` — a cross-side equality present in **every** branch distributes out of the disjunction. `factor_common_cross_equalities` detects such shared equi-terms (structural match across all OR branches via `flatten_or` + `flatten_and`), routes them to the join's `implicit_join_bucket` (becoming the `Inner`/`Hash` join key), and rebuilds the reduced disjunction (`combine_any`) as the residual `Filter` above the join. If stripping the common terms empties a branch (that branch was exactly `A=B`, so the disjunction collapses to `A=B` by absorption), no residual is kept. Purely additive: a disjunction that shares no cross-side equality across all branches is left untouched (declines exactly as before).
+
+== Gate
+
+* `tests/rel_crossjoin_or_factor_e2e.rs` — pgwire e2e: an `(id=cid ∧ tier=A ∧ amt≥100) ∨ (id=cid ∧ tier=B ∧ amt≥50)` comma-join returns the correct `sum` (was `0A000` pre-fix).
+* Planner unit test `comma_join_disjunction_factors_shared_equi_key` — asserts the plan becomes `Filter(p1 ∨ p2)` over an `Inner`/`Hash` join on the shared key; the existing `comma_join_filter_normalizes_to_hash_join_with_residual` still passes (no regression).
+* Native ledger sweep: Q19 flips to native, row-exact vs the DataFusion baseline.
+
+== Non-goals (separate cross-join mechanisms — future work)
+
+* **Q9** — an N-way comma-join where some table pair has *no* direct equi-key (transitive-only, e.g. `part × supplier` joined through `lineitem`): needs equi-key-driven **join reordering**, not OR-factoring.
+* **Q8** — a self-join inside a derived table whose equi-key lives in the *outer* query: needs derived-table predicate propagation.

--- a/tests/rel_crossjoin_or_factor_e2e.rs
+++ b/tests/rel_crossjoin_or_factor_e2e.rs
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-LOWER-6 — a comma-join whose equi-join key appears only inside a
+//! top-level `OR` of range predicates (TPC-H Q19 shape) must normalize to an
+//! equi-join on the native route, not decline with `0A000 … unnormalized cross
+//! join`. The planner factors the shared `c.id = o.cid` out of the disjunction:
+//! `(c.id=o.cid ∧ p1) ∨ (c.id=o.cid ∧ p2)` ≡ `c.id=o.cid ∧ (p1 ∨ p2)`.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+async fn rows(client: &tokio_postgres::Client, sql: &str) -> Vec<Vec<String>> {
+    let msgs = client.simple_query(sql).await.unwrap_or_else(|e| {
+        panic!(
+            "{sql}\n  {}",
+            e.as_db_error()
+                .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+                .unwrap_or_else(|| e.to_string())
+        )
+    });
+    msgs.iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                (0..r.len())
+                    .map(|i| r.get(i).unwrap_or("").to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn native_comma_join_disjunction_equi_key() {
+    std::thread::Builder::new()
+        .name("rel-crossjoin-or-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(body())
+        })
+        .expect("spawn")
+        .join()
+        .expect("panic");
+}
+
+async fn body() {
+    let server = PgServer::start().await.expect("server");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    for ddl in [
+        "DROP TABLE IF EXISTS cust",
+        "DROP TABLE IF EXISTS ord",
+        "CREATE TABLE cust (id INT PRIMARY KEY, tier VARCHAR)",
+        "CREATE TABLE ord (oid INT PRIMARY KEY, cid INT, amt INT)",
+        "INSERT INTO cust VALUES (1,'A'),(2,'B'),(3,'C')",
+        // cid=1(tier A): amt 100,40 ; cid=2(tier B): amt 60,30 ; cid=3(tier C): 200
+        "INSERT INTO ord VALUES (10,1,100),(11,1,40),(12,2,60),(13,2,30),(14,3,200)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+
+    // Q19 shape: the join key `cust.id = ord.cid` appears in BOTH branches of a
+    // top-level OR of (tier, amount) range predicates. Was declined pre-fix with
+    // `0A000 … unnormalized cross join`.
+    //   branch A: tier='A' AND amt>=100 → (1,10) amt 100
+    //   branch B: tier='B' AND amt>=50  → (2,12) amt 60
+    //   sum = 160
+    let got = rows(
+        &client,
+        "SELECT sum(ord.amt) AS rev FROM cust, ord \
+         WHERE (cust.id = ord.cid AND cust.tier = 'A' AND ord.amt >= 100) \
+            OR (cust.id = ord.cid AND cust.tier = 'B' AND ord.amt >= 50)",
+    )
+    .await;
+    assert_eq!(got.len(), 1, "global aggregate is a single row");
+    let rev: i64 = got[0][0].parse().expect("i64");
+    assert_eq!(
+        rev, 160,
+        "OR-of-ANDs comma join must equi-join and sum correctly"
+    );
+
+    eprintln!("✓ TD-REL-LOWER-6 disjunction-shared equi-key normalizes on the native route");
+}


### PR DESCRIPTION
## What

Teaches the planner's `push_predicates` cross→equi normalization to factor a cross-side equi-join key that is shared by **every branch of a top-level disjunction** out of the `OR`, so a comma-join whose join key only lives inside an OR of range predicates (TPC-H **Q19**) normalizes to an equi-join instead of declining as a raw cross product. Closes **TD-REL-LOWER-6**.

## Root cause

A comma-join lowers to `CrossJoin + Filter`; the planner extracts cross-side equalities from the filter's **AND**-conjuncts to build the join key. Q19 hides its key inside a disjunction:

```sql
FROM lineitem, part
WHERE (p_partkey=l_partkey AND p_brand='Brand#12' AND l_quantity>=1  AND ...)
   OR (p_partkey=l_partkey AND p_brand='Brand#23' AND l_quantity>=10 AND ...)
   OR (p_partkey=l_partkey AND ...)
```

`flatten_and` stops at the top-level `OR`, so `p_partkey=l_partkey` is never extracted and the cross product survives to `plan_has_raw_cross_join`, which declines it (`0A000 … unnormalized cross join`).

## Fix

`(A=B ∧ p₁) ∨ (A=B ∧ p₂) ∨ …` is logically `A=B ∧ (p₁ ∨ p₂ ∨ …)` — a cross-side equality in every branch distributes out. New helper `factor_common_cross_equalities` (+ `flatten_or` / `combine_any`) detects the shared equi-terms (structural match across all OR branches), routes them to the join's `implicit_join_bucket` (→ Inner/Hash join key), and rebuilds the reduced disjunction as the residual `Filter` above the join. Absorption handled: if stripping the common terms empties a branch, no residual is kept. **Purely additive** — a disjunction sharing no cross-side equality across all branches is untouched (declines exactly as before).

## Measured (TPC-H ledger, SF 0.001, row-exact vs DataFusion)

- **Q19 flips to native, row-exact** ✓.
- The cross-join family splits into **three distinct mechanisms** — only Q19 is OR-factoring:
  - **Q9** — an N-way join where `part × supplier` have *no direct* equi-key (transitive-only): needs equi-key-driven **join reordering**.
  - **Q8** — a self-join in a derived table whose equi-key lives in the *outer* query: needs derived-table predicate propagation.

## Tests / gates

- `tests/rel_crossjoin_or_factor_e2e.rs` — pgwire e2e: an `(id=cid ∧ tier=A ∧ amt≥100) ∨ (id=cid ∧ tier=B ∧ amt≥50)` comma join returns the correct `sum` (was `0A000` pre-fix).
- Planner unit test `comma_join_disjunction_factors_shared_equi_key`; the existing `comma_join_filter_normalizes_to_hash_join_with_residual` still passes (no regression).
- 54 planner tests green · clippy `-D warnings` · `work-commit-check` · `check_td_adr_unique` · server binary builds.

## Scope / follow-ups

Q9 (join reordering) and Q8 (derived-table predicates) are the remaining cross-join mechanisms — separate, harder, filed as non-goals in the TD.