### PR TITLE
refactor(sst): remove dead read-side prune/chooser config fns (ADR-062 teardown)

### DIFF
--- a/src/storage/engines/core/coalesce_strategy.rs
+++ b/src/storage/engines/core/coalesce_strategy.rs
@@ -69,31 +69,6 @@ pub fn choose_read_strategy(
     }
 }
 
-/// PAX cascade whole-vs-striped read decision (ADR-057 / TD-RDSTRAT-3 S2): `true` to
-/// take the selective **striped** read (only codes + candidate-rerank + OID stripes,
-/// many small GETs, few bytes), `false` for the **whole**-segment read (one GET, all
-/// bytes). Same tier-aware cost model as [`choose_read_strategy`]
-/// (`per_get · gets + per_mib · bytes`) — on cold object storage the per-GET fee is
-/// real, so striped wins only when the byte saving outweighs the extra GETs; on hot
-/// local/NVMe (`per_get ≈ 0`) it wins whenever it moves fewer bytes. Pure +
-/// deterministic; the crossover falls out of the cost model, not a hardcoded
-/// selectivity threshold.
-pub fn choose_whole_vs_striped(
-    is_cloud: bool,
-    whole_bytes: u64,
-    striped_gets: u64,
-    striped_bytes: u64,
-) -> bool {
-    let (per_get, per_mib) = if is_cloud {
-        (CLOUD_PER_GET, CLOUD_PER_MIB)
-    } else {
-        (LOCAL_PER_GET, LOCAL_PER_MIB)
-    };
-    let whole = score(per_get, per_mib, 1, whole_bytes);
-    let striped = score(per_get, per_mib, striped_gets, striped_bytes);
-    striped < whole
-}
-
 /// Whether `path` points at a cold object-store backend (vs hot local/NVMe/page-cache). Mirrors the
 /// `is_cloud_file` prefix check used in `sst_io_layer.rs`, as a free fn shared by the chooser.
 pub fn is_cloud_path(path: &str) -> bool {
@@ -153,55 +128,5 @@ mod tests {
         // syscalls).
         let s = choose_read_strategy(false, 4, 4 * 65536, 1, 4 * 65536);
         assert_eq!(s, CoalesceStrategy::Coalesced);
-    }
-
-    #[test]
-    fn whole_vs_striped_cloud_batched_selective_picks_striped() {
-        // Cloud, big segment, GET-EFFICIENT (batched) striped read: ~4 coalesced
-        // GETs move ~1 MiB vs the whole 100 MiB → striped wins (the byte saving
-        // outweighs the small per-GET fee).
-        assert!(choose_whole_vs_striped(
-            true,
-            100 * 1024 * 1024,
-            4,
-            1024 * 1024
-        ));
-    }
-
-    #[test]
-    fn whole_vs_striped_cloud_get_heavy_picks_whole() {
-        // Cloud, big segment, but an UNBATCHED striped read (many small per-stripe
-        // GETs) — the per-GET fee dominates and beats the byte saving → whole wins.
-        // This is the co-design guard against GET-amplification (ADR-052): on cold
-        // storage the striped read must BATCH (fs.read_ranges) its stripe reads to
-        // win. (The current fs-native cascade path is unbatched, so the chooser
-        // correctly declines it on cloud until batching lands — a follow-up.)
-        assert!(!choose_whole_vs_striped(
-            true,
-            100 * 1024 * 1024,
-            400,
-            1024 * 1024
-        ));
-    }
-
-    #[test]
-    fn whole_vs_striped_cloud_tiny_segment_picks_whole() {
-        // Cloud, tiny segment where the striped read's many GETs cost more than the
-        // whole's 1 GET + its small byte total → whole wins.
-        assert!(!choose_whole_vs_striped(true, 256 * 1024, 400, 200 * 1024));
-    }
-
-    #[test]
-    fn whole_vs_striped_local_fewer_bytes_picks_striped() {
-        // Local (per_get = 0): driven by bytes only → striped wins iff it moves
-        // strictly fewer bytes, regardless of GET count.
-        assert!(choose_whole_vs_striped(
-            false,
-            100 * 1024 * 1024,
-            9999,
-            1024 * 1024
-        ));
-        // Equal bytes ⇒ not strictly cheaper ⇒ whole.
-        assert!(!choose_whole_vs_striped(false, 1024 * 1024, 8, 1024 * 1024));
     }
 }

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -63,60 +63,6 @@ pub fn flush_cluster_ivf() -> bool {
     )
 }
 
