### PR TITLE
fix(frontend): correlated scalar aggregate may be wrapped in scalar arithmetic — TD-REL-LOWER-8 (TPC-H Q17)

### DIFF
--- a/crates/query/proximadb-relational-frontend/src/lib.rs
+++ b/crates/query/proximadb-relational-frontend/src/lib.rs
@@ -1218,17 +1218,16 @@ fn lower_correlated_scalar_aggregate(
     let [item] = select.projection.as_slice() else {
         return Err(unsupported());
     };
-    let (agg_sql, alias) = match item {
+    let (proj_sql, alias) = match item {
         SelectItem::UnnamedExpr(e) => (e, None),
         SelectItem::ExprWithAlias { expr, alias } => (expr, Some(alias.value.clone())),
         _ => return Err(unsupported()),
     };
-    let SqlExpr::Function(f) = agg_sql else {
-        return Err(unsupported());
-    };
-    if !is_aggregate_function_name(&f.name) {
-        return Err(unsupported());
-    }
+    // The projection is a single aggregate, optionally wrapped in scalar
+    // arithmetic over constants / outer columns (e.g. `0.2 * avg(x)` in TPC-H
+    // Q17, `sum(x)/7.0`). Decorrelate the one aggregate as usual; the wrapper is
+    // re-applied to its post-join value column at the end (`build_scalar_over_agg`).
+    let f = single_aggregate_call(proj_sql).ok_or_else(unsupported)?;
     let (inner_plan, inner_scope) = lower_table_factor(&select.from[0].relation, catalog)?;
     let agg = lower_aggregate_call(f, &inner_scope)?;
     // The count-bug: COUNT over an empty correlated group must be 0, but the
@@ -1304,12 +1303,73 @@ fn lower_correlated_scalar_aggregate(
     );
     let value_ty = agg.result_type();
     ctx.hoisted.push(HoistedSub { plan, on: Some(on) });
-    Ok(Expr::column(ColumnRef {
+    let agg_col = Expr::column(ColumnRef {
         name: agg_name,
         ordinal: base + 1,
         ty: value_ty,
         nullable: true,
-    }))
+    });
+    // Re-apply the scalar arithmetic that wrapped the aggregate (a no-op when the
+    // projection was a bare aggregate), with the aggregate replaced by its
+    // post-join value column. Non-aggregate leaves (literals, outer columns)
+    // resolve against the outer scope — valid because the LEFT JOIN places the
+    // outer columns first, so their ordinals are unchanged in the combined row.
+    build_scalar_over_agg(proj_sql, &agg_col, outer_scope)
+}
+
+/// The single aggregate call inside a scalar-subquery projection, which may be
+/// wrapped in scalar arithmetic (`0.2 * avg(x)`, `sum(x) / 7.0`). Returns `None`
+/// when the projection has zero or more than one aggregate (the correlated
+/// scalar-aggregate decorrelation handles exactly one).
+fn single_aggregate_call(sql: &SqlExpr) -> Option<&sqlparser::ast::Function> {
+    fn collect<'a>(sql: &'a SqlExpr, out: &mut Vec<&'a sqlparser::ast::Function>) {
+        match sql {
+            SqlExpr::Function(f) if is_aggregate_function_name(&f.name) => out.push(f),
+            SqlExpr::BinaryOp { left, right, .. } => {
+                collect(left, out);
+                collect(right, out);
+            }
+            SqlExpr::UnaryOp { expr, .. } => collect(expr, out),
+            SqlExpr::Nested(e) => collect(e, out),
+            _ => {}
+        }
+    }
+    let mut v = Vec::new();
+    collect(sql, &mut v);
+    (v.len() == 1).then(|| v[0])
+}
+
+/// Rebuild the scalar arithmetic that wrapped a correlated scalar aggregate,
+/// substituting the (single) aggregate call with `agg_col` — the decorrelated
+/// aggregate's post-join value column. Arithmetic-spine nodes recurse; any other
+/// leaf (a literal or an outer column) lowers against `outer_scope`. There is
+/// exactly one aggregate (guaranteed by [`single_aggregate_call`]), so matching
+/// any aggregate function here yields `agg_col`.
+fn build_scalar_over_agg(
+    sql: &SqlExpr,
+    agg_col: &Expr,
+    outer_scope: &Scope,
+) -> Result<Expr, FrontendError> {
+    match sql {
+        SqlExpr::Function(f) if is_aggregate_function_name(&f.name) => Ok(agg_col.clone()),
+        SqlExpr::BinaryOp { left, op, right } => Ok(Expr::bin(
+            lower_binary_op(op)?,
+            build_scalar_over_agg(left, agg_col, outer_scope)?,
+            build_scalar_over_agg(right, agg_col, outer_scope)?,
+        )),
+        SqlExpr::UnaryOp { op, expr } => {
+            let inner = build_scalar_over_agg(expr, agg_col, outer_scope)?;
+            match lower_unary_op(op)? {
+                Some(u) => Ok(Expr::UnaryOp {
+                    op: u,
+                    expr: Box::new(inner),
+                }),
+                None => Ok(inner),
+            }
+        }
+        SqlExpr::Nested(e) => build_scalar_over_agg(e, agg_col, outer_scope),
+        other => lower_expr_sealed(other, outer_scope),
+    }
 }
 
 /// Resolve a correlation equality's two operands into `(inner_key, outer_key)`
