### PR TITLE
fix(tenant): enforce deployment identity at every ingress

### DIFF
--- a/.github/workflows/layering-check.yml
+++ b/.github/workflows/layering-check.yml
@@ -64,6 +64,9 @@ jobs:
     - name: Run tenant-path guard (DrPathBuilder mandate)
       run: python3 scripts/check_tenant_path_guard.py
 
+    - name: Run tenant ingress contract guard
+      run: python3 scripts/check_tenant_ingress_contract.py
+
     # OSS/enterprise boundary: fails on NEW commercial leaks (pricing/billing/
     # control-plane refs) in non-gated engine code. Known debt is tracked (warn).
     # See docs/12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ProximaDB Build and Test Makefile
 
-.PHONY: all clean build test test-python test-rust test-fast check-fast install-fast-tools benchmark release install help capability-matrix-check workspace-boundaries-check tenant-path-check deterministic-commit-contract-check work-commit-check validated-commit-check workspace-rebuild-baseline panic-policy-report panic-policy-no-regression panic-policy-module-guard panic-policy-baseline v1-proto-usage-report v1-proto-usage-no-regression v1-proto-usage-baseline hygiene-check proto-check verify-openapi-spec gen-go-sdk gen-ts-sdk gen-rust-sdk gen-python-sdk release-check docs-claim-check status-asof-check release-smoke cloud-emulator-test
+.PHONY: all clean build test test-python test-rust test-fast check-fast install-fast-tools benchmark release install help capability-matrix-check workspace-boundaries-check tenant-path-check tenant-ingress-check deterministic-commit-contract-check work-commit-check validated-commit-check workspace-rebuild-baseline panic-policy-report panic-policy-no-regression panic-policy-module-guard panic-policy-baseline v1-proto-usage-report v1-proto-usage-no-regression v1-proto-usage-baseline hygiene-check proto-check verify-openapi-spec gen-go-sdk gen-ts-sdk gen-rust-sdk gen-python-sdk release-check docs-claim-check status-asof-check release-smoke cloud-emulator-test
 
 # Default target
 all: build test
@@ -185,7 +185,11 @@ tenant-path-check:
 	@echo "🏢 Validating tenant path isolation guard..."
 	python3 scripts/check_tenant_path_guard.py
 
-work-commit-check: fmt-check deterministic-commit-contract-check docs-claim-check status-asof-check capability-matrix-check workspace-boundaries-check tenant-path-check panic-policy-module-guard hygiene-check
+tenant-ingress-check:
+	@echo "Validating deployment-aware tenant ingress..."
+	python3 scripts/check_tenant_ingress_contract.py
+
+work-commit-check: fmt-check deterministic-commit-contract-check docs-claim-check status-asof-check capability-matrix-check workspace-boundaries-check tenant-path-check tenant-ingress-check panic-policy-module-guard hygiene-check
 	@echo "✅ work-commit-check: deterministic architecture and commit guardrails passed"
 
 validated-commit-check: work-commit-check
@@ -405,6 +409,7 @@ help:
 	@echo "  capability-matrix-check - Validate docs/_internal/roadmap/CAPABILITY_MATRIX.toml"
 	@echo "  deterministic-commit-contract-check - Validate zero-retry/test/docs guard wiring"
 	@echo "  tenant-path-check  - Enforce DrPathBuilder tenant path guard"
+	@echo "  tenant-ingress-check - Enforce deployment-aware tenant resolution at ingress"
 	@echo "  work-commit-check  - Fast deterministic architecture guard before commit/push"
 	@echo "  proto-check        - Validate generated proto crate and Python/OpenAPI contract drift"
 	@echo "  verify-openapi-spec - Regenerate OpenAPI spec from handlers; fail on drift (TD-126)"

--- a/scripts/check_deterministic_commit_contract.py
+++ b/scripts/check_deterministic_commit_contract.py
@@ -147,6 +147,18 @@ def check_gate_wiring(findings: list[Finding]) -> None:
         ".github/workflows/layering-check.yml",
         "python3 scripts/check_tenant_path_guard.py",
     )
+    require_contains(
+        findings,
+        "gate-wiring",
+        "Makefile",
+        "tenant-ingress-check",
+    )
+    require_contains(
+        findings,
+        "gate-wiring",
+        ".github/workflows/layering-check.yml",
+        "python3 scripts/check_tenant_ingress_contract.py",
+    )
 
 
 def check_architecture_contract(findings: list[Finding]) -> None:

