### PR TITLE
fix(pax): preserve exact tiers across coalesced compaction

### DIFF
--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -606,6 +606,52 @@ impl<'a> PaxBlockReader<'a> {
         Some(out)
     }
 
+    /// Whether every non-null logical embedding row in this block has an
+    /// authoritative f32 representation. Raw `EMBED_BASE` is exact itself;
+    /// lossy base encodings require a matching raw `F32_TIER_BASE` row.
+    /// Decode/shape failures fail closed.
+    pub fn has_exact_vector_authority(&self) -> bool {
+        let base_entries: Vec<_> = self
+            .vparams
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.column_id >= crate::col_id::EMBED_BASE
+                    && entry.column_id < crate::col_id::USER_BASE
+            })
+            .copied()
+            .collect();
+        for base_entry in base_entries {
+            let Some(base_rows) = self.decode_f32_vec_stripe(base_entry.column_id) else {
+                return false;
+            };
+            if base_entry.quant_kind == QUANT_RAW_F32 {
+                continue;
+            }
+            let embedding_index = base_entry.column_id - crate::col_id::EMBED_BASE;
+            let exact_column = crate::col_id::F32_TIER_BASE + embedding_index;
+            if self
+                .vparams
+                .get(exact_column)
+                .is_none_or(|entry| entry.quant_kind != QUANT_RAW_F32)
+            {
+                return false;
+            }
+            let Some(exact_rows) = self.decode_f32_vec_stripe(exact_column) else {
+                return false;
+            };
+            if exact_rows.len() != base_rows.len()
+                || base_rows
+                    .iter()
+                    .zip(&exact_rows)
+                    .any(|(base, exact)| base.is_some() && exact.is_none())
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Decode opaque byte blobs from a raw length-prefixed binary stripe — the
     /// inverse of the writer's `build_bytes_stripe` (used for the msgpack `PROPS`
     /// and `LABELS` columns). Each value is a 4-byte little-endian length prefix

--- a/crates/storage/proximadb-block-format/src/record.rs
+++ b/crates/storage/proximadb-block-format/src/record.rs
@@ -438,10 +438,28 @@ impl FlatRow {
             .unwrap_or_default();
 
         // Embedding stripes are contiguous from EMBED_BASE; probe until absent.
+        // When the independently declared exact tier is present, prefer it for
+        // materialization. This is the compaction/rebuild authority boundary:
+        // EMBED_BASE may be SQ8/RaBitQ and must not silently replace original
+        // f32 merely because it is the primary scan stripe.
         let mut embedding_stripes: Vec<Vec<Option<Vec<f32>>>> = Vec::new();
         let mut e = 0;
-        while let Some(stripe) = reader.decode_f32_vec_stripe(col_id::EMBED_BASE + e) {
-            embedding_stripes.push(stripe);
+        while let Some(base) = reader.decode_f32_vec_stripe(col_id::EMBED_BASE + e) {
+            let exact_column = col_id::F32_TIER_BASE + e;
+            let exact = reader
+                .vector_params()
+                .get(exact_column)
+                .filter(|entry| entry.quant_kind == crate::vparam::QUANT_RAW_F32)
+                .and_then(|_| reader.decode_f32_vec_stripe(exact_column));
+            let materialized = match exact {
+                Some(exact) if exact.len() == base.len() => base
+                    .into_iter()
+                    .zip(exact)
+                    .map(|(approximate, exact)| exact.or(approximate))
+                    .collect(),
+                _ => base,
+            };
+            embedding_stripes.push(materialized);
             e += 1;
         }
 

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -146,8 +146,8 @@ pub struct PaxBlockWriter {
     /// retained. Default from `PROXIMADB_PAX_DROP_TENANT_COL` (off) so the write
     /// format only changes once readers that stamp tenant are deployed.
     drop_tenant_col: bool,
-    /// Opt-in exact-f32 tier (P3 Phase D): when true + RaBitQ quant, the writer
-    /// ALSO emits the raw f32 embedding at `col_id::F32_TIER_BASE + i` (one
+    /// Opt-in exact-f32 tier (P3 Phase D): when true, the writer ALSO emits the
+    /// raw f32 embedding at `col_id::F32_TIER_BASE + i` (one
     /// stripe per embedding column). Read LAZILY — only an exact final rerank or
     /// `include_vectors` decodes it; id+score queries never touch it (zero scan /
     /// egress cost when unused). Default OFF (set via `with_f32_tier`).
@@ -251,7 +251,7 @@ impl PaxBlockWriter {
     }
 
     /// Enable (or disable) the optional exact-f32 tier (P3 Phase D). When true,
-    /// each RaBitQ-coded embedding also gets a co-located raw-f32 stripe at
+    /// each embedding also gets a co-located raw-f32 stripe at
     /// `col_id::F32_TIER_BASE + i` for an exact final rerank / `include_vectors`.
     /// Default OFF; the flush path enables it from the `pax_f32_tier` tag / env.
     pub fn with_f32_tier(mut self, enabled: bool) -> Self {
@@ -529,7 +529,7 @@ impl PaxBlockWriter {
                 // and exact `include_vectors`. The stripe is read LAZILY — id+score
                 // queries never decode it — so the only always-paid cost is the
                 // storage bytes (the egress/scan cost is paid only when used).
-                if self.include_f32_tier && is_rabitq {
+                if self.include_f32_tier {
                     let (f32_stripe, f32_entry) =
                         self.build_raw_f32_vec_stripe(col_id::F32_TIER_BASE + i as i32, &refs)?;
                     stripes.push(f32_stripe);

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -918,7 +918,7 @@ impl PaxSegmentWriter {
             embed_dim: dim,
             embed_count: self.embedding_count as u32,
             embed_quant_tag: 1, // SQ8 (the survivor-rerank data tier)
-            has_f32_tier: false,
+            has_f32_tier: self.f32_tier,
             blocks,
         };
         let footer_body = footer.to_bytes();
@@ -1231,6 +1231,20 @@ pub fn compact_pax_segments(
     tenant_ctx: Option<&str>,
     now_ns: i64,
 ) -> Result<CompactionStats> {
+    let preserve_exact = !inputs.is_empty()
+        && inputs.iter().all(|input| {
+            let Ok(mut scanner) = PaxSegmentScanner::open(input, ScanPredicate::default()) else {
+                return false;
+            };
+            let mut saw_block = false;
+            while let Some(block) = scanner.next_block() {
+                saw_block = true;
+                if !block.has_exact_vector_authority() {
+                    return false;
+                }
+            }
+            saw_block
+        });
     let mut writer = PaxSegmentWriter::new(
         output,
         mode,
@@ -1239,7 +1253,8 @@ pub fn compact_pax_segments(
         schema_fingerprint,
         embedding_count,
         None,
-    );
+    )
+    .with_f32_tier(preserve_exact);
     let mut records_in = 0u64;
     let mut records_out = 0u64;
     let mut tombstones_dropped = 0u64;
@@ -1680,6 +1695,122 @@ mod tests {
                 .iter()
                 .all(|r| r.origin.as_deref() != Some("delete")),
             "the delete tombstone must not survive compaction"
+        );
+    }
+
+    #[test]
+    fn compaction_preserves_exact_only_when_every_input_has_authority() {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+
+        let vector_record = |oid: &str, values: Vec<f32>| {
+            let mut record = make_record(oid, "t", 1);
+            record.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: values.len() as u32,
+                values: EmbeddingValues::Fp32(values),
+                ..Default::default()
+            });
+            record
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let exact_input = dir.path().join("exact.pax");
+        let lossy_input = dir.path().join("lossy.pax");
+        let exact_output = dir.path().join("exact-output.pax");
+        let mixed_output = dir.path().join("mixed-output.pax");
+        let exact_records = vec![
+            vector_record("exact-a", vec![-3.25, 0.123_456_7, 8.75]),
+            vector_record("exact-b", vec![2.5, 4.765_432, -1.125]),
+        ];
+        let lossy_records = vec![
+            vector_record("lossy-a", vec![11.0, -7.123_456, 0.375]),
+            vector_record("lossy-b", vec![6.25, 9.765_432, -4.5]),
+        ];
+
+        let mut exact_writer = PaxSegmentWriter::new(
+            &exact_input,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RaBitQ)
+        .with_f32_tier(true);
+        for record in &exact_records {
+            exact_writer.add_record(record).unwrap();
+        }
+        exact_writer.finish().unwrap();
+
+        let mut lossy_writer = PaxSegmentWriter::new(
+            &lossy_input,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RaBitQ);
+        for record in &lossy_records {
+            lossy_writer.add_record(record).unwrap();
+        }
+        lossy_writer.finish().unwrap();
+
+        compact_pax_segments(
+            std::slice::from_ref(&exact_input),
+            &exact_output,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            &[],
+            &[],
+            None,
+            i64::MAX,
+        )
+        .unwrap();
+        {
+            let mut exact_scanner =
+                PaxSegmentScanner::open(&exact_output, ScanPredicate::default()).unwrap();
+            let exact_block = exact_scanner.next_block().expect("exact compacted block");
+            assert!(exact_block.has_exact_vector_authority());
+        }
+        let mut exact_scanner =
+            PaxSegmentScanner::open(&exact_output, ScanPredicate::default()).unwrap();
+        let exact_back = exact_scanner.read_records(&[], &[], None).unwrap();
+        for got in &exact_back {
+            let want = exact_records
+                .iter()
+                .find(|record| record.oid == got.oid)
+                .unwrap();
+            assert_eq!(
+                got.embeddings[0].as_fp32_slice(),
+                want.embeddings[0].as_fp32_slice()
+            );
+        }
+
+        compact_pax_segments(
+            &[exact_input, lossy_input],
+            &mixed_output,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            &[],
+            &[],
+            None,
+            i64::MAX,
+        )
+        .unwrap();
+        let mut mixed_scanner =
+            PaxSegmentScanner::open(&mixed_output, ScanPredicate::default()).unwrap();
+        let mixed_block = mixed_scanner.next_block().expect("mixed compacted block");
+        assert!(
+            !mixed_block.has_exact_vector_authority(),
+            "a lossy sibling must prevent exact output authority"
         );
     }
 

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -134,8 +134,8 @@ pub fn write_pax_segment(
 }
 
 /// Like [`write_pax_segment`] but optionally emits the exact-f32 tier (P3 Phase
-/// D). When `f32_tier` is true (and the quant is RaBitQ), each embedding also
-/// gets a co-located raw-f32 stripe at `col_id::F32_TIER_BASE + i` for an exact
+/// D). When `f32_tier` is true, each embedding also gets a co-located raw-f32
+/// stripe at `col_id::F32_TIER_BASE + i` for an exact
 /// final rerank / `include_vectors`. The flush path calls this with the resolved
 /// `pax_f32_tier` opt-in; compaction/tests use [`write_pax_segment`] (no tier).
 pub fn write_pax_segment_with_f32_tier(
@@ -297,38 +297,45 @@ fn write_pax_segment_ordered(
     writer.finish()
 }
 
-/// True if any input `.pax` segment carries the opt-in exact-f32 tier
-/// (`F32_TIER_BASE`). Compaction calls this to PRESERVE the tier across
-/// re-encoding — otherwise [`write_pax_segment`] drops it. Reads each `.pax`
-/// input's block metadata only; the inputs are page-cached (just read into
-/// records), so this is cheap. Correct for both env- and tag-opt-in (the source
-/// segment reflects whatever the collection wrote).
+/// True only when every vector row in every input `.pax` segment has an exact
+/// f32 authority. Compaction uses this to decide whether its rewritten RaBitQ
+/// output may retain an exact tier. A raw-f32 `EMBED_BASE` is authoritative;
+/// otherwise every non-null base vector must have a matching raw
+/// `F32_TIER_BASE` row. One exact input never upgrades lossy siblings.
+///
+/// Legacy ProximaBlocks (`.sst` or no extension) are exact authorities. Other
+/// physical formats are not assumed exact without an explicit contract. At
+/// least one PAX input must request/preserve exactness; this keeps the optional
+/// tier default-OFF for legacy-only compactions. Read/parse/decode failures fail
+/// closed to `false`.
 pub fn pax_inputs_have_f32_tier(input_files: &[std::path::PathBuf]) -> bool {
-    use proximadb_block_format::col_id;
+    let mut saw_pax = false;
     for f in input_files {
-        if f.extension().and_then(|e| e.to_str()) != Some("pax") {
-            continue;
+        match f.extension().and_then(|e| e.to_str()) {
+            Some("pax") => {}
+            Some("sst") | None => continue,
+            Some(_) => return false,
         }
+        saw_pax = true;
         let Ok(bytes) = std::fs::read(f) else {
-            continue;
+            return false;
         };
-        // Read block 0's column metadata via the segment scanner. A `.pax`
-        // SEGMENT file is laid out `[block(s)][segment_index][SEGMENT_MAGIC]`;
-        // `PaxBlockReader::open` parses a SINGLE block and reads its footer from
-        // the trailing `BLOCK_FOOTER_SIZE` bytes, so opening the whole file
-        // misreads the segment index/magic as a block footer. The scanner parses
-        // the trailing index + magic and hands back block 0 correctly.
         let Ok(mut scanner) = PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default()) else {
-            continue;
+            return false;
         };
-        let Some(reader) = scanner.next_block() else {
-            continue;
-        };
-        if reader.vector_params().get(col_id::F32_TIER_BASE).is_some() {
-            return true;
+
+        let mut saw_block = false;
+        while let Some(reader) = scanner.next_block() {
+            saw_block = true;
+            if !reader.has_exact_vector_authority() {
+                return false;
+            }
+        }
+        if !saw_block {
+            return false;
         }
     }
-    false
+    saw_pax
 }
 
 /// True iff `bytes` is a `.pax` SEGMENT whose `EMBED_BASE` column is RaBitQ-coded
@@ -409,9 +416,9 @@ pub fn pax_inputs_rerank_quant(
     VectorQuant::Sq8
 }
 
-/// One scored hit from a RaBitQ cascade segment scan: the record's `oid` and its
-/// L2 distance to the query (smaller = nearer), reranked against the co-located
-/// SQ8 column.
+/// One scored hit from the coalesced RaBitQ segment scan, reranked against the
+/// co-located SQ8 column. `distance` carries the canonical public metric value:
+/// Euclidean distance, cosine distance, or positive dot-product similarity.
 #[derive(Debug, Clone)]
 pub struct CascadeHit {
     pub oid: String,
@@ -542,6 +549,18 @@ fn rerank_distance(metric: RankMetric, q: &[f32], v: &[f32]) -> f32 {
             1.0 - dot / (nq * nv + 1e-12)
         }
         RankMetric::DotProduct => -q.iter().zip(v).map(|(a, b)| a * b).sum::<f32>(),
+    }
+}
+
+/// Convert the coalesced reranker's lower-is-better ordering score into the
+/// canonical metric value consumed by the public score conversion. This is a
+/// one-way boundary: sorting happens before it, and callers must not negate or
+/// square-root the value again.
+fn canonical_score_from_rank_score(metric: RankMetric, rank_score: f32) -> f32 {
+    match metric {
+        RankMetric::L2 => rank_score.max(0.0).sqrt(),
+        RankMetric::Cosine => rank_score,
+        RankMetric::DotProduct => -rank_score,
     }
 }
 
@@ -696,6 +715,9 @@ pub async fn rabitq_search_segment_coalesced(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     hits.truncate(k);
+    for hit in &mut hits {
+        hit.distance = canonical_score_from_rank_score(metric, hit.distance);
+    }
     Ok(Some(hits))
 }
 
@@ -990,6 +1012,121 @@ mod tests {
         unsafe {
             std::env::set_var("PROXIMADB_PAX_COALESCED_RABITQ", "0");
         }
+    }
+
+    #[test]
+    fn coalesced_requested_f32_tier_is_emitted_and_materializes_exact() {
+        enable_coalesced_rabitq();
+        use proximadb_block_format::col_id;
+        use proximadb_storage_common::segment_layout::SegmentFooterIndex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("coalesced-exact.pax");
+        let records = vec![
+            rec("a", 1, vec![-7.25, 0.123_456_7, 3.141_592_7]),
+            rec("b", 2, vec![2.75, 8.765_432, -0.333_333_34]),
+            rec("c", 3, vec![11.125, -4.567_891, 9.999_991]),
+        ];
+
+        write_pax_segment_with_f32_tier(
+            &path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            true,
+            Some(1024),
+        )
+        .unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        let footer = SegmentFooterIndex::locate_in_segment(&bytes)
+            .unwrap()
+            .expect("coalesced footer");
+        assert!(footer.has_f32_tier, "footer must declare the exact tier");
+
+        let mut scanner =
+            PaxSegmentScanner::from_bytes(bytes.clone(), ScanPredicate::default()).unwrap();
+        while let Some(block) = scanner.next_block() {
+            assert!(
+                block.vector_params().get(col_id::F32_TIER_BASE).is_some(),
+                "every coalesced block must emit the requested exact tier"
+            );
+        }
+
+        let materialized = read_segment_records(&bytes, &[], &[], None).unwrap();
+        assert_eq!(materialized.len(), records.len());
+        for got in &materialized {
+            let want = records.iter().find(|r| r.oid == got.oid).unwrap();
+            assert_eq!(
+                got.embeddings[0].as_fp32_slice(),
+                want.embeddings[0].as_fp32_slice(),
+                "compaction materialization must prefer exact f32 for {}",
+                got.oid
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_exact_and_lossy_inputs_do_not_claim_exact_output() {
+        disable_coalesced_rabitq();
+        let dir = tempfile::tempdir().unwrap();
+        let exact = dir.path().join("exact.pax");
+        let lossy = dir.path().join("lossy.pax");
+        let records = vec![
+            rec("a", 1, vec![-1.0, 0.123_456_7, 7.0]),
+            rec("b", 2, vec![3.0, 4.765_432, -2.0]),
+        ];
+
+        write_pax_segment_with_f32_tier(
+            &exact,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            true,
+            None,
+        )
+        .unwrap();
+        write_pax_segment_with_f32_tier(
+            &lossy,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert!(pax_inputs_have_f32_tier(std::slice::from_ref(&exact)));
+        assert!(
+            !pax_inputs_have_f32_tier(&[exact.clone(), lossy]),
+            "one exact input must not make a mixed compacted output exact"
+        );
+        assert!(
+            !pax_inputs_have_f32_tier(&[exact, dir.path().join("unknown.arrow")]),
+            "an unrelated physical format must not be assumed exact"
+        );
+    }
+
+    #[test]
+    fn coalesced_rank_scores_cross_the_public_metric_boundary_once() {
+        assert_eq!(
+            canonical_score_from_rank_score(RankMetric::L2, 25.0),
+            5.0,
+            "squared L2 rank score must become canonical Euclidean distance"
+        );
+        assert_eq!(
+            canonical_score_from_rank_score(RankMetric::DotProduct, -6.0),
+            6.0,
+            "negated-dot rank score must become public positive-dot similarity"
+        );
+        assert_eq!(
+            canonical_score_from_rank_score(RankMetric::Cosine, 0.25),
+            0.25,
+            "cosine distance is already canonical"
+        );
     }
 
     /// A coalesced-RaBitQ segment (opt-in) is detected as Pax, carries a non-zero


### PR DESCRIPTION
## Summary

- emit the requested exact f32 tier for coalesced PAX blocks and prefer it during materialization
- preserve exact compaction output only when every logical input row has exact-vector authority
- normalize coalesced L2 and dot-product scores exactly once at the public metric boundary

## Verification

- cargo fmt --check
- cargo clippy --lib --bins -- -D warnings
- cargo check --lib --tests
- cargo check -p proximadb-server
- cargo test --lib coalesced_ -- --nocapture
- cargo test --lib mixed_exact_and_lossy_inputs_do_not_claim_exact_output -- --nocapture
- cargo test -p proximadb-storage-common compaction_preserves_exact_only_when_every_input_has_authority -- --nocapture
- make work-commit-check
- python3 scripts/check_td_adr_unique.py
- python3 scripts/check_no_agent_attribution.py --range origin/develop..HEAD

This is the common exactness prerequisite for the RDSTRAT codec bakeoff; it deliberately contains no codec-selection or benchmark changes.