-/// TD-RDSTRAT-5 S3 (read side): opt-in for the VOE-directory centroid probe-prune
-/// at the PAX cascade. Default OFF — the cascade scans every block; set
-/// `PROXIMADB_PAX_CENTROID_PRUNE=1` to load the Vector Object Economy directory
-/// (cache-first) and scan only the blocks whose centroid survives the prune.
-/// Recall-affecting, so it stays default-OFF behind this flag until the SIFT1M
-/// recall ratchet (CI gate) clears the flip. Falls back to the unfiltered scan
-/// whenever the directory is absent/stale or the segment wasn't clustered.
-pub fn centroid_prune_enabled() -> bool {
-    env_flag_on("PROXIMADB_PAX_CENTROID_PRUNE")
-}
-
-/// Shared truthy-env parser for the block-clustering flags.
-fn env_flag_on(var: &str) -> bool {
-    match std::env::var(var).ok().as_deref().map(str::trim) {
-        Some(v) => matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
-        None => false,
-    }
-}
-
-/// TD-RDSTRAT-5 S3: the centroid probe-prune config, tunable via env so operators
-/// (and the recall gate) can set the `nprobe` aggressiveness and force pruning on
-/// small segments. Defaults to [`BlockPruneConfig::default`] (Sqrt mode, the
-/// production `MIN_BLOCKS_FOR_PRUNING`=100 threshold). Env overrides:
-///   * `PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS` — bypass the 100-block threshold
-///     (e.g. `2` to prune small segments; the recall gate uses this).
-///   * `PROXIMADB_PAX_CENTROID_PRUNE_RATIO` — switch to Ratio mode keeping this
-///     fraction of blocks (0.0–1.0) instead of Sqrt.
-///   * `PROXIMADB_PAX_CENTROID_RADIUS_K` — lever-3 radius weight `k` in the prune
-///     score `d(q,centroid) − k·radius` (default `0.0` = raw centroid distance).
-pub fn centroid_prune_config() -> crate::core::search::BlockPruneConfig {
-    use crate::core::search::{BlockPruneConfig, BlockPruneMode};
-    let mut cfg = BlockPruneConfig::default();
-    if let Some(mb) = std::env::var("PROXIMADB_PAX_CENTROID_PRUNE_MIN_BLOCKS")
-        .ok()
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        cfg.min_blocks_override = Some(mb);
-    }
-    if let Some(r) = std::env::var("PROXIMADB_PAX_CENTROID_PRUNE_RATIO")
-        .ok()
-        .and_then(|v| v.trim().parse::<f32>().ok())
-    {
-        cfg.mode = BlockPruneMode::Ratio;
-        cfg.ratio = r.clamp(0.0, 1.0);
-    }
-    if let Some(k) = std::env::var("PROXIMADB_PAX_CENTROID_RADIUS_K")
-        .ok()
-        .and_then(|v| v.trim().parse::<f32>().ok())
-    {
-        cfg.radius_k = k.max(0.0);
-    }
-    cfg
-}
-
 /// The f32 vector of `record`'s embedding `idx`, if present and Fp32-typed (the
 /// canonical write-time embedding representation — quantization happens inside the
 /// block writer). Non-Fp32 variants return `None` (they don't contribute a key).

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -461,21 +461,6 @@ pub fn coalesced_rabitq_enabled() -> bool {
     )
 }
 
-/// Whether the cost-driven selective (striped) read is engaged (ADR-057 /
-/// TD-RDSTRAT-3 Slice C). Default OFF — the whole-segment read stays the default
-/// until the observe→flip gate; `PROXIMADB_PAX_STRIPED_READ=1` opts in.
-pub fn striped_read_enabled() -> bool {
-    matches!(
-        std::env::var("PROXIMADB_PAX_STRIPED_READ")
-            .ok()
-            .as_deref()
-            .map(str::trim)
-            .map(str::to_ascii_lowercase)
-            .as_deref(),
-        Some("1" | "true" | "on" | "yes")
-    )
-}
-
 /// A coalesced ranged GET over one or more survivor data blocks.
 struct CoalescedFetch {
     start: u64,


### PR DESCRIPTION
Tail of #1029 (dormant read-path removal). These read-side config/chooser functions lost their only production callers when the legacy block-centroid-prune read path was removed; they're dead now.

## Removed (dead — verified zero production callers)
- `striped_read_enabled` (segment_format.rs — `PROXIMADB_PAX_STRIPED_READ` env)
- `centroid_prune_enabled` (block_cluster.rs — `PROXIMADB_PAX_CENTROID_PRUNE` env) + its orphaned `env_flag_on` helper
- `centroid_prune_config` (block_cluster.rs — SST prune-config builder, only the removed `voe_centroid_selected_blocks` used it)
- `choose_whole_vs_striped` (coalesce_strategy.rs — PAX striped-vs-whole cost chooser, now test-only) + its 4 unit tests

## Kept (still live)
`select_blocks_by_centroid` (SWIFT engine), and `is_cloud_path` / `read_strategy_chooser_enabled` / `choose_read_strategy` / `CoalesceStrategy` (the legacy `.sst` reader in `sst_io_layer` + `sst_query_engine`).

## Deferred (write-side, separate concern)
The block-centroid **emission** (`SegmentMeta` `block_centroids`/`block_radii` + writer centroid accumulation + `pax_write_outcome`) — entangled with `IndexEntry` serialization + VOE-directory `vector_format` derivation; a format-level change, not dead-config cleanup.

## Zero overlap with in-flight PRs
`#1026` (frontend) + `#1021` (embedded) touch no SST-storage files.

## Verification
root-lib **7576/7576**; `pax_cascade_prod_search` + `sst_compaction_reclustering` pass; `cargo fmt --check` · `cargo clippy --lib --bins -D warnings` · `make work-commit-check` clean.
