### PR TITLE
refactor(sst): remove dormant legacy RaBitQ read-path (ADR-062 follow-up)

### DIFF
--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -239,96 +239,6 @@ impl SstEngine {
     /// **Metric gate.** Serves only Euclidean collections — the cascade's rerank is
     /// L2-validated (recall 0.932 @ N=100k). Other metrics stay on the generic scan
     /// until the cascade is metric-generalized + re-validated (follow-up).
-    /// TD-RDSTRAT-5 S3: the block indices to scan for `sstable_path`, from the
-    /// Vector Object Economy directory's per-block centroids (loaded cache-first).
-    /// Returns `None` — "scan every block" (unchanged) — whenever the prune can't
-    /// apply: no directory cache, the directory is missing/stale/corrupt, this file
-    /// isn't in the directory, or it carries no centroids (unclustered). So the
-    /// caller degrades safely to the full scan. `Some(indices)` are the survivors of
-    /// [`select_blocks_by_centroid`] over the file's block centroids.
-    async fn voe_centroid_selected_blocks(
-        &self,
-        collection_id: &str,
-        collection_root: &str,
-        sstable_path: &str,
-        query: &[f32],
-        metric: DistanceMetric,
-    ) -> Option<Vec<usize>> {
-        use crate::storage::engines::sst::IndexEntry;
-        use crate::storage::engines::sst::object_economy_directory::load_directory_for;
-        use crate::storage::engines::sst::readers::block_pruning::select_blocks_by_centroid;
-        use proximadb_catalog::CatalogAuthorityMode;
-
-        let cache = self.directory_cache_ref()?;
-        let fs = self.filesystem().get_filesystem(sstable_path).ok()?;
-        let handle = cache.handle_for(collection_id);
-        let (cid, root) = (collection_id.to_string(), collection_root.to_string());
-        let entry = handle
-            .get_or_load(move || async move {
-                load_directory_for(
-                    fs.as_ref(),
-                    &cid,
-                    &root,
-                    0,
-                    CatalogAuthorityMode::RebuildableProjection,
-                )
-                .await
-            })
-            .await;
-        if entry.status.is_degraded() {
-            return None; // missing / stale / corrupt → full scan (mixed-read-safe)
-        }
-        // Match the directory file entry by FILENAME BASENAME, not the full URL:
-        // the emit side records `object_url = "{atomic_op.final_url}/{filename}"`
-        // (flush emission) while the read side gets `sstable_path = entry.url` from
-        // `fs.list` (discover_sstable_files) — the two URLs are built by different
-        // code paths, so scheme/normalization can differ and an exact `==` is
-        // fragile. Filenames are unique within a per-collection directory, so the
-        // basename is the stable join key. (The prune's actual dark-out was the
-        // sidecar never being written on local fs — the emit ENOENTed until the
-        // `oedir/` parent create_dir_all fix in object_economy_directory::store;
-        // this basename match hardens the read against URL drift regardless.)
-        fn basename(u: &str) -> &str {
-            u.rsplit('/').next().unwrap_or(u)
-        }
-        let want = basename(sstable_path);
-        let file = entry
-            .directory
-            .files
-            .iter()
-            .find(|f| basename(&f.object_url) == want)?;
-        // Adapt the directory's per-block centroids → `IndexEntry` (only the
-        // centroid fields matter to the pruner) and reuse the existing prune.
-        let entries: Vec<IndexEntry> = file
-            .blocks
-            .iter()
-            .map(|b| IndexEntry {
-                block_centroid: b.centroid_fp32.clone().unwrap_or_default(),
-                block_centroid_fp16: b.centroid_fp16.clone(),
-                block_radius: b.centroid_radius,
-                ..Default::default()
-            })
-            .collect();
-        // No usable centroids (unclustered segment) ⇒ don't prune.
-        if entries
-            .iter()
-            .all(|e| e.block_centroid.is_empty() && e.block_centroid_fp16.is_none())
-        {
-            return None;
-        }
-        let prune = crate::storage::engines::sst::block_cluster::centroid_prune_config();
-        let total = entries.len();
-        let selected = select_blocks_by_centroid(query, &entries, metric, &prune);
-        // Record the prune outcome so the recall gate can assert the probe engaged
-        // (centroid_pruned_blocks > 0) rather than silently falling back to a full
-        // scan. `total - selected` is how many blocks the centroid probe skipped.
-        crate::observability::io_trace::record_centroid_prune(
-            total as u64,
-            total.saturating_sub(selected.len()) as u64,
-        );
-        Some(selected)
-    }
-
     #[allow(clippy::too_many_arguments)]
     async fn try_pax_cascade(
         &self,
@@ -340,13 +250,6 @@ impl SstEngine {
         collection_id: &str,
         collection_root: &str,
     ) -> anyhow::Result<Option<Vec<OptimizedSearchRecord>>> {
-        use crate::storage::engines::core::coalesce_strategy::{
-            choose_whole_vs_striped, is_cloud_path, read_strategy_chooser_enabled,
-        };
-        use crate::storage::engines::sst::segment_format::{
-            MetaPrune, pax_field_to_col, rabitq_search_segment, rabitq_search_segment_ranged,
-            segment_index_summary, striped_read_enabled,
-        };
         use proximadb_block_format::RankMetric;
         // Map the query metric to a cascade rank metric. Dot/max-IP and exotic
         // metrics stay on the generic scan (unvalidated recall / score polarity);
@@ -415,132 +318,14 @@ impl SstEngine {
             }
         }
 
-        // Decide whole vs selective (striped) read (ADR-057 / TD-RDSTRAT-3). Only
-        // unfiltered queries are eligible for the striped path (metadata pruning
-        // over the ranged reader is a follow-up). Precedence:
-        //   S2 chooser (PROXIMADB_READ_STRATEGY_CHOOSER) — cost-driven, tier-aware:
-        //     estimate the striped vs whole cost from the tail index (one small read)
-        //     and pick via `choose_whole_vs_striped`; the choice is observe-logged.
-        //   else S1b flag (PROXIMADB_PAX_STRIPED_READ) — raw opt-in.
-        // Both default OFF ⇒ whole read. The striped read is byte-identical, so this
-        // only changes cost; any `None` falls through to the whole read (mixed-read-safe).
-        let use_striped = filter_expression.is_none()
-            && if read_strategy_chooser_enabled() {
-                match segment_index_summary(fs.as_ref(), sstable_path).await? {
-                    Some((n_blocks, total_block_bytes, whole_bytes)) => {
-                        // Striped cost estimate (chooser INPUT, not a hardcoded
-                        // selectivity threshold — the flip gate uses real io_trace):
-                        // Stage-1 codes ≈ 1/6 of the block bytes, Stage-2 SQ8 rerank
-                        // ≈ pool·dim, and ~4 coalesced GETs/block + the index GET.
-                        let dim = query_vector.len() as u64;
-                        let striped_bytes_est = total_block_bytes / 6 + pool as u64 * dim;
-                        let striped_gets_est = 1 + 4 * n_blocks;
-                        let is_cloud = is_cloud_path(sstable_path);
-                        let pick_striped = choose_whole_vs_striped(
-                            is_cloud,
-                            whole_bytes,
-                            striped_gets_est,
-                            striped_bytes_est,
-                        );
-                        tracing::debug!(
-                            target: "rdstrat",
-                            pick_striped,
-                            is_cloud,
-                            n_blocks,
-                            whole_bytes,
-                            striped_bytes_est,
-                            striped_gets_est,
-                            "TD-RDSTRAT-3 S2 cascade read-strategy choice (observe)"
-                        );
-                        pick_striped
-                    }
-                    None => false, // index unreadable → whole
-                }
-            } else {
-                striped_read_enabled()
-            };
-
-        // TD-RDSTRAT-5 S3 (default-OFF): centroid probe-prune. When enabled and the
-        // VOE directory yields a block selection for this file, scan ONLY those
-        // blocks via the ranged reader (forces the ranged path). `None` ⇒ no prune
-        // ⇒ the existing whole/striped logic below (mixed-read-safe fallback).
-        let selected_blocks: Option<Vec<usize>> = if filter_expression.is_none()
-            && crate::storage::engines::sst::block_cluster::centroid_prune_enabled()
-        {
-            self.voe_centroid_selected_blocks(
-                collection_id,
-                collection_root,
-                sstable_path,
-                query_vector,
-                distance_metric,
-            )
-            .await
-        } else {
-            None
-        };
-
-        let hits = 'hits: {
-            if let Some(sel) = selected_blocks.as_deref()
-                && let Some(hits) = rabitq_search_segment_ranged(
-                    fs.as_ref(),
-                    sstable_path,
-                    query_vector,
-                    k,
-                    pool,
-                    rank_metric,
-                    Some(sel),
-                )
-                .await?
-            {
-                break 'hits hits;
-            }
-            if use_striped
-                && let Some(hits) = rabitq_search_segment_ranged(
-                    fs.as_ref(),
-                    sstable_path,
-                    query_vector,
-                    k,
-                    pool,
-                    rank_metric,
-                    None,
-                )
-                .await?
-            {
-                break 'hits hits;
-            }
-            // Whole-segment read (default, striped-declined, or filtered).
-            let bytes = fs
-                .read(sstable_path)
-                .await
-                .map_err(|e| anyhow::anyhow!("reading PAX segment {sstable_path}: {e}"))?;
-            let prune = filter_expression.map(|filter| MetaPrune {
-                filter,
-                field_to_col: &pax_field_to_col,
-            });
-            match rabitq_search_segment(&bytes, query_vector, k, pool, rank_metric, prune)? {
-                Some(hits) => hits,
-                None => return Ok(None), // not PAX / no RaBitQ → caller falls back
-            }
-        };
-        let records = hits
-            .into_iter()
-            .map(|h| {
-                let mut r = OptimizedSearchRecord::new(
-                    h.oid,
-                    OptimizedSearchRecord::standardized_distance_to_similarity(
-                        h.distance,
-                        &distance_metric,
-                    ),
-                );
-                // include_vectors: attach the exact f32 vector when the tier
-                // provided one (filter_search_results strips it if not requested).
-                if let Some(v) = h.vector {
-                    r = r.add_vector(v);
-                }
-                r
-            })
-            .collect();
-        Ok(Some(records))
+        // The legacy in-block RaBitQ cascade (whole-read / striped / centroid-prune)
+        // was superseded by coalesced scan-then-rerank (ADR-062 / TD-RDSTRAT-6) and
+        // removed. A non-coalesced RaBitQ segment (none exist after the #1024
+        // default-on flip) or a filtered query falls through to the caller's exact
+        // materialize-and-rank path (`search_pax_file_exact`) — safe degradation,
+        // never an incorrect result.
+        let _ = (collection_id, collection_root);
+        Ok(None)
     }
 
     /// Default RaBitQ candidate-pool size for top-`k` (recall: pool=200→0.708,

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -21,11 +21,9 @@
 use std::path::Path;
 
 use anyhow::Result;
