### PR TITLE
docs(rdstrat): define metric-safe encoding bakeoff

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
@@ -235,16 +235,34 @@ retain that byte in the v1 core as the legacy/default summary.
 
 ```
 entries[] {
+  descriptor_id:u16,
   logical_field_id:i32,
   physical_column_id:i32,
   tier_role:u8,              // index | rerank | exact | metadata
   codec_tag:u8,              // stable ProximaScheme marker
   codec_version:u8,
   compression_tag:u8,
-  parameter_scope:u8,        // none | segment | block | cluster-run
-  flags:u16
+  compression_version:u8,
+  parameter_scope:u8,        // none | segment | block | cluster-run | row
+  vector_transform:u8,       // none | l2-normalized | centered-rotated
+  auxiliary_flags:u16,       // exact-norm-sq | residual-norm | correction-scale
+  source_fidelity:u8,        // exact | lossy
+  quantization_generation:u16
+}
+
+block_tier_assignments[] {
+  block_ordinal:u32,
+  physical_column_id:i32,
+  tier_role:u8,
+  descriptor_id:u16
 }
 ```
+
+Multiple descriptors for the same logical field/tier are permitted because
+write-time fallback can produce mixed SQ8/residual blocks in one segment. The
+block assignment is the footer planning authority; the block-local `ColumnMeta`
+and `VectorParamBlock` repeat the selected codec facts required for independent
+decode. The reader rejects disagreement between them.
 
 Compatibility is asymmetric by design:
 
@@ -260,6 +278,44 @@ Compatibility is asymmetric by design:
 Optional metadata is skippable; an unknown data encoding is not. This is the
 same compatibility distinction that keeps Parquet Bloom additions benign while
 new encodings require reader support.
+
+=== Vector metric and source-fidelity contract
+
+Each logical vector field records the immutable physical contract under which
+the segment was written:
+
+```
+vector_contracts[] {
+  logical_field_id:i32,
+  built_metric:u8,
+  metric_epoch:u64,
+  normalization_contract:u8, // none | enforced-unit-l2
+  durability_policy:u8       // exact-retained | external-authority | approximate-only
+}
+```
+
+Runtime metric support comes from the registered codec implementation keyed by
+`codec_tag`, version, and transform; the file does not assert an unaudited
+supported-metric bitmap. Unit-normalized vectors may share one dot estimator
+for L2/cosine/MIPS. General vectors require the candidate norm for direct
+L2/cosine estimation, or full coordinate reconstruction. L1-family metrics
+cannot use a dot-only TurboQuant/RaBitQ estimator as their candidate stage.
+
+The optional per-row exact squared L2 norm used by an SQ6 experiment is declared
+by `auxiliary_flags`/row parameter scope. It may improve L2 and dot ranking, but
+positive radial rescaling cancels from cosine and does not make reconstructed
+coordinates exact. It must never be surfaced as tier role `exact`.
+
+Physical f32 may be absent only under an explicit catalog durability policy:
+
+* `ExactRetained`: every live block retains authoritative original f32.
+* `ExternalAuthority`: PAX may omit f32, but the catalog names a durable source
+  able to supply every original row for rebuild/compaction.
+* `ApproximateOnly`: original f32 may be irrecoverable; exact search/vector
+  return and unrestricted metric migration are not promised.
+
+The weakest live block determines the collection guarantee. "Any input has
+f32" is never sufficient to mark a compacted output exact.
 
 === BlockColumnStats and optional Bloom payloads
 
@@ -356,6 +412,58 @@ minimum realized-saving threshold fall back to flat SQ8 for that block.
 The encoding map declares the block's chosen codec; block-local parameters live
 in a versioned `VectorParamBlock` extension. Mixed codec blocks in one segment
 are permitted.
+
+=== Equal-protocol codec bake-off
+
+The first implementation does not earn a permanent format tag merely by
+existing. Three isolated worktrees run the same release-profile SIFT1M N=100k,
+100-query, single-file IVF-ON protocol:
+
+* clustered SQ4/SQ6, including the explicitly declared exact-norm experiment;
+* clustered TurboQuant-style 4-bit;
+* clustered multi-bit RaBitQ 4-bit.
+
+The result table records recall@10, range GETs/query, bytes read/query, query
+latency percentiles, persisted bytes/row including parameters, and encode/flush
+time. Total route cost is also reported under ADR-062's durable weights
+`20 * GETs + 5 * MiB_read`. Only an arm clearing recall `>= 0.98`, preserving
+the GET result, and moving bytes materially below `31.7 MB` is eligible. Losing
+experimental codecs are discarded unless independently justified by another
+workload.
+
+Metric compatibility is evaluated separately from the Euclidean SIFT headline:
+L2, cosine, and dot require ranking/score-domain tests; other public metrics
+must either reconstruct and use the generic kernel or bypass the compact
+estimator. Approximate and exact search labels must remain honest.
+
+=== Compaction and metric-change rules
+
+. Read every block's footer assignment and source fidelity; do not infer a
+  file-wide codec or exactness flag from block zero or from any one input.
+. Pass-through is allowed when blocks need no reorder/policy rewrite. This is
+  the only lossless option when no original-vector authority exists.
+. Re-clustering changes row order and cluster-run parameters, so it requires
+  original f32 for every row from an exact tier or declared external authority.
+. If exact source is unavailable, default to pass-through/defer. An explicitly
+  `ApproximateOnly` lossy transcode increments `quantization_generation`, stays
+  lossy, and reruns the recall gate because error compounds.
+. A collection metric change increments `metric_epoch`. Compatible generic
+  reconstruction may continue approximately; estimator-specific tiers are
+  rebuilt or bypassed. Until this reconciliation exists, metric changes must be
+  rejected or executed as an explicit rebuild transaction.
+. Exact queries and exact vector return require an exact authority for every
+  relevant live block.
+
+Before activating a new rerank codec, fix the current exact-tier propagation
+seam: coalesced writers must actually emit a requested exact tier, compaction
+must materialize that tier rather than lossy `EMBED_BASE`, and output exactness
+must require all input rows to have an exact authority.
+
+Also normalize the score boundary before mixed files are compared: the
+coalesced reranker currently produces squared L2 while the canonical distance
+kernel returns Euclidean distance, and its internal negated-dot ordering value
+must be converted back to the public positive-dot similarity exactly once.
+Homogeneous ranking can hide both defects; mixed codecs/files cannot.
 
 === Opt-in and fallback
 

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -159,11 +159,27 @@ defaults, comments, indexes, and mutable properties remain catalog-only. Tier st
 vector field and therefore belong in the encoding map, not as duplicate logical schema
 fields. Full schema-*evolution* reconciliation remains TD-TBL-4 / ADR-047.
 
