### PR TITLE
fix(test): unbreak develop — objstore_zero_vector_recovery uses proximadb_embedded (missed by #1021)

### DIFF
--- a/tests/objstore_zero_vector_recovery_test.rs
+++ b/tests/objstore_zero_vector_recovery_test.rs
@@ -14,7 +14,7 @@
 //! an undefined (norm-0) direction — the suspected reason a flush/index build path
 //! would drop it.
 
-use proximadb::embedded::{EmbeddedConfig, EmbeddedProximaDB};
+use proximadb_embedded::{EmbeddedConfig, EmbeddedProximaDB};
 use std::collections::HashMap;
 
 const COLLECTION: &str = "kv_recovery";


### PR DESCRIPTION
## Problem — develop is red

`#1021` extracted the embedded module to the `proximadb-embedded` crate and updated **every** integration test to `use proximadb_embedded::…` — but missed `tests/objstore_zero_vector_recovery_test.rs`, which still imports the now-removed `proximadb::embedded`. It has **no cfg gate**, so the `Rust Compile (test)` job compiles it unconditionally and fails:

```
error[E0432]: unresolved import `proximadb::embedded`
  --> tests/objstore_zero_vector_recovery_test.rs:17
```

This makes **develop red** (last two develop pushes — #1047, #1050 — both failed CI) and, because PR CI merges with develop, blocks **every open PR** on the `CI Success` aggregator.

## Fix

One-line import swap — exactly what #1021 applied to the 8+ sibling embedded tests:

```diff
-use proximadb::embedded::{EmbeddedConfig, EmbeddedProximaDB};
+use proximadb_embedded::{EmbeddedConfig, EmbeddedProximaDB};
```

`proximadb-embedded` is already a root dev-dependency; the test uses nothing else from the moved module.

## Verification
`cargo check -p proximadb --test objstore_zero_vector_recovery_test` → compiles clean (was the sole remaining `proximadb::embedded` user in `tests/`).