### PR TITLE
ci: reclaim ~25GB preinstalled toolchains on the heavy Rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1233,6 +1233,22 @@ jobs:
           - profile: release
             args: "--release"
     steps:
+      - name: Reclaim disk space
+        # ubuntu-latest ships ~25 GB of preinstalled toolchains this build never
+        # uses (Android SDK, .NET, GHC/Haskell, boost). Removing them frees the
+        # disk the large Rust target/ dir needs — otherwise the runner hits
+        # "No space left on device" and fails the job at random (infra, not code).
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
+
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -1296,6 +1312,22 @@ jobs:
             args: "--doc"
             threads: 4
     steps:
+      - name: Reclaim disk space
+        # ubuntu-latest ships ~25 GB of preinstalled toolchains this build never
+        # uses (Android SDK, .NET, GHC/Haskell, boost). Removing them frees the
+        # disk the large Rust target/ dir needs — otherwise the runner hits
+        # "No space left on device" and fails the job at random (infra, not code).
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
+
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@1.95.0


### PR DESCRIPTION
## What

Adds a **Reclaim disk space** step as the first step of the `rust-build` and `rust-test` jobs, freeing ~25 GB by removing preinstalled toolchains this Rust build never uses (Android SDK, .NET, GHC/Haskell/ghcup, boost) + pruning docker images.

## Why

`Rust Tests (unit)` on #1042 crashed with **`No space left on device`** — the `ubuntu-latest` runner died writing its own log (empty failed-step list = the runner itself died, no test failed). GitHub-hosted runners give only ~14 GB usable disk, and the root-crate `target/` + cargo registry can exhaust it. This is a transient **infra** failure that fails jobs at random, not a code fault.

Freeing the disk up front gives the build ~25 GB of headroom — well clear of its footprint.

## Notes

- **Free fix** — no plan/larger-runner change: `anvai-labs` is on the free tier and this is a public repo (unlimited standard-runner minutes). Larger runners aren't the lever; disk headroom is.
- Best-effort (`|| true`) so the step never fails the job; prints `df -h /` before/after for visibility.
- Applied to the two heavy Rust jobs (`rust-build` builds the server binary; `rust-test` compiles the root-crate test binary). The three sccache compile jobs can get the same step later if they ever disk-flake.

YAML validated (`yaml.safe_load` OK).