--- a/scripts/check_tenant_ingress_contract.py
+++ b/scripts/check_tenant_ingress_contract.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Guard deployment-aware tenant resolution at served network ingress."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (REPO / relative).read_text(encoding="utf-8")
+
+
+def function_body(source: str, function_name: str) -> str:
+    marker = f"async fn {function_name}("
+    start = source.find(marker)
+    if start < 0:
+        raise ValueError(f"missing function {function_name}")
+    opening = source.find("{", start)
+    if opening < 0:
+        raise ValueError(f"missing body for {function_name}")
+
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening : index + 1]
+    raise ValueError(f"unterminated body for {function_name}")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    grpc_files = [
+        "src/network/grpc/v2/document_service.rs",
+        "src/network/grpc/v2/entity_service.rs",
+        "src/network/grpc/v2/fusion_service.rs",
+        "src/network/grpc/v2/graph_service.rs",
+        "src/network/grpc/v2/record_service.rs",
+    ]
+    for relative in grpc_files:
+        source = read(relative)
+        if "grpc_auth::tenant_id(" in source:
+            errors.append(f"{relative}: optional grpc_auth::tenant_id bypass remains")
+        if "extract_tenant_id" in source:
+            errors.append(f"{relative}: local tenant extraction bypass remains")
+        if "grpc_auth::resolved_tenant_id(" not in source:
+            errors.append(f"{relative}: deployment-aware resolver is not used")
+
+    flight = read("src/network/arrow_ipc/service.rs")
+    for method in (
+        "list_flights",
+        "get_flight_info",
+        "get_schema",
+        "do_get",
+        "do_put",
+        "do_action",
+        "do_exchange",
+    ):
+        try:
+            body = function_body(flight, method)
+        except ValueError as error:
+            errors.append(f"src/network/arrow_ipc/service.rs: {error}")
+            continue
+        if ".authenticated_flight_context(" not in body:
+            errors.append(
+                f"src/network/arrow_ipc/service.rs: {method} skips tenant/auth resolution"
+            )
+
+    if ".handle_vector_search_v1(request)" in flight:
+        errors.append("Arrow Flight search uses the tenant-neutral API port")
+    if ".upsert_record_batch(collection_id, records, None)" in flight:
+        errors.append("Arrow Flight action upsert drops the resolved tenant")
+
+    multi_server = read("src/network/multi_server.rs")
+    if multi_server.count("GrpcTenantModeLayer::new(") < 3:
+        errors.append("not every gRPC server composition installs GrpcTenantModeLayer")
+    if multi_server.count("with_tenant_deployment_mode(") < 5:
+        errors.append("not every Flight/pgwire composition receives tenant deployment mode")
+
+    pgwire = read("src/network/postgres/protocol.rs")
+    try:
+        startup = function_body(pgwire, "handle_startup")
+        if "resolve_startup_tenant(" not in startup:
+            errors.append("pgwire startup skips deployment-aware tenant resolution")
+    except ValueError as error:
+        errors.append(f"src/network/postgres/protocol.rs: {error}")
+
+    for error in errors:
+        print(f"ERROR {error}", file=sys.stderr)
+    if errors:
+        print(f"Tenant ingress contract FAILED: {len(errors)} error(s)", file=sys.stderr)
+        return 1
+
+    print("Tenant ingress contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -66,9 +66,9 @@ fn flight_data_wire_bytes(flight_data: &[FlightData]) -> u64 {
         .sum()
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 struct AuthenticatedFlightContext {
-    tenant_id: Option<String>,
+    tenant_id: String,
     capability: Option<DataPlaneCapability>,
 }
 
@@ -141,6 +141,8 @@ pub struct ProximaFlightService {
     /// enforced through the ONE shared primitive in
     /// `authenticated_flight_context`. Default `Open` (legacy behavior).
     tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
+    /// Whether missing request identity may resolve to a configured default.
+    tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
     catalog_manager: Option<Arc<CatalogManager>>,
     /// R-7c.4b: when present, the `rank_features_export` Flight action
     /// drives the multi-phase ranking pipeline through this singleton.
@@ -243,6 +245,7 @@ impl ProximaFlightService {
             collection_service,
             security_coordinator: None,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
+            tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
             catalog_manager: None,
             rank_services: None,
             primary_pod_gate: None,
@@ -335,6 +338,31 @@ impl ProximaFlightService {
     pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
         self.tenant_header_trust = policy;
         self
+    }
+
+    /// Set the request-tenant presence contract independently of authentication.
+    pub fn with_tenant_deployment_mode(
+        mut self,
+        mode: proximadb_tenant::TenantDeploymentMode,
+    ) -> Self {
+        self.tenant_deployment_mode = mode;
+        self
+    }
+
+    fn resolve_tenant_for_mode(
+        tenant_id: Option<&str>,
+        mode: &proximadb_tenant::TenantDeploymentMode,
+    ) -> std::result::Result<String, TonicStatus> {
+        proximadb_tenant::resolve_request_tenant_for_mode(tenant_id, mode).map_err(|error| {
+            match error {
+                proximadb_tenant::ResolveRequestTenantError::MissingTenant => {
+                    TonicStatus::unauthenticated(error.to_string())
+                }
+                proximadb_tenant::ResolveRequestTenantError::InvalidTenant(_) => {
+                    TonicStatus::invalid_argument(error.to_string())
+                }
+            }
+        })
     }
 
     /// Attach xCatalog metadata for relational/table Flight schema resolution.
@@ -575,6 +603,8 @@ impl ProximaFlightService {
                     return Err(TonicStatus::permission_denied(error.to_string()));
                 }
             };
+            let tenant_id =
+                Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
             return Ok(AuthenticatedFlightContext {
                 tenant_id,
                 capability: None,
@@ -620,6 +650,8 @@ impl ProximaFlightService {
                 return Err(TonicStatus::permission_denied(error.to_string()));
             }
         };
+        let tenant_id =
+            Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
         Ok(AuthenticatedFlightContext {
             tenant_id,
             capability,
@@ -1103,6 +1135,7 @@ impl ProximaFlightService {
     async fn handle_vector_search(
         &self,
         request: VectorSearchRequest,
+        tenant_id: &str,
     ) -> Result<Vec<arrow_array::RecordBatch>> {
         debug!(
             collection_id = %request.collection_id,
@@ -1111,7 +1144,10 @@ impl ProximaFlightService {
         );
 
         // Execute search via UnifiedHandlers (reuses existing path)
-        let response = self.api_port.handle_vector_search_v1(request).await?;
+        let response = self
+            .api_port
+            .handle_vector_search_v1_for_tenant(request, Some(tenant_id))
+            .await?;
 
         // Convert results to Arrow RecordBatch
         let search_results = response
@@ -1154,6 +1190,11 @@ impl FlightService for ProximaFlightService {
         &self,
         request: TonicRequest<Criteria>,
     ) -> TonicResult<Self::ListFlightsStream> {
+        let auth_context = self
+            .authenticated_flight_context(request.metadata(), request.peer_certs())
+            .await?;
+        let tenant_context =
+            crate::storage::tenant::TenantContext::for_tenant_id(&auth_context.tenant_id);
         let criteria = request.into_inner();
 
         // Parse collection_id from criteria expression
@@ -1171,7 +1212,11 @@ impl FlightService for ProximaFlightService {
         // Get collections to list
         let collections = if let Some(cid) = collection_id {
             // Get specific collection
-            match self.collection_service.collection(&cid).await {
+            match self
+                .collection_service
+                .get_collection_with_tenant_context(&cid, Some(&tenant_context))
+                .await
+            {
                 Ok(Some(c)) => vec![c],
                 Ok(None) => {
                     return Err(TonicStatus::not_found(format!(
@@ -1189,7 +1234,7 @@ impl FlightService for ProximaFlightService {
         } else {
             // List all collections
             self.collection_service
-                .list_collections()
+                .list_collections_with_tenant_context(Some(&tenant_context))
                 .await
                 .map_err(|e| TonicStatus::internal(format!("Failed to list collections: {}", e)))?
         };
@@ -1226,6 +1271,11 @@ impl FlightService for ProximaFlightService {
         &self,
         request: TonicRequest<FlightDescriptor>,
     ) -> TonicResult<FlightInfo> {
+        let auth_context = self
+            .authenticated_flight_context(request.metadata(), request.peer_certs())
+            .await?;
+        let tenant_context =
+            crate::storage::tenant::TenantContext::for_tenant_id(&auth_context.tenant_id);
         let descriptor = request.into_inner();
 
         // Parse request from descriptor
@@ -1241,7 +1291,7 @@ impl FlightService for ProximaFlightService {
         // Get collection
         let collection = self
             .collection_service
-            .collection(&file_request.collection_id)
+            .get_collection_with_tenant_context(&file_request.collection_id, Some(&tenant_context))
             .await
             .map_err(|e| TonicStatus::internal(format!("Failed to get collection: {}", e)))?
             .ok_or_else(|| {
@@ -1287,6 +1337,11 @@ impl FlightService for ProximaFlightService {
         &self,
         request: TonicRequest<FlightDescriptor>,
     ) -> TonicResult<SchemaResult> {
+        let auth_context = self
+            .authenticated_flight_context(request.metadata(), request.peer_certs())
+            .await?;
+        let tenant_context =
+            crate::storage::tenant::TenantContext::for_tenant_id(&auth_context.tenant_id);
         let descriptor = request.into_inner();
 
         if let Some(schema) =
@@ -1308,7 +1363,7 @@ impl FlightService for ProximaFlightService {
         // Get collection to determine dimension
         let collection = self
             .collection_service
-            .collection(&metadata.collection_id)
+            .get_collection_with_tenant_context(&metadata.collection_id, Some(&tenant_context))
             .await
             .map_err(|e| TonicStatus::internal(format!("Failed to get collection: {}", e)))?
             .ok_or_else(|| TonicStatus::not_found("Collection not found"))?;
@@ -1382,7 +1437,7 @@ impl FlightService for ProximaFlightService {
             // KOU result-egress: meter the actual encoded FlightData bytes (the
             // client picked the compression via the ticket).
             edge.record_result_egress(
-                auth_context.tenant_id.as_deref(),
+                Some(auth_context.tenant_id.as_str()),
                 flight_data_wire_bytes(&flight_data),
             );
 
@@ -1400,7 +1455,11 @@ impl FlightService for ProximaFlightService {
                 &graph_ticket.graph_id,
             )?;
             let stream = self
-                .graph_export_flight_stream(graph_ticket, auth_context.tenant_id.clone(), edge)
+                .graph_export_flight_stream(
+                    graph_ticket,
+                    Some(auth_context.tenant_id.clone()),
+                    edge,
+                )
                 .await?;
             return Ok(TonicResponse::new(stream));
         }
@@ -1416,7 +1475,7 @@ impl FlightService for ProximaFlightService {
 
         // Execute search
         let batches = self
-            .handle_vector_search(search_request)
+            .handle_vector_search(search_request, &auth_context.tenant_id)
             .await
             .map_err(|e| TonicStatus::internal(format!("Search failed: {}", e)))?;
 
@@ -1434,7 +1493,7 @@ impl FlightService for ProximaFlightService {
             ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
                 .map_err(|e| TonicStatus::internal(format!("Failed to encode batches: {}", e)))?;
         edge.record_result_egress(
-            auth_context.tenant_id.as_deref(),
+            Some(auth_context.tenant_id.as_str()),
             flight_data_wire_bytes(&flight_data),
         );
         let stream = stream::iter(flight_data.into_iter().map(Ok));
@@ -1489,7 +1548,7 @@ impl FlightService for ProximaFlightService {
         // pure reads use do_get and don't pass through here.
         check_flight_primary_pod_gate(
             &self.primary_pod_gate,
-            auth_context.tenant_id.as_deref().unwrap_or(""),
+            &auth_context.tenant_id,
             &write_target,
         )?;
 
@@ -1519,7 +1578,7 @@ impl FlightService for ProximaFlightService {
                         table_fqn.as_deref(),
                         operation,
                         metadata.write_mode,
-                        auth_context.tenant_id.as_deref(),
+                        Some(auth_context.tenant_id.as_str()),
                         batch,
                         (operation == FlightWriteOperation::Insert).then_some(&mut insert_seen_ids),
                     )
@@ -1528,7 +1587,7 @@ impl FlightService for ProximaFlightService {
                 FlightWriteOperation::Delete => {
                     self.handle_record_delete_batch(
                         &write_target,
-                        auth_context.tenant_id.as_deref(),
+                        Some(auth_context.tenant_id.as_str()),
                         batch,
                     )
                     .await
@@ -1569,6 +1628,11 @@ impl FlightService for ProximaFlightService {
     }
 
     async fn do_action(&self, request: TonicRequest<Action>) -> TonicResult<Self::DoActionStream> {
+        let auth_context = self
+            .authenticated_flight_context(request.metadata(), request.peer_certs())
+            .await?;
+        let tenant_context =
+            crate::storage::tenant::TenantContext::for_tenant_id(&auth_context.tenant_id);
         let action = request.into_inner();
 
         match action.r#type.as_str() {
@@ -1687,7 +1751,7 @@ impl FlightService for ProximaFlightService {
                 // Create collection via service
                 let result = self
                     .collection_service
-                    .create_collection(&config)
+                    .create_collection_with_tenant_context(&config, Some(&tenant_context))
                     .await
                     .map_err(|e| {
                         TonicStatus::internal(format!("Failed to create collection: {}", e))
@@ -1736,7 +1800,7 @@ impl FlightService for ProximaFlightService {
 
                 // Delete collection via service
                 self.collection_service
-                    .delete_collection(collection_id)
+                    .delete_collection_with_tenant_context(collection_id, Some(&tenant_context))
                     .await
                     .map_err(|e| {
                         TonicStatus::internal(format!("Failed to delete collection: {}", e))
@@ -1777,7 +1841,7 @@ impl FlightService for ProximaFlightService {
                 // Get collection via service
                 let collection = self
                     .collection_service
-                    .collection(collection_id)
+                    .get_collection_with_tenant_context(collection_id, Some(&tenant_context))
                     .await
                     .map_err(|e| TonicStatus::internal(format!("Failed to get collection: {}", e)))?
                     .ok_or_else(|| {
@@ -1814,13 +1878,13 @@ impl FlightService for ProximaFlightService {
                 debug!("Arrow Flight: list_collections");
 
                 // List all collections via service
-                let collections =
-                    self.collection_service
-                        .list_collections()
-                        .await
-                        .map_err(|e| {
-                            TonicStatus::internal(format!("Failed to list collections: {}", e))
-                        })?;
+                let collections = self
+                    .collection_service
+                    .list_collections_with_tenant_context(Some(&tenant_context))
+                    .await
+                    .map_err(|e| {
+                        TonicStatus::internal(format!("Failed to list collections: {}", e))
+                    })?;
 
                 let collection_summaries: Vec<serde_json::Value> = collections
                     .iter()
@@ -1946,7 +2010,11 @@ impl FlightService for ProximaFlightService {
                 // Insert via the canonical rich-record port.
                 let result = self
                     .record_port
-                    .upsert_record_batch(collection_id, records, None)
+                    .upsert_record_batch(
+                        collection_id,
+                        records,
+                        Some(auth_context.tenant_id.as_str()),
+                    )
                     .await
                     .map_err(|e| {
                         TonicStatus::internal(format!("Failed to insert vectors: {}", e))
@@ -2060,6 +2128,14 @@ impl FlightService for ProximaFlightService {
                     vector_count = vector_ids.len(),
                     "Arrow Flight: get_vectors"
                 );
+
+                self.collection_service
+                    .get_collection_with_tenant_context(collection_id, Some(&tenant_context))
+                    .await
+                    .map_err(|e| TonicStatus::internal(format!("Failed to get collection: {}", e)))?
+                    .ok_or_else(|| {
+                        TonicStatus::not_found(format!("Collection not found: {}", collection_id))
+                    })?;
 
                 // Get vectors via vector operations service
                 let mut found_vectors = Vec::new();
@@ -2254,7 +2330,7 @@ impl FlightService for ProximaFlightService {
                 // Get collection
                 let collection = self
                     .collection_service
-                    .collection(collection_id)
+                    .get_collection_with_tenant_context(collection_id, Some(&tenant_context))
                     .await
                     .map_err(|e| TonicStatus::internal(format!("Failed to get collection: {}", e)))?
                     .ok_or_else(|| {
@@ -2501,7 +2577,7 @@ impl FlightService for ProximaFlightService {
                     write_target,
                     table_fqn,
                     operation,
-                    auth_context.tenant_id.clone(),
+                    Some(auth_context.tenant_id.clone()),
                     auth_context.capability.clone(),
                     first_msg,
                     stream,
@@ -2513,7 +2589,7 @@ impl FlightService for ProximaFlightService {
                     write_target,
                     table_fqn,
                     FlightWriteOperation::Delete,
-                    auth_context.tenant_id.clone(),
+                    Some(auth_context.tenant_id.clone()),
                     auth_context.capability.clone(),
                     first_msg,
                     stream,
@@ -2534,7 +2610,7 @@ impl FlightService for ProximaFlightService {
                 self.handle_graph_write_exchange(
                     collection_id,
                     is_nodes,
-                    auth_context.tenant_id.clone(),
+                    Some(auth_context.tenant_id.clone()),
                     first_msg,
                     stream,
                 )
@@ -2545,8 +2621,13 @@ impl FlightService for ProximaFlightService {
                     auth_context.capability.as_ref(),
                     &collection_id,
                 )?;
-                self.handle_bulk_search_exchange(collection_id, first_msg, stream)
-                    .await
+                self.handle_bulk_search_exchange(
+                    collection_id,
+                    auth_context.tenant_id,
+                    first_msg,
+                    stream,
+                )
+                .await
             }
             "data_transfer" => {
                 if auth_context.capability.is_some() {
@@ -2723,7 +2804,8 @@ impl ProximaFlightService {
         })?;
         // Structural isolation: resolve the tenant and route through the scoped handle,
         // which composes `{tenant}/{graph_id}` once. The graph_id stays tenant-clean.
-        let tenant = proximadb_tenant::resolve_request_tenant(tenant_id.as_deref());
+        let tenant =
+            Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
         let ops = graph.for_tenant(&tenant);
 
         let mut total_rows = 0u64;
@@ -2829,7 +2911,8 @@ impl ProximaFlightService {
             TonicStatus::unimplemented("graph Flight path requires the graph backing service")
         })?;
         // Read the SAME structural key the write path composes (`{tenant}/{graph_id}`).
-        let tenant = proximadb_tenant::resolve_request_tenant(tenant_id.as_deref());
+        let tenant =
+            Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
         let gid = crate::graph::scoped_graph_id(&tenant, &ticket.graph_id)
             .map_err(|e| TonicStatus::invalid_argument(format!("invalid tenant: {e}")))?;
         let page = ticket
@@ -2986,6 +3069,7 @@ impl ProximaFlightService {
     async fn handle_bulk_search_exchange(
         &self,
         collection_id: String,
+        tenant_id: String,
         first_msg: FlightData,
         mut stream: TonicStreaming<FlightData>,
     ) -> TonicResult<<Self as FlightService>::DoExchangeStream> {
@@ -3051,13 +3135,14 @@ impl ProximaFlightService {
                 };
 
                 // Execute search
-                let search_response = match self.handle_vector_search(search_request).await {
-                    Ok(batches) => batches,
-                    Err(e) => {
-                        warn!("Search failed for query {}: {}", query_record.oid, e);
-                        continue;
-                    }
-                };
+                let search_response =
+                    match self.handle_vector_search(search_request, &tenant_id).await {
+                        Ok(batches) => batches,
+                        Err(e) => {
+                            warn!("Search failed for query {}: {}", query_record.oid, e);
+                            continue;
+                        }
+                    };
 
                 // Convert result batches to FlightData
                 for result_batch in search_response {

--- a/src/network/arrow_ipc/service_tests.rs
+++ b/src/network/arrow_ipc/service_tests.rs
@@ -230,6 +230,32 @@ fn test_tenant_id_from_flight_metadata_ignores_empty_header() {
 }
 
 #[test]
+fn test_flight_tenant_resolution_rejects_missing_multi_tenant_identity() {
+    let status = ProximaFlightService::resolve_tenant_for_mode(
+        None,
+        &proximadb_tenant::TenantDeploymentMode::MultiTenant,
+    )
+    .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    assert_eq!(
+        status.message(),
+        "tenant id is required in multi-tenant mode"
+    );
+}
+
+#[test]
+fn test_flight_tenant_resolution_defaults_only_in_single_tenant_mode() {
+    let tenant = ProximaFlightService::resolve_tenant_for_mode(
+        None,
+        &proximadb_tenant::TenantDeploymentMode::single_tenant("embedded"),
+    )
+    .unwrap();
+
+    assert_eq!(tenant, "embedded");
+}
+
+#[test]
 fn test_auth_data_from_flight_metadata_accepts_api_key_scheme() {
     let mut metadata = tonic::metadata::MetadataMap::new();
     metadata.insert("authorization", "API-Key key-1".parse().unwrap());

--- a/src/network/grpc/auth.rs
+++ b/src/network/grpc/auth.rs
@@ -24,6 +24,55 @@ use proximadb_tenant::identity_trust::{
 use crate::network::auth::middleware::DataPlaneCapability;
 use crate::security::{AuthenticationData, SecurityCoordinator, UnifiedUserContext};
 
+/// Adds the deployment-wide tenant resolution mode to every gRPC request.
+/// Authentication is an independent optional layer, so this layer is always
+/// installed even in development deployments with security disabled.
+#[derive(Clone)]
+pub struct GrpcTenantModeLayer {
+    mode: proximadb_tenant::TenantDeploymentMode,
+}
+
+impl GrpcTenantModeLayer {
+    pub fn new(mode: proximadb_tenant::TenantDeploymentMode) -> Self {
+        Self { mode }
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcTenantModeService<S> {
+    inner: S,
+    mode: proximadb_tenant::TenantDeploymentMode,
+}
+
+impl<S> Layer<S> for GrpcTenantModeLayer {
+    type Service = GrpcTenantModeService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcTenantModeService {
+            inner,
+            mode: self.mode.clone(),
+        }
+    }
+}
+
+impl<S, B> Service<HttpRequest<B>> for GrpcTenantModeService<S>
+where
+    S: Service<HttpRequest<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: HttpRequest<B>) -> Self::Future {
+        request.extensions_mut().insert(self.mode.clone());
+        self.inner.call(request)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GrpcAuthContext {
     pub user_context: UnifiedUserContext,
@@ -217,12 +266,26 @@ pub fn tenant_id<T>(request: &Request<T>) -> Option<String> {
     tenant_id_from_metadata(request.metadata())
 }
 
-/// The RESOLVED request tenant for gRPC + Arrow Flight — the authenticated /
-/// `x-tenant-id`-metadata tenant, else the ONE canonical [`DEFAULT_TENANT`]
-/// (`proximadb_tenant::resolve_request_tenant`). Data-plane handlers call this so
-/// a bare request lands in the SAME bucket as REST/pgwire instead of `""`.
-pub fn resolved_tenant_id<T>(request: &Request<T>) -> String {
-    proximadb_tenant::resolve_request_tenant(tenant_id(request).as_deref())
+/// Resolve and validate the request tenant under the deployment mode installed
+/// by [`GrpcTenantModeLayer`]. Missing identity fails closed in multi-tenant
+/// mode; an absent layer preserves embedded single-tenant compatibility.
+pub fn resolved_tenant_id<T>(request: &Request<T>) -> Result<String, Status> {
+    let fallback_mode = proximadb_tenant::TenantDeploymentMode::single_tenant_default();
+    let mode = request
+        .extensions()
+        .get::<proximadb_tenant::TenantDeploymentMode>()
+        .unwrap_or(&fallback_mode);
+
+    proximadb_tenant::resolve_request_tenant_for_mode(tenant_id(request).as_deref(), mode).map_err(
+        |error| match error {
+            proximadb_tenant::ResolveRequestTenantError::MissingTenant => {
+                Status::unauthenticated(error.to_string())
+            }
+            proximadb_tenant::ResolveRequestTenantError::InvalidTenant(_) => {
+                Status::invalid_argument(error.to_string())
+            }
+        },
+    )
 }
 
 /// Acting principal (user id) for within-tenant row-level RBAC
@@ -468,13 +531,43 @@ mod tests {
     use crate::security::{AuditConfig, SecurityConfig, SecurityMode};
 
     #[test]
-    fn resolved_tenant_id_defaults_when_no_tenant_present() {
+    fn resolved_tenant_id_defaults_in_single_tenant_mode() {
         // A bare gRPC/Flight request (no auth context, no `x-tenant-id` metadata)
         // resolves to the ONE canonical default — the same bucket REST and pgwire
         // use — instead of the old `""` that split it from REST's `"default"`.
-        let req = Request::new(());
+        let mut req = Request::new(());
+        req.extensions_mut()
+            .insert(proximadb_tenant::TenantDeploymentMode::single_tenant_default());
         assert_eq!(tenant_id(&req), None);
-        assert_eq!(resolved_tenant_id(&req), proximadb_tenant::DEFAULT_TENANT);
+        assert_eq!(
+            resolved_tenant_id(&req).unwrap(),
+            proximadb_tenant::DEFAULT_TENANT
+        );
+    }
+
+    #[test]
+    fn resolved_tenant_id_rejects_missing_tenant_in_multi_tenant_mode() {
+        let mut req = Request::new(());
+        req.extensions_mut()
+            .insert(proximadb_tenant::TenantDeploymentMode::MultiTenant);
+
+        let status = resolved_tenant_id(&req).unwrap_err();
+        assert_eq!(status.code(), Code::Unauthenticated);
+        assert_eq!(
+            status.message(),
+            "tenant id is required in multi-tenant mode"
+        );
+    }
+
+    #[test]
+    fn resolved_tenant_id_accepts_explicit_tenant_in_multi_tenant_mode() {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert("x-tenant-id", "tenant-a".parse().unwrap());
+        req.extensions_mut()
+            .insert(proximadb_tenant::TenantDeploymentMode::MultiTenant);
+
+        assert_eq!(resolved_tenant_id(&req).unwrap(), "tenant-a");
     }
 
     fn security_config() -> SecurityConfig {

--- a/src/network/grpc/v2/document_service.rs
+++ b/src/network/grpc/v2/document_service.rs
@@ -74,7 +74,7 @@ impl ProximaDocumentServiceImpl {
         request: &Request<T>,
         collection_id: &str,
     ) -> Result<(String, String), Status> {
-        let tenant = grpc_auth::resolved_tenant_id(request);
+        let tenant = grpc_auth::resolved_tenant_id(request)?;
         let scoped =
             crate::storage::document::service::scoped_document_collection(&tenant, collection_id)
                 .map_err(|e| Status::invalid_argument(format!("invalid tenant: {e}")))?;

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -166,7 +166,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
     ) -> Result<Response<pv2::UpsertEntityResponse>, Status> {
         // Tenant-CLEAN collection name; each leg is scoped structurally by the resolved tenant.
         let collection = request.get_ref().collection_id.clone();
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         let entity = req
             .entity
@@ -392,7 +392,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         request: Request<pv2::GetEntityRequest>,
     ) -> Result<Response<pv2::GetEntityResponse>, Status> {
         let collection = request.get_ref().collection_id.clone();
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
 
         debug!(
@@ -419,7 +419,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         request: Request<pv2::DeleteEntityRequest>,
     ) -> Result<Response<pv2::DeleteEntityResponse>, Status> {
         let collection = request.get_ref().collection_id.clone();
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
 
         debug!(
@@ -454,7 +454,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
         request: Request<pv2::SearchEntitiesRequest>,
     ) -> Result<Response<pv2::SearchEntitiesResponse>, Status> {
         let collection = request.get_ref().collection_id.clone();
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let principal = grpc_auth::user_id(&request);
         let req = request.into_inner();
 

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -65,9 +65,9 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
         &self,
         request: Request<pv2::FusionSearchRequest>,
     ) -> Result<Response<pv2::FusionSearchResponse>, Status> {
-        // Tenant isolation is structural: the backing vector/graph collections are
-        // tenant-namespaced via `x-tenant-id`. We read it here only for logging.
-        let tenant_id = grpc_auth::tenant_id(&request);
+        // Tenant isolation is structural: resolve the deployment-aware identity
+        // before either backing collection can be reached.
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let principal = grpc_auth::user_id(&request);
         let req = request.into_inner();
 
@@ -108,7 +108,7 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
             route_policy: None,
             graph_id: req.graph_id.clone(),
             // Structural tenant boundary — scopes both fusion legs (TD-ENTITY-TENANT-1).
-            tenant: tenant_id.clone(),
+            tenant: Some(tenant_id.clone()),
             vector_collection: req.vector_collection.clone(),
             query_vector: req.query_vector.clone(),
             max_depth: if req.max_depth == 0 {

--- a/src/network/grpc/v2/graph_service.rs
+++ b/src/network/grpc/v2/graph_service.rs
@@ -352,7 +352,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::CreateGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC CreateNode graph={graph_id}");
@@ -379,7 +379,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetNode graph={graph_id} node={}", req.node_id);
@@ -400,7 +400,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::UpdateGraphNodeRequest>,
     ) -> Result<Response<pv2::GraphNodeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC UpdateNode graph={graph_id}");
@@ -424,7 +424,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::DeleteGraphNodeRequest>,
     ) -> Result<Response<pv2::DeleteGraphNodeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC DeleteNode graph={graph_id} node={}", req.node_id);
@@ -446,7 +446,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::CreateGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC CreateEdge graph={graph_id}");
@@ -470,7 +470,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetEdge graph={graph_id} edge={}", req.edge_id);
@@ -491,7 +491,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::UpdateGraphEdgeRequest>,
     ) -> Result<Response<pv2::GraphEdgeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC UpdateEdge graph={graph_id}");
@@ -515,7 +515,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::DeleteGraphEdgeRequest>,
     ) -> Result<Response<pv2::DeleteGraphEdgeResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC DeleteEdge graph={graph_id} edge={}", req.edge_id);
@@ -537,7 +537,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::QueryGraphNodesRequest>,
     ) -> Result<Response<pv2::QueryGraphNodesResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -578,7 +578,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::QueryGraphEdgesRequest>,
     ) -> Result<Response<pv2::QueryGraphEdgesResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC QueryEdges graph={graph_id}");
@@ -618,7 +618,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphNeighborsRequest>,
     ) -> Result<Response<pv2::GetGraphNeighborsResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!("v2 gRPC GetNeighbors graph={graph_id} node={}", req.node_id);
@@ -642,7 +642,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::TraverseGraphRequest>,
     ) -> Result<Response<pv2::TraverseGraphResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         let start = Instant::now();
@@ -679,7 +679,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphShortestPathRequest>,
     ) -> Result<Response<pv2::GraphShortestPathResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -734,7 +734,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GetGraphStatsRequest>,
     ) -> Result<Response<pv2::GraphStats>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC GetGraphStats graph={graph_id}");
         match self.graph.for_tenant(&tenant).get_stats(&graph_id).await {
@@ -755,7 +755,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::TraverseGraphRequest>,
     ) -> Result<Response<Self::StreamTraverseStream>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         let start = Instant::now();
@@ -799,7 +799,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphConnectedComponentsRequest>,
     ) -> Result<Response<pv2::GraphConnectedComponentsResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC GetConnectedComponents graph={graph_id}");
         match self
@@ -822,7 +822,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphHasCycleRequest>,
     ) -> Result<Response<pv2::GraphHasCycleResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         debug!("v2 gRPC HasCycle graph={graph_id}");
         match self.graph.for_tenant(&tenant).has_cycle(&graph_id).await {
@@ -837,7 +837,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphUniqueConstraintRequest>,
     ) -> Result<Response<pv2::GraphUniqueConstraintResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -867,7 +867,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::GraphUniqueConstraintRequest>,
     ) -> Result<Response<pv2::GraphUniqueConstraintResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -897,7 +897,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::BatchCreateGraphNodesRequest>,
     ) -> Result<Response<pv2::BatchCreateGraphNodesResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -931,7 +931,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::BatchCreateGraphEdgesRequest>,
     ) -> Result<Response<pv2::BatchCreateGraphEdgesResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(
@@ -973,7 +973,7 @@ impl ProximaGraphService for ProximaGraphServiceImpl {
         &self,
         request: Request<pv2::ExecuteGraphQueryRequest>,
     ) -> Result<Response<pv2::ExecuteGraphQueryResponse>, Status> {
-        let tenant = grpc_auth::resolved_tenant_id(&request);
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let graph_id = request.get_ref().graph_id.clone();
         let req = request.into_inner();
         debug!(

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -866,14 +866,6 @@ impl ProximaRecordServiceImpl {
         ProximaRecordServiceServer::new(self)
     }
 
-    fn extract_tenant_id<T>(request: &Request<T>) -> Option<String> {
-        request
-            .metadata()
-            .get("x-tenant-id")
-            .and_then(|value| value.to_str().ok())
-            .map(|value| value.to_string())
-    }
-
     /// Spawn a background PAX write for the given records and register the resulting
     /// `SegmentMeta` with the shared `SegmentRegistry`.
     ///
@@ -1144,8 +1136,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ProximaRecordBatch>,
     ) -> Result<Response<ProximaRecordBatchResponse>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "ingest",
@@ -1177,11 +1168,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // ApiError → tonic::Status conversion at `src/errors/mod.rs:135`
         // adds `x-primary-pod` / `x-tenant-id` / `x-collection-id`
         // trailing metadata so SDKs can parse the redirect target.
-        check_primary_pod_gate(
-            &self.primary_pod_gate,
-            tenant_id.as_deref().unwrap_or(""),
-            &batch.collection_id,
-        )?;
+        check_primary_pod_gate(&self.primary_pod_gate, &tenant_id, &batch.collection_id)?;
 
         let record_ids: Vec<String> = batch
             .records
@@ -1211,7 +1198,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
 
         match self
             .record_ops
-            .handle_record_batch_for_tenant(rich_batch, tenant_id.as_deref())
+            .handle_record_batch_for_tenant(rich_batch, Some(tenant_id.as_str()))
             .await
         {
             Ok(result) => {
@@ -1238,8 +1225,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ProximaRecordBatch>,
     ) -> Result<Response<ProximaRecordBatchResponse>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "ingest",
@@ -1258,11 +1244,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // mutation must gate — not just insert — or a displaced pod silently
         // accepts upserts that the new primary's reader never sees. Runs after
         // auth/validation, before the lane router / storage path.
-        check_primary_pod_gate(
-            &self.primary_pod_gate,
-            tenant_id.as_deref().unwrap_or(""),
-            &batch.collection_id,
-        )?;
+        check_primary_pod_gate(&self.primary_pod_gate, &tenant_id, &batch.collection_id)?;
 
         let record_ids: Vec<String> = batch
             .records
@@ -1292,7 +1274,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
 
         match self
             .record_ops
-            .handle_record_batch_for_tenant(rich_batch, tenant_id.as_deref())
+            .handle_record_batch_for_tenant(rich_batch, Some(tenant_id.as_str()))
             .await
         {
             Ok(result) => {
@@ -1319,8 +1301,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ProximaRecordBatch>,
     ) -> Result<Response<ProximaRecordBatchResponse>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "ingest",
@@ -1336,11 +1317,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         );
 
         // Primary-pod write-router gate (symmetric with `insert_records`).
-        check_primary_pod_gate(
-            &self.primary_pod_gate,
-            tenant_id.as_deref().unwrap_or(""),
-            &batch.collection_id,
-        )?;
+        check_primary_pod_gate(&self.primary_pod_gate, &tenant_id, &batch.collection_id)?;
 
         let record_ids: Vec<String> = batch
             .records
@@ -1365,7 +1342,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
 
         match self
             .record_ops
-            .handle_record_batch_for_tenant(rich_batch, tenant_id.as_deref())
+            .handle_record_batch_for_tenant(rich_batch, Some(tenant_id.as_str()))
             .await
         {
             Ok(result) => Ok(Response::new(Self::batch_result_to_response(
@@ -1385,8 +1362,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ProximaRecordBatch>,
     ) -> Result<Response<ProximaRecordBatchResponse>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "ingest",
@@ -1402,11 +1378,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         );
 
         // Primary-pod write-router gate (symmetric with `insert_records`).
-        check_primary_pod_gate(
-            &self.primary_pod_gate,
-            tenant_id.as_deref().unwrap_or(""),
-            &batch.collection_id,
-        )?;
+        check_primary_pod_gate(&self.primary_pod_gate, &tenant_id, &batch.collection_id)?;
 
         let record_ids: Vec<String> = batch
             .records
@@ -1443,7 +1415,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     collection_id: batch.collection_id.clone(),
                     record_ids: record_ids.clone(),
                 },
-                tenant_id.as_deref(),
+                Some(tenant_id.as_str()),
             )
             .await
         {
@@ -1475,8 +1447,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<TypedSearchResponse>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1505,7 +1476,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             crate::observability::predicate_diagnostics::scope(async {
                 let outcome = self
                     .record_ops
-                    .handle_record_search_for_tenant(search_request, tenant_id.as_deref())
+                    .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()))
                     .await;
                 let tq = crate::observability::predicate_diagnostics::take_turboquant_hints();
                 (outcome, tq)
@@ -1562,8 +1533,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<Self::SearchStreamStream>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1589,7 +1559,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // Execute search
         let response = self
             .record_ops
-            .handle_record_search_for_tenant(search_request, tenant_id.as_deref())
+            .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()))
             .await
             .map_err(|e| Status::internal(format!("Search stream failed: {}", e)))?;
 
@@ -1644,8 +1614,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<Streaming<BatchWriteStreamRequest>>,
     ) -> Result<Response<Self::BatchWriteStreamStream>, Status> {
-        let tenant_id =
-            grpc_auth::tenant_id(&request).or_else(|| Self::extract_tenant_id(&request));
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let data_plane_capability = grpc_auth::data_plane_capability(&request);
         let mut inbound = request.into_inner();
 
@@ -1798,7 +1767,10 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                         | Ok(BatchWriteMode::Upsert)
                         | Ok(BatchWriteMode::Update) => {
                             record_ops
-                                .handle_record_batch_for_tenant(rich_batch, tenant_id.as_deref())
+                                .handle_record_batch_for_tenant(
+                                    rich_batch,
+                                    Some(tenant_id.as_str()),
+                                )
                                 .await
                         }
                         Ok(BatchWriteMode::Delete) => {
@@ -1808,7 +1780,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                                         collection_id: batch.collection_id.clone(),
                                         record_ids: vec![record.id.clone()],
                                     },
-                                    tenant_id.as_deref(),
+                                    Some(tenant_id.as_str()),
                                 )
                                 .await
                         }
@@ -1943,7 +1915,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<CreateSchemaRequest>,
     ) -> Result<Response<CreateSchemaResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         info!("V2 gRPC: CreateSchema - collection='{}'", req.collection_id);
 
@@ -1954,7 +1926,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         let schema_id = update.schema_id.clone();
 
         self.api_handlers
-            .update_collection_schema_metadata(&req.collection_id, update, tenant_id.as_deref())
+            .update_collection_schema_metadata(&req.collection_id, update, Some(tenant_id.as_str()))
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
@@ -1976,13 +1948,13 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<GetSchemaRequest>,
     ) -> Result<Response<GetSchemaResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         debug!("V2 gRPC: GetSchema - collection='{}'", req.collection_id);
 
         let metadata = self
             .api_handlers
-            .get_collection_schema_metadata(&req.collection_id, tenant_id.as_deref())
+            .get_collection_schema_metadata(&req.collection_id, Some(tenant_id.as_str()))
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
@@ -2016,13 +1988,13 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<ListSchemasRequest>,
     ) -> Result<Response<ListSchemasResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         debug!("V2 gRPC: ListSchemas - collection='{}'", req.collection_id);
 
         let metadata = self
             .api_handlers
-            .get_collection_schema_metadata(&req.collection_id, tenant_id.as_deref())
+            .get_collection_schema_metadata(&req.collection_id, Some(tenant_id.as_str()))
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
@@ -2048,7 +2020,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<EvolveSchemaRequest>,
     ) -> Result<Response<EvolveSchemaResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         info!(
             "V2 gRPC: EvolveSchema - collection='{}', base_schema='{}'",
@@ -2089,7 +2061,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // Persist the evolved canonical schema to the catalog sidecar (authority flows
         // through the runtime `UnifiedHandlers` impl of `ApiHandlersPort`).
         self.api_handlers
-            .update_collection_schema_metadata(&req.collection_id, update, tenant_id.as_deref())
+            .update_collection_schema_metadata(&req.collection_id, update, Some(tenant_id.as_str()))
             .await
             .map_err(|e| {
                 if e.to_string().contains("not found") {
@@ -2116,7 +2088,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2CollectionConfig>,
     ) -> Result<Response<V2Collection>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let cfg = request.into_inner();
         info!("V2 gRPC: CreateCollection - name='{}'", cfg.name);
 
@@ -2189,7 +2161,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .handle_collection_operation_for_tenant(req, tenant_id.as_deref())
+            .handle_collection_operation_for_tenant(req, Some(tenant_id.as_str()))
             .await
             .map_err(|e| Status::internal(format!("CreateCollection failed: {e}")))?;
         let coll = resp
@@ -2215,7 +2187,11 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         if let Err(e) = self
             .api_handlers
-            .update_collection_schema_metadata(&cfg.name, canonical_update, tenant_id.as_deref())
+            .update_collection_schema_metadata(
+                &cfg.name,
+                canonical_update,
+                Some(tenant_id.as_str()),
+            )
             .await
         {
             warn!(
@@ -2232,7 +2208,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2GetCollectionRequest>,
     ) -> Result<Response<V2Collection>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req_in = request.into_inner();
         let req = CollectionRequest {
             operation: CollectionOperation::CollectionGet as i32,
@@ -2244,7 +2220,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .handle_collection_operation_for_tenant(req, tenant_id.as_deref())
+            .handle_collection_operation_for_tenant(req, Some(tenant_id.as_str()))
             .await
             .map_err(|e| Status::internal(format!("GetCollection failed: {e}")))?;
         let coll = resp.collection.ok_or_else(|| {
@@ -2257,7 +2233,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2ListCollectionsRequest>,
     ) -> Result<Response<V2ListCollectionsResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let _ = request.into_inner();
         let req = CollectionRequest {
             operation: CollectionOperation::CollectionList as i32,
@@ -2269,7 +2245,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .handle_collection_operation_for_tenant(req, tenant_id.as_deref())
+            .handle_collection_operation_for_tenant(req, Some(tenant_id.as_str()))
             .await
             .map_err(|e| Status::internal(format!("ListCollections failed: {e}")))?;
         let collections = resp.collections.into_iter().map(collection_to_v2).collect();
@@ -2280,7 +2256,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2DeleteCollectionRequest>,
     ) -> Result<Response<V2DeleteCollectionResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req_in = request.into_inner();
         info!("V2 gRPC: DeleteCollection - id='{}'", req_in.collection_id);
         let req = CollectionRequest {
@@ -2292,7 +2268,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             migration_config: Default::default(),
         };
         self.api_handlers
-            .handle_collection_operation_for_tenant(req, tenant_id.as_deref())
+            .handle_collection_operation_for_tenant(req, Some(tenant_id.as_str()))
             .await
             .map_err(|e| Status::internal(format!("DeleteCollection failed: {e}")))?;
         Ok(Response::new(V2DeleteCollectionResponse { success: true }))
@@ -2304,7 +2280,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2QueryRequest>,
     ) -> Result<Response<V2QueryResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -2313,7 +2289,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .execute_sql_v1(q.query, None, collection, tenant_id.as_deref())
+            .execute_sql_v1(q.query, None, collection, Some(tenant_id.as_str()))
             .await
             .map_err(|e| {
                 // A DML lock conflict → ABORTED (retryable); other errors → INTERNAL.
@@ -2353,7 +2329,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<proximadb_v2::GetRecordRequest>,
     ) -> Result<Response<proximadb_v2::GetRecordResponse>, Status> {
-        let tenant_id = Self::extract_tenant_id(&request);
+        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
         let result = self
             .record_ops
@@ -2364,7 +2340,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     include_vector: req.include_vector,
                     include_props: true,
                 },
-                tenant_id.as_deref(),
+                Some(tenant_id.as_str()),
             )
             .await
             .map_err(|e| Status::internal(format!("GetRecord failed: {e}")))?;

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -515,8 +515,11 @@ impl MultiServer {
             } else {
                 tonic::transport::Server::builder()
             };
-            let mut server_builder =
-                server_builder.layer(tower::util::option_layer(if self.rest_auth_enabled {
+            let mut server_builder = server_builder
+                .layer(crate::network::grpc::auth::GrpcTenantModeLayer::new(
+                    self.tenant_deployment_mode.clone(),
+                ))
+                .layer(tower::util::option_layer(if self.rest_auth_enabled {
                     self.security_coordinator.clone().map(|sc| {
                         crate::network::grpc::auth::GrpcAuthLayer::new(sc)
                             .with_header_trust(self.tenant_header_trust)
@@ -697,6 +700,7 @@ impl MultiServer {
             let self_pod_id = services.self_pod_id.clone();
             let api_handlers = services.api_handlers.clone();
             let tenant_header_trust = self.tenant_header_trust;
+            let tenant_deployment_mode = self.tenant_deployment_mode.clone();
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
@@ -708,7 +712,8 @@ impl MultiServer {
                     arrow_collection,
                     arrow_graph,
                 )
-                .with_tenant_header_trust(tenant_header_trust);
+                .with_tenant_header_trust(tenant_header_trust)
+                .with_tenant_deployment_mode(tenant_deployment_mode);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
@@ -882,6 +887,7 @@ impl MultiServer {
                 });
 
             let tenant_header_trust = self.tenant_header_trust;
+            let tenant_deployment_mode = self.tenant_deployment_mode.clone();
             let postgres_handle = tokio::spawn(async move {
                 use crate::network::postgres::PostgresServer;
                 let mut server = PostgresServer::new(
@@ -902,6 +908,7 @@ impl MultiServer {
                 server = server.with_partition_lease_manager(partition_lease_manager);
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
+                server = server.with_tenant_deployment_mode(tenant_deployment_mode);
                 if let Some(limiter) = pgwire_rate_limiter {
                     server = server.with_rate_limiter(limiter);
                 }
@@ -1090,22 +1097,25 @@ impl MultiServer {
                     None
                 })
                 .with_tenant_header_trust(self.tenant_header_trust)
+                .with_tenant_deployment_mode(self.tenant_deployment_mode.clone())
                 .with_catalog_manager(Some(services.catalog_manager.clone()));
             let flight_server =
                 arrow_flight::flight_service_server::FlightServiceServer::new(flight_service)
                     .max_encoding_message_size(512 * 1024 * 1024)
                     .max_decoding_message_size(512 * 1024 * 1024);
 
-            let mut server_builder = tonic::transport::Server::builder().layer(
-                tower::util::option_layer(if self.rest_auth_enabled {
+            let mut server_builder = tonic::transport::Server::builder()
+                .layer(crate::network::grpc::auth::GrpcTenantModeLayer::new(
+                    self.tenant_deployment_mode.clone(),
+                ))
+                .layer(tower::util::option_layer(if self.rest_auth_enabled {
                     self.security_coordinator.clone().map(|sc| {
                         crate::network::grpc::auth::GrpcAuthLayer::new(sc)
                             .with_header_trust(self.tenant_header_trust)
                     })
                 } else {
                     None
-                }),
-            );
+                }));
 
             // Standard grpc.health.v1.Health service for k8s/LB probes.
             let (health_reporter, standard_health_server) = tonic_health::server::health_reporter();
@@ -1188,6 +1198,7 @@ impl MultiServer {
             let direct_write_services = self.build_direct_pgwire_write_services().await?;
             let warehouse_root_url = format!("file://{}/warehouse", self.config.data_dir.display());
             let tenant_header_trust = self.tenant_header_trust;
+            let tenant_deployment_mode = self.tenant_deployment_mode.clone();
             let postgres_handle = tokio::spawn(async move {
                 use crate::network::postgres::PostgresServer;
 
@@ -1220,6 +1231,7 @@ impl MultiServer {
                     server.with_partition_lease_manager(services.partition_lease_manager.clone());
                 server = server.with_warehouse_materialization(warehouse_root_url);
                 server = server.with_tenant_header_trust(tenant_header_trust);
+                server = server.with_tenant_deployment_mode(tenant_deployment_mode);
 
                 if let Err(e) = server.start().await {
                     tracing::error!("❌ PostgreSQL Server error: {}", e);
@@ -1435,8 +1447,11 @@ impl MultiServer {
             } else {
                 tonic::transport::Server::builder()
             };
-            let mut server_builder =
-                server_builder.layer(tower::util::option_layer(if self.rest_auth_enabled {
+            let mut server_builder = server_builder
+                .layer(crate::network::grpc::auth::GrpcTenantModeLayer::new(
+                    self.tenant_deployment_mode.clone(),
+                ))
+                .layer(tower::util::option_layer(if self.rest_auth_enabled {
                     self.security_coordinator.clone().map(|sc| {
                         crate::network::grpc::auth::GrpcAuthLayer::new(sc)
                             .with_header_trust(self.tenant_header_trust)
@@ -1554,6 +1569,7 @@ impl MultiServer {
             let self_pod_id = services.self_pod_id.clone();
             let api_handlers = services.api_handlers.clone();
             let tenant_header_trust = self.tenant_header_trust;
+            let tenant_deployment_mode = self.tenant_deployment_mode.clone();
 
             let arrow_handle = tokio::spawn(async move {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
@@ -1565,7 +1581,8 @@ impl MultiServer {
                     arrow_collection,
                     arrow_graph,
                 )
-                .with_tenant_header_trust(tenant_header_trust);
+                .with_tenant_header_trust(tenant_header_trust)
+                .with_tenant_deployment_mode(tenant_deployment_mode);
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -106,6 +106,8 @@ pub struct PostgresServer {
     /// TD-TENANT-1: the deployment's bare tenant-assertion trust policy,
     /// threaded into every per-connection `PostgresProtocol`. Default `Open`.
     tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
+    /// Whether startup may omit the tenant/catalog and use a default.
+    tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
     /// Whether the server is running
     running: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -149,6 +151,7 @@ impl PostgresServer {
             warehouse_root_url: None,
             rate_limiter: None,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
+            tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
             running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
@@ -157,6 +160,14 @@ impl PostgresServer {
     /// the same `HeaderTrustPolicy` the REST/gRPC/Arrow Flight surfaces hold.
     pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
         self.tenant_header_trust = policy;
+        self
+    }
+
+    pub fn with_tenant_deployment_mode(
+        mut self,
+        mode: proximadb_tenant::TenantDeploymentMode,
+    ) -> Self {
+        self.tenant_deployment_mode = mode;
         self
     }
 
@@ -282,6 +293,7 @@ impl PostgresServer {
                     let warehouse_root_url = self.warehouse_root_url.clone();
                     let rate_limiter = self.rate_limiter.clone();
                     let tenant_header_trust = self.tenant_header_trust;
+                    let tenant_deployment_mode = self.tenant_deployment_mode.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) = Self::handle_connection(
@@ -302,6 +314,7 @@ impl PostgresServer {
                             warehouse_root_url,
                             rate_limiter,
                             tenant_header_trust,
+                            tenant_deployment_mode,
                         )
                         .await
                         {
@@ -346,6 +359,7 @@ impl PostgresServer {
         warehouse_root_url: Option<String>,
         rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
         tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
+        tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
     ) -> Result<()> {
         // Create session
         let session = session_manager.create_session(addr).await?;
@@ -397,6 +411,7 @@ impl PostgresServer {
         // TD-TENANT-1: same bare-assertion trust policy as REST/gRPC/Flight,
         // enforced at the startup handshake and the tenant session vars.
         protocol = protocol.with_tenant_header_trust(tenant_header_trust);
+        protocol = protocol.with_tenant_deployment_mode(tenant_deployment_mode);
 
         // Run protocol loop
         match protocol.run().await {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -110,6 +110,8 @@ pub struct PostgresProtocol {
     /// policies reject it at the assertion point (SQLSTATE 28000) through the
     /// same shared primitive REST/gRPC/Arrow Flight use. Default `Open`.
     tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
+    /// Request-tenant presence/defaulting contract for this deployment.
+    tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -450,6 +452,7 @@ impl PostgresProtocol {
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
+            tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
         }
     }
 
@@ -506,6 +509,7 @@ impl PostgresProtocol {
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
+            tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
         }
     }
 
@@ -554,6 +558,7 @@ impl PostgresProtocol {
             peer_ip: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
             result_bytes_pending: 0,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
+            tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
         }
     }
 
@@ -580,6 +585,22 @@ impl PostgresProtocol {
     pub fn with_tenant_header_trust(mut self, policy: proximadb_tenant::HeaderTrustPolicy) -> Self {
         self.tenant_header_trust = policy;
         self
+    }
+
+    pub fn with_tenant_deployment_mode(
+        mut self,
+        mode: proximadb_tenant::TenantDeploymentMode,
+    ) -> Self {
+        self.tenant_deployment_mode = mode;
+        self
+    }
+
+    fn resolve_startup_tenant(
+        database: Option<&str>,
+        mode: &proximadb_tenant::TenantDeploymentMode,
+    ) -> std::result::Result<String, String> {
+        proximadb_tenant::resolve_request_tenant_for_mode(database, mode)
+            .map_err(|error| error.to_string())
     }
 
     /// TD-TENANT-1: gate a pgwire tenant assertion (startup `database` or the
@@ -826,6 +847,17 @@ impl PostgresProtocol {
         let params = self.read_bytes(param_len).await?;
         let params = self.parse_startup_params(&params)?;
 
+        let startup_tenant = match Self::resolve_startup_tenant(
+            params.get("database").map(String::as_str),
+            &self.tenant_deployment_mode,
+        ) {
+            Ok(tenant) => tenant,
+            Err(message) => {
+                self.send_error("FATAL", "28000", &message).await?;
+                return Err(anyhow!("pgwire tenant resolution rejected: {message}"));
+            }
+        };
+
         // TD-TENANT-1: the startup `database` doubles as the tenant/catalog
         // (TD-064) and pgwire runs trust auth — the assertion is bare by
         // definition. Under a strict policy, reject the connection at the
@@ -843,9 +875,7 @@ impl PostgresProtocol {
             if let Some(user) = params.get("user") {
                 session.user = user.clone();
             }
-            if let Some(database) = params.get("database") {
-                session.database = database.clone();
-            }
+            session.database = startup_tenant;
             // Open-core cache tier hook: a `proximadb_tier` startup parameter
             // (control-plane supplied) records the connection tenant's tier for
             // the cache policy. database == tenant/catalog (TD-064). Opaque id.

--- a/src/network/postgres/protocol_tests.rs
+++ b/src/network/postgres/protocol_tests.rs
@@ -58,6 +58,28 @@ fn transaction_control_is_detected_before_a_multi_statement_batch_runs() {
 }
 
 #[test]
+fn pgwire_startup_tenant_is_required_in_multi_tenant_mode() {
+    let error = PostgresProtocol::resolve_startup_tenant(
+        None,
+        &proximadb_tenant::TenantDeploymentMode::MultiTenant,
+    )
+    .unwrap_err();
+
+    assert_eq!(error, "tenant id is required in multi-tenant mode");
+}
+
+#[test]
+fn pgwire_startup_tenant_defaults_only_in_single_tenant_mode() {
+    let tenant = PostgresProtocol::resolve_startup_tenant(
+        None,
+        &proximadb_tenant::TenantDeploymentMode::single_tenant("embedded"),
+    )
+    .unwrap();
+
+    assert_eq!(tenant, "embedded");
+}
+
+#[test]
 fn substitute_placeholders_handles_two_digit_indices() {
     // The old ordered str::replace turned "$10" into "<val1>0"; verify each
     // placeholder is matched by its full digit run.


### PR DESCRIPTION
Makes deployment mode independent of auth and fails closed for missing multi-tenant identity across gRPC v2, Arrow Flight, and pgwire, with a deterministic ingress contract.\n\nValidation: 7 focused Rust tests; tenant ingress guard; make work-commit-check.