### PR TITLE
docs(adr): ADR-064 query-engine pipeline — decision↔dispatch split, lowering rule-seam + subquery unnesting, structured trace

### DIFF
--- a/docs/10-quality/td/TD-REL-LOWER-5-general-subquery-unnesting-pass.adoc
+++ b/docs/10-quality/td/TD-REL-LOWER-5-general-subquery-unnesting-pass.adoc
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-REL-LOWER-5: General subquery-unnesting lowering pass (replace per-shape arms; close Q2/Q11/Q18/Q20 as one mechanism)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — filed 2026-07-16 under link:../../12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (Decision 2). Phase-2 of the ADR-064 rollout. (Fills the free TD-REL-LOWER-5 slot between -4 and -6.)
+| Priority | P1 — the remaining native TPC-H declines are ALL subquery-shaped and the hand-written machinery does not compose; a general pass closes them together instead of four more bespoke arms.
+| Component | `crates/query/proximadb-relational-frontend` — the subquery lowering (`lower_subquery_join_parts`, `lower_scalar_subquery`, `lower_correlated_scalar_aggregate`) + a new dependent-join / unnesting pass.
+| Evidence | A direct `lower_sql` probe (2026-07-16, develop): remaining declines are **Q2** `Unsupported("correlated scalar subquery")` (multi-table subquery body), **Q11** `Unsupported("HAVING with aggregate calls")` (aggregate-HAVING + scalar subquery), **Q18/Q20** `Unsupported("EXISTS / IN subquery in expression position")` (groupby-having / nested IN). Today's helpers handle only narrow shapes: uncorrelated IN/EXISTS lift, single-table correlated scalar aggregate (TD-REL-LOWER-8 added the arithmetic wrapper), scalar-in-WHERE. Native is 18/22.
+|===
+
+== The finding
+
+Native subquery support accreted as **per-shape special cases**. Each covers a narrow form and they
+do not generalize: a correlated scalar aggregate with a *multi-table* body (Q2), an aggregate in
+HAVING compared to a subquery (Q11), or an IN with a GROUP BY/HAVING or nested IN (Q18/Q20) each needs
+its own new arm. This is the arithmetic-of-diminishing-returns the arc reached (18/22 via 6 arms).
+
+== Direction (per ADR-064 §2.2)
+
+Introduce the **standard general unnesting** algorithm — Neumann & Kemper, "Unnesting Arbitrary
+Queries" (BTW 2015): represent a correlated subquery as a **dependent join**, then push the dependency
+down with algebraic equivalences until it becomes an ordinary (semi/anti/left/inner) join over a
+`GROUP BY` — decorrelating *any* subquery shape (scalar, IN/EXISTS, correlated, nested) with one pass
+rather than shape-by-shape. Landed as the first `Rule` of the ADR-064 lowering rule-seam; the existing
+narrow decorrelators become special-cased fast paths (or are subsumed).
+
+== Gate
+
+Row-exactness vs the DataFusion baseline on the TPC-H ledger for **Q2, Q11, Q18, Q20** (target native
+18/22 → 22/22), plus the existing subquery unit tests unchanged (no regression). Mixed-read-safe by
+construction (pure `LogicalNode` rewrite; no on-disk format touched). Correlated `COUNT` empty-group
+NULL-vs-0 semantics preserved. Land incrementally (one query-family at a time) behind the ratchet.
+
+== Non-goals
+
+Cost-based join *ordering* of the unnested plan (TD-REL-LOWER-7 handles connectivity ordering);
+window-function / recursive-CTE lowering (separate).

