### PR TITLE
docs(td): TD-IOTRACE-3 — actual_scan_gb must be LOGICAL scanned bytes (billing contract)

### DIFF
--- a/docs/10-quality/td/TD-IOTRACE-3-actual-scan-gb-logical-contract.adoc
+++ b/docs/10-quality/td/TD-IOTRACE-3-actual-scan-gb-logical-contract.adoc
@@ -1,0 +1,72 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IOTRACE-3: `actual_scan_gb` must be LOGICAL scanned bytes (billing contract) — coalesced RaBitQ decouples it from physical `bytes_read`
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open**
+| Severity | High — a physical-bytes emission silently under-bills downstream KRU metering ~21–30× on the coalesced RaBitQ path (ADR-062); the field is trusted verbatim by billing consumers.
+| Component | Metering — `crates/modalities/proximadb-observability-engine/src/metering_event.rs`, `search_plan_trace.rs`
+| Related | link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062], link:TD-IOTRACE-2-per-tenant-get-metering.adoc[TD-IOTRACE-2], link:TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6]
+| Pillar | COST
+|===
+
+toc::[]
+
+== Symptom
+
+`SearchPlanTrace.actual_scan_gb` has no pinned definition, and the query path
+does not populate it on the coalesced RaBitQ path. The only per-query byte
+counters that exist today are **physical** (`IoTraceSnapshot.bytes_read`,
+`range_gets` — io_trace.rs). If `actual_scan_gb` is ever wired from those
+physical counters, downstream billing silently collapses:
+
+- The coalesced RaBitQ scan (ADR-062 D2) examines **all** codes per query
+  (`keep=100%`, `scan_fraction = 1.0`) — logically a full-corpus scan — but
+  physically reads only the ~21–30×-compressed codes (`dim/8 + 8` B/row) in
+  ~20 coalesced GETs.
+- Metering consumers (e.g. AnvaiOps `ScanStats.from_response`, and this
+  repo's own `metering_event.rs::build_kru` line ~108) **prefer
+  `actual_scan_gb` verbatim over the derived
+  `corpus_gb × vectors_scanned/total_vectors` fallback** whenever the field
+  is present. A physical-bytes value under-reports the billed scan ~21–30×.
+
+== Contract (the fix pins this)
+
+`actual_scan_gb` = **logical raw-corpus bytes scanned** =
+`collection_raw_bytes × scan_fraction`, where
+`scan_fraction = vectors_scanned / total_vectors`. On the coalesced path
+`vectors_scanned == total_vectors` ⇒ the full raw corpus size.
+
+Physical I/O (`bytes_read`, `range_gets`, `get_ops`) is emitted as **separate
+observability fields** on the metering event (that is TD-IOTRACE-2's scope) —
+never as `actual_scan_gb`.
+
+Downstream decision record: AnvaiOps ADR-0039 (KRU bills logical scanned
+bytes; the compression efficiency is operator margin, not a customer
+discount).
+
+== Fix approach
+
+1. Thread the collection's **raw (uncompressed) corpus bytes** — `N ×
+   dim × 4` for f32, from catalog/collection metadata at query open — to the
+   metering builder (`MeteringInputs.corpus_gb` exists; ensure it is the raw
+   size, not the stored/compressed footprint).
+2. At the query boundary, populate
+   `SearchPlanTrace.actual_scan_gb = raw_corpus_gb × scan_fraction`
+   (coalesced path: `scan_fraction = 1.0`; legacy/pruned paths: the existing
+   `vectors_scanned / total_vectors`).
+3. Doc-comment the field in `search_plan_trace.rs` with the contract above so
+   no future path re-derives it from `IoTraceSnapshot.bytes_read`.
+4. Unit test: a coalesced-RaBitQ-shaped query over a known corpus asserts the
+   emitted `actual_scan_gb` equals the raw corpus size (and NOT the
+   compressed `bytes_read` from the io-trace), while `object_store_gets` /
+   `object_store_bytes_read` (TD-IOTRACE-2 fields) carry the physical truth.
+
+== Non-goals
+
+- No change to what the io-trace measures (physical truth stays physical).
+- No pricing logic in the engine (measure-vs-bill split; rates live
+  downstream).


### PR DESCRIPTION
## What

Files TD-IOTRACE-3: pins the wire contract that `SearchPlanTrace.actual_scan_gb` carries **logical** scanned bytes (`raw_corpus_bytes × scan_fraction`), never the physical `IoTraceSnapshot.bytes_read`.

## Why now

ADR-062's coalesced RaBitQ path (PR1 shipped 2026-07-15) decouples logical scan from physical I/O for the first time: `keep=100%` examines the full corpus while physically reading only ~21–30×-compressed codes in ~20 coalesced GETs. Metering consumers — `metering_event.rs::build_kru` here and downstream billing (AnvaiOps ADR-0039) — prefer `actual_scan_gb` verbatim over the derived `corpus × vectors_scanned/total_vectors` fallback whenever the field is present, so a physical-bytes emission would silently under-bill ~21–30×.

## Scope

Docs-only (one TD file). Fix approach documented in the TD: thread raw corpus bytes to the metering builder, populate `actual_scan_gb` logically at the query boundary, doc-comment the field, and unit-test the coalesced shape. Physical counters remain separate observability fields (TD-IOTRACE-2's scope — complementary, not superseded).

## Validation

`python3 scripts/check_td_adr_unique.py` — 230 TD ids, 0 errors (warnings pre-existing).