### PR TITLE
fix(security): fail closed on configured posture and SQL transactions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -320,13 +320,13 @@ link:docs/SUPPORTED_SURFACE.adoc[`docs/SUPPORTED_SURFACE.adoc`]:
 |===
 | Capability | Status | Notes
 
-| Vector search + filters | Supported | 4 supported storage engines (SST/VIPER/HELIX/NOVA) + AXIS (HNSW/IVF) indexes, metadata filters
+| Vector search + filters | Supported | SST is the supported storage engine; VIPER/HELIX/NOVA are Beta. AXIS (HNSW/IVF) indexes and metadata filters
 | Document store | Beta | WAL‑backed, JSON path queries, full‑text search; canonical record storage is the convergence path
 | Graph traversal | Beta | ORION (in‑memory CSR), WAL persistence, algorithms; some v1-only RPCs deferred
 | Observability logs | Beta | WAL‑backed, partitioned storage, 6 SIEM adapters
 | Observability metrics | Beta | Time‑series aggregation, downsampling
 | Unified multi‑model query | Beta | Cross‑model joins, parallel execution; strongest on function-backed sources
-| Postgres wire protocol | Supported | ANSI SQL for SQL clients (psql/JDBC/ORM), transactions, pgvector-compatible operator; full Postgres/SQL parity remains Experimental
+| Postgres wire protocol | Supported | ANSI SQL for SQL clients (psql/JDBC/ORM), autocommit statements, pgvector-compatible operator; transaction control returns `0A000` and full Postgres/SQL parity remains Experimental
 | Unified port mode | Experimental | Arrow Flight / gRPC service multiplexing is an experimental customer-facing transport
 | Web UI dashboard | Beta | SQL editor, graph visualization, dark/light theme; fronts Beta surfaces
 | Python SDK | Beta | Graph analytics, AutoML, observability, security; wraps Beta surfaces

--- a/docs/00-product/PRD.adoc
+++ b/docs/00-product/PRD.adoc
@@ -663,7 +663,8 @@ Theme: Production-ready with distributed consensus and security hardening.
 
 | Cross-Model ACID Transactions
 | Saga pattern, compensating transactions, read-your-writes consistency
-| ✅ Complete (Mar 2026, TD-038; 2PC with durable participants, MVCC isolation)
+| Experimental foundation only; participant durability, rollback, isolation, and restart
+  conformance remain release gates. pgwire transaction control is unsupported in v0.2.
 
 | SOC 2 Type II Compliance
 | Encryption at rest, complete RBAC, audit trail integrity, change management