-use proximadb_block_format::prune::{FieldToColumn, PruneResult, evaluate_block};
 use proximadb_block_format::{
     BLOCK_MAGIC, BlockCompression, BlockMode, RankMetric, VectorQuant, col_id,
 };
-use proximadb_filter_expression::FilterExpression;
 use proximadb_records::ProximaRecord;
 use proximadb_storage_common::pax_block::{
     PaxSegmentScanner, PaxSegmentWriter, SEGMENT_MAGIC, ScanPredicate, SegmentMeta,
@@ -424,25 +422,15 @@ pub struct CascadeHit {
     pub vector: Option<Vec<f32>>,
 }
 
-/// A metadata pre-prune for the cascade scan: a [`FilterExpression`] plus the
-/// field→column resolver that maps its leaf field names to canonical PAX column
-/// ids. Threaded through [`rabitq_search_segment`] so a block whose zone maps
-/// provably exclude the predicate is skipped **before** the (expensive) RaBitQ
-/// vector pass — the cheapest, most-selective stage of the pruning cascade.
-pub struct MetaPrune<'a> {
-    pub filter: &'a FilterExpression,
-    pub field_to_col: &'a FieldToColumn<'a>,
-}
-
 /// Canonical resolver from a filter field name to its PAX column id for
 /// block/row-group pruning — the single mapper shared by every PAX prune path
