### PR TITLE
docs(td): TD-IOTRACE-2 severity → High (downstream billing input) + TD-IOTRACE-3 reassignment note

### DIFF
--- a/docs/10-quality/td/TD-IOTRACE-2-per-tenant-get-metering.adoc
+++ b/docs/10-quality/td/TD-IOTRACE-2-per-tenant-get-metering.adoc
@@ -7,7 +7,7 @@
 |===
 | Field | Value
 | Status | **Open**
-| Severity | Medium — the co-design KOU (outgress / object-store-request dimension) is not metered per-tenant, even though the io-trace now captures it.
+| Severity | **High** (raised 2026-07-16, was Medium) — downstream re-pricing (AnvaiOps ADR-0041) made the per-query physical counters this TD emits (`object_store_gets`, `object_store_bytes_read`) the **billing input for the physical part of the two-part KRU rate** ($/TB physically scanned). Until this lands, that meter bills $0 (downstream under-return rule — never estimated), i.e. this TD is now revenue-blocking, not just an observability gap. Originally: the co-design KOU (outgress / object-store-request dimension) is not metered per-tenant, even though the io-trace now captures it.
 | Component | Metering — `src/observability/metering_event.rs`
 | Tracked-by | link:../../12-design/STORAGE_FORMAT_DECISION_FRAMEWORK_2026_06_29.adoc[Storage-Format Decision Framework] (PR #553)
 | Pillar | COST, SUS

--- a/docs/10-quality/td/TD-IOTRACE-3-actual-scan-gb-logical-contract.adoc
+++ b/docs/10-quality/td/TD-IOTRACE-3-actual-scan-gb-logical-contract.adoc
@@ -44,9 +44,15 @@ Physical I/O (`bytes_read`, `range_gets`, `get_ops`) is emitted as **separate
 observability fields** on the metering event (that is TD-IOTRACE-2's scope) —
 never as `actual_scan_gb`.
 
-Downstream decision record: AnvaiOps ADR-0039 (KRU bills logical scanned
-bytes; the compression efficiency is operator margin, not a customer
-discount).
+Downstream decision records: AnvaiOps ADR-0039 established the logical/
+physical distinction; **AnvaiOps ADR-0041 (2026-07-16) reassigned billing** —
+the logical `actual_scan_gb` is **no longer priced** (it feeds the pre-query
+cost estimator, fair-use scan envelopes, and observability), and the
+**physical** counters (TD-IOTRACE-2's `object_store_gets` /
+`object_store_bytes_read`) became the billing input for the physical part of
+the two-part KRU rate. This TD's contract is unchanged by that reassignment:
+`actual_scan_gb` stays logical, physical stays separate — the two must never
+be conflated regardless of which one billing consumes.
 
 == Fix approach
 


### PR DESCRIPTION
## What

Docs-only follow-up to #1046, driven by AnvaiOps ADR-0041 (object-store-native re-pricing):

- **TD-IOTRACE-2** severity Medium → **High**: its per-query physical counters (`object_store_gets`, `object_store_bytes_read`) are now the **billing input** for the physical part of the downstream two-part KRU rate ($/TB physically scanned). That meter bills $0 until this TD lands (downstream under-return rule), so the TD is revenue-blocking, not just an observability gap.
- **TD-IOTRACE-3** downstream note updated: the logical `actual_scan_gb` is no longer *priced* (it feeds the pre-query estimator, fair-use envelopes, and observability); the contract itself — logical stays logical, physical stays separate — is unchanged.

## Validation

`python3 scripts/check_td_adr_unique.py` — 236 TD ids, 0 errors (warnings pre-existing).