--- a/docs/10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc
+++ b/docs/10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ROUTE-3: Separate the route DECISION from DISPATCH — make eligibility→selection→trust explicit; dispatch a thin `match backend`
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — filed 2026-07-16 under link:../../12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (Decision 1). Phase-3 of the ADR-064 rollout; independent of the other two.
+| Priority | P2 — maintainability + testability of the hot routing path; unblocks unit-testing routing decisions without running a query, and fixes the cost-cell mis-attribution at the source.
+| Component | `src/network/postgres/relational_pipeline.rs` (the dispatch block), `src/query/compute_scheduler.rs` (`route_select` / `route_select_advised`), per-backend execution adapters.
+| Evidence | The dispatch (relational_pipeline.rs:491-750, ~260 lines) re-decides inside the God-`if`: native-over-parquet primary (:513), DuckDB primary (:596), DataFusion floor (:682), route re-stamp "last-write-wins" (:729-732), native shadow (:739) — plus a separate PAX branch. Adding an engine edits this block (Open/Closed violation); the cost model learns the last-stamped route, not the one decided.
+|===
+
+== The finding
+
+The route *decision* (`route_select`) is clean, but *dispatch* re-decides: it tries a primary engine,
+falls to a floor, and re-stamps the route. Decision logic (which engine, and the primary→floor
+fallback) is entangled with the dispatch mechanism, so: (a) the decision is not authoritative, (b) the
+cost model is fed the wrong route on a fall-through, (c) an engine cannot be added without editing the
+mega-`if`.
+
+== Direction (per ADR-064 §2.1)
+
+Make `route_select` produce an **authoritative** `RouteDecision{ backend, reasons }` from three
+explicit, side-effect-free, unit-testable stages — **eligibility (soundness, ADR-058)** → **selection
+(cost, ADR-050)** → **trust (stats-trust gate, ADR-058 D5)**. Dispatch becomes a thin
+`match decision.backend { … }`; a backend's own primary→floor fallback (e.g. DataFusion is the OLAP
+floor) is a property of that *backend adapter*, not inline route logic — computed once, so the trace
+records the route that was made.
+
+**Constraint (ADR-059):** the `ComputeBackend` enum stays **closed** — this is a separation-of-concerns
+refactor, NOT an open plugin registry (ruled over-engineering; the engine set converges). One
+capability descriptor per backend (ADR-058), no duplicated coverage statements.
+
+== Gate
+
+No-behavior-change refactor: every current route preserved, verified by the TPC-H (22) / TPC-DS (16)
+pgwire conformance ratchets + the perf ledger (same backend served per query as before). New: unit
+tests asserting `shape → RouteDecision.backend` in isolation (no query run); a cost-attribution test
+proving a floor fall-through attributes to the floor cell, not the primary.
+
+== Non-goals
+
+Open plugin registry (ADR-059); changing WHICH engine any query routes to (that is ADR-050/058 cost
+work) — this TD only separates the decision from the dispatch and makes the reasons explicit.