-/// (the relational ranged `read_records_pruned` scan and the RaBitQ cascade's
-/// [`MetaPrune`]). Only the fixed canonical columns carry zone-map stripes; user
-/// metadata lives in opaque `props` (not prunable), so unknown fields return
-/// `None` and the pruner conservatively keeps the block (no false negatives).
+/// (e.g. the relational ranged `read_records_pruned` scan). Only the fixed
+/// canonical columns carry zone-map stripes; user metadata lives in opaque
+/// `props` (not prunable), so unknown fields return `None` and the pruner
+/// conservatively keeps the block (no false negatives).
 ///
-/// A plain `fn` (not a closure) so it coerces to both `&FieldToColumn` and the
-/// `Sync` form the object-storage ranged path requires.
+/// A plain `fn` (not a closure) so it coerces to both the field→column-mapper
+/// trait object form and the `Sync` form the object-storage ranged path requires.
 pub(crate) fn pax_field_to_col(field: &str) -> Option<i32> {
     match field {
         "id" | "oid" => Some(col_id::OID),
@@ -453,134 +441,6 @@ pub(crate) fn pax_field_to_col(field: &str) -> Option<i32> {
         "valid_to" | "valid_to_ns" => Some(col_id::VALID_TO),
         _ => None,
     }
-}
-
-/// Cold-scan a PAX+RaBitQ segment for the `k` nearest neighbours of `query` using
-/// the co-designed cascade (P3 C.2): per block, an optional **metadata stats
-/// pre-prune** skips blocks the predicate provably excludes (the cheap pre-vector
-/// filter), then the RaBitQ codes drive a candidate prefilter (`pool` rows via
-/// `rabitq_rank`), and ONLY those candidates are reranked against the co-located
-/// SQ8 column (`rerank_rows`) — full f32 is never decoded. Hits merge across
-/// blocks into a global top-`k` (nearest-first).
-///
-/// `prune` runs first because it moves the dominant cost term (I/O round-trips):
-/// a skipped block reads neither its codes stripe nor any SQ8 candidate, so the
-/// trace below records fewer bytes/gets for a selective query than the unpruned
-/// baseline. Pruning is conservative (a block is skipped only if it *cannot*
-/// match), so it never drops a true match; final per-row metadata filtering
-/// remains the caller's responsibility (consistent with the materialize-and-score
-/// search path).
-///
-/// Returns `Ok(None)` when `bytes` is not a PAX segment, or is a PAX segment with
-/// no RaBitQ-coded embedding (e.g. SQ8/raw): the caller then falls back to its
-/// normal materialize-and-score path, so this is additive and mixed-read-safe.
-///
-/// Emits a query-scoped I/O trace into the active
-/// [`io_trace`](crate::observability::io_trace) scope (no-op outside one),
-/// modelling the cascade's *logical* reads per kept block — the RaBitQ codes
-/// stripe (stage 1) plus the candidate SQ8 bytes (stage 2). Pruned blocks
-/// contribute nothing, so the trace makes the pruning win observable per the
-/// co-design measure-first mandate. (Whole-segment transport bytes are traced by
-/// the caller that fetched them; ranged codes-only fetches are a follow-up.)
-pub fn rabitq_search_segment(
-    bytes: &[u8],
-    query: &[f32],
-    k: usize,
-    pool: usize,
-    metric: RankMetric,
-    prune: Option<MetaPrune<'_>>,
-) -> Result<Option<Vec<CascadeHit>>> {
-    use crate::observability::io_trace;
-
-    if SegmentFormat::detect(bytes) != SegmentFormat::Pax {
-        return Ok(None);
-    }
-    let mut scanner = PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())?;
-
-    let pool = pool.max(k);
-    let mut any_rabitq = false;
-    let mut hits: Vec<CascadeHit> = Vec::new();
-    while let Some(block) = scanner.next_block() {
-        // Stage 0: metadata stats pre-prune. Skip the whole block — no codes, no
-        // SQ8 — when its zone maps provably exclude the predicate (conservative:
-        // `Skip` only when the block cannot match, so no true match is lost).
-        if let Some(mp) = &prune
-            && evaluate_block(&block, mp.filter, mp.field_to_col) == PruneResult::Skip
-        {
-            continue;
-        }
-
-        // Stage 1: RaBitQ candidate prefilter on the hot codes column. A block
-        // whose EMBED_BASE isn't RaBitQ-encoded yields `None` and is skipped
-        // (mixed-quant segments stay safe).
-        let Some(cand) = block.rabitq_rank(query, pool, metric) else {
-            continue;
-        };
-        any_rabitq = true;
-
-        // Project the cascade's LOGICAL striped read for this kept block: the RaBitQ
-        // codes stripe (stage 1) + the SQ8 bytes for the candidate pool (stage 2) —
-        // what a selective striped read WOULD move for the *real* candidate set. This
-        // is recorded into the distinct `logical_striped_*` counters (NOT the physical
-        // `bytes_read`/`range_gets`, which reflect the whole-segment `fs.read`), so the
-        // striped-vs-whole headroom is measurable per query on real candidate scatter
-        // (ADR-057 / TD-RDSTRAT-3). Projection-only; moves no bytes. Fixes the
-        // TD-RDSTRAT-2 double-count (it previously inflated the physical byte total).
-        let dim = block
-            .vector_params()
-            .get(col_id::EMBED_BASE)
-            .map(|e| e.dim as u64)
-            .unwrap_or(0);
-        let codes_len = block
-            .column_metas()
-            .iter()
-            .find(|m| m.column_id == col_id::EMBED_BASE)
-            .map(|m| m.stripe_len as u64)
-            .unwrap_or(0);
-        io_trace::record_logical_striped(codes_len + cand.len() as u64 * dim, 1);
-
-        // Stage 2 rerank over ONLY the candidate rows. Prefer the EXACT-f32 tier
-        // when present (P3 Phase D: recall ≈ 1.0), else the co-located SQ8 rerank
-        // column, else keep the RaBitQ-coarse order.
-        let scored = block
-            .rerank_rows_f32_exact(0, query, &cand, metric)
-            .or_else(|| block.rerank_rows(0, query, &cand, metric))
-            .unwrap_or_else(|| {
-                cand.iter()
-                    .enumerate()
-                    .map(|(rank, &row)| (row, rank as f32))
-                    .collect()
-            });
-        let oids = block.decode_str_stripe(col_id::OID);
-        // include_vectors: when the f32 tier is present, decode the top-k exact
-        // vectors (top-k rows only — lazy, read-budget-tight) and attach them so
-        // the caller can materialize exact vectors without a second segment scan.
-        let topk: Vec<(usize, f32)> = scored.into_iter().take(k).collect();
-        let topk_rows: Vec<usize> = topk.iter().map(|(r, _)| *r).collect();
-        let f32_vecs = block.decode_f32_tier_rows(0, &topk_rows);
-        for (i, (row, dist)) in topk.into_iter().enumerate() {
-            let oid = oids
-                .as_ref()
-                .and_then(|o| o.get(row).cloned().flatten())
-                .unwrap_or_default();
-            let vector = f32_vecs.as_ref().and_then(|v| v.get(i).cloned().flatten());
-            hits.push(CascadeHit {
-                oid,
-                distance: dist,
-                vector,
-            });
-        }
-    }
-    if !any_rabitq {
-        return Ok(None);
-    }
-    hits.sort_by(|a, b| {
-        a.distance
-            .partial_cmp(&b.distance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    hits.truncate(k);
-    Ok(Some(hits))
 }
 
 /// Whether the coalesced-RaBitQ layout is engaged for new RaBitQ writes
@@ -614,192 +474,6 @@ pub fn striped_read_enabled() -> bool {
             .as_deref(),
         Some("1" | "true" | "on" | "yes")
     )
-}
-
-/// Bounds-checked slice of a block-relative metadata `range` from a buffer that
-/// begins at block-relative `base` (fail-closed on a corrupt footer, no panic).
-fn slice_at<'a>(buf: &'a [u8], base: u64, range: &std::ops::Range<u64>) -> Result<&'a [u8]> {
-    let (s, e) = (range.start.checked_sub(base), range.end.checked_sub(base));
-    match (s, e) {
-        (Some(s), Some(e)) if s <= e && (e as usize) <= buf.len() => {
-            Ok(&buf[s as usize..e as usize])
-        }
-        _ => anyhow::bail!("striped read: metadata range {range:?} outside buffer (base {base})"),
-    }
-}
-
-/// **Selective (striped) cascade** over a PAX segment on the engine's own
-/// filesystem (ADR-057 / TD-RDSTRAT-3 Slice C): the ranged analogue of
-/// [`rabitq_search_segment`]. Reads ONLY the tail segment index + per surviving
-/// block the RaBitQ codes stripe (Stage-1 rank) + the SQ8 candidate-rerank stripe
-/// (Stage-2) + the OID stripe — never the whole segment — via `fs.read_range`,
-/// composing the `BlockLayout` ranged primitives. Returns the SAME top-`k`
-/// `CascadeHit`s as the whole-segment cascade for the default SQ8 config (parity
-/// gated in tests); `Ok(None)` when the tail index can't be located from a bounded
-/// suffix or no block is RaBitQ-coded, so the caller falls back to the whole read
-/// (mixed-read-safe). Physical bytes/GETs are recorded by the fs layer, so the
-/// striped read's real cost is observable in `io_trace`. Metadata pruning (filtered
-/// queries) is a follow-up — the caller routes only unfiltered queries here.
-pub async fn rabitq_search_segment_ranged(
-    fs: &dyn proximadb_storage_filesystem_types::FileSystem,
-    path: &str,
-    query: &[f32],
-    k: usize,
-    pool: usize,
-    metric: RankMetric,
-    // TD-RDSTRAT-5 S3: when `Some`, scan ONLY these block indices (the centroid
-    // probe-prune survivors). `None` scans every block (unchanged behaviour). An
-    // index out of range is simply never matched (no panic).
-    selected: Option<&[usize]>,
-) -> Result<Option<Vec<CascadeHit>>> {
-    use proximadb_block_format::BlockFooter;
-    use proximadb_block_format::ranged::{BlockLayout, footer_tail_range, metadata_ranges};
-    use proximadb_storage_common::pax_block::SegmentIndex;
-
-    let size = fs
-        .metadata(path)
-        .await
-        .map_err(|e| anyhow::anyhow!("striped read stat {path}: {e}"))?
-        .size;
-    if size < SEGMENT_MAGIC.len() as u64 {
-        return Ok(None);
-    }
-
-    // Locate the tail segment index from a bounded suffix (grown ×8 on miss); if it
-    // still doesn't fit at full size, decline → caller reads the whole segment.
-    let mut suffix_len = (64 * 1024u64).min(size);
-    let index = loop {
-        let suffix = fs
-            .read_range(path, size - suffix_len, suffix_len)
-            .await
-            .map_err(|e| anyhow::anyhow!("striped read suffix {path}: {e}"))?;
-        if !suffix.ends_with(SEGMENT_MAGIC) {
-            return Ok(None); // not a PAX segment
-        }
-        let before_magic = &suffix[..suffix.len() - SEGMENT_MAGIC.len()];
-        match SegmentIndex::locate(before_magic) {
-            Ok(idx) => break idx,
-            Err(_) if suffix_len < size => suffix_len = (suffix_len * 8).min(size),
-            Err(_) => return Ok(None),
-        }
-    };
-
-    let pool = pool.max(k);
-    let mut any_rabitq = false;
-    let mut hits: Vec<CascadeHit> = Vec::new();
-    for (block_idx, entry) in index.blocks.iter().enumerate() {
-        // S3 centroid prune: skip blocks the probe-prune didn't select.
-        if let Some(sel) = selected
-            && !sel.contains(&block_idx)
-        {
-            continue;
-        }
-        let (off, bsz) = (entry.offset, entry.size as u64);
-        if off + bsz > size {
-            anyhow::bail!("striped read: block [{off}..+{bsz}] past segment {size}");
-        }
-
-        // Footer (last 32 B) → metadata extent (one ranged read) → BlockLayout.
-        let fr = footer_tail_range(bsz)?;
-        let footer_bytes = fs
-            .read_range(path, off + fr.start, fr.end - fr.start)
-            .await?;
-        let footer = BlockFooter::from_bytes(&footer_bytes)?;
-        let mr = metadata_ranges(&footer, bsz);
-        let footer_start = bsz - proximadb_block_format::BLOCK_FOOTER_SIZE as u64;
-        let mut meta_start = mr.col_meta.start;
-        if let Some(r) = &mr.vparam {
-            meta_start = meta_start.min(r.start);
-        }
-        if let Some(r) = &mr.rgdir {
-            meta_start = meta_start.min(r.start);
-        }
-        let meta_buf = if footer_start > meta_start {
-            fs.read_range(path, off + meta_start, footer_start - meta_start)
-                .await?
-        } else {
-            Vec::new()
-        };
-        let col_meta = slice_at(&meta_buf, meta_start, &mr.col_meta)?;
-        let vparam = match &mr.vparam {
-            Some(r) => Some(slice_at(&meta_buf, meta_start, r)?),
-            None => None,
-        };
-        let rgdir = match &mr.rgdir {
-            Some(r) => Some(slice_at(&meta_buf, meta_start, r)?),
-            None => None,
-        };
-        let layout = BlockLayout::assemble(footer, col_meta, vparam, rgdir)?;
-
-        // Stage 1: fetch ONLY the codes stripe, rank.
-        let Some(cr) = layout.column_stripe_range(col_id::EMBED_BASE) else {
-            continue;
-        };
-        let codes = fs
-            .read_range(path, off + cr.start, cr.end - cr.start)
-            .await?;
-        let Some(cand) = layout.rabitq_rank(query, pool, metric, &codes) else {
-            continue; // not RaBitQ-coded
-        };
-        any_rabitq = true;
-        if cand.is_empty() {
-            continue;
-        }
-
-        // Stage 2: fetch the SQ8 rerank stripe, rerank ONLY the candidate rows.
-        let scored: Vec<(usize, f32)> = match layout.column_stripe_range(col_id::RERANK_BASE) {
-            Some(rr) => {
-                let rer = fs
-                    .read_range(path, off + rr.start, rr.end - rr.start)
-                    .await?;
-                layout
-                    .rerank_candidate_rows(col_id::RERANK_BASE, query, &cand, metric, &rer)
-                    .unwrap_or_else(|| {
-                        cand.iter()
-                            .enumerate()
-                            .map(|(rank, &row)| (row, rank as f32))
-                            .collect()
-                    })
-            }
-            None => cand
-                .iter()
-                .enumerate()
-                .map(|(rank, &row)| (row, rank as f32))
-                .collect(),
-        };
-        let topk: Vec<(usize, f32)> = scored.into_iter().take(k).collect();
-
-        // Fetch the OID stripe once for this block, attach ids.
-        let oids = match layout.column_stripe_range(col_id::OID) {
-            Some(o) => {
-                let ob = fs.read_range(path, off + o.start, o.end - o.start).await?;
-                layout.decode_str_column(col_id::OID, &ob)
-            }
-            None => None,
-        };
-        for (row, dist) in topk {
-            let oid = oids
-                .as_ref()
-                .and_then(|o| o.get(row).cloned().flatten())
-                .unwrap_or_default();
-            hits.push(CascadeHit {
-                oid,
-                distance: dist,
-                vector: None,
-            });
-        }
-    }
-
-    if !any_rabitq {
-        return Ok(None);
-    }
-    hits.sort_by(|a, b| {
-        a.distance
-            .partial_cmp(&b.distance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    hits.truncate(k);
-    Ok(Some(hits))
 }
 
 /// A coalesced ranged GET over one or more survivor data blocks.
@@ -1025,48 +699,6 @@ pub async fn rabitq_search_segment_coalesced(
     Ok(Some(hits))
 }
 
-/// Cheap cost inputs for the S2 read-strategy chooser, read from the tail segment
-/// index alone (one small ranged read — no per-block metadata, no stripe bytes):
-/// `(n_blocks, total_block_bytes, segment_size)`. Returns `None` when the index
-/// can't be located from a bounded suffix (caller then defaults to the whole read).
-/// `total_block_bytes` (Σ block sizes) is the whole-read byte cost; the striped read
-/// touches only a fraction (codes + candidate rerank), estimated by the caller.
-pub async fn segment_index_summary(
-    fs: &dyn proximadb_storage_filesystem_types::FileSystem,
-    path: &str,
-) -> Result<Option<(u64, u64, u64)>> {
-    use proximadb_storage_common::pax_block::SegmentIndex;
-
-    let size = fs
-        .metadata(path)
-        .await
-        .map_err(|e| anyhow::anyhow!("index-summary stat {path}: {e}"))?
-        .size;
-    if size < SEGMENT_MAGIC.len() as u64 {
-        return Ok(None);
-    }
-    let mut suffix_len = (64 * 1024u64).min(size);
-    loop {
-        let suffix = fs
-            .read_range(path, size - suffix_len, suffix_len)
-            .await
-            .map_err(|e| anyhow::anyhow!("index-summary suffix {path}: {e}"))?;
-        if !suffix.ends_with(SEGMENT_MAGIC) {
-            return Ok(None);
-        }
-        let before_magic = &suffix[..suffix.len() - SEGMENT_MAGIC.len()];
-        match SegmentIndex::locate(before_magic) {
-            Ok(idx) => {
-                let n_blocks = idx.blocks.len() as u64;
-                let total_block_bytes: u64 = idx.blocks.iter().map(|b| b.size as u64).sum();
-                return Ok(Some((n_blocks, total_block_bytes, size)));
-            }
-            Err(_) if suffix_len < size => suffix_len = (suffix_len * 8).min(size),
-            Err(_) => return Ok(None),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1202,14 +834,13 @@ mod tests {
         assert_eq!(oids, vec!["w1", "w2"]);
     }
 
-    /// M1 (ADR-049): a `VectorQuant::RawF32` PAX segment carries no RaBitQ codes,
-    /// so the RaBitQ cascade (`rabitq_search_segment`) returns `None` for it. The
-    /// search dispatch then takes the exact PAX scan (`search_pax_file_exact`),
-    /// which materialises records via `read_segment_records`. This proves the two
-    /// foundations of that path: a RawF32 PAX segment round-trips to EXACT f32
-    /// vectors (recall 1.0), and the cascade correctly reports it as a miss.
+    /// M1 (ADR-049): a `VectorQuant::RawF32` PAX segment round-trips to EXACT f32
+    /// vectors (recall 1.0) — proving the foundation of the exact PAX scan path
+    /// (`search_pax_file_exact`, which materialises records via
+    /// `read_segment_records`). RawF32 decodes to the exact input vectors, not an
+    /// approximation (unlike RaBitQ/SQ8 reconstruction).
     #[test]
-    fn rawf32_pax_segment_round_trips_exact_and_misses_rabitq_cascade() {
+    fn rawf32_pax_segment_round_trips_exact() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rawf32.pax");
         let records: Vec<ProximaRecord> = (0..8)
@@ -1244,21 +875,6 @@ mod tests {
                 want.oid
             );
         }
-
-        // The RaBitQ cascade must report a miss (no RaBitQ codes) — the exact
-        // PAX scan in the search dispatch handles this segment instead.
-        let query = records[0]
-            .embeddings
-            .first()
-            .expect("query embedding")
-            .as_fp32_slice()
-            .to_vec();
-        assert!(
-            rabitq_search_segment(&bytes, &query, 4, 8, RankMetric::L2, None)
-                .unwrap()
-                .is_none(),
-            "RawF32 PAX has no RaBitQ codes → cascade must return None (exact scan handles it)"
-        );
     }
 
     /// Mixed-read-safe coexistence (storage-format mandate #8). A store rolling
@@ -1358,131 +974,6 @@ mod tests {
             "larger target_block must yield fewer blocks: {large} >= {small}"
         );
         assert!(large >= 1, "at least one block");
-    }
-
-    #[test]
-    fn rabitq_search_segment_metadata_pruning_skips_blocks() {
-        use proximadb_filter_expression::ComparisonOperator;
-
-        const DIM: usize = 32;
-        const N: usize = 300;
-        const K: usize = 10;
-        const POOL: usize = 50;
-        // Two clusters with a large gap in created_at so no PAX block can
-        // straddle the filter boundary. The gap (100k ns ≈ many block widths)
-        // guarantees the zone-map min/max of any block falls entirely on one
-        // side of THRESHOLD, making the prune deterministic regardless of the
-        // exact block boundaries the writer produces on different runners.
-        //   records 0..199:   created_at = 1_000 + i     (prunable)
-        //   records 200..299: created_at = 100_000 + i   (surviving)
-        const THRESHOLD: i64 = 50_000;
-
-        let gen_vec = |seed: u64| -> Vec<f32> {
-            let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
-            (0..DIM)
-                .map(|_| {
-                    s ^= s >> 30;
-                    s = s.wrapping_mul(0xBF58_476D_1CE4_E5B9);
-                    s ^= s >> 27;
-                    ((s >> 11) as f32 / (1u64 << 53) as f32) * 2.0 - 1.0
-                })
-                .collect()
-        };
-        let corpus: Vec<Vec<f32>> = (0..N).map(|i| gen_vec(i as u64)).collect();
-
-        // Force several blocks with a small block-size threshold so early blocks
-        // fall entirely below THRESHOLD and become prunable.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("metaprune.pax");
-        let mut w = PaxSegmentWriter::new(
-            &path,
-            BlockMode::Pax,
-            BlockCompression::None,
-            "col",
-            0,
-            1,
-            Some(2048),
-        )
-        .with_quant(VectorQuant::RaBitQ);
-        for (i, v) in corpus.iter().enumerate() {
-            // Two clusters: [0..200) at 1k+i, [200..300) at 100k+i.
-            let ts = if i < 200 {
-                1_000 + i as i64
-            } else {
-                100_000 + i as i64
-            };
-            w.add_record(&rec(&format!("v{i}"), ts, v.clone())).unwrap();
-        }
-        let meta = w.finish().unwrap();
-        assert!(
-            meta.block_count >= 3,
-            "test needs multiple blocks, got {}",
-            meta.block_count
-        );
-        let bytes = std::fs::read(&path).unwrap();
-
-        // A query that lives in a SURVIVING block (created_at 100290 >= THRESHOLD).
-        let query = corpus[290].clone();
-
-        let filter = FilterExpression::Comparison {
-            field: "created_at".to_string(),
-            operator: ComparisonOperator::GreaterThanOrEqual,
-            value: serde_json::json!(THRESHOLD),
-        };
-        // Use the SAME canonical mapper the relational pruned-read path uses.
-        let f2c = pax_field_to_col;
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .unwrap();
-
-        // Baseline: no prune — scans every block.
-        let baseline = rt.block_on(crate::observability::io_trace::scope(async {
-            let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, None)
-                .unwrap()
-                .expect("PAX+RaBitQ segment");
-            let snap = crate::observability::io_trace::snapshot().unwrap();
-            (hits, snap.logical_striped_bytes, snap.logical_striped_gets)
-        }));
-
-        // Pruned: created_at filter skips the early blocks before the vector pass.
-        let pruned = rt.block_on(crate::observability::io_trace::scope(async {
-            let mp = MetaPrune {
-                filter: &filter,
-                field_to_col: &f2c,
-            };
-            let hits = rabitq_search_segment(&bytes, &query, K, POOL, RankMetric::L2, Some(mp))
-                .unwrap()
-                .expect("PAX+RaBitQ segment");
-            let snap = crate::observability::io_trace::snapshot().unwrap();
-            (hits, snap.logical_striped_bytes, snap.logical_striped_gets)
-        }));
-
-        // (1) The round-trip win: pruning projects strictly fewer striped bytes.
-        // The cascade's logical striped-read counters (`logical_striped_bytes` /
-        // `_gets`, ADR-057 / TD-RDSTRAT-3) are always-on, so both are asserted.
-        assert!(
-            pruned.1 < baseline.1,
-            "metadata prune must reduce logical striped bytes: pruned ({}) vs baseline ({})",
-            pruned.1,
-            baseline.1,
-        );
-        assert!(
-            pruned.2 < baseline.2,
-            "metadata prune must reduce logical striped GETs: pruned ({}) vs baseline ({})",
-            pruned.2,
-            baseline.2,
-        );
-        assert!(
-            pruned.2 >= 1,
-            "at least the surviving block must be scanned"
-        );
-
-        // (2) Soundness: the surviving block is not dropped — its vector is returned.
-        assert!(
-            pruned.0.iter().any(|h| h.oid == "v290"),
-            "pruning must keep blocks that can match (v290 lives in a surviving block)"
-        );
     }
 
     // ── ADR-062 / TD-RDSTRAT-6 coalesced-RaBitQ layout ───────────────────────


### PR DESCRIPTION
Follow-up to #1024 (default-on canonical flip). Coalesced scan-then-rerank now handles every unfiltered RaBitQ query; filtered queries fall through to the exact materialize-and-rank path. The legacy in-block cascade it superseded is dead code — removed here.

## Removed (dormant read-path)
- **`segment_format.rs`**: `rabitq_search_segment` (whole-read per-block cascade), `rabitq_search_segment_ranged` (ranged cascade), `slice_at`, `segment_index_summary` (tail-index cost summary), the `MetaPrune` struct — all only-used-by the removed arms. Converted the `rawf32` test to its remaining exact-round-trip scope; deleted the metadata-prune test. **Kept `pax_field_to_col`** (still used by `src/services/record_store.rs`).
- **`search/mod.rs`**: `try_pax_cascade` collapses to metric-gate → coalesced scan-then-rerank dispatch (unfiltered) → `Ok(None)`. Deleted the dead `voe_centroid_selected_blocks` method.

## Retained (a focused follow-up teardown PR — not this one)
The prune-config/chooser pub fns that lost their callers (`centroid_prune_enabled`, `centroid_prune_config`, `choose_whole_vs_striped`, `striped_read_enabled` — clippy-clean, `pub`) + the write-side block-centroid emission (`SegmentMeta` `block_centroids`/`block_radii` + `pax_write_outcome`). `select_blocks_by_centroid` stays — the **SWIFT engine** uses it.

## Zero overlap with in-flight PRs
Checked at open time: #1026 (relational/frontend) and #1021 (`embedded` crate) touch no SST-storage files — this PR's files (`segment_format.rs`, `search/mod.rs`) have no concurrent editors.

## Verification
root-lib **7580/7580**; `pax_cascade_prod_search` + `sst_compaction_reclustering` integration tests pass; `cargo fmt --check` · `cargo clippy --lib --bins -D warnings` · `make work-commit-check` clean.
