### PR TITLE
docs(adr): ADR-065 Accepted — tier regions (co-design review + decisive no-IVF measurement)

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc
@@ -295,3 +295,15 @@ the bytes phase.
 * 2026-07-16 — full N=1M follow-up measured recall `0.968` and `61` GETs/query
   for flat SQ8. The bytes bake-off found no winner; adaptive M, actual-byte
   `IopsBudget` geometry, and scalable cluster fitting are prerequisites.
+* 2026-07-16 — PR2 stack (#1060) cleared both gates: recall `0.990`, `36`
+  GETs/query at SIFT1M (adaptive-M + per-segment invariants cache +
+  encoding-aware block threshold + per-provider `IopsBudget` + zstd). The
+  decisive no-IVF run (production sign-bit-bootstrap flush path) then measured
+  recall `0.985`, `40` GETs, `35 s` flush — clearing both gates *without*
+  `cluster_order_pca_ivf` ordering (~80x faster than the IVF-at-flush eval
+  opt-in). **IVF ordering is not load-bearing** for the coalesced layout; its
+  only benefit (bytes: 250 MB with vs 430 MB without) is the block dead weight
+  link:../../12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc[ADR-065]
+  Region B removes via density. ADR-065 flipped to Accepted; regions use
+  sign-bit row order, PR3 = Region B (SQ8 hoist). `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`
+  remains available for A/B but is no longer the eval default.

--- a/docs/12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc
+++ b/docs/12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc
@@ -14,6 +14,18 @@
 co-design review round before acceptance; the open questions are owned by the
 tier-regions handoff document.
 
+**Co-design review (2026-07-16):** the open questions are resolved inline below
+— Q1 (reuse the #1061 recovery staging seam), Q3 (a `FileSystem`-layer
+read-through range cache, NOT `SstTieringIntegration` — the coalesced reader
+bypasses tiering), and io-trace visibility (the two-class trace system already
+exists: ADR-027/030/TD-160 — PR3 measures bytes/query from day one). Q2/Q4/Q5
+are refined and deferred to PR3/PR4 implementation. **One NEW question gates
+Acceptance:** whether the coalesced layout needs `cluster_order_pca_ivf`
+ordering at all (recall is ordering-independent; the bytes win is Region B
+density, not IVF co-location) — decided by a decisive no-IVF SIFT1M run that
+also collapses the ~47 min eval flush. Acceptance is held until that result
+folds back.
+
 == Context — the remaining cost term is block dead weight, not GETs
 
 Post-PR2 at N=1M: 36 GETs but **250 MB/query** (up from 139 MB — bigger
@@ -93,23 +105,75 @@ bound in practice.
 3. Region D becomes the pure result store (synergy: ADR-055 P-Shred user
    columns and OLAP scans get a props-contiguous layout for free).
 
-== Open questions (handoff-owned)
+== Open questions — resolution status (2026-07-16 co-design review)
 
-1. Writer buffering: regions are written sequentially in one PUT — memory
-   budget for buffering B/C during flush at large segments; streaming
-   multi-part upload interaction.
-2. Region ↔ block row-order coupling and the footer region table shape
-   (self-describing invariants from ADR-062 must extend cleanly).
-3. Cache tiering engagement: the RAM LRU (PR2) covers A(+B); local NVMe/SSD
-   for larger regions — `SstTieringIntegration` exists but is whole-file
-   *placement* tiering (opt-in, off): is it the right seam for a
-   read-through range cache for PAX regions, or does that need a new
-   `FileSystem`-layer cache? (Downstream cost model: blended COGS =
-   miss-rate × cloud GET price — AnvaiOps ADR-0043.)
-4. Result-store block sizing once vectors leave the blocks (row-data blocks
-   can shrink toward result-read granularity).
-5. Mixed legacy/coalesced/region segments in one collection — chooser +
-   mixed-read policy (ADR-061/045 pattern).
+=== Resolved in this review
+
+* **Q1 — Writer buffering → reuse the #1061 recovery staging.** #1061
+  (`fix(wal): object-store recovery restartable`, in flight) already adds
+  temp-local staging + a create-only `write_if_absent` publication in the flush
+  path (`sst/flush/mod.rs`). The region writer stages Regions B/C to temp-local,
+  emits the single segment object (HEADER-prefix → A → B → C → D → footer →
+  magic) in one PUT, and publishes via the same `write_if_absent` seam. No new
+  commit protocol; #1061's idempotent publication is the vehicle. PR3 rebases
+  onto #1061 and reuses its staging. (Multi-part upload is a backend
+  optimization under the same seam — deferred.)
+* **Q3 — Cache tiering → a `FileSystem`-layer read-through range cache, NOT
+  `SstTieringIntegration`.** Evidence: the coalesced reader
+  (`rabitq_search_segment_coalesced`) reads straight from one
+  `fs: &dyn FileSystem` resolved by URL scheme at `sst/search/mod.rs:265`; it
+  **bypasses `SstTieringIntegration` entirely** — tiering only decides
+  placement-at-rest (flush/compaction time) and records access *after* reads
+  (`sst/search/coordinator.rs:84`, observational). It never redirects reads, so
+  it cannot serve a hot-tier NVMe range cache. The right seam is a ranged-cache
+  wrapper in the `FileSystem` resolution chain (the existing
+  `CachingFileSystem` + decompression cache are the closer primitives). Regions
+  make this ~10× more effective per byte: A+B are small, hot, and text-free.
+  Hit/miss counters feed ADR-0043's T2 trigger and the blended-COGS model
+  (miss-rate × cloud GET price).
+
+* **io-trace visibility → already implemented; PR3 measures bytes/query from
+  day one.** The two-class trace system is in place: ADR-027 (strategy), ADR-030
+  (one I/O boundary → route-cost / cache / billing observers), TD-160 (the
+  `io-trace` cargo feature, default OFF, gates *perf emission* only; billing is
+  always-on). Per-query GET/bytes/cache-hit/latency already live in
+  `IoTraceSnapshot` (`observability-engine/src/io_trace.rs:535`). **No need to
+  build a trace system before PR3** — enable the feature in the eval. The real
+  gaps are *billing accuracy*, not measurement: TD-IOTRACE-2 (wire physical
+  GET/bytes into the KRU billing event — Open, revenue-blocking) and
+  TD-IOTRACE-3 (pin `actual_scan_gb` to LOGICAL bytes so coalesced-RaBitQ
+  compression doesn't under-bill ~21–30×). Both land parallel to PR3
+  (customer-visible meter; not a PR3 gate).
+
+=== Refined — deferred to PR3/PR4 implementation
+
+* **Q2 — Footer region table.** Extend `SegmentFooterIndex` with a region
+  table `(offset, len, kind)` beside the existing block table; layout-version
+  bump. Self-describing invariants extend cleanly (ADR-062 footer pattern).
+  Exact encoding is a PR3 detail.
+* **Q4 — Result-store (Region D) sizing.** Tension: vector-reads want small D
+  blocks; OLAP/P-Shred scans (ADR-055) want big contiguous props runs.
+  Resolution sketch: D tuned for result-reads; OLAP goes through the PAX-native
+  scan / DataFusion path (a separate read shape). To be validated in PR4.
+* **Q5 — Mixed segments.** Legacy/coalesced/region layouts in one collection:
+  extend the `SEG_HEADER_MAGIC` presence-field chooser
+  (`is_coalesced_segment`) to detect the region layout (new magic `PXH2`, or a
+  region-count in the header prefix); migration via normal compaction
+  (mixed-read-safe, ADR-061/045).
+
+=== NEW — gated on the decisive measurement (2026-07-16)
+
+* **Does the coalesced layout need `cluster_order_pca_ivf` ordering at all?**
+  This ADR assumes regions are written in IVF order. But recall is driven by
+  adaptive-M + scan-then-rerank (ordering-independent), and the bytes/GET win
+  comes from Region B *density* (pure SQ8 → the coalescing gap absorbs ~10×
+  more survivors per range), **not** from IVF co-location. The decisive no-IVF
+  run (production flush path = sign-bit bootstrap; eval knob
+  `PROXIMADB_SIFT_IVF_FLUSH=0`) tests it: if recall holds ≈0.99 and GETs ≤50,
+  IVF ordering is unnecessary for the coalesced layout — which also collapses
+  the ~47 min SIFT1M flush (the PCA+IVF re-cluster dominates it; it is an eval
+  opt-in `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`, not the production write path).
+  *Status: measurement in flight; result folds back here before Acceptance.*
 
 == Consequences
 

--- a/docs/12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc
+++ b/docs/12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc
@@ -2,29 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 = ADR-065: Clustered tier regions (column families) within the single atomic segment — extend ADR-062's hoisted-region pattern to SQ8 / fp32 / row data
 
-:status: Proposed (2026-07-16 — awaiting co-design + first-principles review; see the tier-regions handoff)
+:status: Accepted (2026-07-16 — co-design review complete; gated IVF-ordering question resolved by a decisive no-IVF SIFT1M measurement)
 :date: 2026-07-16
 :deciders: architecture
 :relates-to: link:ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062] (extends D2; upholds D1), ADR-052 (round-trips dominate), ADR-020 (WAL authority; manifest-level atomicity), ADR-036 (per-object access tier), ADR-055 (P-Shred user columns → the row-data family), link:../../10-quality/td/TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6] (PR2 measured baseline), link:../../10-quality/td/TD-RDSTRAT-7-clustered-residual-pax-bytes.adoc[TD-RDSTRAT-7] (bytes phase; codec bake-off rejected)
 
 == Status
 
