### PR TITLE
fix(frontend): order comma-join FROM entries by equi-connectivity — TD-REL-LOWER-7 (TPC-H Q9/Q8)

### DIFF
--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -259,9 +259,32 @@ fn lower_select(
     // a left-deep chain of CROSS joins, with the equality predicates in WHERE
     // acting as the join conditions (the optimizer rewrites Cross+Filter into
     // hash joins). This is the classic ANSI/TPC-H join spelling.
-    let (mut plan, mut scope) = lower_table_with_joins(&select.from[0], catalog)?;
-    for twj in &select.from[1..] {
-        let (right, right_scope) = lower_table_with_joins(twj, catalog)?;
+    //
+    // Lower every top-level entry once, then ORDER the comma entries by
+    // equi-join connectivity before building the chain: a FROM-order accident
+    // (a pair with no direct equi-key placed adjacent — e.g. `part, supplier`,
+    // joined only transitively through `lineitem` in TPC-H Q9) would otherwise
+    // leave a raw cross product that the native route declines. Comma/inner
+    // joins commute and column refs resolve by name against the reordered
+    // scope, so this preserves semantics; it is a no-op when the FROM order is
+    // already fully connected or when connectivity can't be resolved.
+    let lowered = select
+        .from
+        .iter()
+        .map(|twj| lower_table_with_joins(twj, catalog))
+        .collect::<Result<Vec<_>, _>>()?;
+    let order = comma_join_order(
+        &lowered.iter().map(|(_, s)| s).collect::<Vec<_>>(),
+        select.selection.as_ref(),
+    );
+    let mut lowered: Vec<Option<(LogicalNode, Scope)>> = lowered.into_iter().map(Some).collect();
+    let mut order_iter = order.into_iter();
+    let first = order_iter
+        .next()
+        .expect("FROM is non-empty (checked above)");
+    let (mut plan, mut scope) = lowered[first].take().expect("each index taken once");
+    for idx in order_iter {
+        let (right, right_scope) = lowered[idx].take().expect("each index taken once");
         scope = scope.concat(&right_scope);
         plan = LogicalNode::Join {
             left: Box::new(plan),
@@ -459,6 +482,109 @@ fn flatten_sql_and(expr: &SqlExpr) -> Vec<&SqlExpr> {
     let mut out = Vec::new();
     rec(expr, &mut out);
     out
+}
+
+/// A column reference split into an optional table/alias qualifier and the bare
+/// column name (`n1.n_nationkey` → `(Some("n1"), "n_nationkey")`).
+type ColIdent = (Option<String>, String);
+
+/// Order comma-separated FROM entries so the left-deep CROSS chain has an
+/// equi-join key at every level. Greedy connectivity walk over the equi-graph
+/// derived from the WHERE clause: start from the first entry and always append
+/// the lowest-index remaining entry that shares an equi-key with an
+/// already-placed entry — so a FROM order that is already fully connected is
+/// reproduced unchanged. Returns the identity order when there are fewer than
+/// three entries, no WHERE clause, or a disconnected component remains (a
+/// genuine cross product). Reordering only ever helps: inner joins commute and
+/// column refs resolve by name, so a correct result never changes.
+fn comma_join_order(scopes: &[&Scope], where_clause: Option<&SqlExpr>) -> Vec<usize> {
+    let n = scopes.len();
+    if n < 3 {
+        return (0..n).collect();
+    }
+    let Some(where_expr) = where_clause else {
+        return (0..n).collect();
+    };
+    let mut adj = vec![vec![false; n]; n];
+    for conj in flatten_sql_and(where_expr) {
+        if let Some((a, b)) = equi_column_pair(conj)
+            && let (Some(i), Some(j)) = (entry_of_column(&a, scopes), entry_of_column(&b, scopes))
+            && i != j
+        {
+            adj[i][j] = true;
+            adj[j][i] = true;
+        }
+    }
+    let mut placed = vec![false; n];
+    let mut order = Vec::with_capacity(n);
+    placed[0] = true;
+    order.push(0);
+    while order.len() < n {
+        // Lowest-index unplaced entry connected to any placed entry; if the
+        // graph is disconnected, fall back to the lowest-index unplaced entry
+        // (that component genuinely cross-joins — same as before).
+        let next = (0..n)
+            .find(|&j| !placed[j] && (0..n).any(|i| placed[i] && adj[i][j]))
+            .or_else(|| (0..n).find(|&j| !placed[j]));
+        let pick = next.expect("order.len() < n implies an unplaced entry");
+        placed[pick] = true;
+        order.push(pick);
+    }
+    order
+}
+
+/// If `expr` is `col = col` between two column identifiers, return both parts.
+fn equi_column_pair(expr: &SqlExpr) -> Option<(ColIdent, ColIdent)> {
+    let SqlExpr::BinaryOp {
+        left,
+        op: BinaryOperator::Eq,
+        right,
+    } = expr
+    else {
+        return None;
+    };
+    Some((column_ident(left)?, column_ident(right)?))
+}
+
+/// A bare or qualified column identifier as `(table?, column)`; `None` for any
+/// non-identifier expression (literals, arithmetic, function calls).
+fn column_ident(expr: &SqlExpr) -> Option<ColIdent> {
+    match expr {
+        SqlExpr::Identifier(id) => Some((None, id.value.clone())),
+        SqlExpr::CompoundIdentifier(parts) if parts.len() >= 2 => Some((
+            Some(parts[parts.len() - 2].value.clone()),
+            parts[parts.len() - 1].value.clone(),
+        )),
+        SqlExpr::Nested(inner) => column_ident(inner),
+        _ => None,
+    }
+}
+
+/// Which FROM entry (index into `scopes`) owns a column identifier — qualified
+/// by table/alias match, unqualified by *unique* column-name ownership. `None`
+/// when the column resolves to no entry or is ambiguous across entries (the
+/// connectivity edge is simply dropped — conservative, never incorrect).
+fn entry_of_column(ident: &ColIdent, scopes: &[&Scope]) -> Option<usize> {
+    let (table, col) = ident;
+    match table {
+        Some(t) => scopes.iter().position(|s| {
+            s.columns
+                .iter()
+                .any(|c| &c.table == t && &c.column.name == col)
+        }),
+        None => {
+            let mut found = None;
+            for (i, s) in scopes.iter().enumerate() {
+                if s.columns.iter().any(|c| &c.column.name == col) {
+                    if found.is_some() {
+                        return None; // ambiguous across entries — drop the edge
+                    }
+                    found = Some(i);
+                }
+            }
+            found
+        }
+    }
 }
 
 /// If `conj` is a liftable subquery predicate, lower it to the parts of a Semi/Anti
@@ -2397,6 +2523,59 @@ mod tests {
 
     fn lower(sql: &str) -> LogicalNode {
         lower_sql(sql, &catalog()).unwrap_or_else(|e| panic!("lower failed: {e:?}"))
+    }
+
+    fn parse_where(sql: &str) -> Option<SqlExpr> {
+        let stmts = Parser::parse_sql(&GenericDialect {}, sql).expect("parse");
+        match &stmts[0] {
+            Statement::Query(q) => match &*q.body {
+                SetExpr::Select(s) => s.selection.clone(),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn comma_join_order_places_hub_between_disconnected_tables() {
+        // TD-REL-LOWER-7 (Q9 shape): `a` and `b` share no direct equi-key; both
+        // join only to the hub. FROM order [a, b, hub] would cross-join a×b, so
+        // the reorder must move the hub between them → [a, hub, b], every
+        // adjacency sharing an equi-key.
+        let schema = |cols: &[&str]| {
+            RelationalSchema::new(
+                cols.iter()
+                    .map(|c| ColumnInfo::new(*c, ProximaType::Int64, true))
+                    .collect(),
+            )
+        };
+        let a = Scope::from_table("a", &schema(&["a_id", "a_href"]));
+        let b = Scope::from_table("b", &schema(&["b_id", "b_href"]));
+        let hub = Scope::from_table("hub", &schema(&["h_id", "h_val"]));
+
+        let scopes = [&a, &b, &hub];
+        let w = parse_where(
+            "SELECT 1 FROM a, b, hub WHERE a.a_href = hub.h_id AND b.b_href = hub.h_id",
+        );
+        assert_eq!(
+            comma_join_order(&scopes, w.as_ref()),
+            vec![0, 2, 1],
+            "hub moves between the two otherwise-disconnected tables"
+        );
+
+        // An already fully-connected FROM order is reproduced unchanged.
+        let scopes2 = [&a, &hub, &b];
+        let w2 = parse_where(
+            "SELECT 1 FROM a, hub, b WHERE a.a_href = hub.h_id AND b.b_href = hub.h_id",
+        );
+        assert_eq!(
+            comma_join_order(&scopes2, w2.as_ref()),
+            vec![0, 1, 2],
+            "already-connected order is a no-op"
+        );
+
+        // No WHERE ⇒ identity (nothing to connect on).
+        assert_eq!(comma_join_order(&scopes, None), vec![0, 1, 2]);
     }
 
     /// A `DATE 'YYYY-MM-DD'` typed literal lowers to the canonical

--- a/docs/10-quality/td/TD-REL-LOWER-7-nway-comma-join-connectivity-reorder.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-7-nway-comma-join-connectivity-reorder.adoc
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-7: N-way comma join declines when FROM order places a non-equi-adjacent pair (TPC-H Q9, Q8)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **FIXED 2026-07-15** — the relational frontend now orders comma-separated FROM entries by equi-join connectivity (derived from the WHERE clause) before building the left-deep CROSS chain, so every level has a join key. Filed + fixed in one PR from the post-#1026 native ledger taxonomy.
+| Priority | P2 — the classic ANSI/TPC-H "star/snowflake" comma-join spelling declines the native route as a raw cross product whenever the *textual* FROM order places two tables with no direct equi-key adjacent. TPC-H **Q9** (`part, supplier` joined only through `lineitem`) and **Q8** (an 8-table comma join, incl. a self-join, inside a derived table).
+| Component | `crates/query/proximadb-relational-frontend` — `lower_select` FROM lowering + the new `comma_join_order` / `equi_column_pair` / `entry_of_column` helpers.
+| Evidence | Native ledger sweep: Q9 / Q8 → `0A000 native execution declined an unnormalized cross join`. The frontend lowers a comma FROM into a left-deep `CrossJoin` chain in *textual* order; the planner normalizes each level to an equi-join only when the adjacent pair shares a cross-side equality. Q9's FROM lists `part, supplier` first, but they connect only transitively through `lineitem`, so `part × supplier` stays a raw cross product and declines.
+|===
+
+== The finding
+
+`FROM a, b, c` lowers to `((a × b) × c)` in textual order, ordinals assigned by that
+order, WHERE equalities pulled into join keys per level by the planner. When two adjacent
+entries share no direct equi-key (only a transitive path through a third table), their level
+is left as a cross product. This is purely a FROM-*order* accident: the same tables in a
+connectivity-respecting order join cleanly.
+
+== The fix
+
+Before building the chain, `lower_select` lowers every top-level FROM entry once, then
+`comma_join_order` computes a connectivity order: it builds an equi-graph from the WHERE
+clause (`equi_column_pair` extracts `col = col` conjuncts; `entry_of_column` maps each
+column to its owning entry by qualified-alias or unique-name), then does a greedy walk —
+start at the first entry, always append the lowest-index remaining entry that shares an
+equi-key with an already-placed entry. Every non-first entry therefore connects to the
+prefix, so each left-deep level has a join key. Because the reorder is applied wherever a
+comma FROM is lowered — including inside a **derived-table subquery** — it also fixes Q8's
+nested 8-table comma join (that is why Q8 flips without any separate derived-table work).
+
+**Correctness:** comma/inner joins commute and associate, and column references resolve by
+name against the reordered scope (ordinals are assigned *after* the reorder), so a correct
+result never changes. It is a **no-op** when the FROM order is already fully connected (the
+greedy walk reproduces it), when there are fewer than three entries, or when the WHERE
+clause is absent. Ambiguous / unresolvable columns simply drop their edge — conservative,
+never incorrect. The only observable difference is the column order of a bare `SELECT *`.
+
+== Gate
+
+* `tests/rel_join_reorder_e2e.rs` — pgwire e2e: a `pt, sp, li` comma join where `pt`/`sp`
+  connect only through the hub `li` returns the correct `count` (was `0A000` pre-fix), incl.
+  a residual-filter variant.
+* Frontend unit test `comma_join_order_places_hub_between_disconnected_tables` — asserts the
+  hub moves between the two disconnected tables, and that an already-connected order (and a
+  WHERE-less query) is a no-op.
+* Native ledger sweep (TPC-H SF 0.001): **Q9 and Q8 flip to native, row-exact vs the
+  DataFusion baseline (14→16/22); zero row-diffs, no previously-passing query regresses.**
+
+== Non-goals
+
+Cost-based join *ordering* (choosing the cheapest connected order for performance) remains
+out of scope — this only ensures a *valid* equi-connected order exists so the native route
+does not decline. Cross-side equalities hidden inside an `OR` are handled separately by
+TD-REL-LOWER-6.

--- a/tests/rel_join_reorder_e2e.rs
+++ b/tests/rel_join_reorder_e2e.rs
@@ -1,0 +1,173 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-LOWER-7 — an N-way comma join whose FROM order places two tables with
+//! no direct equi-key adjacent (TPC-H Q9: `part, supplier` joined only through
+//! `lineitem`) must reorder by equi-connectivity so the left-deep chain has a
+//! join key at every level, instead of declining `0A000 … unnormalized cross
+//! join`. Here `pt` and `sp` connect only through the hub `li`.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+async fn rows(client: &tokio_postgres::Client, sql: &str) -> Vec<Vec<String>> {
+    let msgs = client.simple_query(sql).await.unwrap_or_else(|e| {
+        panic!(
+            "{sql}\n  {}",
+            e.as_db_error()
+                .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+                .unwrap_or_else(|| e.to_string())
+        )
+    });
+    msgs.iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                (0..r.len())
+                    .map(|i| r.get(i).unwrap_or("").to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn native_nway_comma_join_reorders_by_connectivity() {
+    std::thread::Builder::new()
+        .name("rel-join-reorder-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(body())
+        })
+        .expect("spawn")
+        .join()
+        .expect("panic");
+}
+
+async fn body() {
+    let server = PgServer::start().await.expect("server");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    for ddl in [
+        "DROP TABLE IF EXISTS pt",
+        "DROP TABLE IF EXISTS sp",
+        "DROP TABLE IF EXISTS li",
+        "CREATE TABLE pt (pk INT PRIMARY KEY, pname VARCHAR)",
+        "CREATE TABLE sp (sk INT PRIMARY KEY, snat VARCHAR)",
+        "CREATE TABLE li (lid INT PRIMARY KEY, lpk INT, lsk INT)",
+        "INSERT INTO pt VALUES (1,'A'),(2,'B')",
+        "INSERT INTO sp VALUES (10,'X'),(20,'Y')",
+        // li rows join pt on lpk=pk and sp on lsk=sk — all three match a pt+sp.
+        "INSERT INTO li VALUES (100,1,10),(101,2,20),(102,1,20)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+
+    // Q9 shape: FROM order puts `pt, sp` adjacent, but they share NO direct
+    // equi-key — both join only through the hub `li`. Was declined pre-fix with
+    // `0A000 … unnormalized cross join`; the reorder makes it li-in-the-middle.
+    let got = rows(
+        &client,
+        "SELECT count(*) AS n FROM pt, sp, li WHERE pt.pk = li.lpk AND sp.sk = li.lsk",
+    )
+    .await;
+    assert_eq!(got.len(), 1);
+    let n: i64 = got[0][0].parse().expect("i64");
+    assert_eq!(n, 3, "each li row joins exactly one pt and one sp");
+
+    // And with an extra filter, to exercise a residual over the reordered chain.
+    let got2 = rows(
+        &client,
+        "SELECT count(*) AS n FROM pt, sp, li \
+         WHERE pt.pk = li.lpk AND sp.sk = li.lsk AND pt.pname = 'A'",
+    )
+    .await;
+    let n2: i64 = got2[0][0].parse().expect("i64");
+    assert_eq!(n2, 2, "pt.pname='A' (pk=1) matches li rows 100 and 102");
+
+    eprintln!(
+        "✓ TD-REL-LOWER-7 N-way comma join reorders by equi-connectivity on the native route"
+    );
+}


### PR DESCRIPTION
## What
Orders comma-separated FROM entries by equi-join connectivity (from the WHERE clause) **before** building the left-deep CROSS chain, so every join level has a key. Closes **TD-REL-LOWER-7**. Fixes TPC-H **Q9** and **Q8**, which declined `0A000 … unnormalized cross join` purely due to FROM *textual* order.

## Root cause
`FROM a, b, c` → left-deep `((a×b)×c)` in text order; the planner makes each level an equi-join only if the adjacent pair shares a cross-side equality. Q9 lists `part, supplier` first, but they connect only transitively through `lineitem` → `part × supplier` stays a raw cross product → declines.

## Fix (frontend, zero ordinal churn)
`lower_select` lowers each entry once, then `comma_join_order` does a greedy connectivity walk over the WHERE equi-graph (`equi_column_pair` + `entry_of_column`): start at the first entry, always append the lowest-index remaining entry sharing an equi-key with the placed prefix. Every non-first entry connects to the prefix → a key at every level. Done in the **frontend** (before ordinals are assigned) so there is **zero ordinal remapping** — vs a 500+ LOC deep rewrite in the planner.

**Correctness:** comma/inner joins commute + associate, refs resolve by name against the reordered scope → a correct result never changes. **No-op** when already fully connected, `<3` entries, or no WHERE; ambiguous columns drop their edge (conservative). Only a bare `SELECT *` column order can change.

## Measured (TPC-H ledger, SF 0.001, row-exact vs DataFusion)
- **Q9 and Q8 both flip to native, row-exact** — native **14→16/22**, **zero row-diffs, no regression**.
- Q8 flips too because the reorder applies **recursively** to the comma join inside its derived-table subquery (so its 8-table self-join orders cleanly).
- Combined with #1028 (Q19 OR-factoring) → **17/22**.

## Tests / gates
- `tests/rel_join_reorder_e2e.rs` — pgwire hub-connected comma join returns the right `count` (+ residual-filter variant); was `0A000` pre-fix.
- Frontend unit test `comma_join_order_places_hub_between_disconnected_tables` (hub moves between disconnected tables; already-connected + no-WHERE are no-ops).
- 115 frontend+planner tests · clippy `-D warnings` · `work-commit-check` · `check_td_adr_unique` · server binary builds.

## Scope
Cost-based join ordering (choosing the *cheapest* connected order) remains out of scope — this only guarantees a *valid* equi-connected order exists so the native route doesn't decline.