### PR TITLE
docs(td): TD-OLAP-1 Slice 2 empirical boundary — relational tables don't flush .pax

### DIFF
--- a/docs/10-quality/td/TD-OLAP-1-pax-native-vectorized-scan-feeds-datafusion.adoc
+++ b/docs/10-quality/td/TD-OLAP-1-pax-native-vectorized-scan-feeds-datafusion.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — slice 1 **landed 2026-07-06**: `src/datafusion/engine_adapters/pax_adapter.rs` `PaxSplitReader` (the 7th `SplitReader`) bridges the canonical `PaxBlockReader` → Arrow `RecordBatch` with the full zone-map/bloom prune stack (i64/f64/str/bytes decode; f32-vector decode deferred); 3 unit tests green (decode-correctness, zone-map prune of disjoint blocks, empty-filter-never-prunes), `clippy --lib --bins` clean, td-adr-unique 0 errors; env-gated `PROXIMADB_DF_PAX_READER` (default OFF), NOT wired into any route. The substrate (typed stripes + zone maps + hierarchical prune) is reused as-is from `PaxBlockReader` — TD-154/TD-162a-2/TD-162a-3 were satisfied by the existing reader. **Slice 1.5 landed 2026-07-07:** fixed a latent #706 bug — `PaxBlockReader::open(whole_file)` CRC-fails on real `.pax` *segments* (`[blocks][index][SEGMENT_MAGIC]`); `decode_segment` now iterates blocks via `PaxSegmentScanner`. Tests rewritten to real segments (`write_pax_segment`); 3/3 green; clippy/fmt clean. **Remaining:** slice 2 = route flip + `EngineType::Pax` + real PAX split-planning (gated on the TD-OLAP-4 ledger, per ADR-052 observe→ingest→act); slice 3 = consolidate the ad-hoc `SstBlockStream` stub onto `PaxBlockReader` (converge-don't-duplicate)
+| Status | Open — slice 1 **landed 2026-07-06**: `src/datafusion/engine_adapters/pax_adapter.rs` `PaxSplitReader` (the 7th `SplitReader`) bridges the canonical `PaxBlockReader` → Arrow `RecordBatch` with the full zone-map/bloom prune stack (i64/f64/str/bytes decode; f32-vector decode deferred); 3 unit tests green (decode-correctness, zone-map prune of disjoint blocks, empty-filter-never-prunes), `clippy --lib --bins` clean, td-adr-unique 0 errors; env-gated `PROXIMADB_DF_PAX_READER` (default OFF), NOT wired into any route. The substrate (typed stripes + zone maps + hierarchical prune) is reused as-is from `PaxBlockReader` — TD-154/TD-162a-2/TD-162a-3 were satisfied by the existing reader. **Slice 1.5 landed 2026-07-07:** fixed a latent #706 bug — `PaxBlockReader::open(whole_file)` CRC-fails on real `.pax` *segments* (`[blocks][index][SEGMENT_MAGIC]`); `decode_segment` now iterates blocks via `PaxSegmentScanner`. Tests rewritten to real segments (`write_pax_segment`); 3/3 green; clippy/fmt clean. **Remaining:** slice 2 = route flip + `EngineType::Pax` + real PAX split-planning (gated on the TD-OLAP-4 ledger, per ADR-052 observe→ingest→act); slice 3 = consolidate the ad-hoc `SstBlockStream` stub onto `PaxBlockReader` (converge-don't-duplicate). **Slice 2 attempt 2026-07-15 surfaced a boundary — see §"Slice 2 wiring attempt + empirical boundary": pgwire relational `CREATE TABLE` tables do NOT flush `.pax` (WAL/memtable-backed), so the route must target a PAX-segment-producing collection class, and the base path must be derived via `DrPathBuilder` (catalog `layout.location` is `None`).**
 | Priority | **P1a** in the ADR-052 execution order — after the P0 stats/ledger slices; gated on the substrate TDs. SRP: the scan owns scan+prune only; OCP: a new route added behind the frozen ADR-039/`ComputeBackend` seam; LSP: the scan `ExecutionPlan` is substitutable — identical conformance ratchets on both routes
 | Severity | High — the OLAP execution model itself; the lever ADR-052 invariants 1–2 turn into code
 | Component | `proximadb-block-format` (scan), `src/datafusion/proxima_scan_exec.rs`, `proximadb-relational-algebra` (`LogicalNode::Scan` lowering), `compute_scheduler.rs`
@@ -51,6 +51,46 @@ DataFusion's vectorized operators instead of the row-wise iterator. Rerun with
 gap, **Slice 2 (route flip behind the cost crossover, default-off) is the actively-tracked
 next step**, still gated on the TD-OLAP-4 ledger promotion rule (observe → ingest → act,
 ADR-052).