--- a/docs/10-quality/td/TD-TRACE-1-structured-route-and-decline-trace.adoc
+++ b/docs/10-quality/td/TD-TRACE-1-structured-route-and-decline-trace.adoc
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-TRACE-1: Structured per-query route + decline + execution trace (one source of truth for EXPLAIN / cost model / billing)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** — filed 2026-07-16 under link:../../12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (Decision 3). Phase-1 (highest ROI) of the ADR-064 rollout.
+| Priority | P1 — leverage multiplier. The native-coverage arc (#1003→#1044) repeatedly paid to *manually unmask* silent declines and confirm routes by hand; a structured trace turns each into a one-line read and fixes the ADR-050 cost mis-attribution.
+| Component | `crates/modalities/proximadb-observability-engine` (`io_trace.rs` `IoTraceSnapshot`), `src/query/compute_scheduler.rs` (routing reasons), `src/network/postgres/relational_pipeline.rs` (dispatch + `record_route`), `crates/query/proximadb-relational-frontend` (decline reasons), EXPLAIN surface.
+| Evidence | `IoTraceSnapshot` (io_trace.rs:535-594) records `bytes_read`/`range_gets`/`compute_ms` + ONE `route` stamp, set last-write-wins (`record_route` io_trace.rs:258; re-stamped at relational_pipeline.rs:729-732) — the ADR-050 mis-attribution the cost comments already flag. Declines are a silent `None` → legacy → masking message.
+|===
+
+== The finding
+
+Observability today answers "how much I/O / compute" but not **"why this route"** or **"why this
+decline"**. The route is a single stamped tuple (last write wins), so a primary-then-floor fall-through
+attributes the floor's measured quantities to the wrong cost cell. Frontend declines vanish into the
+legacy path behind a generic message.
+
+== Direction (per ADR-064 §2.3)
+
+Elevate the snapshot to a structured `QueryTrace`: `routing{ eligible, selected, reasons }` +
+`lowering{ rules_fired, declines:[{node, why}] }` + `exec:[{op, rows_in/out, ms, bytes, spill}]`,
+layered ON the existing `IoTraceSnapshot` substrate (no new observer plumbing — reuse the always-on
+billing observer + the harness capture). Default-**lean** (cheap counters always; the verbose
+reason/op detail materializes only under `EXPLAIN [ANALYZE]` or a debug gate) so the hot path stays
+allocation-cheap. The cost model consumes the *decision that was made* (with reasons), not the last
+stamp; billing hangs off the same trace (co-design "meter every dimension").
+
+== Gate
+
+Unit: a route decision records its eligibility/selection/trust reasons; a frontend decline records
+`{node, why}`. e2e: `EXPLAIN` over a declining query surfaces the real reason (not the masking
+message); `EXPLAIN ANALYZE` shows per-op rows/ms. No change to served results; cost-cell attribution
+regression test (floor fall-through attributes to the floor, not the primary).
+
+== Non-goals
+
+Distributed tracing / OpenTelemetry export (separate); the vector-search `predicate_diagnostics` bus
+(ADR-023, already exists) — this is the *relational* query trace.

--- a/docs/12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc
+++ b/docs/12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-064: Query-engine pipeline — separate route DECISION from DISPATCH, a rule-seam for native LOWERING, and one structured per-query TRACE
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (filed 2026-07-16). Grounded in a multi-agent code investigation against `origin/develop` (every in-code claim cited `file:line`) and the measured native-coverage arc #1003/#1011/#1014/#1026/#1028/#1031/#1044 (TPC-H native 4/22 → 18/22). Decider sign-off pending.
+| Decider | Vijaykumar Singh (2026-07-16)
+| Date | 2026-07-16
+| Relates to | link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (the swappable `ComputeBackend` seam this keeps clean), link:ADR-050-statistics-fed-datafusion-route-selection.adoc[ADR-050] (the cost router this feeds attributed samples), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine — meter every dimension, measured-not-asserted), link:ADR-058-engine-routing-eligibility-selection-stats-trust.adoc[ADR-058] (eligibility→selection→trust — this ADR *operationalizes* it in the dispatch), link:ADR-059-duckdb-local-plugin-olap-engine.adoc[ADR-059] (the "engine set converges — no open registry" ruling this ADR RESPECTS)
+| Refines | ADR-058 — makes the three routing axes *explicit staged code*, not an imperative `if`. ADR-050 — the structured trace fixes the last-write-wins route mis-attribution that poisons the cost cells.
+| Tracked under | link:../../10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc[TD-ROUTE-3] (routing), link:../../10-quality/td/TD-REL-LOWER-5-general-subquery-unnesting-pass.adoc[TD-REL-LOWER-5] (lowering), link:../../10-quality/td/TD-TRACE-1-structured-route-and-decline-trace.adoc[TD-TRACE-1] (tracing)
+| Non-goals | A full Calcite-style cost-based optimizer rewrite; an **open backend registry** (ADR-059 ruled it over-engineering — the enum stays closed); native OLAP hash-join/agg operators (ADR-052 — those stay DataFusion).
+|===
+
+== 1. Context — first principles
+
+A cloud database query engine is, from first principles, a **pipeline of distinct concerns**:
+
+[listing]
+----
+   SQL text
+      │
+      ▼
+ ┌─────────┐   ┌─────────┐   ┌──────────┐   ┌────────┐   ┌──────────┐   ┌─────────┐   ┌───────┐
+ │  PARSE  │──▶│  LOWER  │──▶│ OPTIMIZE │──▶│ ROUTE  │──▶│ DISPATCH │──▶│ EXECUTE │──▶│ METER │
+ │ (sqlparse)  │(SQL→plan)   │(rewrite) │   │(decide │   │(hand to  │   │(engine) │   │(trace/│
+ └─────────┘   └─────────┘   └──────────┘   │ engine)│   │ engine)  │   └─────────┘   │ bill) │
+                                            └────────┘   └──────────┘                 └───────┘
+      each box is ONE responsibility, with ONE stable seam to the next (SOLID / co-design "boundary is the contract")
+----
+
+ProximaDB has the right *macro* shape (pgwire → shared `LogicalNode` → `ComputeScheduler` →
+`ComputeBackend`, ADR-039). But three boxes have eroded internally, and the native-coverage arc
+(4/22 → 18/22 TPC-H, one bespoke lowering arm per query) surfaced each one repeatedly:
+
+* **ROUTE and DISPATCH are conflated.** `ComputeScheduler::route_select`
+  (`src/query/compute_scheduler.rs:503`) makes a clean decision, but the *dispatch*
+  (`src/network/postgres/relational_pipeline.rs:491-750`, ~260 lines) then **re-decides** — it tries
+  native-over-parquet, then DuckDB, then PAX, then a DataFusion floor, and **re-stamps the route
+  "last-write-wins"** (`:729-732`). The decision is not authoritative; the dispatch is a God-`if`.
+* **LOWER has no rule seam.** `lower_sql` (`crates/query/proximadb-relational-frontend/src/lib.rs:117`)
+  + the planner passes (`push_predicates:939`, `push_projections:1888`) are hand-written; every query
+  shape is a bespoke `if let SqlExpr::X` arm. Declines fall through a silent `None` → the legacy path,
+  which emits a **masking** error ("comma-separated FROM") that hides the real cause.
+* **METER records counts, not reasons.** `IoTraceSnapshot`
+  (`crates/modalities/proximadb-observability-engine/src/io_trace.rs:535-594`) captures
+  `bytes_read`/`range_gets`/`compute_ms` + a single `route` stamp — but **no structured record of
+  *why*** a query routed where or *why* it declined/lowered a given way.
+
+=== 1.1 What "today" looks like (the God-`if` dispatch)
+
+[listing]
+----
+ route_select() ─▶ SelectRouteDecision{ backend }        // clean DECISION
+        │
+        ▼
+ relational_pipeline.rs:491  if parquet_backed && matches!(decision.backend, DataFusionLocal|Native|DuckDbCompat) {
+     ├─ [513] try native-over-parquet (MetadataElidable/ScalarAggregate) ─┐   these are all DECISION
+     ├─ [596] #[cfg(duckdb)] try DuckDB (join/agg + clean delta) ─────────┤   logic living INSIDE
+     ├─ [682] DataFusion FLOOR (always) ; [729] re-stamp route ───────────┤   the dispatch — the
+     └─ [739] optional native SHADOW probe ──────────────────────────────┘   decision isn't final
+   }
+   // + a separate PAX branch (added for TD-OLAP-1 Slice 2), + the Volcano fall-through below
+----
+
+Adding an engine means editing this block (an Open/Closed violation); the route the cost model
+learns from is whatever was stamped last (a documented mis-attribution failure mode).
+
+== 2. Decision
+
+Restore the three eroded boxes to single-responsibility seams. **Three decisions, three tracked TDs.**
+
+=== 2.1 Decision 1 — separate route DECISION from DISPATCH (TD-ROUTE-3)
+
+Make the decision *authoritative* and the dispatch *dumb*. The eligibility → selection → trust axes
+of ADR-058 become **explicit, unit-testable stages**; dispatch is a thin `match backend`:
+
+[listing]
+----
+  IDEAL:
+   QueryShape
+      │
+      ▼
+  ┌──────────────── ROUTE (pure decision, no I/O, no side effects) ─────────────────┐
+  │  ① ELIGIBILITY   for each backend: can it serve this shape SOUNDLY?  (ADR-058)   │
+  │       filter ─▶ { eligible backends }        (capability descriptor, ADR-054 v3) │
+  │  ② SELECTION     cheapest eligible by the cost cells                (ADR-050)    │
+  │  ③ TRUST         stats-trust gate for external parquet              (ADR-058 D5) │
+  │       ─▶ RouteDecision{ backend, reasons:[why eligible/selected/trusted] }       │
+  └──────────────────────────────────────────────────────────────────────────────────┘
+      │
+      ▼
+  DISPATCH:  match decision.backend {                    // thin, no re-deciding
+     Native        => volcano.run(plan),
+     DataFusionLocal => df.run(plan),                    // its OWN fallback lives HERE, not in route
+     DuckDbCompat  => duck.run(plan),
+     ...            // adding an engine = one arm + one capability descriptor; NOT editing a God-if
+  }
+----
+
+**Constraint (ADR-059):** the `ComputeBackend` enum stays **closed** — this is NOT an open plugin
+registry (ruled over-engineering; the engine set converges). The win is *separation of concerns* +
+one capability descriptor per backend (no duplicated coverage statements, per ADR-058), not a
+plugin system. "Try primary then fall to floor" becomes a property of the *backend* (a backend may
+declare a fallback), not inline route logic — so the decision the cost model learns from is the one
+that was made, computed once.
+
+=== 2.2 Decision 2 — a rule-seam for native LOWERING + a general subquery-unnesting pass (TD-REL-LOWER-5)
+
+The native frontend/planner gets the same discipline the OLAP engine already has behind ADR-039:
+DataFusion's operators are chosen by a **rule optimizer**; the native lowering should be too, instead
+of hand-written arms.
+
+[listing]
+----
+  TODAY:  lower_sql = one giant recursive descent; each shape = a bespoke `if let SqlExpr::X` arm.
+          #1014 alias, #1026 agg-arith, #1028 OR-factor, #1031 join-reorder, #1044 corr-scalar-wrapper
+          → 5 unrelated special cases that do not COMPOSE. Remaining Q2/Q11/Q18/Q20 need 4 MORE arms.
+
+  IDEAL:  a Rule registry applied to fixpoint (the Calcite / DataFusion-optimizer discipline):
+          ┌──────────────────────────────────────────────┐
+          │  trait Rule { matches(node)->bool;            │   each past fix = ONE named, unit-testable
+          │               apply(node)->Result<node> }     │   rule; declines carry a STRUCTURED reason
+          └──────────────────────────────────────────────┘   (node + why), surfaced in EXPLAIN — not a
+              apply_rules(plan, &REGISTRY) ─▶ fixpoint       silent None → masking legacy message.
+----
+
+The high-value first rule is **general subquery unnesting** (the standard algorithm — Neumann &
+Kemper, "Unnesting Arbitrary Queries", BTW 2015): a single dependent-join → decorrelation pass that
+handles the whole subquery class (scalar, IN/EXISTS/semi-anti, correlated, nested) — replacing the
+4 remaining per-shape gaps (Q2 multi-table-body correlated scalar; Q11 aggregate-HAVING + scalar
+subquery; Q18/Q20 IN-in-expression / nested) with ONE mechanism. Target: native TPC-H 18/22 → 22/22.
+
+=== 2.3 Decision 3 — one structured per-query TRACE (TD-TRACE-1)
+
+Elevate `IoTraceSnapshot` from *counters* to a *structured decision + execution record*, one source
+of truth for EXPLAIN, the cost model, and billing:
+
+[listing]
+----
+  QueryTrace {
+    routing:  { eligible:[...], selected: Native, reasons:[ "df ineligible: no spill for grouped join",
+                                                             "native cheaper: 0.4ms vs 1.1ms cell" ] }
+    lowering: { rules_fired:[ "OrFactorRule", "JoinReorderRule" ],
+                declines:[ { node: "IN-subquery", why: "no unnesting rule matched (Q18 groupby-having)" } ] }
+    exec:     [ { op: "HashJoin",  rows_in: 6M, rows_out: 1.2M, ms: 24, bytes: 0, spill: false }, ... ]
+    io:       { bytes_read, range_gets, compute_ms }   ← the EXISTING IoTraceSnapshot substrate
+  }
+     │                    │                     │
+     ▼                    ▼                     ▼
+  EXPLAIN ANALYZE   cost model (attributed,   billing (KRU/KOU per dimension,
+  (truly diagnostic) NOT last-write-wins)     co-design "meter every dimension")
+----
+
+This directly fixes the ADR-050 mis-attribution (the cost cell learns the route that was *made*, with
+its reasons) and makes "why did this decline/route here" a **one-line read** instead of the manual
+unmasking the native-coverage arc kept paying.
+
+== 3. Co-design ties (ADR-052 spine)
+
+* **Measured, not asserted** — every routing decision + decline reason is recorded, so promotions ride
+  the trace, not a heuristic. The unnesting pass is gated on the row-exact-vs-DataFusion ledger.
+* **Standard outside, vertical inside** — internals (rule engine, capability descriptor, structured
+  trace) are free to co-design; the seams exposed stay standard (pgwire, `LogicalNode`, ADR-039).
+* **Meter every dimension** — one trace feeds both the cost model and per-tenant billing; the I/O
+  boundary still carries `TenantContext` (fail-closed).
+* **The boundary is the contract** — decision↔dispatch, lowering rule seam, and trace are each a
+  single explicit seam, restoring SOLID to the three eroded boxes.
+
+== 4. Consequences
+
+* **Positive:** routing + lowering become unit-testable *without running a query* (the slow
+  e2e-per-fix loop that this arc used becomes fast unit assertions); adding an engine is additive;
+  the remaining subquery declines close as one mechanism; EXPLAIN/cost/billing share one truth.
+* **Cost / risk:** TD-ROUTE-3 touches the hot dispatch path (must preserve every current route,
+  behind a no-behavior-change refactor + the existing conformance ratchets). TD-REL-LOWER-5 is a new
+  pass (mixed-read-safe by construction — pure plan rewrite, gated on recall/row-exact). TD-TRACE-1
+  adds a per-query struct (must stay allocation-cheap; default-lean, verbose only under EXPLAIN).
+* **Explicitly deferred:** full optimizer rewrite; open registry (ADR-059); native OLAP operators
+  (ADR-052).
+
+== 5. Rollout (phased; each slice its own PR + green proof)
+
+[cols="1,2,3",options="header"]
+|===
+| Order | TD | Rationale
+| 1 | link:../../10-quality/td/TD-TRACE-1-structured-route-and-decline-trace.adoc[TD-TRACE-1] | Highest leverage — accelerates every other item (turns manual decline-unmasking into a one-line read); additive, low-risk (default-lean).
+| 2 | link:../../10-quality/td/TD-REL-LOWER-5-general-subquery-unnesting-pass.adoc[TD-REL-LOWER-5] | Closes Q2/Q11/Q18/Q20 as ONE mechanism (native → 22/22 target) instead of 4 more bespoke arms.
+| 3 | link:../../10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc[TD-ROUTE-3] | Independent; the maintainability + testability refactor of the dispatch God-`if`. Land any time behind the conformance ratchets.
+|===
+
+Verification for each: unit tests (rule/route in isolation) + pgwire e2e + the TPC-H/DS ledger
+(row-exact vs DataFusion) + `check_td_adr_unique` + `work-commit-check`. No behavior change until a
+slice's ledger evidence justifies flipping any default (ADR-052 observe → ingest → act).