--- a/docs/01-quick-start/architecture-basics.md
+++ b/docs/01-quick-start/architecture-basics.md
@@ -119,9 +119,9 @@ flowchart TB
   style NOVA fill:#9b59b6,color:#fff
 ```
 
-4 supported storage engines for different workloads (SWIFT and RAPTOR also exist
-but are **experimental**, off by default behind the `experimental-engines` cargo
-feature — not part of the supported surface):
+SST is the Supported storage engine. VIPER, HELIX, and NOVA are Beta options for
+different workloads. SWIFT and RAPTOR are **experimental**, off by default behind
+the `experimental-engines` cargo feature and not part of the supported surface:
 
 | Engine | Best For | Performance |
 |--------|----------|-------------|

--- a/docs/03-api-reference/postgres.adoc
+++ b/docs/03-api-reference/postgres.adoc
@@ -105,6 +105,9 @@ the items below; they will return SQL-conformant errors if you try them:
 * Joins.
 * System tables (`pg_class`, `xcatalog.namespaces`).
 * Prepared statements / Bind / Execute pipelining for parameterised queries.
+* Transactions. pgwire is autocommit-only; `BEGIN`, `COMMIT`, `ROLLBACK`, and
+  savepoint control return SQLSTATE `0A000`. A simple-query batch containing
+  transaction control is rejected before any statement in that batch executes.
 * PostgreSQL-style OLTP parity: full MVCC transactions, foreign-key enforcement, unique/check
   constraint enforcement, trigger/stored-procedure behavior, and cross-shard consistency. These
   require the TD-110 storage/constraint foundation.

--- a/docs/05-concepts/architecture.adoc
+++ b/docs/05-concepts/architecture.adoc
@@ -312,7 +312,7 @@ flowchart TB
 
 == Current Implementation Notes
 
-* **Phase 1 Complete**: 4 supported storage engines (SST/VIPER/HELIX/NOVA; SWIFT/RAPTOR are experimental), WAL, APIs, quantization, AXIS indexes.
+* **Phase 1 Complete**: SST is Supported; VIPER/HELIX/NOVA are Beta; SWIFT/RAPTOR are Experimental. WAL, APIs, quantization, and AXIS indexes are present at the tiers listed in the support contract.
 * **Phase 2 Complete**: Cross-model queries, graph database (ORION), document store, observability.
 * **Phase 3 In Progress**: External catalogs, streaming/CDC, distributed operations.
 * **Phase 4 Foundations Beta**: Time-series (TST) and event-sourcing engines are complete; hybrid search (BM25) is wired. Product packaging, API parity, and at-scale validation are in progress -- these are Beta surfaces in v0.2.

--- a/docs/12-design/adr/ADR-018-pgwire-sql-parity-roadmap.adoc
+++ b/docs/12-design/adr/ADR-018-pgwire-sql-parity-roadmap.adoc
@@ -2,7 +2,7 @@
 :toc: left
 :toclevels: 3
 :icons: font
-:last-updated: 2026-05-28
+:last-updated: 2026-07-15
 
 == Status
 
@@ -23,6 +23,12 @@ transaction semantics require the TD-110 foundation first: xCatalog constraint m
 native row/delta commit, primary-key/unique/check/foreign-key enforcement, MVCC visibility,
 Volcano strong-freshness execution, DataFusion snapshot-plus-delta reads, and distributed
 consistency gates.
+
+2026-07-15 safety amendment: until the transaction gates in Phase 2/3 pass, pgwire is explicitly
+autocommit-only. All transaction-control statements return SQLSTATE `0A000`. In the simple-query
+protocol, a batch containing transaction control is rejected before any statement executes. This
+supersedes the earlier Phase 1 no-op command-tag posture, which allowed clients to infer atomicity
+that the storage layer could not provide.
 
 == Context
 
@@ -99,9 +105,9 @@ feature is honest about its behaviour.
 |===
 | Item | Status | Where | Effort
 
-| 1.1 Silent transaction bug — multi-statement split, BEGIN /
-COMMIT / ROLLBACK tags, autocommit warning, savepoint 0A000
-| **Done** (ac969aa12)
+| 1.1 Silent transaction bug — multi-statement split plus whole-batch
+transaction-control rejection (`0A000`) before execution
+| **Done** (safety posture strengthened 2026-07-15)
 | `src/network/postgres/protocol.rs`
 | 0.5d
 
@@ -419,8 +425,8 @@ Effort: 7–10d.
    tests.** Without `pg_class` + `pg_attribute`, every modern ORM
    refuses to connect on first probe.
 3. **Phase 2's real transactions (P2.D) gate any multi-statement
-   write workflow.** Until P2.D lands, every transactional client
-   sees a `WARNING` log every time it sends BEGIN.
+   write workflow.** Until P2.D lands, every transaction-control
+   statement fails with SQLSTATE `0A000`; clients must not infer atomicity.
 4. **Phase 3's MVCC (P3.B) gates real concurrent workloads.**
    Until P3.B, ProximaDB is functionally an autocommit database —
    fine for read-mostly workloads, unsafe for write-contended ones.

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -90,8 +90,8 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
   metadata (pgwire cannot) and uses HTTP/2 + protobuf. Relational SELECTs route
   through the same pipeline as pgwire (ComputeScheduler → DataFusion/Volcano);
   DDL/DML route through the same tenant-scoped `DdlService`/`DmlService` seams —
-  all scoped to the `x-tenant-id` tenant (TD-064). Multi-statement transactions
-  (BEGIN/COMMIT) remain pgwire-only (this RPC is single-statement).
+  all scoped to the `x-tenant-id` tenant (TD-064). This RPC is single-statement;
+  pgwire is also autocommit-only and rejects transaction control with SQLSTATE `0A000`.
 | Supported (vector/graph SQL + tenant-scoped relational SELECT/DDL/DML)
 
 | *REST/gRPC `/api/v2/query`* (unified query port)
@@ -126,15 +126,18 @@ query endpoint, and `/api/v2/query` is *not* SQL-over-REST. Route by language:
 * pgwire is *SQL-only* and cannot serve UQL/AQL/Cypher; those non-SQL languages require the
   unified query port (`/api/v2/query`) or the graph service — they are not replaceable by pgwire.
 * SQL is served by *two surfaces* (TD-121/TD-135). *pgwire* serves the PostgreSQL ecosystem
-  (psql/JDBC/BI/ORM, Postgres-native auth) and supports multi-statement transactions. The gRPC
+  (psql/JDBC/BI/ORM, Postgres-native auth) in autocommit mode. `BEGIN`, `COMMIT`, `ROLLBACK`,
+  savepoints, and other transaction-control statements return SQLSTATE `0A000`; a simple-query
+  batch containing transaction control is rejected before any statement in the batch executes.
+  The gRPC
   `ProximaRecordService.ExecuteQuery` RPC is *token/SSO-authenticated* (bearer/JWT in metadata,
   which pgwire's password/MD5 auth cannot carry) and serves vector/graph-extension SQL (e.g.
   `VECTOR_SEARCH`) plus *tenant-scoped relational SQL — SELECT reads AND DDL/DML writes*: SELECTs
   route through the *same* pipeline pgwire uses (`ComputeScheduler::route_select` →
   DataFusion/Volcano); DDL (CREATE/ALTER/DROP) and DML (INSERT/UPDATE/DELETE) route through the
   *same* tenant-scoped `DdlService`/`DmlService` seams — all scoped to the `x-tenant-id` tenant
-  (TD-064). *Out of scope on gRPC:* multi-statement transactions (BEGIN/COMMIT) — the RPC is
-  single-statement; use pgwire for transactional batches. It is *not* deprecated. For large
+  (TD-064). *Out of scope on gRPC:* multi-statement transactions — the RPC is single-statement.
+  It is *not* deprecated. For large
   columnar result sets prefer Arrow Flight.
 * *Apache Calcite*, if adopted, is an *internal* federated-SQL planner behind pgwire and the
   Federated path — not a client surface, and not a substitute for the non-SQL languages.

--- a/scripts/check_doc_authority.py
+++ b/scripts/check_doc_authority.py
@@ -11,12 +11,15 @@ Rules are declarative (regex + allow-list), not asciidoc-table parsing (brittle)
 
   1. Retired graph engines PULSAR/QUASAR may appear ONLY in allow-listed
      retirement/migration docs. Anywhere else is a violation (use ORION).
-  2. "6/six storage engines" is always wrong — there are 4 supported (SST, VIPER,
-     HELIX, NOVA) plus 2 experimental (SWIFT, RAPTOR).
+  2. Claims of 4/6 supported storage engines are wrong — SST is Supported;
+     VIPER/HELIX/NOVA are Beta; SWIFT/RAPTOR are Experimental.
   3. SWIFT, RAPTOR, and Arrow Flight are experimental: any in-scope doc that
      mentions one of them must ALSO carry the word "experimental" (the
      off-by-default caveat). A doc listing them as supported without that caveat
      is a violation.
+  4. pgwire is autocommit-only. Customer-facing docs may not claim that it
+     supports multi-statement transactions or recommend it for transactional
+     batches until the protocol conformance gate proves atomic rollback.
 
 Exit 0 = clean, 1 = violation(s) found, 2 = usage error.
 """
@@ -28,6 +31,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+SUPPORT_AUTHORITY = ROOT / "docs/SUPPORTED_SURFACE.adoc"
 
 # Customer-facing narrative docs in scope. Excludes the authority doc itself plus
 # internal/historical/design trees (_internal, _archive, 12-design, 06-internals).
@@ -55,12 +59,31 @@ RETIRED_ALLOW = {
 
 RETIRED_RE = re.compile(r"\b(?:PULSAR|QUASAR)\b")
 COUNT_RE = re.compile(r"\b(?:six|6)\s+storage[\s-]?engines?", re.IGNORECASE)
+SUPPORTED_COUNT_RE = re.compile(
+    r"\b(?:four|4|six|6)\s+supported\s+storage[\s-]?engines?", re.IGNORECASE
+)
 EXPERIMENTAL_TERMS = {
     "SWIFT": re.compile(r"\bSWIFT\b"),
     "RAPTOR": re.compile(r"\bRAPTOR\b"),
     "Arrow Flight": re.compile(r"\bArrow\s+Flight\b"),
 }
 EXPERIMENTAL_MARKER_RE = re.compile(r"\bexperimental\b", re.IGNORECASE)
+PGWIRE_TRANSACTION_CLAIMS = {
+    "multi-statement transaction support": re.compile(
+        r"supports\s+multi-statement\s+transactions", re.IGNORECASE
+    ),
+    "pgwire-only transaction support": re.compile(
+        r"multi-statement\s+transactions\s*\(BEGIN/COMMIT\)\s+remain\s+pgwire-only",
+        re.IGNORECASE,
+    ),
+    "transactional batch recommendation": re.compile(
+        r"use\s+pgwire\s+for\s+transactional\s+batches", re.IGNORECASE
+    ),
+    "README transaction capability": re.compile(
+        r"Postgres\s+wire\s+protocol\s*\|\s*Supported\s*\|[^\n]*\btransactions\b",
+        re.IGNORECASE,
+    ),
+}
 
 
 def scope_files() -> list[Path]:
@@ -101,10 +124,15 @@ def check_file(p: Path) -> list[str]:
 
     # Rule 2: engine-count claim is always wrong.
     for i, line in enumerate(lines, start=1):
-        if COUNT_RE.search(line):
+        if SUPPORTED_COUNT_RE.search(line):
             violations.append(
-                f"{rel_p}:{i}: claims '6/six storage engines' — there are 4 "
-                f"supported (SST/VIPER/HELIX/NOVA); SWIFT/RAPTOR are experimental"
+                f"{rel_p}:{i}: claims multiple supported storage engines — SST is the "
+                f"only Supported engine; VIPER/HELIX/NOVA are Beta"
+            )
+        elif COUNT_RE.search(line):
+            violations.append(
+                f"{rel_p}:{i}: claims '6/six storage engines' — SST is Supported; "
+                f"VIPER/HELIX/NOVA are Beta; SWIFT/RAPTOR are Experimental"
             )
 
     # Rule 3: experimental terms require the 'experimental' caveat in the same file.
@@ -117,6 +145,15 @@ def check_file(p: Path) -> list[str]:
                 f"'experimental' caveat — mark it off-by-default or drop the mention"
             )
 
+    for label, rx in PGWIRE_TRANSACTION_CLAIMS.items():
+        match = rx.search(text)
+        if match is not None:
+            line = text.count("\n", 0, match.start()) + 1
+            violations.append(
+                f"{rel_p}:{line}: {label} contradicts the autocommit-only pgwire "
+                f"contract — transaction control must return SQLSTATE 0A000"
+            )
+
     return violations
 
 
@@ -124,6 +161,16 @@ def main() -> int:
     violations: list[str] = []
     for p in scope_files():
         violations.extend(check_file(p))
+    authority_text = SUPPORT_AUTHORITY.read_text(encoding="utf-8", errors="replace")
+    for label, rx in PGWIRE_TRANSACTION_CLAIMS.items():
+        match = rx.search(authority_text)
+        if match is not None:
+            line = authority_text.count("\n", 0, match.start()) + 1
+            violations.append(
+                f"{rel(SUPPORT_AUTHORITY)}:{line}: {label} contradicts the "
+                f"autocommit-only pgwire contract — transaction control must return "
+                f"SQLSTATE 0A000"
+            )
 
     if violations:
         print(

--- a/src/database.rs
+++ b/src/database.rs
@@ -51,6 +51,19 @@ pub struct ProximaDB {
     )>,
 }
 
+async fn initialize_configured_security(
+    config: Option<security::SecurityConfig>,
+) -> anyhow::Result<Option<Arc<security::SecurityCoordinator>>> {
+    let Some(config) = config.filter(|config| config.enabled) else {
+        return Ok(None);
+    };
+
+    let coordinator = security::initialize_security(config)
+        .await
+        .map_err(|error| anyhow::anyhow!("enabled security initialization failed: {error:#}"))?;
+    Ok(Some(Arc::new(coordinator)))
+}
+
 fn resolve_server_tenant_mode(
     server_tenant: &proximadb_config::ServerTenantConfig,
     security_config: Option<&security::SecurityConfig>,
@@ -490,26 +503,8 @@ impl ProximaDB {
         tracing::debug!("✅ ProximaDB::new - Multi-server config created successfully");
 
         // Initialize security coordinator if configured
-        let security_config = config
-            .security
-            .clone()
-            .filter(|sec_cfg| sec_cfg.enabled && sec_cfg.authentication.enabled);
-        let security: Option<Arc<security::SecurityCoordinator>> = if let Some(sec_cfg) =
-            security_config.clone()
-        {
-            match security::initialize_security(sec_cfg).await {
-                Ok(coordinator) => Some(Arc::new(coordinator)),
-                Err(err) => {
-                    tracing::warn!(
-                        "Security initialization failed, continuing with security disabled: {:?}",
-                        err
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        let security_config = config.security.clone().filter(|sec_cfg| sec_cfg.enabled);
+        let security = initialize_configured_security(config.security.clone()).await?;
 
         // Initialize LLM engine if configured
         let llm_engine = if let Some(llm_cfg) = config.llm.clone() {
@@ -526,7 +521,9 @@ impl ProximaDB {
 
         // Create MultiServer with SharedServices (network orchestrator)
         tracing::debug!("🔧 ProximaDB::new - Creating MultiServer...");
-        let rest_auth_enabled = security_config.is_some();
+        let rest_auth_enabled = security_config
+            .as_ref()
+            .is_some_and(|sec_cfg| sec_cfg.authentication.enabled);
         let tenant_deployment_mode =
             resolve_server_tenant_mode(&config.server.tenant, security_config.as_ref())?;
         // Capture the drainer's record + vector services BEFORE shared_services
@@ -1482,5 +1479,91 @@ mod async_ingest_wiring_tests {
     fn parse_partition_list_rejects_garbage() {
         assert_eq!(parse_partition_list("abc"), None);
         assert_eq!(parse_partition_list("0..abc"), None);
+    }
+}
+
+#[cfg(test)]
+mod security_initialization_tests {
+    use super::initialize_configured_security;
+    use crate::security::auth_service::{JwtConfig, SSOConfig};
+    use crate::security::security_coordinator::{ComplianceConfig, TenantTrustConfig, TlsConfig};
+    use crate::security::{
+        AuthenticationConfig, AuthenticationMethod, EncryptionConfig, KeyStoreConfig, MtlsConfig,
+        RBACConfig, SecurityConfig, SecurityMode,
+    };
+    use proximadb_security::AuditConfig;
+    use std::collections::HashMap;
+
+    fn security_config(enabled: bool) -> SecurityConfig {
+        SecurityConfig {
+            enabled,
+            mode: SecurityMode::Production,
+            authentication: AuthenticationConfig {
+                enabled: true,
+                methods: vec![AuthenticationMethod::ClientCertificate],
+                require_authentication: true,
+                default_session_timeout_minutes: 60,
+                api_keys: HashMap::new(),
+                jwt: JwtConfig {
+                    enabled: false,
+                    secret: String::new(),
+                    access_token_expiration_minutes: 15,
+                    refresh_token_expiration_days: 7,
+                    issuer: String::new(),
+                    audience: String::new(),
+                    algorithm: "HS256".to_string(),
+                },
+                sso: SSOConfig {
+                    enabled: false,
+                    providers: Vec::new(),
+                    token_cache_ttl_minutes: 5,
+                    aws_iam: None,
+                    azure_ad: None,
+                },
+                mtls: MtlsConfig {
+                    enabled: true,
+                    ca_cert_path: None,
+                    require_client_cert: true,
+                    cn_role_mapping: HashMap::new(),
+                },
+            },
+            rbac: RBACConfig::default(),
+            audit: AuditConfig::default(),
+            tls: TlsConfig {
+                enabled: false,
+                require_client_certificates: false,
+                cert_file: None,
+                key_file: None,
+                ca_file: None,
+            },
+            compliance: ComplianceConfig {
+                frameworks: Vec::new(),
+                data_residency: None,
+                encryption_at_rest: false,
+                encryption_in_transit: false,
+            },
+            encryption: EncryptionConfig::default(),
+            key_store: KeyStoreConfig::default(),
+            tenant: TenantTrustConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn enabled_security_initialization_failure_is_fatal() {
+        let error = match initialize_configured_security(Some(security_config(true))).await {
+            Ok(_) => panic!("enabled invalid security must fail startup"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("mTLS"));
+    }
+
+    #[tokio::test]
+    async fn disabled_security_remains_an_explicit_oss_posture() {
+        let security = initialize_configured_security(Some(security_config(false)))
+            .await
+            .expect("disabled security must not initialize its invalid providers");
+
+        assert!(security.is_none());
     }
 }

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -112,6 +112,33 @@ pub struct PostgresProtocol {
     tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TransactionControlPolicy {
+    Unsupported,
+}
+
+fn transaction_control_policy(query: &str) -> Option<TransactionControlPolicy> {
+    let normalized = query.trim().trim_end_matches(';').trim().to_uppercase();
+    let words: Vec<&str> = normalized.split_whitespace().collect();
+    let first = words.first().copied().unwrap_or_default();
+    let second = words.get(1).copied().unwrap_or_default();
+    let is_control = matches!(
+        first,
+        "BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "ABORT" | "SAVEPOINT" | "RELEASE"
+    ) || (first == "START" && second == "TRANSACTION")
+        || (first == "PREPARE" && second == "TRANSACTION")
+        || (first == "SET" && matches!(second, "TRANSACTION" | "CONSTRAINTS"))
+        || (words.as_slice().starts_with(&[
+            "SET",
+            "SESSION",
+            "CHARACTERISTICS",
+            "AS",
+            "TRANSACTION",
+        ]));
+
+    is_control.then_some(TransactionControlPolicy::Unsupported)
+}
+
 /// Slice 6.3 gate-input bundle. Distinct type per surface for module
 /// privacy; the wire contract (gate logic + error semantics) is the
 /// same as gRPC v2 and Arrow Flight.
@@ -876,6 +903,17 @@ impl PostgresProtocol {
         let query = self.parse_cstring(body)?;
         debug!("Received query: {}", query);
 
+        if transaction_control_policy(&query).is_some() {
+            self.send_error(
+                "ERROR",
+                "0A000",
+                "transactions are not supported; pgwire executes individual statements in autocommit mode",
+            )
+            .await?;
+            self.send_ready_for_query('I').await?;
+            return Ok(());
+        }
+
         if Self::is_set_statement(&query) {
             match self.execute_set_parameter(&query).await {
                 Ok(()) => {}
@@ -902,6 +940,19 @@ impl PostgresProtocol {
         // disappeared. This was a data-loss bug, not a feature gap.
         let statements = Self::split_sql_statements(&query);
         if statements.is_empty() {
+            self.send_ready_for_query('I').await?;
+            return Ok(());
+        }
+        if statements
+            .iter()
+            .any(|statement| transaction_control_policy(statement).is_some())
+        {
+            self.send_error(
+                "ERROR",
+                "0A000",
+                "transactions are not supported; pgwire executes individual statements in autocommit mode",
+            )
+            .await?;
             self.send_ready_for_query('I').await?;
             return Ok(());
         }
@@ -1171,80 +1222,12 @@ impl PostgresProtocol {
     ) -> Result<()> {
         let upper = query.to_uppercase();
 
-        // Transaction control. ProximaDB does not yet implement real
-        // MVCC isolation, so BEGIN/COMMIT/ROLLBACK are autocommit
-        // no-ops at the engine level. We still emit the correct
-        // PostgreSQL command tag so clients (psql, ORM drivers,
-        // connection poolers) parse the response normally instead of
-        // silently mis-classifying it. The tracing warning records
-        // the autocommit truth so operator dashboards can surface it
-        // until real transactions land in Phase 3.
-        //
-        // Previously these statements fell through to
-        // `send_command_complete("OK")` at the bottom of this
-        // method — which caused multi-statement queries like
-        // `BEGIN; INSERT ...; COMMIT;` to look successful while
-        // silently dropping work. See ADR-018 for the autocommit
-        // contract and the Phase 3 plan for real transactions.
-        let trimmed_upper = upper.trim();
-        let trimmed_upper = trimmed_upper
-            .strip_suffix(';')
-            .map(str::trim)
-            .unwrap_or(trimmed_upper);
-        if trimmed_upper == "BEGIN"
-            || trimmed_upper == "BEGIN TRANSACTION"
-            || trimmed_upper == "BEGIN WORK"
-            || trimmed_upper == "START TRANSACTION"
-        {
-            warn!(
-                target: "proximadb::pgwire::transactions",
-                "BEGIN observed; ProximaDB pgwire is autocommit-only — \
-                 isolation/savepoints are not yet implemented"
-            );
-            return self.send_command_complete("BEGIN").await;
-        }
-        if trimmed_upper == "COMMIT"
-            || trimmed_upper == "COMMIT TRANSACTION"
-            || trimmed_upper == "COMMIT WORK"
-            || trimmed_upper == "END"
-            || trimmed_upper == "END TRANSACTION"
-            || trimmed_upper == "END WORK"
-        {
-            return self.send_command_complete("COMMIT").await;
-        }
-        if trimmed_upper == "ROLLBACK"
-            || trimmed_upper == "ROLLBACK TRANSACTION"
-            || trimmed_upper == "ROLLBACK WORK"
-            || trimmed_upper == "ABORT"
-            || trimmed_upper == "ABORT TRANSACTION"
-            || trimmed_upper == "ABORT WORK"
-        {
-            // Loud warning because ROLLBACK is the dangerous one:
-            // clients calling ROLLBACK expect uncommitted writes to
-            // disappear, but under autocommit each statement has
-            // already committed and there is nothing to roll back.
-            // Phase 3 will replace this with real rollback semantics.
-            warn!(
-                target: "proximadb::pgwire::transactions",
-                "ROLLBACK observed but pgwire is autocommit-only — \
-                 prior statements in this query have ALREADY been \
-                 applied; this ROLLBACK has no effect"
-            );
-            return self.send_command_complete("ROLLBACK").await;
-        }
-        if trimmed_upper.starts_with("SAVEPOINT ")
-            || trimmed_upper.starts_with("RELEASE SAVEPOINT ")
-            || trimmed_upper.starts_with("ROLLBACK TO ")
-        {
-            // Loud error: savepoints have no defensible autocommit
-            // emulation, and tools that issue them (e.g. SQLAlchemy
-            // nested-transaction emulation) MUST know they are not
-            // supported instead of silently misbehaving.
+        if transaction_control_policy(query).is_some() {
             return self
                 .send_error(
                     "ERROR",
                     "0A000",
-                    "savepoints are not supported (autocommit-only pgwire)",
+                    "transactions are not supported; pgwire executes individual statements in autocommit mode",
                 )
                 .await;
         }

--- a/src/network/postgres/protocol_tests.rs
+++ b/src/network/postgres/protocol_tests.rs
@@ -10,6 +10,54 @@ fn test_frontend_message() {
 }
 
 #[test]
+fn transaction_control_is_rejected_until_atomic_semantics_exist() {
+    for statement in [
+        "BEGIN",
+        "BEGIN TRANSACTION;",
+        "BEGIN ISOLATION LEVEL SERIALIZABLE",
+        "START TRANSACTION",
+        "START TRANSACTION READ ONLY",
+        "COMMIT",
+        "COMMIT AND CHAIN",
+        "END WORK",
+        "ROLLBACK",
+        "ROLLBACK AND NO CHAIN",
+        "ABORT TRANSACTION",
+        "SAVEPOINT nested",
+        "RELEASE nested",
+        "RELEASE SAVEPOINT nested",
+        "ROLLBACK TO nested",
+        "PREPARE TRANSACTION 'tx-1'",
+        "COMMIT PREPARED 'tx-1'",
+        "ROLLBACK PREPARED 'tx-1'",
+        "SET TRANSACTION ISOLATION LEVEL READ COMMITTED",
+        "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY",
+        "SET CONSTRAINTS ALL DEFERRED",
+    ] {
+        assert_eq!(
+            transaction_control_policy(statement),
+            Some(TransactionControlPolicy::Unsupported),
+            "{statement} must not report false transaction success"
+        );
+    }
+
+    assert_eq!(transaction_control_policy("SELECT 1"), None);
+}
+
+#[test]
+fn transaction_control_is_detected_before_a_multi_statement_batch_runs() {
+    let statements = PostgresProtocol::split_sql_statements(
+        "BEGIN; INSERT INTO orders (id) VALUES (1); COMMIT;",
+    );
+
+    assert!(
+        statements
+            .iter()
+            .any(|statement| transaction_control_policy(statement).is_some())
+    );
+}
+
+#[test]
 fn substitute_placeholders_handles_two_digit_indices() {
     // The old ordered str::replace turned "$10" into "<val1>0"; verify each
     // placeholder is matched by its full digit run.


### PR DESCRIPTION
Fails startup when enabled security cannot initialize, preserves explicit OSS security-off behavior, rejects unsupported transaction-control batches atomically, and reconciles release-facing capability claims. Validation: focused Rust tests; make work-commit-check.