### PR TITLE
fix(wal): make object-store recovery restartable

### DIFF
--- a/crates/storage/proximadb-storage-encryption/src/filesystem.rs
+++ b/crates/storage/proximadb-storage-encryption/src/filesystem.rs
@@ -195,6 +195,22 @@ impl FileSystem for EncryptedFilesystem {
         self.write_encrypted(path, data, options).await
     }
 
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let actual_path = self.actual_path(path);
+        let encrypted = self
+            .encryption
+            .encrypt_file(path, data)
+            .map_err(|e| Self::crypto_error("encryption", path, e))?;
+        self.underlying
+            .write_if_absent(&actual_path, &encrypted, options)
+            .await
+    }
+
     async fn sync_file(&self, path: &str) -> FsResult<()> {
         if self.encrypted_exists(path).await? {
             let actual_path = self.actual_path(path);

--- a/crates/storage/proximadb-storage-encryption/src/lib.rs
+++ b/crates/storage/proximadb-storage-encryption/src/lib.rs
@@ -26,7 +26,7 @@ pub mod wal_encryption;
 
 use aes_gcm::{
     Aes256Gcm, Nonce,
-    aead::{Aead, AeadCore, KeyInit, OsRng},
+    aead::{Aead, AeadCore, KeyInit, OsRng, Payload},
 };
 use anyhow::Result;
 use sha2::{Digest, Sha256};
@@ -105,6 +105,83 @@ pub fn decrypt_data(key: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>> {
     cipher
         .decrypt(nonce, encrypted_data)
         .map_err(|e| anyhow::anyhow!("Decryption failed: {}", e))
+}
+
+/// AES-GCM encryption with authenticated-but-plaintext associated data.
+pub fn encrypt_data_with_aad(key: &[u8; 32], plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
+    let cipher = Aes256Gcm::new(key.into());
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let mut ciphertext = cipher
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("Encryption failed: {e}"))?;
+    let mut result = Vec::with_capacity(nonce.len() + ciphertext.len());
+    result.extend_from_slice(&nonce);
+    result.append(&mut ciphertext);
+    Ok(result)
+}
+
+pub fn decrypt_data_with_aad(key: &[u8; 32], ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
+    if ciphertext.len() < 12 {
+        return Err(anyhow::anyhow!("Ciphertext too short"));
+    }
+    let cipher = Aes256Gcm::new(key.into());
+    let (nonce, encrypted_data) = ciphertext.split_at(12);
+    cipher
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: encrypted_data,
+                aad,
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("Decryption failed: {e}"))
+}
+
+pub fn generate_aes_gcm_nonce() -> [u8; 12] {
+    let generated = Aes256Gcm::generate_nonce(&mut OsRng);
+    let mut nonce = [0u8; 12];
+    nonce.copy_from_slice(&generated);
+    nonce
+}
+
+pub fn encrypt_data_with_nonce_and_aad(
+    key: &[u8; 32],
+    plaintext: &[u8],
+    nonce: &[u8; 12],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
+    Aes256Gcm::new(key.into())
+        .encrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("Encryption failed: {e}"))
+}
+
+pub fn decrypt_data_with_nonce_and_aad(
+    key: &[u8; 32],
+    ciphertext: &[u8],
+    nonce: &[u8; 12],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
+    Aes256Gcm::new(key.into())
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: ciphertext,
+                aad,
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("Decryption failed: {e}"))
 }
 
 /// Derive encryption key from master password using HKDF

--- a/crates/storage/proximadb-storage-encryption/src/wal_encryption.rs
+++ b/crates/storage/proximadb-storage-encryption/src/wal_encryption.rs
@@ -9,12 +9,15 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use super::key_manager::{KeyVersionId, KeyVersionManager};
-use super::{decrypt_data, encrypt_data};
+use super::{
+    decrypt_data, decrypt_data_with_aad, decrypt_data_with_nonce_and_aad, encrypt_data,
+    encrypt_data_with_nonce_and_aad, generate_aes_gcm_nonce,
+};
 
 /// WAL segment metadata with encryption info
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +32,10 @@ pub struct WalSegmentMetadata {
     pub encrypted: bool,
     /// Segment size in bytes
     pub size_bytes: u64,
+    /// AES-GCM nonce for self-describing WAL envelopes. Legacy segments keep
+    /// the nonce prefixed to the ciphertext and deserialize this as `None`.
+    #[serde(default)]
+    pub nonce: Option<Vec<u8>>,
 }
 
 /// WAL encryption layer
@@ -63,6 +70,7 @@ impl WALEncryptionLayer {
                 key_version: self.key_manager.current_version(),
                 encrypted: false,
                 size_bytes: plaintext.len() as u64,
+                nonce: None,
             };
             return Ok((plaintext.to_vec(), metadata));
         }
@@ -78,6 +86,7 @@ impl WALEncryptionLayer {
             key_version,
             encrypted: true,
             size_bytes: ciphertext.len() as u64,
+            nonce: None,
         };
 
         debug!(
@@ -89,6 +98,71 @@ impl WALEncryptionLayer {
         );
 
         Ok((ciphertext, metadata))
+    }
+
+    pub fn prepare_segment_metadata(
+        &self,
+        segment_name: &str,
+        segment_id: u64,
+        plaintext_len: usize,
+    ) -> WalSegmentMetadata {
+        WalSegmentMetadata {
+            segment_name: segment_name.to_string(),
+            segment_id,
+            key_version: self.key_manager.current_version(),
+            encrypted: self.encryption_enabled,
+            size_bytes: if self.encryption_enabled {
+                plaintext_len.saturating_add(16) as u64
+            } else {
+                plaintext_len as u64
+            },
+            nonce: self
+                .encryption_enabled
+                .then(|| generate_aes_gcm_nonce().to_vec()),
+        }
+    }
+
+    pub fn encrypt_segment_with_metadata_and_aad(
+        &self,
+        metadata: &WalSegmentMetadata,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>> {
+        if !metadata.encrypted {
+            return Ok(plaintext.to_vec());
+        }
+        let key = self
+            .key_manager
+            .derive_wal_key(&metadata.segment_name, metadata.segment_id);
+        let nonce: [u8; 12] = metadata
+            .nonce
+            .as_deref()
+            .context("WAL envelope encryption metadata has no nonce")?
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("WAL envelope nonce must be 12 bytes"))?;
+        encrypt_data_with_nonce_and_aad(&key, plaintext, &nonce, aad)
+    }
+
+    pub fn decrypt_segment_with_aad(
+        &self,
+        metadata: &WalSegmentMetadata,
+        ciphertext: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>> {
+        if !metadata.encrypted {
+            return Ok(ciphertext.to_vec());
+        }
+        let key = self
+            .key_manager
+            .derive_wal_key(&metadata.segment_name, metadata.segment_id);
+        if let Some(nonce) = metadata.nonce.as_deref() {
+            let nonce: [u8; 12] = nonce
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("WAL envelope nonce must be 12 bytes"))?;
+            decrypt_data_with_nonce_and_aad(&key, ciphertext, &nonce, aad)
+        } else {
+            decrypt_data_with_aad(&key, ciphertext, aad)
+        }
     }
 
     /// Decrypt WAL segment after reading