### PR DESCRIPTION
## What
Files **ADR-064** (Proposed) + three work-item TDs capturing the target architecture behind this session's native-coverage arc (TPC-H native **4/22→18/22**), which reached diminishing returns via **one bespoke lowering arm per query**. First-principles + co-design reasoning, with **ASCII-art diagrams** (repo has no Mermaid toolchain).

## First-principles framing
A query engine = `parse → lower → optimize → route → dispatch → execute → meter`. Three boxes eroded internally and surfaced repeatedly this arc:
1. **ROUTE ↔ DISPATCH conflated** — `route_select` decides cleanly, but the ~260-line dispatch God-`if` (`relational_pipeline.rs:491-750`) re-decides (native-over-parquet / duckdb / pax / datafusion-floor) and re-stamps the route last-write-wins (`:729-732`), poisoning the ADR-050 cost cells.
2. **LOWER has no rule seam** — each shape is an ad-hoc `if let SqlExpr::X` arm; declines fall through a silent `None` → masking legacy message.
3. **METER records counts, not reasons** — `IoTraceSnapshot` has no structured "why routed / why declined".

## Decisions (3 tracked TDs)
- **TD-ROUTE-3** — separate decision from dispatch; make ADR-058's *eligibility→selection→trust* explicit + unit-testable; dispatch a thin `match backend`. **Closed enum preserved** — ADR-059 ruled an open registry over-engineering, so this is separation-of-concerns, *not* a plugin registry.
- **TD-REL-LOWER-5** — a **general subquery-unnesting pass** (Neumann/Kemper dependent-join decorrelation) closing Q2/Q11/Q18/Q20 as ONE mechanism (**18/22 → 22/22**) instead of 4 more bespoke arms.
- **TD-TRACE-1** — one **structured per-query trace** (routing reasons + lowering/decline reasons + per-op metrics) feeding EXPLAIN + the cost model (fixes last-write-wins) + billing.

## Positioning
Operationalizes **ADR-050** (cost router) + **ADR-058** (eligibility/selection/trust); respects **ADR-039** (swappable seam) + **ADR-059** (no open registry); co-design spine per **ADR-052** (measured-not-asserted, meter-every-dimension). **ADR-064** chosen to avoid colliding with #1040's in-flight ADR-063.

## Rollout (phased, each its own PR + green proof)
1. **TD-TRACE-1** (leverage multiplier — turns manual decline-unmasking into a one-line read), 2. **TD-REL-LOWER-5** (native → 22/22), 3. **TD-ROUTE-3** (independent maintainability refactor). Non-goals: full optimizer rewrite, open registry, native OLAP operators.

Docs-only. td-adr-unique 0 errors (ADR-064 + 3 TD ids unique); work-commit-check green; no code touched.