### PR TITLE
docs(rdstrat): record deferred-bytes bakeoff rejection

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **PR1 shipped (#1019, 2026-07-15); phased program remains active.** PR1 measured recall@10 `0.984`, `20` range GETs/query, and `31.7 MB` read/query. The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]. The deferred bytes phase is now specified by link:TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7]. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
+| Status | **PR1 shipped (#1019, 2026-07-15); scale contract needs follow-up.** PR1's N=100k run measured recall@10 `0.984`, `20` range GETs/query, and `31.7 MB` read/query. A verified N=1M follow-up measured flat SQ8 at recall `0.968`, `61` GETs/query, and `138,851,704` bytes/query, exposing fixed survivor-M and unwired-`IopsBudget` prerequisites. The deferred codec bake-off in link:TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7] produced no eligible winner. The *decision rationale, alternatives, and consequences* live in link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]. Supersedes the *block-centroid-prune* path (link:TD-RDSTRAT-4-centroid-block-clustering-and-segment-directory.adoc[TD-RDSTRAT-4] Lever B / link:TD-RDSTRAT-5-cache-first-voe-directory-activation-codesign.adoc[TD-RDSTRAT-5]) as the object-storage end-state; block-prune is retained as an optional coarse pre-filter for monster collections.
 | Severity | High — `per_get=20.0` is the dominant vector-route cost-model term; block-pruning is measured GET-capped (link:../../_internal/status/SIFT1M_VOE_COMPACTED_RECALL_PARETO_2026_07_15.adoc[the eval]), so the GET lever is unreachable until this lands.
 | Component | `src/storage/engines/sst/segment_format.rs` (writer+reader); `crates/storage/proximadb-block-format/src/writer.rs::PaxBlockWriter` (`:134`) + `crates/storage/proximadb-storage-common/src/pax_block.rs::PaxSegmentScanner` (`:887`) + `stripe.rs::SegmentMeta`; `src/storage/engines/sst/search/mod.rs::try_pax_cascade`; `src/storage/engines/core/coalesce_strategy.rs` + `sst_query_engine.rs::{plan_selected_block_ranges (:733), ObjectRangeCoalescePolicy (:289)}`; `src/storage/engines/sst/compaction.rs`; `crates/storage/proximadb-storage-common` (a NEW per-backend `IopsBudget` — NOT the `StorageProfile` workload enum); `crates/storage/proximadb-storage-filesystem-types` (`FileSystem::read_ranges` — default is a sequential loop; the GET win is the coalesce policy's); `crates/storage/proximadb-object-store/src/lib.rs::put_if_absent` (`:247`, create-only — compaction CAS via Iceberg fresh-name+manifest-swap, ADR-020).
 | Relates | link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (decision), link:TD-RDSTRAT-3-pax-cascade-striped-read-chooser-slices.adoc[TD-RDSTRAT-3] (rerank substrate), link:TD-WLP-9-voe-centroid-prune-recall-fail-closed-gate.adoc[TD-WLP-9] (gate), ADR-061 (pre-GA in-place/amend), ADR-046/045 (mixed-read/readability), ADR-036 (storage profile), ADR-020 (WAL authority; footer is advisory), ADR-047 (collection-as-table schema)
@@ -211,6 +211,11 @@ amendment sanctions.
   ordering; (b) **isolate the per-file "~1 RaBitQ GET" win on a compacted/single-file collection**
   so it is not conflated with the PR2 GET-budget compaction win (the flush→compaction scheduler is
   currently unwired — `segment_format.rs:185`).
+* **N=1M scale follow-up (2026-07-16):** flat SQ8 reached recall@10 `0.968`,
+  `61` range GETs/query, and `138,851,704` bytes/query. This fails the 0.98/50
+  gates and invalidates a segment-size-independent pool of 1,000 candidates.
+  The declared `IopsBudget` is not yet the active PAX writer geometry; see
+  link:../../_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc[the evidence].
 * Compaction test (PR2): N→1 merge → fewer RaBitQ GETs/query + re-clustered tighter locality.
 * PR2/PR3 follow-ups (not PR1 gates): footer-index sizing at scale (Q2); bloom FPP/sizing (Q6);
   the schema-footer vs catalog-authority invariant (Q3).
@@ -249,3 +254,6 @@ the bytes phase.
   `31.7 MB` read/query. Linked the active bytes phase TD-RDSTRAT-7 and reconciled the spec with
   the shipped footer-v1 core/default-OFF gate; full typed metadata uses footer v2 while new
   readers retain the v1 path.
+* 2026-07-16 — full N=1M follow-up measured recall `0.968` and `61` GETs/query
+  for flat SQ8. The bytes bake-off found no winner; adaptive M, actual-byte
+  `IopsBudget` geometry, and scalable cluster fitting are prerequisites.

--- a/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc
@@ -8,11 +8,13 @@
 | Field | Value
 
 | Status
-| **Proposed implementation design (2026-07-15).** This is the deferred BYTES
-  phase of link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062]
-  after PR1 (#1019) moved GETs. This document is the required codec/layout audit
-  and implementation contract; code follows in a separate TDD PR after this
-  design lands.
+| **First implementation bake-off rejected (2026-07-16); redesign active.**
+  Residual SQ6 was the only compact arm to clear recall at N=100k, but saved only
+  7.0% query bytes and was 3.4x slower. TurboQuant4 and multi-bit RaBitQ4 missed
+  recall by about six points. At genuine N=1M, flat SQ8 itself measured recall
+  `0.968` and `61` GETs/query; SQ6 fell to `0.950`. No codec/footer-v2 writer from
+  this bake-off ships. Adapt survivor M, wire `IopsBudget`, and scale the cluster
+  producer before evaluating another encoding.
 
 | Severity
 | High — PR1 measured `bytes_read/query = 31.7 MB` at recall@10 `0.984` and
@@ -62,6 +64,10 @@ Kernel compression ratios and codec microbenchmarks are diagnostic only. The
 headline is the end-to-end query counter under the same single-file, IVF-ON
 protocol because range over-read, codebook bytes, footer bytes, and survivor
 locality all contribute to the actual route-cost term.
+
+The 2026-07-16 equal-protocol bake-off and full N=1M follow-up are recorded in
+link:../../_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc[the dated evidence].
+No arm met this definition of done.
 
 == Settled constraints inherited from ADR-062
 
@@ -413,10 +419,10 @@ The encoding map declares the block's chosen codec; block-local parameters live
 in a versioned `VectorParamBlock` extension. Mixed codec blocks in one segment
 are permitted.
 
-=== Equal-protocol codec bake-off
+=== Equal-protocol codec bake-off — measured, no winner
 
 The first implementation does not earn a permanent format tag merely by
-existing. Three isolated worktrees run the same release-profile SIFT1M N=100k,
+existing. Three isolated worktrees ran the same release-profile SIFT1M N=100k,
 100-query, single-file IVF-ON protocol:
 
 * clustered SQ4/SQ6, including the explicitly declared exact-norm experiment;
@@ -430,6 +436,32 @@ time. Total route cost is also reported under ADR-062's durable weights
 the GET result, and moving bytes materially below `31.7 MB` is eligible. Losing
 experimental codecs are discarded unless independently justified by another
 workload.
+
+Measured result: residual SQ6 + exact squared norm reached recall `0.981` but
+only reduced bytes/query from `32,020,233` to `29,775,220` and increased mean
+query latency from `11,756 us` to `39,688 us`. TurboQuant4 reached recall
+`0.921`; multi-bit RaBitQ4 reached `0.917`. Both 4-bit arms read about
+`25.12 MB/query`. All three are rejected.
+
+At genuine N=1M, flat measured recall `0.968`, `61` GETs/query, and
+`138,851,704` bytes/query; SQ6 measured `0.950`, `61`, and `128,722,140`.
+The fixed pool is 1,000 candidates at both scales (1% of N=100k versus 0.1% of
+N=1M), so the scale gate must be restored before another rerank codec is judged.
+
+=== Prerequisites exposed by N=1M
+
+* **Adaptive survivor M.** Replace the segment-size-independent 1,000-candidate
+  contract with a measured recall/confidence rule and charge its survivor blocks
+  to the GET/byte budget.
+* **Wire the existing budget.** `IopsBudget` declares local 1 MiB and cloud
+  4 MiB targets, but PAX still uses a 3 MiB threshold with a fixed 1 KiB/row
+  proxy, yielding about 3,072 rows/block regardless of encoding or dimension.
+* **Scale the producer.** N=1M IVF flushes took 44-48 minutes at d128; the sampled
+  hot path was `kmeans_clustering_seeded`. Higher dimension requires scalable,
+  deterministic fitting first.
+* **Dimension sweep.** Measure real d128/384/768/1536/3072 L2, cosine, and dot
+  workloads. Better estimator concentration is possible, but the mandatory
+  RaBitQ region, rerank bytes, and fitting work all grow with dimension.
 
 Metric compatibility is evaluated separately from the Euclidean SIFT headline:
 L2, cosine, and dot require ranking/score-domain tests; other public metrics
@@ -546,6 +578,10 @@ survivor-block codec and is not tuned in the bytes PR.
 * All repository format, clippy/check, server-binary, TD uniqueness, attribution,
   and work-commit guards pass before the implementation PR targets `develop`.
 
+The 2026-07-16 bake-off satisfies the evidence requirement but **does not
+satisfy the acceptance gates**. The TD remains active; none of the prototype
+codec tags or footer-v2 writes are accepted for production.
+
 == History
 
 * 2026-07-15 — filed after PR1 #1019 landed. Audit established one shared codec
@@ -553,3 +589,7 @@ survivor-block codec and is not tuned in the bytes PR.
   codebooks local to each PAX block, a clean footer-v2 section layout with v1
   read fallback, typed optional
   Bloom references, and fail-closed unknown encoding behavior.
+* 2026-07-16 — serialized release bake-off rejected residual SQ6, TurboQuant4,
+  and multi-bit RaBitQ4. Genuine N=1M validation also failed the flat control's
+  recall/GET gates and exposed fixed-M, unwired-`IopsBudget`, and k-means scaling
+  prerequisites. No storage-format implementation ships from this phase.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -301,6 +301,20 @@ at the same N=100k single-file IVF-ON SIFT workload. The accepted rerank encodin
 the PR1 byte result while clearing recall and GET gates; losing prototypes do not become
 durable format variants merely because they were implemented for evaluation.
 
+The 2026-07-16 bake-off produced no winner. At N=100k residual SQ6 reached
+recall `0.981` but saved only 7.0% query bytes and was 3.4x slower; TurboQuant4
+and multi-bit RaBitQ4 reached recall `0.921` and `0.917`. At genuine N=1M the
+flat control itself fell to recall `0.968` and `61` GETs/query, while SQ6 reached
+`0.950` with the same GET count. D8 remains a design seam, not an accepted
+encoding. No prototype receives a durable tag.
+
+The N=1M result measures two prerequisites to D6/D8. Top-M is fixed at 1,000
+for top-10 regardless of segment rows; it shrinks from 1% of N=100k to 0.1% of
+N=1M and must become a measured segment-scale/confidence rule. `IopsBudget`
+exists, but PAX still cuts at a 3 MiB threshold using a fixed 1 KiB/row estimate
+(about 3,072 rows/block), rather than realized encoded bytes. Self-derived
+geometry is not implemented until that path is wired for local/cloud targets.
+
 An exact norm is metric auxiliary data, not an exact-vector tier. It can improve magnitude-
 sensitive L2/dot estimates, is algebraically irrelevant to cosine after positive radial
 rescaling, and supplies no L1-specific guarantee. `exact` remains reserved for original f32
@@ -386,6 +400,10 @@ leaving RaBitQ at the header.
   `SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc` and `BENCHMARK_EVIDENCE.toml`.
 * **TD-RDSTRAT-7 bytes ratchet:** same end-to-end protocol, recall@10 `>= 0.98`, no material
   GET regression, and bytes/query materially below `31.7 MB`. Codec-only ratios are diagnostic.
+* **N=1M scale ratchet (measured 2026-07-16, currently failing):** flat SQ8
+  recall@10 `0.968`, `61` GETs/query, `138,851,704` bytes/query. Restore
+  recall/GET via adaptive M and actual-byte block geometry before accepting
+  another bytes codec. Evidence: `RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc`.
 * Compaction test: N→1 merge yields fewer RaBitQ GETs/query + re-clustered tighter locality.
 
 == Initial open questions and resolution
@@ -447,3 +465,15 @@ stable physical field IDs with catalog/footer/block authority separation; skippa
 metadata but fail-closed unknown data encodings; auxiliary-region Bloom references; and a
 default-OFF clustered-residual SQ4 rerank encoding that replaces flat SQ8 only for eligible
 blocks. The RaBitQ header decision is unchanged.
+
+== Scale/bake-off amendment (2026-07-16)
+
+The serialized release bake-off rejected residual SQ6, TurboQuant4, and
+multi-bit RaBitQ4; no footer-v2 data encoding ships. A verified full TEXMEX
+N=1M run then showed that the flat control also misses the recall and GET gates.
+D6/D8 sequencing is amended accordingly: adaptive survivor M, realized-byte
+`IopsBudget` geometry, and scalable deterministic cluster fitting precede any
+new compact rerank tag. Higher-dimensional embeddings are evaluated, not
+assumed to help: the mandatory RaBitQ scan grows as
+`N * (ceil(dim/8)+8)`, as do rerank bytes and fitting cost. The header-first and
+Parquet-style footer decisions remain unchanged.

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -45,7 +45,7 @@ notes = "Non-regression baseline only — explicitly NOT a cost/recall SLA (rout
 
 [[claims]]
 id = "coalesced_rabitq_scan_rerank_sift"
-claim = "ADR-062 coalesced-RaBitQ scan-then-rerank reaches the ~0.99 recall regime at ~20 ranged GETs/query — vs the legacy block-centroid-prune ceiling of ~0.87 @ ~370 GETs (an 18.5x GET reduction, moving the dominant per_get cost term)"
+claim = "At N=100k, ADR-062 coalesced-RaBitQ scan-then-rerank reaches the ~0.99 recall regime at ~20 ranged GETs/query — vs the legacy block-centroid-prune ceiling of ~0.87 @ ~370 GETs (an 18.5x GET reduction, moving the dominant per_get cost term)"
 metric = "recall@10 + range_gets_per_query"
 status = "measured"
 asserted_in = [
@@ -59,6 +59,23 @@ hardware = "Local macOS arm64 (Apple Silicon), no other workload"
 date = "2026-07-15"
 version = "develop @ 3a703d0d0 (+ ADR-062/TD-RDSTRAT-6 PR1: coalesced_rabitq feature)"
 notes = "Single-file collection (one flush batch) with the IVF flush opt-in ON (PROXIMADB_PAX_FLUSH_CLUSTER=ivf) — isolates the per-file ~1 RaBitQ GET win from the PR2 GET-budget compaction. N=100000 subset, 100 queries, top-10, Euclidean, brute-force ground truth. Measured recall@10 = 0.984, range_gets/query = 20. Indicative dev-machine run, not an SLA; bytes_read/query (31.7 MB) is the deferred post-PR1 lever (clustered SQ8/fp32 compression)."
+
+[[claims]]
+id = "rdstrat6_bytes_codec_bakeoff_sift"
+claim = "The first deferred-bytes bake-off has no eligible codec: at N=100k SQ6 saves 7.0% query bytes but is 3.4x slower; TQ4/RaBitQ4 fail recall, and at N=1M flat SQ8 and SQ6 both fail the recall/GET gates"
+metric = "recall@10 + range_gets_per_query + bytes_read_per_query + latency + persisted_bytes_per_row"
+status = "measured"
+asserted_in = [
+  "docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc",
+  "docs/10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc",
+]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
+bench_command = "N=100k: set PROXIMADB_SIFT_N=100000; N=1M: omit PROXIMADB_SIFT_N; both: PROXIMADB_SIFT_DATASET_DIR=<verified-sift> PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture"
+artifact = "docs/_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), serialized release runs, no competing benchmark"
+date = "2026-07-16"
+version = "flat eae1cdf4e; SQ6 base 4f0cccf30 + diff sha256 9bddadab; TQ4 3a091c254; RaBitQ4 b4abf4cbc"
+notes = "N=100k flat/SQ6/TQ4/RaBitQ4 recall = 0.991/0.981/0.921/0.917; bytes/query = 32020233/29775220/25124981/25124830; GETs/query = 19. Verified TEXMEX N=1M: flat recall 0.968, 61 GETs, 138851704 bytes/query; SQ6 recall 0.950, 61 GETs, 128722140 bytes/query. Prototype code intentionally discarded after rejection; artifact records source states and dataset hashes. Indicative dev-machine evidence, not an SLA."
 
 # ---------------------------------------------------------------------------
 # UNVERIFIED — a bench exists, but no dated artifact backs the claimed number.

--- a/docs/_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc
+++ b/docs/_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-7 deferred-bytes bake-off and full SIFT1M gate (2026-07-16)
+:toc: macro
+
+toc::[]
+
+== Decision
+
+No evaluated compact rerank encoding is eligible to ship. Residual SQ6 was the
+only prototype that cleared recall@10 `>= 0.98` at N=100k, but it reduced query
+bytes by only 7.0% and made mean query latency 3.4x worse. TurboQuant4 and
+multi-bit RaBitQ4 reduced bytes by about 21.5% but missed the recall floor by
+5.9 and 6.3 percentage points.
+
+At genuine N=1M, both flat SQ8 and residual SQ6 fail the recall and GET gates.
+This exposes prerequisites below the codec layer: the RaBitQ survivor pool stays
+fixed at 1,000 while the segment grows 10x, and the declared `IopsBudget` is not
+wired into PAX block geometry. SQ6 does not repair either issue and further
+reduces recall. No durable codec tag or footer-v2 writer is accepted from this
+bake-off.
+
+== Protocol and provenance
+
+All arms used the same release-profile ignored eval,
+`tests/sift_pax_recall_ratchet_test.rs::sift_coalesced_rabitq_scan_rerank_eval`:
+one flush batch, one segment, IVF ordering ON, 100 queries, top-10, Euclidean.
+Runs were serialized and used isolated `target/` directories.
+
+Arm selection used no additional gate for flat SQ8,
+`PROXIMADB_PAX_CLUSTERED_RESIDUAL_SQ4=1` for the SQ6 prototype,
+`PROXIMADB_PAX_COALESCED_RERANK=tq4` for TurboQuant4, and
+`PROXIMADB_PAX_COALESCED_RERANK=rabitq4` for multi-bit RaBitQ4. Every command
+set `PROXIMADB_SIFT_DATASET_DIR`, `PROXIMADB_SIFT_QUERIES=100`, and the recall
+floor `PROXIMADB_SIFT_COALESCED_RECALL_FLOOR=0.98`; N=100k additionally set
+`PROXIMADB_SIFT_N=100000`.
+
+N=100k used a subset plus brute-force ground truth. N=1M omitted
+`PROXIMADB_SIFT_N`, consumed all base rows, and used supplied TEXMEX ground
+truth. Full-dataset SHA-256 values were:
+
+[cols="1,2", options="header"]
+|===
+| File | SHA-256
+| `sift_base.fvecs` | `21f66e2975057b5728ba56de1c825bac4f4d89d596609ae985741c6242631816`
+| `sift_query.fvecs` | `f7fc9be140accdfd64116c2fa2365ecdb69b8f084970c6b0532db5ff79ac8fdc`
+| `sift_groundtruth.ivecs` | `2b71de0a8d5a83e6a84eec3e23fb8b611d8801dd9b3a6cd62f070ab65ea65f4f`
+|===
+
+Hardware was local macOS arm64 Apple Silicon. Results are comparative evidence,
+not an SLA. Source states: flat `eae1cdf4e2aa46329635f32ab947dffa50a460a4`;
+SQ6 base `4f0cccf305d8b604ab023455f6d19f23deb8c466` plus experimental diff
+SHA-256 `9bddadabac0196a4d8afcbdb881f6e4b69cff338dd006ac61144bbc403c6ef61`;
+TurboQuant4 `3a091c2541f239785631363f30ccadb148eebd58`; multi-bit RaBitQ4
+`b4abf4cbcdcc2f5e3815ff1f61fa3f720e3acd1f`.
+
+== N=100k equal-protocol bake-off
+
+[cols="2,1,1,1,1,1,1,1", options="header"]
+|===
+| Tier | Recall@10 | GETs/q | Bytes/q | Persisted B/row | Flush ms | Mean/p95 us | Gate
+| Flat SQ8 | 0.991 | 19 | 32,020,233 | 260.68 | 157,413 | 11,756 / 14,413 | control
+| Residual SQ6 + exact norm | 0.981 | 19 | 29,775,220 | 241.08 | 156,382 | 39,688 / 54,402 | reject: bytes/latency
+| TurboQuant4 | 0.921 | 19 | 25,124,981 | 200.86 | 157,007 | 86,865 / 119,276 | reject: recall
+| Multi-bit RaBitQ4 | 0.917 | 19 | 25,124,830 | 200.86 | 156,210 | 83,299 / 117,107 | reject: recall
+|===
+
+ADR-062 diagnostic route costs, `20 * GETs + 5 * MiB_read`, are approximately
+532.7, 522.0, 499.8, and 499.8. Recall remains a hard constraint rather than a
+weighted term.
+
+== Genuine N=1M scale gate
+
+[cols="2,1,1,1,1,1,1,1", options="header"]
+|===
+| Tier | Recall@10 | GETs/q | Bytes/q | Persisted B/row | Flush ms | Mean/p95 us | Gate
+| Flat SQ8 | 0.968 | 61 | 138,851,704 | 262.31 | 2,882,310 | 81,239 / 101,360 | reject: recall/GETs
+| Residual SQ6 + exact norm | 0.950 | 61 | 128,722,140 | 235.71 | 2,650,480 | 169,997 / 259,812 | reject: recall/GETs/latency
+|===
+
+SQ6 saves 7.3% query bytes and 10.1% persisted bytes at full scale, but loses
+another 1.8 recall points and is 2.1x slower. The already-rejected 4-bit arms
+were not given another approximately 48-minute N=1M flush each.
+
+== Findings below the codec
+
+=== Candidate pool must scale
+
+`pax_rabitq_pool_for_top_k(10)` returns 1,000 candidates at both sizes: 1% of
+N=100k but 0.1% of N=1M. The scan ranks every row, but true neighbors must enter
+top-M before rerank can recover them. The follow-up must choose M from measured
+segment-scale recall or score confidence, then charge the added survivor blocks
+to the GET/byte budget. A top-k-only fixed multiplier is not a scale contract.
+
+=== `IopsBudget` is not active writer geometry
+
+Declared targets are local 1 MiB, cloud 4 MiB, and unknown-backend 2 MiB. This
+eval leaves `PROXIMADB_PAX_BLOCK_SIZE` unset; the writer uses a 3 MiB threshold
+and estimates every row as exactly 1 KiB, cutting near 3,072 rows regardless of
+encoding or dimension. At d128, 262 B/row including the 24 B/row RaBitQ region
+makes data blocks accidentally smaller than 1 MiB. The writer must instead use
+realized data-tier bytes/row and backend `IopsBudget`; the header region keeps
+its independent file/cache budget.
+
+=== Higher dimension is a trade, not an assumed rescue
+
+The mandatory region is `N * (ceil(d/8)+8)`: about 24 MB at d128, 104 MB at
+d768, 200 MB at d1536, and 392 MB at d3072 for one million rows. SQ8 survivor
+bytes grow as `d`, packed SQ6 as `0.75d`, and codebook/fitting work also grows.
+Normalized isotropic embeddings may improve a rotated binary estimator and
+permit smaller M; real model embeddings can be anisotropic with tight neighbor
+margins. Sweep d128/384/768/1536/3072 on real cosine and L2/dot workloads with
+adaptive M and local/cloud budgets; include mandatory region bytes.
+
+=== Producer scalability
+
+Full-scale flushes took about 48 and 44 minutes. A stack sample located the hot
+path at `cluster_order_pca_ivf -> kmeans_clustering_seeded`. Higher-dimensional
+trials require deterministic sampled/mini-batch or parallel fitting, or a
+reusable collection-level plan, while retaining one producer of row order and
+residual-run assignments.
+
+== Outcome for TD-RDSTRAT-7
+
+Footer-v2 descriptor tables, block-local parameters, mixed per-block
+assignments, fail-closed unknown encodings, and source fidelity remain valid.
+Sequencing changes:
+
+. restore N=1M recall/GET gates with adaptive M on flat SQ8;
+. wire actual bytes and backend `IopsBudget` into PAX block geometry;
+. scale deterministic cluster fitting;
+. only then test another codec and allocate a tag if recall, GETs, bytes, and
+  latency all pass.
+
+Until then flat SQ8 remains the accepted rerank tier and footer-v2 codec writes
+remain default OFF/unshipped.

--- a/docs/_internal/status/SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc
+++ b/docs/_internal/status/SIFT1M_COALESCED_RABITQ_RECALL_2026_07_15.adoc
@@ -72,3 +72,12 @@ default 0.95 — recall 0.984 clears it; the ratchet only goes up. GET budget fl
 * PR3 per-block OID bloom (`vector_by_id` fast path) — the `StatsKind` structure
   is emitted now; population/wiring is PR3.
 * Multi-file GET scaling, footer/bloom sizing at scale, schema-evolution — all PR2/PR3/follow-on.
+
+== 2026-07-16 full-scale follow-up
+
+This artifact is intentionally the N=100k PR1 measurement; its `0.984` recall
+and `20` GETs/query must not be generalized to N=1M. A verified full TEXMEX
+N=1M, 100-query follow-up measured flat SQ8 at recall@10 `0.968`, `61`
+GETs/query, and `138,851,704` bytes/query. The deferred-bytes bake-off and the
+scale prerequisites it exposed are recorded in
+link:RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc[the 2026-07-16 evidence].


### PR DESCRIPTION
## Outcome

Records the serialized release-profile TD-RDSTRAT-7 bakeoff and genuine SIFT1M scale follow-up. No compact rerank prototype met the acceptance gates, so this PR ships evidence and decision refinements only.

## Measured evidence

- N=100k: flat/SQ6/TQ4/RaBitQ4 recall 0.991/0.981/0.921/0.917; all at 19 GETs/query
- N=1M: flat 0.968 recall, 61 GETs, 138851704 bytes/query; SQ6 0.950 recall, 61 GETs, 128722140 bytes/query
- SQ6 is rejected despite modest byte savings; both 4-bit arms are rejected on recall
- full-scale run exposes fixed survivor M, unwired IopsBudget geometry, and seeded-kmeans scaling prerequisites

## Documentation changes

- adds the dated benchmark artifact with dataset hashes and source-state provenance
- updates ADR-062 and TD-RDSTRAT-6/7 without accepting a codec tag or footer-v2 writer
- scopes the original PR1 claim explicitly to N=100k
- adds a measured BENCHMARK_EVIDENCE.toml claim

## Validation

- make work-commit-check
- python3 scripts/validate_benchmark_evidence.py
- python3 scripts/check_td_adr_unique.py
- python3 scripts/check_no_agent_attribution.py --range origin/develop..HEAD
- git diff --check