-The footer encoding map declares `{ logical_field_id, physical_column_id, tier_role,
-codec_tag, codec_version, compression_tag, parameter_scope }`. `codec_tag` is the stable
-shared `ProximaScheme` marker. Codec parameters needed to decode one PAX block remain in that
-block's `VectorParamBlock`, so a fetched block is self-sufficient and the segment footer does
-not duplicate codebooks.
+The footer encoding map is a descriptor table, not one file-global codec choice. It declares
+`{ descriptor_id, logical_field_id, physical_column_id, tier_role, codec_tag, codec_version,
+compression_tag/version, parameter_scope, vector_transform, auxiliary flags,
+source_fidelity, quantization_generation }`. Each footer block entry carries the compact
+descriptor ID selected for each physical tier. This is required because one segment may mix a
+new rerank encoding with write-time SQ8 fallback blocks. It also lets footer-only ranged
+planning determine row stride and required parameters without first fetching every block
+footer. `codec_tag` is the stable shared `ProximaScheme` marker.
+
+Codec parameters needed to decode one PAX block remain in that block's
+`VectorParamBlock`, so a fetched block is self-sufficient and the segment footer does not
+duplicate codebooks. The descriptor records semantics and parameter scope; it does not carry
+the centroid/codebook payload.
+
+Each immutable file also records the vector field's `metric_epoch`, the metric under which
+estimator-specific tiers were built, and its normalization contract (`none` or enforced
+unit-L2). Runtime metric support is derived from the registered
+`(codec_tag, codec_version, vector_transform)` implementation rather than trusting a serialized
+"supported metrics" claim. A catalog distance-metric change advances the metric epoch and
+requires compatibility validation or a rebuild before the file can serve the new estimator
+path.
 
 Compatibility distinguishes legacy metadata from unknown data bytes: a v1 footer uses the PR1
 block-local SQ8 path, but a v2 footer requires its encoding map. An explicitly unknown
@@ -277,6 +293,26 @@ inconsistent dimensions, non-finite inputs, or insufficient realized byte saving
 to flat SQ8 and are declared as such in the encoding map. Lossy activation requires an
 end-to-end SIFT gate: bytes/query materially below `31.7 MB`, recall@10 `>= 0.98`, and no
 material regression from PR1's GET result. Codec microbenchmarks are not headline evidence.
+
+The implementation choice is ratcheted by an equal-protocol bake-off, not fixed by the first
+codec prototype. Clustered SQ4/SQ6 (with an explicitly declared optional exact squared-norm
+parameter), clustered TurboQuant-style 4-bit, and clustered multi-bit RaBitQ 4-bit are measured
+at the same N=100k single-file IVF-ON SIFT workload. The accepted rerank encoding must beat
+the PR1 byte result while clearing recall and GET gates; losing prototypes do not become
+durable format variants merely because they were implemented for evaluation.
+
+An exact norm is metric auxiliary data, not an exact-vector tier. It can improve magnitude-
+sensitive L2/dot estimates, is algebraically irrelevant to cosine after positive radial
+rescaling, and supplies no L1-specific guarantee. `exact` remains reserved for original f32
+values.
+
+Exact-f32 presence is a per-block physical fact plus a catalog durability policy:
+`ExactRetained`, `ExternalAuthority`, or `ApproximateOnly`. Compaction/re-clustering may
+re-encode from original f32 supplied by every input block or the declared external authority.
+Without such a source it must pass blocks through/defer, unless `ApproximateOnly` explicitly
+permits lossy transcoding; that path increments `quantization_generation` and never relabels
+the output exact. Query guarantees follow the weakest live block, not whether any one input
+file has f32.
 
 == First principles / rationale
 


### PR DESCRIPTION
Amends ADR-062 and TD-RDSTRAT-7 before the bytes-code PR. Defines the equal-protocol SQ6/TurboQuant-4/multi-bit-RaBitQ-4 bakeoff, per-block footer encoding descriptors, metric/source-fidelity contracts, optional-f32 durability modes, and lossless compaction/rebuild rules. Also records the exact-tier propagation and mixed score-domain blockers that code must fix before activation.\n\nValidation: make work-commit-check; TD/ADR uniqueness; doc authority; attribution guard.