@@ -244,6 +318,40 @@ mod tests {
             .decrypt_segment(&metadata, &ciphertext)
             .expect("failed to decrypt segment");
         assert_eq!(decrypted, plaintext.to_vec());
+    }
+
+    #[test]
+    fn envelope_nonce_and_aad_are_authenticated() {
+        unsafe {
+            std::env::set_var(
+                "TEST_PROXIMADB_MASTER_KEY",
+                "test-master-key-32-bytes-long-here!!",
+            );
+        }
+        let key_manager = std::sync::Arc::new(
+            KeyManager::from_env("TEST_PROXIMADB_MASTER_KEY")
+                .expect("failed to create key manager"),
+        );
+        let layer = WALEncryptionLayer::new(
+            std::sync::Arc::new(KeyVersionManager::new(key_manager)),
+            true,
+        );
+        let metadata = layer.prepare_segment_metadata("wal", 7, 7);
+        assert_eq!(metadata.nonce.as_deref().map(<[u8]>::len), Some(12));
+        let ciphertext = layer
+            .encrypt_segment_with_metadata_and_aad(&metadata, b"payload", b"header")
+            .unwrap();
+        assert_eq!(
+            layer
+                .decrypt_segment_with_aad(&metadata, &ciphertext, b"header")
+                .unwrap(),
+            b"payload"
+        );
+        assert!(
+            layer
+                .decrypt_segment_with_aad(&metadata, &ciphertext, b"tampered")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/counting.rs
@@ -195,6 +195,14 @@ impl FileSystem for CountingFileSystem {
     async fn write(&self, path: &str, data: &[u8], options: Option<FileOptions>) -> FsResult<()> {
         self.inner.write(path, data, options).await
     }
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        self.inner.write_if_absent(path, data, options).await
+    }
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
         self.inner.append(path, data).await
     }

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -521,6 +521,22 @@ pub trait FileSystem: Send + Sync + std::fmt::Debug {
     /// Write file contents
     async fn write(&self, path: &str, data: &[u8], options: Option<FileOptions>) -> FsResult<()>;
 
+    /// Atomically create a new file/object, failing with [`FilesystemError::AlreadyExists`]
+    /// when the key is already present. Recovery protocols use this as their commit
+    /// primitive; implementations must not emulate it with a racy exists-then-write.
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let _ = (data, options);
+        Err(FilesystemError::InvalidOperation(format!(
+            "{} does not support conditional create for {path}",
+            self.filesystem_type()
+        )))
+    }
+
     /// Sync file data to disk (fsync/fdatasync)
     /// Ensures data durability after write operations
     /// Returns Ok(()) if sync is not supported by the filesystem

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -285,20 +285,39 @@ impl RecordOpsService {
 
     /// Lease-on-write: make the shared primary-pod registry truthful for
     /// `(tenant, collection)` by acquiring/confirming this pod's durable
-    /// collection lease before the write proceeds. Keyed by the collection NAME
-    /// (`request.collection_id`) and the transport tenant id — the exact pair the
-    /// network gates' `consult_for_write` uses — so the binding this populates is
-    /// the one the gates read. Idempotent + cheap after the first write (registry
-    /// fast-path; the renew loop keeps the lease warm). A missing manager still
+    /// collection lease before the write proceeds. The durable key is always the
+    /// resolved canonical collection UUID; aliases/names must never fork the
+    /// generation fence used by WAL recovery. Idempotent + cheap after the first
+    /// write (registry fast-path; the renew loop keeps the lease warm). A missing manager still
     /// indicates embedded/single-node operation; once a manager is wired, conflicts
     /// and acquire errors reject the write instead of proceeding fail-open.
-    async fn ensure_collection_lease(&self, tenant_id: &str, collection_name: &str) -> Result<()> {
+    async fn ensure_collection_lease(
+        &self,
+        tenant_id: &str,
+        collection_name: &str,
+        canonical_collection_id: &str,
+    ) -> Result<()> {
         let Some(manager) = self.lease_manager.read().ok().and_then(|g| g.clone()) else {
             return Ok(());
         };
         let now_ms = chrono::Utc::now().timestamp_millis();
+        let routing_owned = manager
+            .ensure_owned(tenant_id, canonical_collection_id, now_ms)
+            .await?;
+        if !routing_owned {
+            tracing::warn!(
+                target = "proximadb.primary_pod.lease_on_write",
+                tenant_id = %tenant_id,
+                collection_id = %collection_name,
+                "lease-on-write: this pod is not the primary for the collection; rejecting write"
+            );
+            return Err(anyhow!(
+                "this pod is not the primary for collection '{}'",
+                collection_name
+            ));
+        }
         match manager
-            .ensure_owned(tenant_id, collection_name, now_ms)
+            .begin_writer_incarnation(tenant_id, canonical_collection_id, now_ms)
             .await
         {
             Ok(true) => Ok(()),
@@ -306,12 +325,12 @@ impl RecordOpsService {
                 tracing::warn!(
                     target = "proximadb.primary_pod.lease_on_write",
                     tenant_id = %tenant_id,
-                    collection_id = %collection_name,
-                    "lease-on-write: this pod is not the primary for the collection; rejecting write"
+                    collection_id = %canonical_collection_id,
+                    "writer incarnation is fenced; rejecting WAL write"
                 );
                 Err(anyhow!(
                     "this pod is not the primary for collection '{}'",
-                    collection_name
+                    canonical_collection_id
                 ))
             }
             Err(e) => {
@@ -491,7 +510,7 @@ impl RecordOpsService {
             ));
         }
         if let Err(e) = self
-            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name, &collection_id)
             .await
         {
             return Ok(BatchOperationResult::failure(
@@ -561,7 +580,7 @@ impl RecordOpsService {
             ));
         }
         if let Err(e) = self
-            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name, &collection_id)
             .await
         {
             return Ok(BatchOperationResult::failure(
@@ -642,7 +661,7 @@ impl RecordOpsService {
             ));
         }
         if let Err(e) = self
-            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name)
+            .ensure_collection_lease(tenant_id.unwrap_or(""), &collection_name, &collection_id)
             .await
         {
             return Ok(BatchOperationResult::failure(

--- a/src/cluster/partition_lease.rs
+++ b/src/cluster/partition_lease.rs
@@ -45,6 +45,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::{OnceLock, RwLock as StdRwLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -2049,6 +2050,47 @@ impl PartitionLeaseStore {
         }
     }
 
+    /// Begin a new writer process incarnation. Unlike lease renewal, this always
+    /// advances the durable generation, including when the same pod id held the
+    /// previous lease. That makes `{generation, process-local sequence}` a total
+    /// order across process restarts without adding I/O per WAL batch.
+    pub async fn begin_writer_incarnation_with_key(
+        &self,
+        key: &ResourceKey,
+        holder_pod: &str,
+        now_ms: i64,
+        lease_ms: i64,
+    ) -> Result<LeaseOutcome> {
+        let committer = self.committer_for_key(key)?;
+        let (parent, generation) = match self.read_key(key).await? {
+            None => (None, 1),
+            Some((version, lease)) => {
+                if !lease.released && !lease.is_expired(now_ms) && lease.holder_pod != holder_pod {
+                    return Ok(LeaseOutcome::Held { by: lease });
+                }
+                (Some(version), lease.generation.saturating_add(1))
+            }
+        };
+        let lease = PartitionLease::with_key(
+            key.clone(),
+            holder_pod,
+            generation,
+            now_ms,
+            now_ms.saturating_add(lease_ms),
+        );
+        let payload = serde_json::to_vec(&lease).context("encoding writer incarnation lease")?;
+        match committer
+            .commit_fenced(parent, generation, bytes::Bytes::from(payload))
+            .await?
+        {
+            CommitOutcome::Committed(_) => Ok(LeaseOutcome::Acquired(lease)),
+            CommitOutcome::Conflict { .. } => match self.read_key(key).await? {
+                Some((_, latest)) => Ok(LeaseOutcome::Fenced { latest }),
+                None => Ok(LeaseOutcome::Fenced { latest: lease }),
+            },
+        }
+    }
+
     /// Legacy compatibility: convert (tenant_id, collection_id) to ResourceKey
     /// and delegate to acquire_with_key.
     async fn acquire_via_key(
@@ -2167,6 +2209,27 @@ pub struct PartitionLeaseManager {
     /// Full-key leases held by this pod that are not represented in the legacy
     /// `(tenant, collection)` primary-pod registry.
     held_resource_keys: DashMap<String, ResourceKey>,
+    /// Incarnation bumps already performed by this process. A new manager on
+    /// restart starts empty and therefore performs a fresh durable CAS bump.
+    writer_incarnations: DashMap<String, (u64, i64)>,
+}
+
+fn global_manager_slot() -> &'static StdRwLock<Option<Arc<PartitionLeaseManager>>> {
+    static SLOT: OnceLock<StdRwLock<Option<Arc<PartitionLeaseManager>>>> = OnceLock::new();
+    SLOT.get_or_init(|| StdRwLock::new(None))
+}
+
+pub fn install_global_partition_lease_manager(manager: Arc<PartitionLeaseManager>) {
+    if let Ok(mut slot) = global_manager_slot().write() {
+        *slot = Some(manager);
+    }
+}
+
+pub fn global_partition_lease_manager() -> Option<Arc<PartitionLeaseManager>> {
+    global_manager_slot()
+        .read()
+        .ok()
+        .and_then(|slot| slot.clone())
 }
 
 impl PartitionLeaseManager {
@@ -2184,6 +2247,7 @@ impl PartitionLeaseManager {
             lease_ms,
             strategies: DashMap::new(),
             held_resource_keys: DashMap::new(),
+            writer_incarnations: DashMap::new(),
         }
     }
 
@@ -2258,6 +2322,45 @@ impl PartitionLeaseManager {
             return Ok(true);
         }
         self.acquire(tenant_id, collection_id, now_ms).await
+    }
+
+    /// Ensure this process has a durable, incarnation-unique epoch for the
+    /// canonical collection UUID and publish it to the WAL token provider.
+    pub async fn begin_writer_incarnation(
+        &self,
+        tenant_id: &str,
+        canonical_collection_id: &str,
+        now_ms: i64,
+    ) -> Result<bool> {
+        let cache_key = format!("{tenant_id}/{canonical_collection_id}");
+        if let Some(state) = self.writer_incarnations.get(&cache_key)
+            && now_ms < state.1
+        {
+            crate::storage::persistence::write_ahead_log::RecoveryTokenProvider::global()
+                .register_incarnation(tenant_id, canonical_collection_id, state.0, state.1);
+            return Ok(true);
+        }
+
+        let key = ResourceKey::legacy_collection(tenant_id, canonical_collection_id);
+        let outcome = self
+            .store
+            .begin_writer_incarnation_with_key(&key, &self.self_pod_id, now_ms, self.lease_ms)
+            .await?;
+        match outcome {
+            LeaseOutcome::Acquired(lease) => {
+                self.writer_incarnations
+                    .insert(cache_key, (lease.generation, lease.expires_at_ms));
+                crate::storage::persistence::write_ahead_log::RecoveryTokenProvider::global()
+                    .register_incarnation(
+                        tenant_id,
+                        canonical_collection_id,
+                        lease.generation,
+                        lease.expires_at_ms,
+                    );
+                Ok(true)
+            }
+            LeaseOutcome::Held { .. } | LeaseOutcome::Fenced { .. } => Ok(false),
+        }
     }
 
     /// Read the current durable leaseholder for `(tenant, collection)` — the
@@ -2405,6 +2508,46 @@ impl PartitionLeaseManager {
                     );
                     crate::metrics::dml_lock_metrics::record_renewal_failure("collection");
                     still_owned += 1;
+                }
+            }
+        }
+
+        let incarnations = self
+            .writer_incarnations
+            .iter()
+            .map(|entry| (entry.key().clone(), *entry.value()))
+            .collect::<Vec<_>>();
+        for (identity, (_epoch, _expiry)) in incarnations {
+            let Some((tenant_id, collection_id)) = identity.split_once('/') else {
+                continue;
+            };
+            let key = ResourceKey::legacy_collection(tenant_id, collection_id);
+            match self
+                .store
+                .acquire_with_key(&key, &self.self_pod_id, now_ms, self.lease_ms)
+                .await
+            {
+                Ok(LeaseOutcome::Acquired(lease)) => {
+                    self.writer_incarnations
+                        .insert(identity.clone(), (lease.generation, lease.expires_at_ms));
+                    crate::storage::persistence::write_ahead_log::RecoveryTokenProvider::global()
+                        .register_incarnation(
+                            tenant_id,
+                            collection_id,
+                            lease.generation,
+                            lease.expires_at_ms,
+                        );
+                    still_owned += 1;
+                }
+                Ok(LeaseOutcome::Held { .. } | LeaseOutcome::Fenced { .. }) => {
+                    self.writer_incarnations.remove(&identity);
+                    let _ = crate::storage::persistence::write_ahead_log::RecoveryTokenProvider::global()
+                        .expire(collection_id);
+                }
+                Err(error) => {
+                    // Keep the last durable expiry. Allocation fails closed once
+                    // it passes, even if renewal keeps returning transient errors.
+                    tracing::warn!(resource = %identity, %error, "writer incarnation renewal failed");
                 }
             }
         }
@@ -3129,6 +3272,36 @@ mod tests {
             pod,
             LEASE_MS,
         )
+    }
+
+    #[tokio::test]
+    async fn writer_incarnation_bumps_epoch_after_same_pod_restart() -> Result<()> {
+        let backing = shared_backing();
+        let first_process = test_manager(&backing, "stable-pod-id");
+        assert!(
+            first_process
+                .begin_writer_incarnation("tenant", "canonical-uuid", 1)
+                .await?
+        );
+        let (_, first) = store(&backing)
+            .read("tenant", "canonical-uuid")
+            .await?
+            .expect("first incarnation lease");
+
+        // A fresh manager represents a process restart but deliberately keeps
+        // the pod identity. It must bump, not renew/reuse, the generation.
+        let restarted_process = test_manager(&backing, "stable-pod-id");
+        assert!(
+            restarted_process
+                .begin_writer_incarnation("tenant", "canonical-uuid", 2)
+                .await?
+        );
+        let (_, second) = store(&backing)
+            .read("tenant", "canonical-uuid")
+            .await?
+            .expect("second incarnation lease");
+        assert!(second.generation > first.generation);
+        Ok(())
     }
 
     /// `validate_fencing` is the storage-boundary contract (A6). None =

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -2120,6 +2120,9 @@ impl SharedServices {
                         pod_id.clone(),
                         10_000,
                     ));
+                    crate::cluster::partition_lease::install_global_partition_lease_manager(
+                        manager.clone(),
+                    );
                     // P1a: keep held leases warm. Without this the renew loop
                     // never runs in production (it was only spawned in tests),
                     // so held leases lapse after the 10s TTL and the

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -169,7 +169,18 @@ impl SstEngine {
                     (BlockFormat::PaxBlock, "pax")
                 }
             };