@@ -2523,6 +2583,46 @@ mod tests {
 
     fn lower(sql: &str) -> LogicalNode {
         lower_sql(sql, &catalog()).unwrap_or_else(|e| panic!("lower failed: {e:?}"))
+    }
+
+    #[test]
+    fn correlated_scalar_aggregate_allows_arithmetic_wrapper() {
+        // TD-REL-LOWER-8 (TPC-H Q17): a correlated scalar aggregate wrapped in
+        // scalar arithmetic (`0.5 * avg(total)`) must decorrelate — previously
+        // only a BARE aggregate lowered; the `k *` wrapper declined.
+        let wrapped = lower_sql(
+            "SELECT id FROM users WHERE age < \
+             (SELECT 0.5 * avg(total) FROM orders WHERE orders.uid = users.id)",
+            &catalog(),
+        );
+        assert!(
+            wrapped.is_ok(),
+            "wrapped correlated scalar agg must lower: {wrapped:?}"
+        );
+
+        // No regression: the bare form still lowers.
+        assert!(
+            lower_sql(
+                "SELECT id FROM users WHERE age < \
+                 (SELECT avg(total) FROM orders WHERE orders.uid = users.id)",
+                &catalog()
+            )
+            .is_ok()
+        );
+
+        // A non-aggregate scalar subquery projection is still not this path
+        // (declines or takes the uncorrelated path) — the wrapper must contain
+        // exactly one aggregate. `count` over an empty correlated group is still
+        // declined (NULL-vs-0 bug).
+        assert!(
+            lower_sql(
+                "SELECT id FROM users WHERE age < \
+                 (SELECT count(total) FROM orders WHERE orders.uid = users.id)",
+                &catalog()
+            )
+            .is_err(),
+            "correlated COUNT still declines (empty-group NULL-vs-0)"
+        );
     }
 
     fn parse_where(sql: &str) -> Option<SqlExpr> {

--- a/docs/10-quality/td/TD-REL-LOWER-8-correlated-scalar-aggregate-arithmetic-wrapper.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-8-correlated-scalar-aggregate-arithmetic-wrapper.adoc
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-8: Correlated scalar aggregate wrapped in scalar arithmetic declines (TPC-H Q17)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **FIXED 2026-07-16** — the correlated scalar-aggregate decorrelation now accepts the aggregate wrapped in scalar arithmetic (`0.2 * avg(x)`, `sum(x)/7.0`); the wrapper is re-applied to the decorrelated value column. Filed + fixed in one PR from the post-#1031 native subquery-decline probe.
+| Priority | P2 — a common ANSI shape (a threshold that is a scaled per-group aggregate). TPC-H **Q17** (`l_quantity < (SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey)`).
+| Component | `crates/query/proximadb-relational-frontend` — `lower_correlated_scalar_aggregate` + the new `single_aggregate_call` / `build_scalar_over_agg` helpers.
+| Evidence | Direct `lower_sql` probe: a **bare** correlated scalar aggregate lowers (`… < (SELECT avg(l_quantity) …)` = OK), but the **arithmetic-wrapped** form declines (`… < (SELECT 0.2 * avg(l_quantity) …)` = `Unsupported("correlated scalar subquery")`). So the ONLY gap is the wrapper, not the decorrelation.
+|===
+
+== The finding
+
+`lower_correlated_scalar_aggregate` already decorrelates a single-key correlated scalar
+aggregate into a `LEFT JOIN` over a `GROUP BY` (a non-matching outer row null-pads, the correct
+SQL result for `avg/min/max/sum` over an empty set; `COUNT` stays declined for the NULL-vs-0
+bug). But it required the subquery projection to be **exactly one bare aggregate function** —
+`0.2 * avg(l_quantity)` is a `BinaryOp` wrapping the aggregate, so it fell out at the
+`SqlExpr::Function` match and declined.
+
+== The fix
+
+`single_aggregate_call` extracts the one aggregate from a scalar-arithmetic projection
+(recursing `BinaryOp` / `UnaryOp` / `Nested`; `None` if zero or >1 aggregate). The existing
+decorrelation runs on that aggregate. At the end, `build_scalar_over_agg` rebuilds the wrapping
+arithmetic with the aggregate substituted by its **post-join value column** — the arithmetic
+spine recurses; other leaves (literals, outer columns) lower against the outer scope, valid
+because the `LEFT JOIN` places outer columns first so their ordinals are unchanged in the
+combined row. A bare aggregate is the degenerate no-op case (unchanged behavior). This mirrors
+the projection-side aggregate-hoist of TD-REL-LOWER-4.
+
+== Gate
+
+* `tests/rel_correlated_scalar_arith_e2e.rs` — pgwire e2e: `qty < (SELECT 0.2 * avg(qty) FROM
+  line WHERE lpk = pk)` returns the row-exact `sum` (was `correlated scalar subquery` decline).
+* Frontend unit test `correlated_scalar_aggregate_allows_arithmetic_wrapper` — wrapped lowers,
+  bare still lowers (no regression), correlated `COUNT` still declines (NULL-vs-0). The three
+  existing `correlated_scalar_*` tests are unchanged.
+* Native ledger sweep: Q17 flips to native, row-exact vs the DataFusion baseline.
+
+== Non-goals
+
+Correlated scalar aggregate with a **multi-table** subquery body (TPC-H Q2 — joins inside the
+subquery); `HAVING` with aggregate calls + scalar subquery (Q11); `IN`/`EXISTS` subquery in
+expression position (Q18/Q20). Each is a distinct remaining mechanism.

--- a/tests/rel_correlated_scalar_arith_e2e.rs
+++ b/tests/rel_correlated_scalar_arith_e2e.rs
@@ -1,0 +1,161 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-REL-LOWER-8 (TPC-H Q17) — a correlated scalar aggregate wrapped in scalar
+//! arithmetic (`qty < (SELECT 0.2 * avg(qty) FROM line WHERE line.lpk = part.pk)`)
+//! must decorrelate and execute on the native route (was declined: only a BARE
+//! correlated aggregate lowered). Proves the arithmetic wrapper is re-applied to
+//! the decorrelated aggregate value, row-exact.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().expect("addr").port();
+    drop(l);
+    p
+}
+struct PgServer {
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+impl PgServer {
+    async fn start() -> anyhow::Result<Self> {
+        let pg_port = free_port();
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.unified_mode = false;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(r) if r.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => anyhow::bail!("REST not ready"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+    fn conn_str(&self) -> String {
+        format!(
+            "host=127.0.0.1 port={} user=postgres dbname=proximadb sslmode=disable",
+            self.pg_port
+        )
+    }
+}
+impl Drop for PgServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+async fn rows(client: &tokio_postgres::Client, sql: &str) -> Vec<Vec<String>> {
+    let msgs = client.simple_query(sql).await.unwrap_or_else(|e| {
+        panic!(
+            "{sql}\n  {}",
+            e.as_db_error()
+                .map(|d| format!("[{}] {}", d.code().code(), d.message()))
+                .unwrap_or_else(|| e.to_string())
+        )
+    });
+    msgs.iter()
+        .filter_map(|m| match m {
+            tokio_postgres::SimpleQueryMessage::Row(r) => Some(
+                (0..r.len())
+                    .map(|i| r.get(i).unwrap_or("").to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn native_correlated_scalar_aggregate_with_arithmetic_wrapper() {
+    std::thread::Builder::new()
+        .name("rel-corr-scalar-e2e-16m".into())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(body())
+        })
+        .expect("spawn")
+        .join()
+        .expect("panic");
+}
+
+async fn body() {
+    let server = PgServer::start().await.expect("server");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("connect");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    for ddl in [
+        "DROP TABLE IF EXISTS line",
+        "DROP TABLE IF EXISTS part",
+        "CREATE TABLE part (pk INT PRIMARY KEY, brand VARCHAR)",
+        "CREATE TABLE line (lid INT PRIMARY KEY, lpk INT, qty INT)",
+        "INSERT INTO part VALUES (1,'X'),(2,'X')",
+        // pk=1 lines qty {2,100}: avg=51, 0.2*avg=10.2 → qty<10.2 ⇒ {2}
+        // pk=2 lines qty {5,500}: avg=252.5, 0.2*avg=50.5 → qty<50.5 ⇒ {5}
+        "INSERT INTO line VALUES (10,1,2),(11,1,100),(12,2,5),(13,2,500)",
+    ] {
+        client.simple_query(ddl).await.expect("ddl");
+    }
+
+    // Q17 shape: qty below 0.2× the per-part average — the correlated scalar
+    // aggregate is wrapped in `0.2 *`. Qualifying: line(2) at pk=1, line(5) at
+    // pk=2 → sum(qty) = 7. (Was declined: `correlated scalar subquery`.)
+    let got = rows(
+        &client,
+        "SELECT sum(qty) AS s FROM line, part \
+         WHERE pk = lpk AND brand = 'X' \
+           AND qty < (SELECT 0.2 * avg(qty) FROM line WHERE lpk = pk)",
+    )
+    .await;
+    assert_eq!(got.len(), 1, "global aggregate is a single row");
+    let s: i64 = got[0][0].parse().expect("i64");
+    assert_eq!(s, 7, "only qty below 0.2*avg(per-part) qualify: 2 + 5 = 7");
+
+    eprintln!("✓ TD-REL-LOWER-8 correlated scalar aggregate w/ arithmetic wrapper on native route");
+}


### PR DESCRIPTION
## What
Lets the correlated scalar-aggregate decorrelation accept the aggregate **wrapped in scalar arithmetic** (`0.2 * avg(x)`, `sum(x)/7.0`). Closes **TD-REL-LOWER-8**; fixes TPC-H **Q17**, which declined `correlated scalar subquery`.

## Root cause (measured, not guessed)
A direct `lower_sql` probe showed the **bare** correlated aggregate already decorrelates (`… < (SELECT avg(x) …)` = OK), but the **wrapped** form declines (`… < (SELECT 0.2 * avg(x) …)`). `lower_correlated_scalar_aggregate` required the subquery projection to be exactly one bare `SqlExpr::Function`; Q17's `0.2 * avg(…)` is a `BinaryOp`, so it fell out and declined. **The only gap was the wrapper.**

## Fix
- `single_aggregate_call` — extract the one aggregate from a scalar-arithmetic projection (recurse `BinaryOp`/`UnaryOp`/`Nested`; `None` for zero or >1).
- Existing decorrelation runs on it (LEFT JOIN over GROUP BY; `COUNT` still declined for the NULL-vs-0 bug).
- `build_scalar_over_agg` — rebuild the wrapping arithmetic with the aggregate substituted by its **post-join value column**; the spine recurses, other leaves (literals, outer columns) lower against the outer scope (valid — the LEFT JOIN places outer columns first, so their ordinals are unchanged). Bare aggregate = degenerate no-op. Mirrors TD-REL-LOWER-4's projection-side hoist.

## Measured (TPC-H ledger, SF 0.001)
**Q17 flips to native, row-exact vs DataFusion — native 17→18/22, zero row-diffs, no regression.**

## Tests / gates
- `tests/rel_correlated_scalar_arith_e2e.rs` — pgwire e2e: `qty < (SELECT 0.2*avg(qty) FROM line WHERE lpk = pk)` returns the row-exact `sum` (was declined).
- Frontend unit test `correlated_scalar_aggregate_allows_arithmetic_wrapper` (wrapped lowers; bare still lowers; correlated `COUNT` still declines). 117 frontend+planner tests green · clippy `-D` · work-commit-check · td-unique · server builds.

## Scope / remaining
The other 4 subquery declines are distinct, harder mechanisms: **Q2** (correlated scalar with a multi-table subquery body), **Q11** (aggregate-in-HAVING + scalar-subquery-in-HAVING), **Q18/Q20** (IN-subquery in expression position — groupby-having / nested).