+
+== Slice 2 wiring attempt + empirical boundary (2026-07-15)
+
+A Slice 2 route-flip was prototyped end-to-end and **surfaced a boundary the design/scope
+traces did not** — recorded here so the next attempt targets the right table class from the
+start (measure-before-implement).
+
+**Wiring built (correct + compiling, default-OFF):** an opt-in marker `pax_olap_route` (a
+truthy table property, `CREATE TABLE … WITH (pax_olap_route='1')`, read from
+`CatalogTableSchema.properties`) drives a `catalog_table_pax_route_base()` detector →
+`QueryShape.pax_backed` → the existing `ComputeScheduler` PAX branch (which already gates on
+`PROXIMADB_DF_PAX_READER`). Dispatch adds a `PaxTableSpec { name, base_path, arrow schema,
+name_to_col_id }` (col_id from `CatalogColumn.id`; Arrow via `relational_schema_to_arrow`) to
+`QueryExecutionContext`, and `DataFusionLocalEngine` registers each via the existing
+`register_pax_location()` (`PaxSplitReader` over `discover_pax_segments`). All compiled clean.
+
+**The blocker (empirical, decisive):** a pgwire **relational** collection (`CREATE TABLE`)
+**does not flush its data to `.pax` segments at all** — after `force_flush_collection` + a 2 s
+wait, an instrumented e2e found **zero `.pax` files** anywhere under the data dir (only
+`observability/` + `pgwire/`). These tables are WAL + memtable-backed (the DirectWal→Memtable
+relational path, correct-by-construction — see TD-REL-SCAN-1); the `.pax` segment format +
+flush is the **vector/SST-engine** collection path. So a `PaxSplitReader` has nothing to read
+for a relational table, and the restrict-to-flushed route can never serve one. A route-PROOF
+e2e (insert-after-flush, so PAX would see only flushed rows) confirmed the query was served by
+Volcano, not PAX.
+
+Secondary gap found along the way: `CatalogStorageLayout.location` is **`None`** for these
+native collections, so a PAX base path cannot be read from the catalog — it must be derived
+via `DrPathBuilder::build(namespace, collection_id).segments_subprefix()` **prefixed with the
+storage-root URL** (three inconsistent path conventions exist: SST-flush
+`{base_location}/{collection_id}/data`, `DrPathBuilder` `data/{tenant}/{ns}/{coll}/segments/`,
+and the native-engine MVP `{PROXIMADB_DATA_DIR}/collections/{table}` — reconcile before wiring).
+
+**Corrected scope / next attempt.** Slice 2's PAX route is for **PAX-segment-producing
+collections** (vector/embedding, or SST-materialized), queried relationally — **not** pgwire
+`CREATE TABLE` relational tables, which correctly stay on the WAL/memtable Volcano path. The
+next attempt MUST (a) create a collection class that actually flushes `.pax`, (b) resolve the
+segments base path via `DrPathBuilder` + storage root (not `layout.location`), and (c) prove
+row-exactness over real flushed segments before any promotion. Alternatively, giving relational
+tables a flush-to-PAX materialization is separate storage-engine work, not part of the route.
 
 == Rollout (observe → ingest → act; default-off)
 


### PR DESCRIPTION
## What
Records the decisive finding from a prototyped **TD-OLAP-1 Slice 2** (PAX-scan route) attempt, so the next attempt targets the right table class from the start (measure-before-implement).

## The finding (empirical, not in any design trace)
A pgwire **relational `CREATE TABLE` collection does NOT flush its data to `.pax` segments.** After `force_flush_collection` + a 2 s wait, an instrumented e2e found **zero `.pax` files** anywhere under the data dir (only `observability/` + `pgwire/`). These tables are **WAL + memtable-backed** (DirectWal→Memtable, TD-REL-SCAN-1); `.pax` is the **vector/SST-engine** path. So a `PaxSplitReader` has nothing to read for a relational table, and the restrict-to-flushed route can never serve one — a **route-proof e2e** (insert-after-flush → PAX would see only flushed rows) confirmed **Volcano served, not PAX**.

## Wiring status
The detection/registration/route wiring was built and **compiles** (opt-in `pax_olap_route` marker → `QueryShape.pax_backed` → the existing `ComputeScheduler` PAX branch → `register_pax_location`/`PaxSplitReader`), but is **not shipped** — it can't be proven end-to-end with any available table class, so committing it would violate the prove-before-ship bar. Its exact approach + seams are documented in the TD for a clean rebuild.

## Secondary gap
`CatalogStorageLayout.location` is **`None`** for native collections → a PAX base path must be **derived** via `DrPathBuilder::build(namespace, collection_id).segments_subprefix()` + the storage-root URL. Three inconsistent path conventions exist (SST-flush `{base}/{coll}/data`, DrPathBuilder `data/{tenant}/{ns}/{coll}/segments/`, native-engine MVP `{DATA_DIR}/collections/{table}`) — reconcile before wiring.

## Corrected scope (next attempt)
Slice 2's PAX route is for **PAX-segment-producing collections** (vector/embedding or SST-materialized), queried relationally — **not** pgwire relational tables (which correctly stay on Volcano). Next attempt: (a) create a PAX-producing collection class, (b) derive the base path via `DrPathBuilder` + storage root, (c) prove row-exactness over real flushed segments before promotion.

Docs-only (updates existing TD-OLAP-1). td-adr-unique 0 errors; work-commit-check green.