-        let sst_filename = codec.generate(0, file_extension); // Level 0 for flush
+        let sst_filename = params
+            .hints
+            .get("recovery_materialization_id")
+            .and_then(|value| value.as_str())
+            .map(|id| {
+                let safe_id: String = id
+                    .chars()
+                    .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+                    .collect();
+                format!("L0_recovery_{safe_id}.{file_extension}")
+            })
+            .unwrap_or_else(|| codec.generate(0, file_extension)); // Level 0 for flush
         debug!(
             "🔧 SST: Creating {} file: {} for collection: {}",
             if block_format == BlockFormat::ArrowBlock {
@@ -463,12 +474,65 @@ impl SstEngine {
         });
         let bytes_written = file_metadata.size;
 
-        // Commit the atomic operation
-        tracing::debug!(operation_id = %atomic_op.operation_id, "Committing atomic operation");
-        self.atomic_coordinator()
-            .finalize_atomic_operation(&atomic_op.operation_id)
-            .await
-            .context("Failed to commit atomic flush operation")?;
+        let recovery_materialization = params
+            .hints
+            .get("recovery_materialization_id")
+            .and_then(|value| value.as_str());
+        let mut already_materialized = false;
+        if recovery_materialization.is_some() {
+            // The deterministic segment object is the recovery commit record.
+            // Create-only publication closes the crash window between flush and
+            // WAL retirement without a second marker object.
+            let staged_bytes = fs
+                .read(&staging_url)
+                .await
+                .context("reading staged recovery segment")?;
+            let final_url = format!("{}/{}", atomic_op.final_url, filename);
+            let final_fs = self.filesystem().get_filesystem(&final_url)?;
+            match final_fs
+                .write_if_absent(
+                    &final_url,
+                    &staged_bytes,
+                    Some(crate::storage::persistence::filesystem::FileOptions {
+                        create_dirs: true,
+                        overwrite: false,
+                        ..Default::default()
+                    }),
+                )
+                .await
+            {
+                Ok(()) => {}
+                Err(crate::storage::persistence::filesystem::FilesystemError::AlreadyExists(_)) => {
+                    let existing = final_fs
+                        .read(&final_url)
+                        .await
+                        .context("verifying existing recovery segment")?;
+                    if existing != staged_bytes {
+                        anyhow::bail!(
+                            "recovery segment collision at {final_url}: deterministic name exists with different bytes"
+                        );
+                    }
+                    already_materialized = true;
+                }
+                Err(error) => return Err(error).context("publishing recovery segment"),
+            }
+            if let Err(error) = self
+                .atomic_coordinator()
+                .abort_atomic_operation(
+                    &atomic_op.operation_id,
+                    "recovery segment published with conditional create",
+                )
+                .await
+            {
+                tracing::warn!(%error, "failed to clean recovery staging operation");
+            }
+        } else {
+            tracing::debug!(operation_id = %atomic_op.operation_id, "Committing atomic operation");
+            self.atomic_coordinator()
+                .finalize_atomic_operation(&atomic_op.operation_id)
+                .await
+                .context("Failed to commit atomic flush operation")?;
+        }
         tracing::debug!(
             final_url = %atomic_op.final_url,
             filename = %filename,
@@ -543,6 +607,32 @@ impl SstEngine {
 
         let final_file_path = format!("{}/{}", atomic_op.final_url, filename);
 
+        if already_materialized {
+            return Ok(FlushResult {
+                success: true,
+                collections_affected: vec![params.collection_id.clone().unwrap_or_default()],
+                entries_flushed: Some(entries_written),
+                bytes_written: Some(bytes_written),
+                files_created: Some(0),
+                file_paths: vec![final_file_path],
+                duration_ms: Some(0),
+                completed_at: Utc::now(),
+                engine_metrics: HashMap::from([
+                    (
+                        "engine".to_string(),
+                        serde_json::Value::String("SST".to_string()),
+                    ),
+                    (
+                        "already_materialized".to_string(),
+                        serde_json::Value::Bool(true),
+                    ),
+                ]),
+                compaction_triggered: false,
+                compaction_error: None,
+                flushed_batch_ids: params.batch_ids.clone(),
+            });
+        }
+
         // Check if compaction should be triggered (per-collection tag cascade,
         // TD-WLP-2 — the global env stays the master kill-switch).
         let collection_tags: &[String] = params
@@ -551,9 +641,17 @@ impl SstEngine {
             .and_then(|c| c.config.as_ref())
             .map(|cfg| cfg.tags.as_slice())
             .unwrap_or(&[]);
-        let should_trigger_compaction = self
-            .should_trigger_compaction(storage_url, collection_tags)
-            .await?;
+        let suppress_recovery_compaction = params
+            .hints
+            .get("suppress_compaction_until_wal_retired")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let should_trigger_compaction = if suppress_recovery_compaction {
+            false
+        } else {
+            self.should_trigger_compaction(storage_url, collection_tags)
+                .await?
+        };
 
         // TD-WLP-7 (ADR-061 D3): actually EXECUTE compaction when armed. Before
         // this, the flush only set `compaction_triggered` and nothing scheduled

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -294,6 +294,11 @@ impl SstEngine {
         params: &FlushParameters,
         block_format: BlockFormat,
     ) -> Result<FlushResult> {
+        let recovery_materialization = params
+            .hints
+            .get("recovery_materialization_id")
+            .and_then(|value| value.as_str());
+
         // Begin atomic operation
         let staging_config = StagingConfig {
             base_url: storage_url.to_string(),
@@ -307,16 +312,41 @@ impl SstEngine {
 
         tracing::debug!(storage_url = %storage_url, filename = %filename, "Starting flush operation");
 
-        let atomic_op = self
-            .atomic_coordinator()
-            .begin_atomic_operation(&staging_config)
-            .await
-            .context("Failed to begin atomic flush operation")?;
+        let atomic_op = if recovery_materialization.is_some() {
+            // Recovery publishes directly to the deterministic final object via
+            // write_if_absent. Track it as zero-copy managed so abort only removes
+            // coordinator metadata and never tries to delete an object-store
+            // staging prefix that was intentionally never created.
+            self.atomic_coordinator()
+                .begin_zero_copy_managed_operation(&staging_config)
+                .await
+                .context("Failed to begin recovery publication")?
+        } else {
+            self.atomic_coordinator()
+                .begin_atomic_operation(&staging_config)
+                .await
+                .context("Failed to begin atomic flush operation")?
+        };
 
         tracing::debug!(staging_url = %atomic_op.staging_url, final_url = %atomic_op.final_url, "Atomic operation initialized");
 
-        // Write to staging using appropriate writer based on block format
-        let staging_url = format!("{}/{}", atomic_op.staging_url, filename);
+        // PAX/Arrow writers materialize through a local path. During recovery the
+        // resulting bytes are published directly to the deterministic object name
+        // with write_if_absent, so using the object-store transaction staging URL
+        // here would create a local `adls:/...` path and then try to read an object
+        // that was never uploaded. Keep a scoped local directory alive until the
+        // conditional publication completes. Normal flushes retain their existing
+        // transaction-coordinator staging path.
+        let recovery_staging = if recovery_materialization.is_some() {
+            Some(tempfile::tempdir().context("creating local recovery staging directory")?)
+        } else {
+            None
+        };
+        let staging_url = if let Some(directory) = recovery_staging.as_ref() {
+            format!("file://{}", directory.path().join(filename).display())
+        } else {
+            format!("{}/{}", atomic_op.staging_url, filename)
+        };
         tracing::debug!(staging_path = %staging_url, "Full staging path constructed");
 
         // Count entries for writing
@@ -474,10 +504,6 @@ impl SstEngine {
         });
         let bytes_written = file_metadata.size;
 
-        let recovery_materialization = params
-            .hints
-            .get("recovery_materialization_id")
-            .and_then(|value| value.as_str());
         let mut already_materialized = false;
         if recovery_materialization.is_some() {
             // The deterministic segment object is the recovery commit record.
@@ -518,13 +544,10 @@ impl SstEngine {
             }
             if let Err(error) = self
                 .atomic_coordinator()
-                .abort_atomic_operation(
-                    &atomic_op.operation_id,
-                    "recovery segment published with conditional create",
-                )
+                .finalize_atomic_operation(&atomic_op.operation_id)
                 .await
             {
-                tracing::warn!(%error, "failed to clean recovery staging operation");
+                tracing::warn!(%error, "failed to finalize recovery publication tracking");
             }
         } else {
             tracing::debug!(operation_id = %atomic_op.operation_id, "Committing atomic operation");
@@ -1390,6 +1413,77 @@ mod tests {
             3,
             "the live flush path must index all flushed vectors into AXIS (TD-112)"
         );
+    }
+
+    #[tokio::test]
+    async fn recovery_materialization_is_idempotent() {
+        use crate::proto::proximadb_v1::{
+            Collection, CollectionConfig, StorageAssignment, StorageEngine,
+        };
+        use crate::storage::traits::UnifiedStorageFormat;
+
+        let engine = create_test_engine().await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let collection_id = "recovery_idempotence";
+        let collection = Collection {
+            id: collection_id.to_string(),
+            config: Some(CollectionConfig {
+                name: collection_id.to_string(),
+                dimension: 4,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: temp_dir.path().to_string_lossy().into_owned(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut hints = std::collections::HashMap::new();
+        hints.insert(
+            "recovery_materialization_id".to_string(),
+            serde_json::Value::String("00000000000000000001-00000000000000000007-digest".into()),
+        );
+        hints.insert(
+            "recovery_content_digest".to_string(),
+            serde_json::Value::String("digest".into()),
+        );
+        hints.insert(
+            "suppress_compaction_until_wal_retired".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let params = FlushParameters {
+            collection_id: Some(collection_id.to_string()),
+            vector_records: vec![
+                create_test_vector("v0", vec![1.0, 0.0, 0.0, 0.0]),
+                create_test_vector("v1", vec![0.0, 1.0, 0.0, 0.0]),
+            ],
+            force: true,
+            synchronous: true,
+            hints,
+            timeout_ms: None,
+            trigger_compaction: false,
+            batch_ids: vec![],
+            collection_config: Some(collection),
+            estimated_size: 0,
+        };
+
+        let first = engine
+            .do_flush(&params)
+            .await
+            .expect("first materialization");
+        assert_eq!(first.files_created, Some(1));
+
+        let replay = engine.do_flush(&params).await.expect("idempotent replay");
+        assert_eq!(replay.files_created, Some(0));
+        assert_eq!(
+            replay
+                .engine_metrics
+                .get("already_materialized")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(replay.file_paths, first.file_paths);
     }
 
     // ---- Phase C: per-collection PAX opt-out tag + global kill-switch ----

--- a/src/storage/persistence/filesystem/aws_s3.rs
+++ b/src/storage/persistence/filesystem/aws_s3.rs
@@ -23,7 +23,7 @@ use object_store::ObjectStore;
 use object_store::ObjectStoreExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjPath;
-use object_store::{Attribute, Attributes, PutOptions, PutPayload};
+use object_store::{Attribute, Attributes, PutMode, PutOptions, PutPayload};
 use std::sync::Arc;
 
 use super::{
@@ -205,6 +205,39 @@ impl FileSystem for AwsS3FileSystem {
             }
         }
         Ok(())
+    }
+
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let (bucket, key) = Self::parse(path)?;
+        let store = self.store_for(&bucket)?;
+        let dst = ObjPath::from(key);
+        let mut attributes = Attributes::new();
+        if let Some(tier) = options.as_ref().and_then(FileOptions::access_tier) {
+            attributes.insert(Attribute::StorageClass, tier.as_s3_storage_class().into());
+        }
+        let result = store
+            .put_opts(
+                &dst,
+                PutPayload::from(data.to_vec()),
+                PutOptions {
+                    mode: PutMode::Create,
+                    attributes,
+                    ..Default::default()
+                },
+            )
+            .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(object_store::Error::AlreadyExists { .. }) => {
+                Err(FilesystemError::AlreadyExists(path.to_string()))
+            }
+            Err(error) => Err(Self::net("S3 conditional put", error)),
+        }
     }
 
     async fn append(&self, _path: &str, _data: &[u8]) -> FsResult<()> {

--- a/src/storage/persistence/filesystem/azure_blob.rs
+++ b/src/storage/persistence/filesystem/azure_blob.rs
@@ -39,7 +39,7 @@ use object_store::ObjectStore;
 use object_store::ObjectStoreExt;
 use object_store::azure::MicrosoftAzureBuilder;
 use object_store::path::Path as ObjPath;
-use object_store::{Attribute, Attributes, PutOptions, PutPayload};
+use object_store::{Attribute, Attributes, PutMode, PutOptions, PutPayload};
 use std::sync::Arc;
 
 use super::{
@@ -256,6 +256,39 @@ impl FileSystem for AzureBlobFileSystem {
             }
         }
         Ok(())
+    }
+
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let (container, blob) = Self::parse(path)?;
+        let store = self.store_for(&container)?;
+        let dst = ObjPath::from(blob);
+        let mut attributes = Attributes::new();
+        if let Some(tier) = options.as_ref().and_then(FileOptions::access_tier) {
+            attributes.insert(Attribute::StorageClass, tier.as_azure_access_tier().into());
+        }
+        let result = store
+            .put_opts(
+                &dst,
+                PutPayload::from(data.to_vec()),
+                PutOptions {
+                    mode: PutMode::Create,
+                    attributes,
+                    ..Default::default()
+                },
+            )
+            .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(object_store::Error::AlreadyExists { .. }) => {
+                Err(FilesystemError::AlreadyExists(path.to_string()))
+            }
+            Err(error) => Err(Self::net("Azure conditional put", error)),
+        }
     }
 
     async fn append(&self, _path: &str, _data: &[u8]) -> FsResult<()> {

--- a/src/storage/persistence/filesystem/caching_filesystem.rs
+++ b/src/storage/persistence/filesystem/caching_filesystem.rs
@@ -340,6 +340,24 @@ impl FileSystem for UnifiedCachingFilesystem {
         Ok(())
     }
 
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let cache_key = self.cache_key(path);
+        self.metadata_cache.invalidate(&cache_key).await;
+        self.disk_cache.invalidate(path).await;
+        self.underlying_fs
+            .write_if_absent(path, data, options)
+            .await?;
+        if self.should_cache_locally(path, data.len()) {
+            self.disk_cache.put(path, data).await;
+        }
+        Ok(())
+    }
+
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
         let cache_key = self.cache_key(path);
 

--- a/src/storage/persistence/filesystem/gcs_store.rs
+++ b/src/storage/persistence/filesystem/gcs_store.rs
@@ -86,6 +86,59 @@ impl GcsFileSystem {
     fn net(ctx: &str, e: impl std::fmt::Display) -> FilesystemError {
         FilesystemError::Network(format!("{ctx}: {e}"))
     }
+
+    async fn list_paginated(
+        &self,
+        path: &str,
+        max_results: Option<i32>,
+    ) -> FsResult<Vec<DirEntry>> {
+        let (bucket, prefix) = Self::parse(path)?;
+        let mut entries = Vec::new();
+        let mut page_token = None;
+
+        loop {
+            let requested_page_token = page_token.clone();
+            let res = self
+                .client
+                .list_objects(&ListObjectsRequest {
+                    bucket: bucket.clone(),
+                    prefix: Some(prefix.clone()),
+                    max_results,
+                    page_token: requested_page_token.clone(),
+                    ..Default::default()
+                })
+                .await
+                .map_err(|e| Self::net("GCS list_objects", e))?;
+
+            for obj in res.items.unwrap_or_default() {
+                let name = obj.name.rsplit('/').next().unwrap_or(&obj.name).to_string();
+                entries.push(DirEntry {
+                    name,
+                    url: format!("gs://{bucket}/{}", obj.name),
+                    metadata: FsFileMetadata {
+                        path: format!("gs://{bucket}/{}", obj.name),
+                        size: obj.size.max(0) as u64,
+                        is_directory: false,
+                        etag: Some(obj.etag),
+                        ..Default::default()
+                    },
+                });
+            }
+
+            page_token = res.next_page_token.filter(|token| !token.is_empty());
+            match &page_token {
+                None => break,
+                Some(next) if Some(next) == requested_page_token.as_ref() => {
+                    return Err(FilesystemError::Network(format!(
+                        "GCS list_objects returned a repeated page token for {path}"
+                    )));
+                }
+                Some(_) => {}
+            }
+        }
+
+        Ok(entries)
+    }
 }
 
 #[async_trait]
@@ -211,32 +264,7 @@ impl FileSystem for GcsFileSystem {
     }
 
     async fn list(&self, path: &str) -> FsResult<Vec<DirEntry>> {
-        let (bucket, prefix) = Self::parse(path)?;
-        let res = self
-            .client
-            .list_objects(&ListObjectsRequest {
-                bucket: bucket.clone(),
-                prefix: Some(prefix),
-                ..Default::default()
-            })
-            .await
-            .map_err(|e| Self::net("GCS list_objects", e))?;
-        let mut entries = Vec::new();
-        for obj in res.items.unwrap_or_default() {
-            let name = obj.name.rsplit('/').next().unwrap_or(&obj.name).to_string();
-            entries.push(DirEntry {
-                name,
-                url: format!("gs://{bucket}/{}", obj.name),
-                metadata: FsFileMetadata {
-                    path: format!("gs://{bucket}/{}", obj.name),
-                    size: obj.size.max(0) as u64,
-                    is_directory: false,
-                    etag: Some(obj.etag),
-                    ..Default::default()
-                },
-            });
-        }
-        Ok(entries)
+        self.list_paginated(path, None).await
     }
 
     async fn create_dir(&self, _path: &str) -> FsResult<()> {
@@ -308,5 +336,44 @@ mod tests {
         })
         .await;
         assert!(fs.is_ok(), "anonymous+endpoint client should build offline");
+    }
+
+    #[tokio::test]
+    #[ignore = "needs fake-gcs-server — set PROXIMADB_GCS_TEST_ENDPOINT"]
+    async fn list_consumes_all_pages_against_fake_gcs() {
+        let Ok(endpoint) = std::env::var("PROXIMADB_GCS_TEST_ENDPOINT") else {
+            eprintln!("skip: set PROXIMADB_GCS_TEST_ENDPOINT with fake-gcs-server running");
+            return;
+        };
+        let bucket = std::env::var("PROXIMADB_GCS_TEST_BUCKET")
+            .unwrap_or_else(|_| "proximadb-test".to_string());
+        let fs = GcsFileSystem::new(GcsConfig {
+            endpoint_url: Some(endpoint),
+            anonymous: true,
+            project_id: Some("proximadb".to_string()),
+        })
+        .await
+        .expect("fake-gcs client");
+        let prefix = format!("td-objstore-4/{}/", uuid::Uuid::new_v4());
+
+        for index in 0..5 {
+            let path = format!("gs://{bucket}/{prefix}{index}.bcwal");
+            fs.write(&path, &[index], None).await.expect("seed object");
+        }
+
+        let prefix_path = format!("gs://{bucket}/{prefix}");
+        assert!(
+            !fs.exists(&prefix_path).await.expect("prefix HEAD"),
+            "a flat-key prefix must not exist as an exact object"
+        );
+        let entries = fs
+            .list_paginated(&prefix_path, Some(2))
+            .await
+            .expect("multi-page prefix LIST");
+        assert_eq!(entries.len(), 5, "LIST must consume every GCS page");
+
+        for entry in entries {
+            fs.delete(&entry.url).await.expect("cleanup object");
+        }
     }
 }

--- a/src/storage/persistence/filesystem/gcs_store.rs
+++ b/src/storage/persistence/filesystem/gcs_store.rs
@@ -212,6 +212,37 @@ impl FileSystem for GcsFileSystem {
         Ok(())
     }
 
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        _options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let (bucket, object) = Self::parse(path)?;
+        let upload_type = UploadType::Simple(Media::new(object));
+        let result = self
+            .client
+            .upload_object(
+                &UploadObjectRequest {
+                    bucket,
+                    if_generation_match: Some(0),
+                    ..Default::default()
+                },
+                data.to_vec(),
+                &upload_type,
+            )
+            .await;
+        match result {
+            Ok(_) => Ok(()),
+            Err(google_cloud_storage::http::Error::Response(response))
+                if response.code == 409 || response.code == 412 =>
+            {
+                Err(FilesystemError::AlreadyExists(path.to_string()))
+            }
+            Err(error) => Err(Self::net("GCS conditional upload_object", error)),
+        }
+    }
+
     async fn append(&self, _path: &str, _data: &[u8]) -> FsResult<()> {
         Err(FilesystemError::InvalidOperation(
             "GCS objects are immutable; append is unsupported".to_string(),

--- a/src/storage/persistence/filesystem/local.rs
+++ b/src/storage/persistence/filesystem/local.rs
@@ -558,6 +558,52 @@ impl FileSystem for LocalFileSystem {
         Ok(())
     }
 
+    async fn write_if_absent(
+        &self,
+        path: &str,
+        data: &[u8],
+        options: Option<FileOptions>,
+    ) -> FsResult<()> {
+        let resolved_path = PathBuf::from(self.resolve_path(path)?);
+        if options.as_ref().is_some_and(|o| o.create_dirs)
+            && let Some(parent) = resolved_path.parent()
+        {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(FilesystemError::Io)?;
+        }
+
+        let data_to_write = if let Some(ref encryption) = self.encryption_layer {
+            encryption.encrypt_file(path, data).map_err(|e| {
+                FilesystemError::Io(std::io::Error::other(format!(
+                    "Encryption failed for {path}: {e}"
+                )))
+            })?
+        } else {
+            data.to_vec()
+        };
+
+        let mut file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&resolved_path)
+            .await
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    FilesystemError::AlreadyExists(resolved_path.display().to_string())
+                } else {
+                    FilesystemError::Io(e)
+                }
+            })?;
+        file.write_all(&data_to_write)
+            .await
+            .map_err(FilesystemError::Io)?;
+        if self.config.sync_enabled {
+            file.sync_all().await.map_err(FilesystemError::Io)?;
+        }
+        Ok(())
+    }
+
     async fn append(&self, path: &str, data: &[u8]) -> FsResult<()> {
         let path_str = self.resolve_path(path)?;
         let resolved_path = PathBuf::from(path_str);
@@ -1904,5 +1950,33 @@ mod tests {
                 path
             );
         }
+    }
+
+    #[tokio::test]
+    async fn write_if_absent_is_atomic_and_preserves_first_value() {
+        let temp_dir = TempDir::new().unwrap();
+        let fs = LocalFileSystem::new(LocalConfig {
+            root_dir: Some(temp_dir.path().to_path_buf()),
+            sync_enabled: true,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        fs.write_if_absent(
+            "commit.pax",
+            b"first",
+            Some(FileOptions {
+                create_dirs: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let error = fs
+            .write_if_absent("commit.pax", b"second", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, FilesystemError::AlreadyExists(_)));
+        assert_eq!(fs.read("commit.pax").await.unwrap(), b"first");
     }
 }

--- a/src/storage/persistence/filesystem/scheme_validation.rs
+++ b/src/storage/persistence/filesystem/scheme_validation.rs
@@ -41,8 +41,12 @@ impl FilesystemScheme {
         match s {
             "file" => Ok(Self::File),
             "s3" => Ok(Self::S3),
-            "gs" => Ok(Self::GoogleCloudStorage),
-            "adls" => Ok(Self::AzureDataLakeStorage),
+            // Backends may return their canonical scheme from LIST even when
+            // the caller used an alias (Azure returns `az://` for an
+            // `adls://` request). Normalize every registered alias here so a
+            // listed URL can always be fed back into FilesystemFactory.
+            "gs" | "gcs" => Ok(Self::GoogleCloudStorage),
+            "adls" | "az" | "azure" => Ok(Self::AzureDataLakeStorage),
             "abfs" => Ok(Self::AzureBlobStorage),
             "hdfs" => Ok(Self::Hdfs),
             _ => Err(FilesystemError::UnsupportedScheme(s.to_string())),
@@ -51,7 +55,9 @@ impl FilesystemScheme {
 
     /// Get all supported schemes as strings
     pub fn all_schemes() -> &'static [&'static str] {
-        &["file", "s3", "gs", "adls", "abfs", "hdfs"]
+        &[
+            "file", "s3", "gs", "gcs", "adls", "az", "azure", "abfs", "hdfs",
+        ]
     }
 }
 
@@ -158,6 +164,16 @@ mod tests {
             FilesystemScheme::parse_scheme("gs").unwrap(),
             FilesystemScheme::GoogleCloudStorage
         );
+        assert_eq!(
+            FilesystemScheme::parse_scheme("gcs").unwrap(),
+            FilesystemScheme::GoogleCloudStorage
+        );
+        for alias in ["adls", "az", "azure"] {
+            assert_eq!(
+                FilesystemScheme::parse_scheme(alias).unwrap(),
+                FilesystemScheme::AzureDataLakeStorage
+            );
+        }
         assert!(FilesystemScheme::parse_scheme("invalid").is_err());
     }
 
@@ -178,6 +194,10 @@ mod tests {
         assert_eq!(
             extract_scheme("s3://bucket/path").unwrap(),
             FilesystemScheme::S3
+        );
+        assert_eq!(
+            extract_scheme("az://container/path").unwrap(),
+            FilesystemScheme::AzureDataLakeStorage
         );
     }
 
@@ -202,6 +222,9 @@ mod tests {
         assert!(is_supported_scheme("file"));
         assert!(is_supported_scheme("s3"));
         assert!(is_supported_scheme("gs"));
+        assert!(is_supported_scheme("gcs"));
+        assert!(is_supported_scheme("az"));
+        assert!(is_supported_scheme("azure"));
         assert!(!is_supported_scheme("invalid"));
     }
 }

--- a/src/storage/persistence/write_ahead_log/avro_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/avro_serialization_strategy.rs
@@ -498,6 +498,7 @@ impl WALBatchStrategy for AvroSerializationStrategy {
                     size_bytes: 0,
                     format: SerializationFormat::Avro,
                     encryption_metadata: None, // Sync doesn't have encryption metadata
+                    recovery_token: None,
                 };
 
                 // Use filesystem sync_file to ensure durability

--- a/src/storage/persistence/write_ahead_log/bincode_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/bincode_serialization_strategy.rs
@@ -603,6 +603,7 @@ impl WALBatchStrategy for BincodeSerializationStrategy {
                     size_bytes: 0,
                     format: SerializationFormat::Bincode,
                     encryption_metadata: None, // Sync doesn't have encryption metadata
+                    recovery_token: None,
                 };
 
                 // Use filesystem sync_file to ensure durability

--- a/src/storage/persistence/write_ahead_log/disk_manager.rs
+++ b/src/storage/persistence/write_ahead_log/disk_manager.rs
@@ -11,7 +11,9 @@ use tracing::{debug, info, warn};
 
 use crate::storage::encryption::WALEncryptionLayer;
 use crate::storage::encryption::wal_encryption::WalSegmentMetadata;
-use crate::storage::persistence::filesystem::FilesystemFactory;
+use crate::storage::persistence::filesystem::{
+    DirEntry, FileSystem, FilesystemError, FilesystemFactory,
+};
 use crate::storage::persistence::write_ahead_log::BatchId;
 use crate::storage::persistence::write_ahead_log::serialization::SerializationFormat;
 use proximadb_kernel::checksum::Crc32;
@@ -56,6 +58,8 @@ pub struct WalFileInfo {
 }
 
 impl WriteAheadLogDiskManager {
+    const LIST_ATTEMPTS: usize = 3;
+
     /// Create a new disk manager
     pub fn new(filesystem_factory: Arc<FilesystemFactory>, wal_base_url: impl AsRef<str>) -> Self {
         Self::with_encryption(filesystem_factory, wal_base_url, None)
@@ -368,14 +372,7 @@ impl WriteAheadLogDiskManager {
         );
 
         let filesystem = self.filesystem_factory.get_filesystem(&dir_url)?;
-
-        // Check if directory exists
-        if !filesystem.exists(&dir_url).await? {
-            debug!("WriteBuffer directory does not exist: {}", dir_url);
-            return Ok(Vec::new());
-        }
-
-        let entries = filesystem.list(&dir_url).await?;
+        let entries = Self::list_prefix(&*filesystem, &dir_url).await?;
         let mut wal_files = Vec::new();
 
         debug!("Raw entries from filesystem: {} entries", entries.len());
@@ -396,14 +393,10 @@ impl WriteAheadLogDiskManager {
             // Backward-compat path: {base}/{collection_id}/write_buffer/
             let legacy_url =
                 Self::join_url(&self.wal_base_url, &[collection_id, "write_buffer"], true);
-            if filesystem.exists(&legacy_url).await.unwrap_or(false)
-                && let Ok(legacy_fs) = self.filesystem_factory.get_filesystem(&legacy_url)
-                && let Ok(entries) = legacy_fs.list(&legacy_url).await
-            {
-                for entry in entries {
-                    if let Some(file_info) = self.parse_wal_filename(&entry.url, collection_id) {
-                        wal_files.push(file_info);
-                    }
+            let legacy_fs = self.filesystem_factory.get_filesystem(&legacy_url)?;
+            for entry in Self::list_prefix(&*legacy_fs, &legacy_url).await? {
+                if let Some(file_info) = self.parse_wal_filename(&entry.url, collection_id) {
+                    wal_files.push(file_info);
                 }
             }
         }
@@ -414,6 +407,44 @@ impl WriteAheadLogDiskManager {
             collection_id
         );
         Ok(wal_files)
+    }
+
+    /// LIST is authoritative for a prefix. Object stores return an empty page for an
+    /// absent prefix; the local backend reports a missing directory as NotFound.
+    /// Normalize only those absent forms to empty. Every other failure is retried and
+    /// then returned so recovery cannot silently reinterpret an auth/network/throttle
+    /// failure as data absence (ADR-063 D3-D5 / TD-OBJSTORE-4 S1).
+    async fn list_prefix(filesystem: &dyn FileSystem, prefix: &str) -> Result<Vec<DirEntry>> {
+        for attempt in 1..=Self::LIST_ATTEMPTS {
+            match filesystem.list(prefix).await {
+                Ok(entries) => return Ok(entries),
+                Err(error) if Self::is_absent_list_error(&error) => return Ok(Vec::new()),
+                Err(error) if attempt < Self::LIST_ATTEMPTS => {
+                    warn!(
+                        "WAL prefix LIST failed for {} (attempt {}/{}): {}",
+                        prefix,
+                        attempt,
+                        Self::LIST_ATTEMPTS,
+                        error
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(50 * attempt as u64)).await;
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("Failed to LIST WAL prefix {prefix}"));
+                }
+            }
+        }
+
+        unreachable!("LIST retry loop always returns")
+    }
+
+    fn is_absent_list_error(error: &FilesystemError) -> bool {
+        match error {
+            FilesystemError::NotFound(_) => true,
+            FilesystemError::Io(error) => error.kind() == std::io::ErrorKind::NotFound,
+            _ => false,
+        }
     }
 
     /// Delete a WAL file
@@ -638,5 +669,54 @@ mod tests {
             .await
             .expect("Failed to list files");
         assert_eq!(final_list.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn list_missing_prefix_is_empty_and_legacy_prefix_is_discoverable() {
+        let (manager, temp_dir) = create_test_manager().await;
+        let collection_id = "legacy_collection";
+
+        assert!(
+            manager
+                .list_collection_files(collection_id)
+                .await
+                .expect("missing prefixes are empty")
+                .is_empty()
+        );
+
+        let batch_id = BatchId::new();
+        let legacy_dir = temp_dir.path().join(collection_id).join("write_buffer");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy directory");
+        std::fs::write(
+            legacy_dir.join(format!("{}.bcwal", batch_id.to_base62())),
+            b"legacy WAL",
+        )
+        .expect("legacy WAL object");
+
+        let files = manager
+            .list_collection_files(collection_id)
+            .await
+            .expect("legacy LIST fallback");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].batch_id, batch_id);
+        assert!(files[0].file_url.contains("/write_buffer/"));
+    }
+
+    #[tokio::test]
+    async fn list_error_fails_closed_instead_of_looking_empty() {
+        let (manager, temp_dir) = create_test_manager().await;
+        let collection_id = "broken_collection";
+        let collection_dir = temp_dir.path().join(collection_id);
+        std::fs::create_dir_all(&collection_dir).expect("collection directory");
+        std::fs::write(collection_dir.join("wal"), b"not a directory").expect("blocking file");
+
+        let error = manager
+            .list_collection_files(collection_id)
+            .await
+            .expect_err("a LIST failure must not be treated as an empty prefix");
+        assert!(
+            error.to_string().contains("Failed to LIST WAL prefix"),
+            "unexpected error: {error:#}"
+        );
     }
 }

--- a/src/storage/persistence/write_ahead_log/disk_manager.rs
+++ b/src/storage/persistence/write_ahead_log/disk_manager.rs
@@ -6,6 +6,7 @@
 //! TD-016: Integrated with WALEncryptionLayer for AES-256-GCM encryption at rest.
 
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -16,6 +17,7 @@ use crate::storage::persistence::filesystem::{
 };
 use crate::storage::persistence::write_ahead_log::BatchId;
 use crate::storage::persistence::write_ahead_log::serialization::SerializationFormat;
+use crate::storage::persistence::write_ahead_log::{RecoveryToken, RecoveryTokenProvider};
 use proximadb_kernel::checksum::Crc32;
 
 /// Centralized manager for all WAL disk operations
@@ -26,6 +28,9 @@ pub struct WriteAheadLogDiskManager {
     wal_base_url: String,
     /// Optional WAL encryption layer (TD-016)
     encryption_layer: Option<Arc<WALEncryptionLayer>>,
+    /// Injected ordering-token provider. The default constructors use the
+    /// process provider populated by the canonical partition-lease manager.
+    recovery_token_provider: Arc<RecoveryTokenProvider>,
     /// Statistics
     stats: Arc<tokio::sync::RwLock<WalDiskManagerStats>>,
 }
@@ -55,10 +60,32 @@ pub struct WalFileInfo {
     pub format: SerializationFormat,
     /// Encryption metadata (TD-016)
     pub encryption_metadata: Option<WalSegmentMetadata>,
+    /// Ordered token parsed from the object name. The tenant is populated from
+    /// the authenticated envelope when the object is read.
+    pub recovery_token: Option<RecoveryToken>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadWalBatch {
+    pub data: Vec<u8>,
+    pub recovery_token: Option<RecoveryToken>,
+    pub record_ordinals: Vec<u32>,
+    pub checksum_crc32: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WalObjectEnvelope {
+    version: u16,
+    recovery_token: RecoveryToken,
+    payload_checksum_crc32: u32,
+    vector_count: u64,
+    encryption_metadata: Option<WalSegmentMetadata>,
+    record_ordinals: Vec<u32>,
 }
 
 impl WriteAheadLogDiskManager {
     const LIST_ATTEMPTS: usize = 3;
+    const ENVELOPE_MAGIC: &'static [u8; 8] = b"PXWAL02\0";
 
     /// Create a new disk manager
     pub fn new(filesystem_factory: Arc<FilesystemFactory>, wal_base_url: impl AsRef<str>) -> Self {
@@ -70,6 +97,20 @@ impl WriteAheadLogDiskManager {
         filesystem_factory: Arc<FilesystemFactory>,
         wal_base_url: impl AsRef<str>,
         encryption_layer: Option<Arc<WALEncryptionLayer>>,
+    ) -> Self {
+        Self::with_encryption_and_token_provider(
+            filesystem_factory,
+            wal_base_url,
+            encryption_layer,
+            RecoveryTokenProvider::global(),
+        )
+    }
+
+    pub fn with_encryption_and_token_provider(
+        filesystem_factory: Arc<FilesystemFactory>,
+        wal_base_url: impl AsRef<str>,
+        encryption_layer: Option<Arc<WALEncryptionLayer>>,
+        recovery_token_provider: Arc<RecoveryTokenProvider>,
     ) -> Self {
         let wal_base_url = wal_base_url.as_ref().to_string();
         let encryption_enabled = encryption_layer.as_ref().is_some_and(|e| e.is_enabled());
@@ -88,6 +129,7 @@ impl WriteAheadLogDiskManager {
             filesystem_factory,
             wal_base_url,
             encryption_layer,
+            recovery_token_provider,
             stats: Arc::new(tokio::sync::RwLock::new(WalDiskManagerStats::default())),
         }
     }
@@ -148,6 +190,28 @@ impl WriteAheadLogDiskManager {
         Self::join_url(&self.wal_base_url, &[collection_id, "wal", &fname], false)
     }
 
+    fn tokenized_batch_url(
+        &self,
+        collection_id: &str,
+        batch_id: &BatchId,
+        format: SerializationFormat,
+        token: &RecoveryToken,
+    ) -> String {
+        let ext = match format {
+            SerializationFormat::ProtocolBuffers => "pbwal",
+            SerializationFormat::Bincode => "bcwal",
+            SerializationFormat::Avro => "avwal",
+        };
+        let fname = format!(
+            "{:020}-{:020}-{}.{}",
+            token.epoch,
+            token.sequence,
+            batch_id.to_base62(),
+            ext
+        );
+        Self::join_url(&self.wal_base_url, &[collection_id, "wal", &fname], false)
+    }
+
     /// Build manifest URL: .../{collection_id}/wal/manifest.log
     pub fn manifest_url(&self, collection_id: &str) -> String {
         // Use collection_id directly - collection IDs are already short base62 UUIDs
@@ -185,7 +249,11 @@ impl WriteAheadLogDiskManager {
         vector_count: u64,
         sync_to_disk: bool,
     ) -> Result<WalFileInfo> {
-        let file_url = self.batch_url(collection_id, batch_id, format);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let recovery_token = self
+            .recovery_token_provider
+            .allocate(collection_id, now_ms)?;
+        let file_url = self.tokenized_batch_url(collection_id, batch_id, format, &recovery_token);
 
         debug!(
             "📝 Writing WriteBuffer batch {} for collection {} to {} ({} bytes)",
@@ -204,30 +272,37 @@ impl WriteAheadLogDiskManager {
         // Always attempt directory creation for uniform semantics (no-op on object stores)
         let _ = filesystem.create_dir_all(&dir_url).await;
 
-        // TD-016: Encrypt data before writing if encryption is enabled
-        let (data_to_write, encryption_metadata) =
-            if let Some(ref encryption_layer) = self.encryption_layer {
-                debug!("🔒 Encrypting WAL segment before write");
-                let segment_name = format!("{}_{}", collection_id, batch_id.to_base62());
-                // Use batch_id components to create a unique u64 for key derivation
-                let segment_id = batch_id.timestamp_ms() ^ (batch_id.counter() as u64);
-                match encryption_layer.encrypt_segment(&segment_name, segment_id, data) {
-                    Ok((encrypted, metadata)) => {
-                        debug!(
-                            "✅ WAL segment encrypted ({} -> {} bytes)",
-                            data.len(),
-                            encrypted.len()
-                        );
-                        (encrypted, Some(metadata))
-                    }
-                    Err(e) => {
-                        warn!("⚠️  WAL encryption failed, writing unencrypted: {}", e);
-                        (data.to_vec(), None)
-                    }
-                }
-            } else {
-                (data.to_vec(), None)
-            };
+        let checksum = Crc32::checksum(data);
+        let encryption_metadata = self.encryption_layer.as_ref().map(|layer| {
+            layer.prepare_segment_metadata(
+                &format!("{}_{}", collection_id, batch_id.to_base62()),
+                batch_id.timestamp_ms() ^ u64::from(batch_id.counter()),
+                data.len(),
+            )
+        });
+        let envelope = WalObjectEnvelope {
+            version: 2,
+            recovery_token: recovery_token.clone(),
+            payload_checksum_crc32: checksum,
+            vector_count,
+            encryption_metadata: encryption_metadata.clone(),
+            record_ordinals: (0..vector_count)
+                .map(|ordinal| u32::try_from(ordinal))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .context("WAL batch has more records than the recovery ordinal can represent")?,
+        };
+        let header = serde_json::to_vec(&envelope).context("serializing WAL object envelope")?;
+        let payload = match (&self.encryption_layer, &encryption_metadata) {
+            (Some(layer), Some(metadata)) => layer
+                .encrypt_segment_with_metadata_and_aad(metadata, data, &header)
+                .context("encrypting WAL payload with authenticated envelope")?,
+            _ => data.to_vec(),
+        };
+        let mut data_to_write = Vec::with_capacity(12 + header.len() + payload.len());
+        data_to_write.extend_from_slice(Self::ENVELOPE_MAGIC);
+        data_to_write.extend_from_slice(&(header.len() as u32).to_be_bytes());
+        data_to_write.extend_from_slice(&header);
+        data_to_write.extend_from_slice(&payload);
 
         // Write data atomically; for object stores this will write to a temp and
         // then rename to the final path.
@@ -236,7 +311,7 @@ impl WriteAheadLogDiskManager {
             ::create_metadata_strategy(&*filesystem, None)?;
         let file_options = strategy.create_file_options(&*filesystem, &file_url)?;
         filesystem
-            .write(&file_url, &data_to_write, Some(file_options))
+            .write_if_absent(&file_url, &data_to_write, Some(file_options))
             .await
             .context("Failed to write WriteBuffer batch to disk")?;
 
@@ -250,7 +325,6 @@ impl WriteAheadLogDiskManager {
         }
 
         // Register in global manifest
-        let checksum = Crc32::checksum(&data_to_write);
         let file_name = file_url.split('/').next_back().unwrap_or("").to_string();
 
         use crate::storage::persistence::write_ahead_log::manifest;
@@ -293,6 +367,7 @@ impl WriteAheadLogDiskManager {
             size_bytes: data_to_write.len() as u64,
             format,
             encryption_metadata,
+            recovery_token: Some(recovery_token),
         };
 
         debug!("✅ Successfully wrote WAL batch to disk: {:?}", file_info);
@@ -301,6 +376,10 @@ impl WriteAheadLogDiskManager {
 
     /// Read a serialized batch from disk
     pub async fn read_batch(&self, file_info: &WalFileInfo) -> Result<Vec<u8>> {
+        Ok(self.read_batch_with_envelope(file_info).await?.data)
+    }
+
+    pub async fn read_batch_with_envelope(&self, file_info: &WalFileInfo) -> Result<ReadWalBatch> {
         let file_url = file_info.file_url.clone();
 
         debug!(
@@ -316,8 +395,65 @@ impl WriteAheadLogDiskManager {
             .await
             .context("Failed to read WAL batch from disk")?;
 
-        // Track the encrypted data length before potential moves
+        // Track the object length before parsing/decrypting.
         let encrypted_len = encrypted_data.len();
+
+        if encrypted_data.starts_with(Self::ENVELOPE_MAGIC) {
+            if encrypted_data.len() < 12 {
+                anyhow::bail!("truncated WAL envelope at {file_url}");
+            }
+            let header_len = u32::from_be_bytes(encrypted_data[8..12].try_into()?) as usize;
+            let header_end = 12usize
+                .checked_add(header_len)
+                .context("WAL envelope header length overflow")?;
+            if header_end > encrypted_data.len() {
+                anyhow::bail!("truncated WAL envelope header at {file_url}");
+            }
+            let header = &encrypted_data[12..header_end];
+            let envelope: WalObjectEnvelope =
+                serde_json::from_slice(header).context("decoding WAL object envelope")?;
+            if envelope.version != 2 {
+                anyhow::bail!("unsupported WAL envelope version {}", envelope.version);
+            }
+            if let Some(name_token) = &file_info.recovery_token
+                && (name_token.epoch != envelope.recovery_token.epoch
+                    || name_token.sequence != envelope.recovery_token.sequence)
+            {
+                anyhow::bail!("WAL filename token does not match authenticated envelope");
+            }
+            if envelope.record_ordinals.len() != envelope.vector_count as usize
+                || envelope
+                    .record_ordinals
+                    .iter()
+                    .enumerate()
+                    .any(|(index, ordinal)| *ordinal as usize != index)
+            {
+                anyhow::bail!("invalid WAL record ordinal sequence");
+            }
+            let payload = &encrypted_data[header_end..];
+            let data = match (&self.encryption_layer, &envelope.encryption_metadata) {
+                (Some(layer), Some(metadata)) if metadata.encrypted => layer
+                    .decrypt_segment_with_aad(metadata, payload, header)
+                    .context("decrypting authenticated WAL envelope")?,
+                (None, Some(metadata)) if metadata.encrypted => {
+                    anyhow::bail!("encrypted WAL object has no configured encryption layer")
+                }
+                _ => payload.to_vec(),
+            };
+            if Crc32::checksum(&data) != envelope.payload_checksum_crc32 {
+                anyhow::bail!("WAL payload checksum mismatch at {file_url}");
+            }
+            let mut stats = self.stats.write().await;
+            stats.total_bytes_read += encrypted_len as u64;
+            stats.total_files_read += 1;
+            drop(stats);
+            return Ok(ReadWalBatch {
+                data,
+                recovery_token: Some(envelope.recovery_token),
+                record_ordinals: envelope.record_ordinals,
+                checksum_crc32: envelope.payload_checksum_crc32,
+            });
+        }
 
         // TD-016: Decrypt data after reading if it was encrypted
         let data = if let Some(ref metadata) = file_info.encryption_metadata {
@@ -359,7 +495,12 @@ impl WriteAheadLogDiskManager {
         }
 
         debug!("✅ Successfully read {} bytes from disk", data.len());
-        Ok(data)
+        Ok(ReadWalBatch {
+            checksum_crc32: Crc32::checksum(&data),
+            data,
+            recovery_token: None,
+            record_ordinals: Vec::new(),
+        })
     }
 
     /// List all WAL files for a collection
@@ -372,7 +513,7 @@ impl WriteAheadLogDiskManager {
         );
 
         let filesystem = self.filesystem_factory.get_filesystem(&dir_url)?;
-        let entries = Self::list_prefix(&*filesystem, &dir_url).await?;
+        let entries = Self::list_prefix_entries(&*filesystem, &dir_url).await?;
         let mut wal_files = Vec::new();
 
         debug!("Raw entries from filesystem: {} entries", entries.len());
@@ -394,7 +535,7 @@ impl WriteAheadLogDiskManager {
             let legacy_url =
                 Self::join_url(&self.wal_base_url, &[collection_id, "write_buffer"], true);
             let legacy_fs = self.filesystem_factory.get_filesystem(&legacy_url)?;
-            for entry in Self::list_prefix(&*legacy_fs, &legacy_url).await? {
+            for entry in Self::list_prefix_entries(&*legacy_fs, &legacy_url).await? {
                 if let Some(file_info) = self.parse_wal_filename(&entry.url, collection_id) {
                     wal_files.push(file_info);
                 }
@@ -414,7 +555,10 @@ impl WriteAheadLogDiskManager {
     /// Normalize only those absent forms to empty. Every other failure is retried and
     /// then returned so recovery cannot silently reinterpret an auth/network/throttle
     /// failure as data absence (ADR-063 D3-D5 / TD-OBJSTORE-4 S1).
-    async fn list_prefix(filesystem: &dyn FileSystem, prefix: &str) -> Result<Vec<DirEntry>> {
+    pub(crate) async fn list_prefix_entries(
+        filesystem: &dyn FileSystem,
+        prefix: &str,
+    ) -> Result<Vec<DirEntry>> {
         for attempt in 1..=Self::LIST_ATTEMPTS {
             match filesystem.list(prefix).await {
                 Ok(entries) => return Ok(entries),
@@ -541,7 +685,21 @@ impl WriteAheadLogDiskManager {
             _ => return None,
         };
 
-        // Parse batch ID
+        // New names are epoch-first; legacy names contain only the batch id.
+        let (batch_id_str, recovery_token) = match batch_id_str.split_once('-') {
+            Some((epoch, rest)) => {
+                let (sequence, encoded_batch_id) = rest.split_once('-')?;
+                (
+                    encoded_batch_id,
+                    Some(RecoveryToken {
+                        tenant_id: String::new(),
+                        epoch: epoch.parse().ok()?,
+                        sequence: sequence.parse().ok()?,
+                    }),
+                )
+            }
+            None => (batch_id_str, None),
+        };
         let batch_id = BatchId::from_base62(batch_id_str)?;
 
         Some(WalFileInfo {
@@ -551,6 +709,7 @@ impl WriteAheadLogDiskManager {
             size_bytes: 0, // Will be filled by caller if needed
             format,
             encryption_metadata: None, // Path parsing doesn't have encryption metadata
+            recovery_token,
         })
     }
 }
@@ -594,7 +753,13 @@ mod tests {
             .await
             .expect("Failed to write batch");
         assert_eq!(file_info.collection_id, collection_id);
-        assert_eq!(file_info.size_bytes, data.len() as u64);
+        assert!(file_info.size_bytes > data.len() as u64);
+        let token = file_info
+            .recovery_token
+            .as_ref()
+            .expect("new WAL objects carry recovery tokens");
+        let file_name = file_info.file_url.split('/').next_back().unwrap();
+        assert!(file_name.starts_with(&format!("{:020}-{:020}-", token.epoch, token.sequence)));
 
         // Read batch
         let read_data = manager
@@ -605,8 +770,8 @@ mod tests {
 
         // Check stats
         let stats = manager.get_stats().await.expect("Failed to get stats");
-        assert_eq!(stats.total_bytes_written, data.len() as u64);
-        assert_eq!(stats.total_bytes_read, data.len() as u64);
+        assert_eq!(stats.total_bytes_written, file_info.size_bytes);
+        assert_eq!(stats.total_bytes_read, file_info.size_bytes);
         assert_eq!(stats.total_files_written, 1);
         assert_eq!(stats.total_files_read, 1);
     }

--- a/src/storage/persistence/write_ahead_log/disk_manager.rs
+++ b/src/storage/persistence/write_ahead_log/disk_manager.rs
@@ -287,7 +287,7 @@ impl WriteAheadLogDiskManager {
             vector_count,
             encryption_metadata: encryption_metadata.clone(),
             record_ordinals: (0..vector_count)
-                .map(|ordinal| u32::try_from(ordinal))
+                .map(u32::try_from)
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .context("WAL batch has more records than the recovery ordinal can represent")?,
         };

--- a/src/storage/persistence/write_ahead_log/manifest/service.rs
+++ b/src/storage/persistence/write_ahead_log/manifest/service.rs
@@ -384,7 +384,7 @@ impl GlobalManifestService {
             deduped
                 .entry(entry.batch_id.clone())
                 .and_modify(|existing| {
-                    if entry.global_lsn > existing.global_lsn {
+                    if should_replace_manifest_entry(existing, &entry) {
                         *existing = entry.clone();
                     }
                 })
@@ -985,6 +985,58 @@ impl GlobalManifestService {
 
         debug!("GlobalManifestService shut down");
         Ok(())
+    }
+}
+
+fn status_rank(status: WalEntryStatus) -> u8 {
+    match status {
+        WalEntryStatus::Active => 0,
+        WalEntryStatus::Flushed => 1,
+        WalEntryStatus::Archived | WalEntryStatus::RolledBack => 2,
+    }
+}
+
+fn should_replace_manifest_entry(
+    existing: &GlobalManifestEntry,
+    incoming: &GlobalManifestEntry,
+) -> bool {
+    incoming.global_lsn > existing.global_lsn
+        || (incoming.global_lsn == existing.global_lsn
+            && status_rank(incoming.status) > status_rank(existing.status))
+}
+
+#[cfg(test)]
+mod manifest_status_tests {
+    use super::*;
+    use crate::storage::persistence::write_ahead_log::BatchId;
+    use crate::storage::persistence::write_ahead_log::serialization::SerializationFormat;
+
+    fn entry(status: WalEntryStatus) -> GlobalManifestEntry {
+        let mut entry = GlobalManifestEntry::new(
+            7,
+            "collection".to_string(),
+            &BatchId::new(),
+            "batch.bcwal".to_string(),
+            1,
+            1,
+            SerializationFormat::Bincode,
+            1,
+            "file:///tmp".to_string(),
+        );
+        entry.status = status;
+        entry
+    }
+
+    #[test]
+    fn equal_lsn_flushed_supersedes_active() {
+        assert!(should_replace_manifest_entry(
+            &entry(WalEntryStatus::Active),
+            &entry(WalEntryStatus::Flushed)
+        ));
+        assert!(!should_replace_manifest_entry(
+            &entry(WalEntryStatus::Flushed),
+            &entry(WalEntryStatus::Active)
+        ));
     }
 }
 

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -114,6 +114,7 @@ pub mod pitr; // Point-in-Time Recovery manager
 pub mod proto_serialization_strategy; // Clean architecture proto implementation
 pub mod recovery_manager; // New centralized recovery operations
 pub mod recovery_thread_pool; // Thread pool for parallel recovery
+pub mod recovery_token;
 pub mod serialization; // New pure serialization layer // Slug codec for collection paths
 
 // Optimized WAL components (Phase 1 implementation) - now consolidated into WriteAheadLogManager
@@ -158,6 +159,7 @@ pub use recovery_thread_pool::{
     RecoveryPoolStats, RecoveryThreadPool, get_recovery_thread_pool,
     initialize_recovery_thread_pool,
 };
+pub use recovery_token::{RecoveryToken, RecoveryTokenProvider};
 
 // DIP: Re-export path resolver types for convenient access
 pub use crate::storage::trait_components::path_resolver::{

--- a/src/storage/persistence/write_ahead_log/proto_serialization_strategy.rs
+++ b/src/storage/persistence/write_ahead_log/proto_serialization_strategy.rs
@@ -384,6 +384,7 @@ impl WALBatchStrategy for ProtoSerializationStrategy {
                 size_bytes: 0,
                 format: SerializationFormat::ProtocolBuffers,
                 encryption_metadata: None, // Delete operation doesn't need encryption metadata
+                recovery_token: None,
             };
             let _ = self.disk_manager.delete_file(&file_info).await;
         }
@@ -483,6 +484,7 @@ impl WALBatchStrategy for ProtoSerializationStrategy {
                     size_bytes: 0,
                     format: SerializationFormat::ProtocolBuffers,
                     encryption_metadata: None, // Sync doesn't have encryption metadata
+                    recovery_token: None,
                 };
 
                 // Use filesystem sync_file to ensure durability

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -17,8 +17,7 @@ use tracing::{debug, info, trace, warn};
 use crate::storage::BatchId;
 use crate::storage::persistence::write_ahead_log::{
     WALFlushCoordinator, WalFileInfo, WriteAheadLogDiskManager,
-    recovery_thread_pool::get_recovery_thread_pool, serialization::SerializationFormat,
-    serialization::SerializerFactory,
+    recovery_thread_pool::get_recovery_thread_pool, serialization::SerializerFactory,
 };
 use crate::storage::traits::UnifiedStorageFormat;
 
@@ -174,12 +173,6 @@ impl RecoveryManager {
             all_entries.len()
         );
 
-        if all_entries.is_empty() {
-            info!("📝 No active WAL entries to recover (manifest is empty or all entries flushed)");
-            recovery_guard.complete(0, 0).await;
-            return Ok(WalRecoveryStats::default());
-        }
-
         info!(
             "📂 Found {} WAL batches across collections (sorted by global LSN)",
             all_entries.len()
@@ -196,10 +189,14 @@ impl RecoveryManager {
         }
 
         // Group by collection for organized recovery
-        let collections_to_recover: std::collections::HashSet<String> = all_entries
+        let mut collections_to_recover: std::collections::HashSet<String> = all_entries
             .iter()
             .map(|e| e.collection_id.clone())
             .collect();
+        // The manifest is only a cache. Catalog boot registers engines before
+        // recovery, so their canonical collection ids must also be LISTed even
+        // when the async manifest pointer is empty.
+        collections_to_recover.extend(self.storage_engines.read().await.keys().cloned());
         let collections: Vec<String> = collections_to_recover.into_iter().collect();
         info!(
             "Found {} collections to recover using {} threads",
@@ -405,204 +402,258 @@ impl RecoveryManager {
             collection_id, recovery_mode
         );
 
-        if recovery_mode == RecoveryMode::DirectToStorage {
-            let engines = storage_engines.read().await;
-            trace!(
-                "Checking WAL recovery storage engine registration for collection {} across {} engines",
-                collection_id,
-                engines.len()
-            );
+        Self::recover_collection_authoritative(
+            collection_id,
+            disk_manager.clone(),
+            storage_engines.clone(),
+            recovery_mode,
+            &progress_callback,
+        )
+        .await
+    }
 
-            if !engines.contains_key(collection_id) {
-                warn!(
-                    "⏭️ Skipping recovery for collection {}: No storage engine registered. \
-                    Collection will be initialized fresh if accessed.",
-                    collection_id
-                );
-                // Return 0 vectors recovered instead of error - allows graceful degradation
-                return Ok((0, 0));
-            }
-            trace!(
-                "Storage engine found for WAL recovery collection {}",
-                collection_id
+    async fn recover_collection_authoritative(
+        collection_id: &str,
+        disk_manager: Arc<WriteAheadLogDiskManager>,
+        storage_engines: Arc<tokio::sync::RwLock<HashMap<String, Arc<dyn UnifiedStorageFormat>>>>,
+        _recovery_mode: RecoveryMode,
+        progress_callback: &Option<RecoveryProgressCallback>,
+    ) -> Result<(u64, u64)> {
+        if !storage_engines.read().await.contains_key(collection_id) {
+            anyhow::bail!(
+                "no storage engine registered for WAL recovery collection {collection_id}"
             );
         }
-
-        // Get entries from global manifest
-        let entries =
+        let manifest_entries =
             crate::storage::persistence::write_ahead_log::manifest::get_collection_entries(
                 collection_id,
             )
             .await;
-        debug!(
-            "Found {} WAL manifest entries for collection {}",
-            entries.len(),
-            collection_id
-        );
-
-        let mut vectors_recovered = 0u64;
-        let mut files_recovered = 0u64;
-
-        for (idx, e) in entries.iter().enumerate() {
-            trace!(
-                "Processing WAL entry {}/{}: batch_id={}, lsn={}, size={}",
-                idx + 1,
-                entries.len(),
-                e.batch_id,
-                e.global_lsn,
-                e.size_bytes
-            );
-
-            // Use full_url() from manifest entry (includes storage_url + file_path)
-            let file_url = e.full_url();
-
-            // Convert string format to SerializationFormat
-            let format = match e.format.as_str() {
-                "proto" => SerializationFormat::ProtocolBuffers,
-                "bincode" => SerializationFormat::Bincode,
-                "avro" => SerializationFormat::Avro,
-                _ => SerializationFormat::ProtocolBuffers, // Default fallback
-            };
-
-            let file_info = WalFileInfo {
-                collection_id: collection_id.to_string(),
-                batch_id: BatchId::from_base62(&e.batch_id).unwrap_or_default(),
-                file_url: file_url.clone(),
-                size_bytes: e.size_bytes,
-                format,
-                encryption_metadata: None, // Recovery doesn't have encryption metadata
-            };
-
-            debug!(
-                "🔄 Recovering WAL batch {} from {} (LSN: {}, {} bytes)",
-                e.batch_id, file_url, e.global_lsn, e.size_bytes
-            );
-
-            match disk_manager.read_batch(&file_info).await {
-                Ok(data) => {
-                    trace!("Read {} bytes from WAL file {}", data.len(), file_url);
-                    let checksum = proximadb_kernel::checksum::Crc32::checksum(&data);
-                    if checksum != e.checksum_crc32 {
-                        warn!("Checksum mismatch for {}, skipping", file_info.file_url);
-                        continue;
-                    }
-
-                    let serializer = SerializerFactory::create(file_info.format);
-                    let vectors = serializer
-                        .deserialize_batch(&data)
-                        .context("Failed to deserialize WAL data")?;
-                    let count = vectors.len() as u64;
-
-                    let result = Self::flush_recovered_vectors(
-                        &file_info,
-                        vectors,
-                        &disk_manager,
-                        &storage_engines,
-                        recovery_mode,
-                        &e.storage_url,
-                    )
-                    .await?;
-
-                    if result.success {
-                        files_recovered += 1;
-                        vectors_recovered += count;
-
-                        // CRITICAL: Mark as flushed BEFORE deleting WAL file
-                        // This ensures manifest is updated even if deletion fails
-                        match crate::storage::persistence::write_ahead_log::manifest::mark_flushed(
-                            std::slice::from_ref(&e.batch_id),
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                debug!("✅ Marked batch {} as Flushed in manifest", e.batch_id);
-
-                                // Only delete WAL file after successful manifest update
-                                if let Err(e) =
-                                    disk_manager.delete_wal_file_url(&file_info.file_url).await
-                                {
-                                    warn!(
-                                        "Failed to delete WAL file {} after successful recovery: {}",
-                                        file_info.file_url, e
-                                    );
-                                    // Continue - data is safely recovered and manifest is updated
-                                } else {
-                                    debug!("🗑️ Deleted WAL file {}", file_info.file_url);
-                                }
-
-                                info!(
-                                    "✅ Recovered and flushed batch {} (LSN: {}, {} vectors) - marked as Flushed",
-                                    e.batch_id, e.global_lsn, count
-                                );
-                            }
-                            Err(err) => {
-                                // CRITICAL: If manifest update fails, DO NOT delete WAL file
-                                // File will be recovered again on next restart
-                                warn!(
-                                    "❌ Failed to mark batch {} as Flushed in manifest: {}. Keeping WAL file for retry.",
-                                    e.batch_id, err
-                                );
-                                warn!(
-                                    "⚠️  WAL file {} will be recovered again on next server restart",
-                                    file_info.file_url
-                                );
-                            }
-                        }
-                    }
-                    if let Some(cb) = &progress_callback {
-                        cb(RecoveryProgress {
-                            current_file: idx + 1,
-                            total_files: entries.len(),
-                            current_collection: collection_id.to_string(),
-                            vectors_recovered,
-                            bytes_processed: e.size_bytes,
-                        });
-                    }
-                }
-                Err(read_err) => {
-                    // WAL file doesn't exist or can't be read
-                    warn!(
-                        "⚠️  Failed to read WAL file {} for collection {}: {}. \
-                          This may indicate the file was already deleted or flushed in a previous recovery.",
-                        file_info.file_url, collection_id, read_err
-                    );
-
-                    // Check if this entry is already marked as Flushed in manifest
-                    // If so, this is expected. If not, this is a problem.
-                    if e.status == crate::storage::persistence::write_ahead_log::manifest::WalEntryStatus::Active {
-                        warn!("⚠️  WARNING: WAL file missing but manifest shows status=Active. \
-                              Data may have been lost if storage engine flush didn't complete.");
-                    }
-                }
-            }
+        let listed = disk_manager.list_collection_files(collection_id).await?;
+        if listed.is_empty() {
+            return Ok((0, 0));
         }
 
-        // Process non-manifest files as best-effort
-        let listed = disk_manager
-            .list_collection_files(collection_id)
-            .await
-            .unwrap_or_default();
-        for fi in listed {
-            if let Some(name) = fi.file_url.split('/').next_back()
-                && entries.iter().any(|m| m.file_path.ends_with(name))
+        struct ReplayObject {
+            file: WalFileInfo,
+            data: Vec<u8>,
+            token: Option<crate::storage::persistence::write_ahead_log::RecoveryToken>,
+            manifest_lsn: Option<u64>,
+            manifested: bool,
+            checksum: u32,
+            records: Vec<proximadb_records::ProximaRecord>,
+        }
+
+        let manifests_by_name: HashMap<_, _> = manifest_entries
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .file_path
+                    .split('/')
+                    .next_back()
+                    .map(|name| (name.to_string(), entry))
+            })
+            .collect();
+        let mut replay = Vec::with_capacity(listed.len());
+        for file in listed {
+            let file_name = file.file_url.split('/').next_back().unwrap_or("");
+            let manifest = manifests_by_name.get(file_name).copied();
+            if let Some(entry) = manifest
+                && entry.status
+                    != crate::storage::persistence::write_ahead_log::manifest::WalEntryStatus::Active
             {
+                // Flushed is the cache's durable skip-list: materialization
+                // committed before this status was published. Never replay it,
+                // because later compaction may legitimately consume the original
+                // deterministic L0 segment while a failed WAL delete leaves this
+                // object behind.
+                if matches!(
+                    entry.status,
+                    crate::storage::persistence::write_ahead_log::manifest::WalEntryStatus::Flushed
+                        | crate::storage::persistence::write_ahead_log::manifest::WalEntryStatus::Archived
+                        | crate::storage::persistence::write_ahead_log::manifest::WalEntryStatus::RolledBack
+                ) && let Err(error) = disk_manager.delete_wal_file_url(&file.file_url).await
+                {
+                    warn!(file = %file.file_url, %error, "failed to retire skipped WAL object");
+                }
                 continue;
             }
-            let count =
-                Self::recover_file_internal(&fi, &disk_manager, &storage_engines, recovery_mode)
-                    .await?;
-            vectors_recovered += count;
-            files_recovered += 1;
+            let read = disk_manager.read_batch_with_envelope(&file).await?;
+            if let Some(entry) = manifest
+                && read.checksum_crc32 != entry.checksum_crc32
+            {
+                anyhow::bail!("manifest checksum mismatch for {}", file.file_url);
+            }
+            let records = SerializerFactory::create(file.format)
+                .deserialize_batch(&read.data)
+                .with_context(|| format!("deserializing {}", file.file_url))?;
+            if !read.record_ordinals.is_empty() && read.record_ordinals.len() != records.len() {
+                anyhow::bail!("record ordinal count mismatch for {}", file.file_url);
+            }
+            replay.push(ReplayObject {
+                file,
+                data: read.data,
+                token: read.recovery_token,
+                manifest_lsn: manifest.map(|entry| entry.global_lsn),
+                manifested: manifest.is_some(),
+                checksum: read.checksum_crc32,
+                records,
+            });
+        }
+        if replay.is_empty() {
+            return Ok((0, 0));
         }
 
-        // Note: Global manifest cleanup is handled separately via checkpoint system
-        // No need for per-collection manifest compaction
+        let storage_url = Self::storage_base_from_wal_url(&replay[0].file)?;
+        if replay
+            .iter()
+            .any(|object| object.token.is_none() && !object.manifested)
+        {
+            let fresh = replay.len() == 1
+                && manifest_entries.is_empty()
+                && !Self::collection_has_segments(collection_id, &storage_url, &disk_manager)
+                    .await?;
+            if !fresh {
+                anyhow::bail!(
+                    "tokenless orphan WAL for collection {collection_id} overlaps existing WAL/segments; explicit operator ordering is required"
+                );
+            }
+        }
 
-        info!(
-            "✅ Recovered {} vectors from {} files for collection {}",
-            vectors_recovered, files_recovered, collection_id
-        );
-        Ok((vectors_recovered, files_recovered))
+        if let Some(tenant_id) = replay
+            .iter()
+            .filter_map(|object| object.token.as_ref())
+            .map(|token| token.tenant_id.as_str())
+            .find(|tenant| !tenant.is_empty())
+        {
+            if let Some(manager) = crate::cluster::partition_lease::global_partition_lease_manager()
+            {
+                if !manager
+                    .begin_writer_incarnation(
+                        tenant_id,
+                        collection_id,
+                        chrono::Utc::now().timestamp_millis(),
+                    )
+                    .await?
+                {
+                    anyhow::bail!("collection {collection_id} recovery is fenced by another pod");
+                }
+            } else if crate::storage::persistence::write_ahead_log::recovery_token::certified_mode()
+            {
+                anyhow::bail!("certified recovery has no partition lease manager");
+            }
+        }
+
+        replay.sort_by(|left, right| match (&left.token, &right.token) {
+            (None, None) => left.manifest_lsn.cmp(&right.manifest_lsn),
+            (None, Some(_)) => std::cmp::Ordering::Less,
+            (Some(_), None) => std::cmp::Ordering::Greater,
+            (Some(left), Some(right)) => left.cmp(right),
+        });
+
+        use sha2::{Digest, Sha256};
+        let mut digest = Sha256::new();
+        let mut latest_by_oid: HashMap<String, (usize, proximadb_records::ProximaRecord)> =
+            HashMap::new();
+        let mut order = 0usize;
+        for object in &replay {
+            if let Some(token) = &object.token {
+                digest.update(token.epoch.to_be_bytes());
+                digest.update(token.sequence.to_be_bytes());
+            } else {
+                digest.update(object.manifest_lsn.unwrap_or_default().to_be_bytes());
+            }
+            digest.update(&object.data);
+            for record in &object.records {
+                // Latest mutation wins in durable token order. Tombstones remain
+                // materialized so they continue suppressing values in older segments.
+                latest_by_oid.insert(record.oid.clone(), (order, record.clone()));
+                order = order.saturating_add(1);
+            }
+        }
+        let mut ordered = latest_by_oid.into_values().collect::<Vec<_>>();
+        ordered.sort_by_key(|(record_order, _)| *record_order);
+        let vectors = ordered
+            .into_iter()
+            .map(|(_, record)| record)
+            .collect::<Vec<_>>();
+        let digest = format!("{:x}", digest.finalize());
+        let range = match (
+            replay.first().and_then(|object| object.token.as_ref()),
+            replay.last().and_then(|object| object.token.as_ref()),
+        ) {
+            (Some(first), Some(last)) => format!(
+                "{:020}-{:020}_{:020}-{:020}",
+                first.epoch, first.sequence, last.epoch, last.sequence
+            ),
+            _ => format!("legacy-{}", replay[0].file.batch_id.to_base62()),
+        };
+        let materialization_id = format!("{range}-{digest}");
+        let batch_ids = replay.iter().map(|object| object.file.batch_id).collect();
+        let result = Self::flush_recovered_range(
+            collection_id,
+            vectors.clone(),
+            batch_ids,
+            &storage_engines,
+            &storage_url,
+            &materialization_id,
+            &digest,
+        )
+        .await?;
+        if !result.success {
+            anyhow::bail!("recovery materialization failed for collection {collection_id}");
+        }
+
+        if crate::storage::persistence::write_ahead_log::manifest::get_service().is_some() {
+            for object in replay.iter().filter(|object| !object.manifested) {
+                let file_name = object
+                    .file
+                    .file_url
+                    .split('/')
+                    .next_back()
+                    .unwrap_or("")
+                    .to_string();
+                let entry =
+                crate::storage::persistence::write_ahead_log::manifest::GlobalManifestEntry::new(
+                    0,
+                    collection_id.to_string(),
+                    &object.file.batch_id,
+                    file_name,
+                    object.data.len() as u64,
+                    object.checksum,
+                    object.file.format,
+                    object.records.len() as u64,
+                    storage_url.clone(),
+                );
+                crate::storage::persistence::write_ahead_log::manifest::append_sync(entry).await?;
+            }
+            let batch_id_strings = replay
+                .iter()
+                .map(|object| object.file.batch_id.to_base62())
+                .collect::<Vec<_>>();
+            crate::storage::persistence::write_ahead_log::manifest::mark_flushed(&batch_id_strings)
+                .await?;
+        } else if crate::storage::persistence::write_ahead_log::recovery_token::certified_mode() {
+            anyhow::bail!("certified recovery cannot repair an uninitialized manifest cache");
+        }
+        for object in &replay {
+            if let Err(error) = disk_manager
+                .delete_wal_file_url(&object.file.file_url)
+                .await
+            {
+                warn!(file = %object.file.file_url, %error, "recovery committed; WAL retirement will retry next boot");
+            }
+        }
+        if let Some(callback) = progress_callback {
+            callback(RecoveryProgress {
+                current_file: replay.len(),
+                total_files: replay.len(),
+                current_collection: collection_id.to_string(),
+                vectors_recovered: vectors.len() as u64,
+                bytes_processed: replay.iter().map(|object| object.data.len() as u64).sum(),
+            });
+        }
+        Ok((vectors.len() as u64, replay.len() as u64))
     }
 
     /// Recover a single WAL file (public API)
@@ -693,6 +744,82 @@ impl RecoveryManager {
         }
 
         Ok(vector_count)
+    }
+
+    fn storage_base_from_wal_url(file: &WalFileInfo) -> Result<String> {
+        file.file_url
+            .split(&format!("/{}/wal/", file.collection_id))
+            .next()
+            .filter(|base| !base.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("cannot derive storage base from {}", file.file_url))
+    }
+
+    async fn collection_has_segments(
+        collection_id: &str,
+        storage_url: &str,
+        disk_manager: &Arc<WriteAheadLogDiskManager>,
+    ) -> Result<bool> {
+        let data_url = format!(
+            "{}/{}/data/",
+            storage_url.trim_end_matches('/'),
+            collection_id
+        );
+        let filesystem = disk_manager
+            .filesystem_factory()
+            .get_filesystem(&data_url)?;
+        let entries =
+            WriteAheadLogDiskManager::list_prefix_entries(&*filesystem, &data_url).await?;
+        Ok(entries.iter().any(|entry| {
+            let name = entry.name.to_ascii_lowercase();
+            name.ends_with(".pax") || name.ends_with(".sst") || name.ends_with(".arrow")
+        }))
+    }
+
+    async fn flush_recovered_range(
+        collection_id: &str,
+        vectors: Vec<proximadb_records::ProximaRecord>,
+        batch_ids: Vec<BatchId>,
+        storage_engines: &Arc<tokio::sync::RwLock<HashMap<String, Arc<dyn UnifiedStorageFormat>>>>,
+        storage_url: &str,
+        materialization_id: &str,
+        content_digest: &str,
+    ) -> Result<crate::storage::traits::FlushResult> {
+        let engines = storage_engines.read().await;
+        let engine = engines.get(collection_id).ok_or_else(|| {
+            anyhow::anyhow!("No storage engine registered for collection {collection_id}")
+        })?;
+        let collection_config =
+            if let Some(collection) = super::resolve_collection_from_catalog(collection_id).await {
+                Some(collection)
+            } else {
+                Self::create_minimal_collection_config(collection_id, storage_url)
+            };
+        let mut hints = HashMap::new();
+        hints.insert(
+            "recovery_materialization_id".to_string(),
+            serde_json::Value::String(materialization_id.to_string()),
+        );
+        hints.insert(
+            "recovery_content_digest".to_string(),
+            serde_json::Value::String(content_digest.to_string()),
+        );
+        hints.insert(
+            "suppress_compaction_until_wal_retired".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let params = crate::storage::traits::FlushParameters {
+            collection_id: Some(collection_id.to_string()),
+            collection_config,
+            force: true,
+            synchronous: true,
+            vector_records: vectors,
+            batch_ids,
+            hints,
+            trigger_compaction: false,
+            ..Default::default()
+        };
+        engine.do_flush(&params).await
     }
 
     /// Flush recovered vectors to storage engine

--- a/src/storage/persistence/write_ahead_log/recovery_token.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_token.rs
@@ -1,0 +1,147 @@
+//! Durable ordering tokens carried by object-store WAL objects (ADR-063 / TD-OBJSTORE-4).
+
+use anyhow::{Result, anyhow, bail};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RecoveryToken {
+    pub tenant_id: String,
+    pub epoch: u64,
+    pub sequence: u64,
+}
+
+#[derive(Debug)]
+struct TokenState {
+    tenant_id: String,
+    epoch: u64,
+    next_sequence: AtomicU64,
+    expires_at_ms: AtomicI64,
+}
+
+#[derive(Debug, Default)]
+pub struct RecoveryTokenProvider {
+    states: DashMap<String, Arc<TokenState>>,
+}
+
+impl RecoveryTokenProvider {
+    pub fn global() -> Arc<Self> {
+        static PROVIDER: OnceLock<Arc<RecoveryTokenProvider>> = OnceLock::new();
+        PROVIDER.get_or_init(|| Arc::new(Self::default())).clone()
+    }
+
+    /// Install/refresh the durable writer incarnation for a canonical collection UUID.
+    pub fn register_incarnation(
+        &self,
+        tenant_id: &str,
+        collection_id: &str,
+        epoch: u64,
+        expires_at_ms: i64,
+    ) {
+        if let Some(existing) = self.states.get(collection_id)
+            && existing.tenant_id == tenant_id
+            && existing.epoch == epoch
+        {
+            existing
+                .expires_at_ms
+                .store(expires_at_ms, Ordering::Release);
+            return;
+        }
+        self.states.insert(
+            collection_id.to_string(),
+            Arc::new(TokenState {
+                tenant_id: tenant_id.to_string(),
+                epoch,
+                next_sequence: AtomicU64::new(0),
+                expires_at_ms: AtomicI64::new(expires_at_ms),
+            }),
+        );
+    }
+
+    pub fn allocate(&self, collection_id: &str, now_ms: i64) -> Result<RecoveryToken> {
+        if let Some(state) = self.states.get(collection_id) {
+            let expiry = state.expires_at_ms.load(Ordering::Acquire);
+            if now_ms >= expiry {
+                bail!(
+                    "writer incarnation for collection {collection_id} expired at {expiry}; refusing WAL acknowledgement"
+                );
+            }
+            return Ok(RecoveryToken {
+                tenant_id: state.tenant_id.clone(),
+                epoch: state.epoch,
+                sequence: state.next_sequence.fetch_add(1, Ordering::AcqRel),
+            });
+        }
+
+        if certified_mode() {
+            bail!(
+                "no durable writer incarnation for collection {collection_id} in certified object-store mode"
+            );
+        }
+
+        // Embedded/R&D compatibility only. Certified deployments fail closed above.
+        static FALLBACK_EPOCH: OnceLock<u64> = OnceLock::new();
+        let epoch = *FALLBACK_EPOCH.get_or_init(|| {
+            let micros = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_micros() as u64;
+            micros ^ u64::from(std::process::id())
+        });
+        let state = Arc::new(TokenState {
+            tenant_id: String::new(),
+            epoch,
+            next_sequence: AtomicU64::new(1),
+            expires_at_ms: AtomicI64::new(i64::MAX),
+        });
+        match self.states.entry(collection_id.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => {
+                let state = entry.get();
+                Ok(RecoveryToken {
+                    tenant_id: state.tenant_id.clone(),
+                    epoch: state.epoch,
+                    sequence: state.next_sequence.fetch_add(1, Ordering::AcqRel),
+                })
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(state);
+                Ok(RecoveryToken {
+                    tenant_id: String::new(),
+                    epoch,
+                    sequence: 0,
+                })
+            }
+        }
+    }
+
+    pub fn expire(&self, collection_id: &str) -> Result<()> {
+        let state = self
+            .states
+            .get(collection_id)
+            .ok_or_else(|| anyhow!("unknown writer incarnation for {collection_id}"))?;
+        state.expires_at_ms.store(0, Ordering::Release);
+        Ok(())
+    }
+}
+
+pub fn certified_mode() -> bool {
+    std::env::var("PROXIMADB_SERVERLESS_CERTIFIED")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_incarnation_allocates_monotonic_sequences_and_expires_closed() {
+        let provider = RecoveryTokenProvider::default();
+        provider.register_incarnation("tenant", "collection", 9, 100);
+        assert_eq!(provider.allocate("collection", 1).unwrap().sequence, 0);
+        assert_eq!(provider.allocate("collection", 2).unwrap().sequence, 1);
+        assert!(provider.allocate("collection", 100).is_err());
+    }
+}

--- a/tests/objstore_url_construction_test.rs
+++ b/tests/objstore_url_construction_test.rs
@@ -289,3 +289,26 @@ fn no_strip_and_reprepend_pattern_in_src() {
         offenders
     );
 }
+
+/// ADR-063 D5 / TD-OBJSTORE-4 S1: flat object stores answer prefix discovery
+/// through LIST. HEAD/exists on the literal directory key must never gate WAL
+/// enumeration again.
+#[test]
+fn wal_prefix_listing_has_no_exists_gate() {
+    let source = include_str!("../src/storage/persistence/write_ahead_log/disk_manager.rs");
+    let start = source
+        .find("pub async fn list_collection_files")
+        .expect("list_collection_files source");
+    let rest = &source[start..];
+    let end = rest.find("/// Delete a WAL file").expect("method boundary");
+    let implementation = &rest[..end];
+
+    assert!(
+        !implementation.contains(".exists("),
+        "WAL prefix enumeration must LIST directly; exists() is exact-key HEAD on object stores"
+    );
+    assert!(
+        !implementation.contains("if let Ok(entries)"),
+        "WAL prefix enumeration must propagate LIST errors instead of treating them as empty"
+    );
+}


### PR DESCRIPTION
## Summary

Implements ADR-063 / TD-OBJSTORE-4 object-store-native WAL recovery. Prefix LIST is authoritative, recovery ordering is carried in durable tokens, and recovered SST materialization is crash-idempotent through deterministic naming plus conditional create.

The Azurite restart gate found and this branch fixes two additional production-path gaps: Azure LIST returns canonical `az://` URLs that the centralized scheme parser previously rejected, and path-based PAX writers require scoped local staging before direct conditional publication to object storage.

### Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

### Move / Decomposition Inventory

- [x] No files/modules moved
- [ ] Pure move only
- [ ] Move plus behavior change

### Changes

- Make object-store prefix LIST authoritative and fail closed on LIST errors.
- Add durable incarnation/sequence recovery tokens and deterministic replay ordering.
- Add create-only filesystem writes across local, S3, Azure, GCS, caching, counting, encryption, and WAL encryption layers.
- Materialize recovered SST ranges under deterministic digest-bearing names; repeated publication verifies existing bytes and becomes a no-op.
- Suppress recovery compaction until WAL retirement and retain tombstones/latest-record semantics during ordered replay.
- Fix GCS pagination and Azure/GCS canonical scheme aliases.
- Add focused coverage for deterministic double materialization and backend behavior.

### Related Work

Implements ADR-063 / TD-OBJSTORE-4 and follows the accepted ADR text from #1049. Related design review: #1040.

## Test Plan

### Rust Tests

- [x] Targeted WAL/recovery unit tests pass
- [x] Azure object-store process restart integration test passes
- [x] Formatting passes
- [ ] Full CI suite (delegated to GitHub Actions)

### Test Commands Run

```bash
cargo fmt --check
cargo check -p proximadb --lib --features azure,gcp,aws
cargo check -p proximadb-server --features azure
cargo test -p proximadb --lib --features azure recovery_materialization_is_idempotent -- --nocapture
cargo test -p proximadb --lib --features azure storage::persistence::filesystem::scheme_validation::tests -- --nocapture

PROXIMADB_OBJECT_STORE_URL=adls://proximadb-test \
PROXIMADB_AZURE_EMULATOR=1 \
AZURE_STORAGE_USE_EMULATOR=true \
AZURE_ALLOW_HTTP=true \
AZURE_STORAGE_ACCOUNT=devstoreaccount1 \
cargo test -p proximadb-server --features azure \
  --test object_store_restart_recovery \
  zero_vector_kv_record_survives_restart -- \
  --ignored --nocapture --test-threads=1
```

The Azurite gate passed after a clean rebase onto `origin/develop`. The test starts a server, writes the zero-vector KV records, crashes it, starts a second server on a fresh local disk, recovers through object-store LIST/WAL materialization, and reads both records successfully.

## Performance Impact

No synchronous manifest-pointer PUT is added to the normal WAL write path. Recovery uses local segment staging followed by one conditional object create. Recovery-token allocation is process-local after the incarnation fence is cached.

## Breaking Changes

None. Legacy tokenless orphan WAL is intentionally fail-closed unless non-overlap can be proven.

## Security Considerations

- [x] No new dependencies
- [x] No secrets or production credentials in code
- [x] Authenticated encryption wrappers preserve create-only semantics
- [x] Certified recovery fails closed when fencing/token prerequisites are unavailable

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests cover the reported restart regression and repeated materialization
- [ ] All CI checks pass