-**Proposed.** Drafted from the post-PR2 measured evidence (#1060 stack: recall
-0.987/0.990, GETs 8/36 at 100k/1M) and a downstream cost analysis. Needs the
-co-design review round before acceptance; the open questions are owned by the
-tier-regions handoff document.
+**Accepted (2026-07-16).** Drafted from the post-PR2 measured evidence (#1060
+stack: recall 0.987/0.990, GETs 8/36 at 100k/1M) and a downstream cost
+analysis, then taken through the co-design review round.
 
-**Co-design review (2026-07-16):** the open questions are resolved inline below
-— Q1 (reuse the #1061 recovery staging seam), Q3 (a `FileSystem`-layer
-read-through range cache, NOT `SstTieringIntegration` — the coalesced reader
-bypasses tiering), and io-trace visibility (the two-class trace system already
-exists: ADR-027/030/TD-160 — PR3 measures bytes/query from day one). Q2/Q4/Q5
-are refined and deferred to PR3/PR4 implementation. **One NEW question gates
-Acceptance:** whether the coalesced layout needs `cluster_order_pca_ivf`
-ordering at all (recall is ordering-independent; the bytes win is Region B
-density, not IVF co-location) — decided by a decisive no-IVF SIFT1M run that
-also collapses the ~47 min eval flush. Acceptance is held until that result
-folds back.
+**Co-design review (2026-07-16) — open questions resolved inline below:** Q1
+(reuse the #1061 recovery staging seam), Q3 (a `FileSystem`-layer read-through
+range cache, NOT `SstTieringIntegration` — the coalesced reader bypasses
+tiering), and io-trace visibility (the two-class trace system already exists:
+ADR-027/030/TD-160 — PR3 measures bytes/query from day one). Q2/Q4/Q5 are
+refined and deferred to PR3/PR4 implementation.
+
+**Gated question RESOLVED — the coalesced layout does NOT need
+`cluster_order_pca_ivf` ordering.** The decisive no-IVF SIFT1M run (production
+flush path = sign-bit bootstrap; eval knob `PROXIMADB_SIFT_IVF_FLUSH=0`)
+measured **recall@10 = 0.985, GETs/query = 40, flush = 35 s** — both gates
+cleared (≥0.98 recall, ≤50 GETs), and the flush dropped ~80× (47 min → 35 s).
+IVF's only benefit was the bytes term (250 MB with IVF vs 430 MB without — it
+co-locates survivors into tighter coalesced ranges), but that bytes bloat is
+*exactly the block dead weight this ADR's Region B (SQ8 hoist) removes via
+density, not ordering*. **Decision: drop IVF from the coalesced path; regions
+are written in sign-bit (cheap) row order; PR3 = Region B restores the bytes
+term to ~25–43 MB via SQ8 density.** The `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in
+remains available for IVF-quality A/B but is no longer the eval default.
 
 == Context — the remaining cost term is block dead weight, not GETs
 
@@ -161,19 +168,20 @@ bound in practice.
   region-count in the header prefix); migration via normal compaction
   (mixed-read-safe, ADR-061/045).
 
-=== NEW — gated on the decisive measurement (2026-07-16)
+=== Resolved — the IVF-ordering question (decisive measurement, 2026-07-16)
 
-* **Does the coalesced layout need `cluster_order_pca_ivf` ordering at all?**
-  This ADR assumes regions are written in IVF order. But recall is driven by
-  adaptive-M + scan-then-rerank (ordering-independent), and the bytes/GET win
-  comes from Region B *density* (pure SQ8 → the coalescing gap absorbs ~10×
-  more survivors per range), **not** from IVF co-location. The decisive no-IVF
-  run (production flush path = sign-bit bootstrap; eval knob
-  `PROXIMADB_SIFT_IVF_FLUSH=0`) tests it: if recall holds ≈0.99 and GETs ≤50,
-  IVF ordering is unnecessary for the coalesced layout — which also collapses
-  the ~47 min SIFT1M flush (the PCA+IVF re-cluster dominates it; it is an eval
-  opt-in `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`, not the production write path).
-  *Status: measurement in flight; result folds back here before Acceptance.*
+* **The coalesced layout does NOT need `cluster_order_pca_ivf` ordering.**
+  Recall is driven by adaptive-M + scan-then-rerank (ordering-independent), and
+  the bytes/GET win comes from Region B *density* (pure SQ8 → the coalescing gap
+  absorbs ~10× more survivors per range), **not** from IVF co-location. The
+  decisive no-IVF SIFT1M run (production flush path = sign-bit bootstrap; eval
+  knob `PROXIMADB_SIFT_IVF_FLUSH=0`) measured **recall@10 = 0.985, GETs/query =
+  40, flush = 35 s** — both gates cleared, flush down ~80× (47 min → 35 s).
+  IVF's only benefit was the bytes term (250 MB with IVF vs 430 MB without);
+  that is precisely the block dead weight Region B removes via density.
+  *Result: drop IVF from the coalesced path; regions in sign-bit row order; PR3
+  = Region B restores bytes via SQ8 density. Recorded in
+  link:../../_internal/status/SIFT1M_NOIVF_DECISIVE_2026_07_16.adoc[the artifact].*
 
 == Consequences
 

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -77,6 +77,22 @@ date = "2026-07-16"
 version = "flat eae1cdf4e; SQ6 base 4f0cccf30 + diff sha256 9bddadab; TQ4 3a091c254; RaBitQ4 b4abf4cbc"
 notes = "N=100k flat/SQ6/TQ4/RaBitQ4 recall = 0.991/0.981/0.921/0.917; bytes/query = 32020233/29775220/25124981/25124830; GETs/query = 19. Verified TEXMEX N=1M: flat recall 0.968, 61 GETs, 138851704 bytes/query; SQ6 recall 0.950, 61 GETs, 128722140 bytes/query. Prototype code intentionally discarded after rejection; artifact records source states and dataset hashes. Indicative dev-machine evidence, not an SLA."
 
+[[claims]]
+id = "coalesced_rabitq_noivf_decisive_sift1m"
+claim = "ADR-065 gated question RESOLVED: the coalesced scan-then-rerank layout does NOT need cluster_order_pca_ivf ordering. The production flush path (sign-bit bootstrap, no IVF opt-in) measures recall@10 = 0.985 and GETs/query = 40 at full SIFT1M — both gates cleared (>=0.98 recall, <=50 GETs) — with flush wall time 35 s (~80x faster than the 47 min IVF-at-flush path). IVF's only benefit is the bytes term (250 MB with vs 430 MB without), which is precisely the block dead weight ADR-065 Region B (SQ8 hoist) removes via density, not ordering. Decision: drop IVF; regions in sign-bit row order; PR3 = Region B."
+metric = "recall@10 + range_gets_per_query + bytes_read_per_query + flush_wall_time"
+status = "measured"
+asserted_in = [
+  "docs/12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc",
+]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
+bench_command = "PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_QUERIES=100 PROXIMADB_SIFT_IVF_FLUSH=0 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture"
+artifact = "docs/_internal/status/SIFT1M_NOIVF_DECISIVE_2026_07_16.adoc"
+hardware = "Local macOS arm64 (Apple Silicon)"
+date = "2026-07-16"
+version = "develop @ 549b77fa6 (+ perf/coalesced-pr2-cache-geometry PR2 stack)"
+notes = "Full SIFT1M, single-file collection, 100 queries, top-10, Euclidean, provided GT. IVF OFF = sign-bit bootstrap = the production L0 flush path. Baseline IVF ON (PR2): recall 0.990, 36 GETs, 250 MB, ~47 min flush. The 0.985 recall / 40 GETs here are the production-representative numbers (no eval-only IVF opt-in). The bytes rise (250->430 MB) is the block dead weight Region B will remove via SQ8 density. NOTE: the PROXIMADB_SIFT_IVF_FLUSH=0 knob was added transiently to the eval (gates the set_var at line 486) for this measurement; landing it as a committed eval feature is a pending harness follow-up so the bench_command is reproducible as-is. Indicative dev-machine run, not an SLA."
+
 # ---------------------------------------------------------------------------
 # UNVERIFIED — a bench exists, but no dated artifact backs the claimed number.
 # ---------------------------------------------------------------------------

--- a/docs/_internal/status/SIFT1M_NOIVF_DECISIVE_2026_07_16.adoc
+++ b/docs/_internal/status/SIFT1M_NOIVF_DECISIVE_2026_07_16.adoc
@@ -1,0 +1,84 @@
+= SIFT1M decisive no-IVF run — the coalesced layout does not need IVF ordering (2026-07-16)
+
+:toc: macro
+
+toc::[]
+
+== Why this run
+
+ADR-065 (clustered tier regions) assumed regions are written in
+`cluster_order_pca_ivf` order. But for the coalesced scan-then-rerank layout,
+recall is driven by adaptive-M (scan reads ALL RaBitQ codes, keep=100%) — it is
+*ordering-independent* — and the bytes/GET win comes from Region B *density*
+(pure SQ8), not from IVF co-location. The `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`
+opt-in (the only thing that applies `cluster_order_pca_ivf` at flush) costs
+~47 min at SIFT1M because it trains a PCA + assigns every vector to an IVF cell
+on the flush path.
+
+This run answers the gated question: is IVF ordering load-bearing? If recall
+holds ≥0.98 and GETs ≤50 *without* IVF (the production sign-bit-bootstrap flush
+path), IVF is unnecessary — which also collapses the eval's 47 min flush.
+
+== Run provenance
+
+- **Date:** 2026-07-16
+- **Hardware:** local macOS arm64 (Apple Silicon, shared dev machine — indicative, *not* an SLA)
+- **Toolchain:** `rust-toolchain.toml` pinned 1.95.0, `--release` (8m35s compile, 35.85s test)
+- **Dataset:** full SIFT1M from ANN-benchmarks (TEXMEX `.fvecs`), N=1,000,000, 128d, Euclidean.
+  Provided ground truth: 10,000 queries × 100 neighbours. 100 queries used.
+- **Command:**
+  `PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_QUERIES=100 \
+   PROXIMADB_SIFT_IVF_FLUSH=0 cargo test --release --test sift_pax_recall_ratchet_test \
+   sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture`
+- **The knob:** `PROXIMADB_SIFT_IVF_FLUSH=0` skips the `set_var("PROXIMADB_PAX_FLUSH_CLUSTER","ivf")`
+  in the eval, so the flush uses `cluster_order` (the model-free sign-bit bootstrap =
+  the production L0 flush path). Confirmed off by wall time (35 s flush vs ~47 min).
+
+== Result
+
+[cols="1,1,1,1,1", options="header"]
+|===
+| metric | IVF ON (PR2 baseline) | **IVF OFF (this run)** | delta | gate
+
+| recall@10        | 0.990        | **0.985**        | −0.005 | ≥ 0.98 ✅
+| range_gets/query | 36           | **40**           | +4     | ≤ 50 ✅
+| bytes_read/query | 250 MB       | 430 MB           | +180 MB | — (worse)
+| flush wall time  | ~47 min      | **35 s**         | ~80× faster | —
+|===
+
+== Interpretation
+
+* **Both gates clear without IVF** (recall 0.985 ≥ 0.98; GETs 40 ≤ 50). The
+  0.005 recall dip and +4 GETs are the cost of weaker survivor locality under
+  the sign-bit bootstrap — immaterial to the gates.
+
+* **IVF's only benefit is the bytes term** (250 MB with vs 430 MB without):
+  IVF co-locates survivors into tighter coalesced ranges, so each ranged GET
+  spans less dead weight between survivors. Without it, survivors scatter and
+  the coalescing policy absorbs wider gaps (≈10.75 MB/GET vs ≈6.9 MB/GET).
+
+* **That bytes bloat is exactly what ADR-065 Region B removes — via density,
+  not ordering.** In a pure SQ8 region (128 B/row, no props/fp32/meta), even
+  scattered survivors carry negligible dead weight between them. So once PR3
+  lands Region B, the bytes term drops to ~25–43 MB regardless of row order,
+  and IVF's bytes advantage evaporates.
+
+* **The 47 min flush was paying for nothing structural.** PCA+IVF at flush is
+  an eval opt-in; production never used it (production flush = sign-bit
+  bootstrap, which this run exercises). Dropping it cuts the eval flush ~80×
+
+== Decision
+
+**Drop IVF from the coalesced path.** ADR-065 regions are written in sign-bit
+(cheap) row order; PR3 (Region B, SQ8 hoist) restores the bytes term via SQ8
+density. The `PROXIMADB_PAX_FLUSH_CLUSTER=ivf` opt-in stays available for
+IVF-quality A/B but is no longer the eval default. ADR-065 flips to Accepted on
+this result.
+
+== What is NOT measured here
+
+* Region B (ADR-065 PR3) is not yet implemented — the ~25–43 MB/query target is
+  the *prediction* from SQ8 density (Region B @1M×128d ≈ 128 MB total vs the
+  ~1.7 GB block region with props); measured in PR3.
+* 10M+ scale (recall gate AND downstream coverage unmeasured past 1M — the
+  standing guard from TD-RDSTRAT-6's downstream note).


### PR DESCRIPTION
Takes ADR-065 (clustered tier regions — extend ADR-062's hoisted-region pattern to SQ8/fp32/row data) through the co-design review round to **Accepted**.

## What changed
- **Open questions resolved inline:** Q1 (reuse the in-flight #1061 recovery staging seam — temp-local + `write_if_absent`); Q3 (a `FileSystem`-layer read-through range cache, **not** `SstTieringIntegration` — the coalesced reader bypasses tiering at `search/mod.rs:265`); io-trace visibility (the two-class trace system **already exists**: ADR-027/030/TD-160 — PR3 measures bytes/query from day one; gaps TD-IOTRACE-2/3 are billing-accuracy, parallel to PR3). Q2/Q4/Q5 refined, deferred to PR3/PR4.
- **Gated question RESOLVED** by a decisive no-IVF SIFT1M run: the production sign-bit-bootstrap flush path measures **recall@10 = 0.985, GETs/q = 40, flush = 35 s** — both gates cleared, flush ~80× faster than the IVF-at-flush opt-in (47 min). IVF ordering is **not load-bearing**; its only benefit (bytes) is the block dead weight Region B removes via density. **Decision: drop IVF; regions in sign-bit row order; PR3 = Region B (SQ8 hoist).**

## Files
- `ADR-065-...adoc` — Proposed → Accepted; open questions resolved/refined/resolved-gated.
- `SIFT1M_NOIVF_DECISIVE_2026_07_16.adoc` — evidence artifact (with-IVF vs no-IVF table).
- `BENCHMARK_EVIDENCE.toml` — `coalesced_rabitq_noivf_decisive_sift1m` claim.
- `TD-RDSTRAT-6-...adoc` — history entry (PR2 gates cleared + the no-IVF decision).

## KSU note (at-rest cost)
Regions are a **layout rearrangement**, not a data-volume change — same RaBitQ/SQ8/fp32/row payload, one object per segment (ADR-062 D1 upheld). KSU-neutral to slightly **reduced**: homogeneous regions compress better under zstd, and fp32 becomes an **optional** Region C (collections that don't need exact vectors drop the fp32 tier they were forced to carry inline).

Implementation PRs (PR3 Region B, PR4 Region C) follow on a merged #1060 + #1061 foundation.