### PR TITLE
feat(pax): TD-RDSTRAT-7 lossless clustered + scalar-stripe compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7036,6 +7036,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "metal",
+ "proximadb-compression",
  "proximadb-config",
  "proximadb-hardware-caps",
  "proximadb-runtime-common",

--- a/crates/horizontal/proximadb-codec/Cargo.toml
+++ b/crates/horizontal/proximadb-codec/Cargo.toml
@@ -33,6 +33,7 @@ serde.workspace = true
 tracing.workspace = true
 proximadb-hardware-caps.workspace = true
 proximadb-runtime-common.workspace = true
+proximadb-compression.workspace = true
 # Optional GPU/Metal support (Apple Silicon). Gated behind the `gpu`/`metal` features.
 metal = { version = "0.27", optional = true }
 

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/clustered_for_bitpack.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/clustered_for_bitpack.rs
@@ -102,6 +102,21 @@ struct EncodedChunk {
     payload: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ChunkDirectoryEntry {
+    row_start: usize,
+    row_count: usize,
+    kind: u8,
+    payload_start: usize,
+    payload_len: usize,
+}
+
+struct ParsedClusteredU8 {
+    dimension: usize,
+    row_count: usize,
+    chunks: Vec<ChunkDirectoryEntry>,
+}
+
 /// Encode row-major fixed-dimension u8 data using cluster-local FOR/bit-pack.
 ///
 /// The transform is exact. Each cluster run is split into independently
@@ -163,6 +178,72 @@ pub fn encode_u8_rows(
 
 /// Decode a complete payload produced by [`encode_u8_rows`].
 pub fn decode_u8_rows(data: &[u8]) -> Result<Vec<u8>> {
+    let parsed = parse_clustered_u8(data)?;
+    let output_len = parsed
+        .row_count
+        .checked_mul(parsed.dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 output length overflow"))?;
+    let mut output = vec![0u8; output_len];
+    for chunk in &parsed.chunks {
+        let decoded = decode_chunk(data, &parsed, chunk)?;
+        let output_start = chunk
+            .row_start
+            .checked_mul(parsed.dimension)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 output start overflow"))?;
+        let output_end = output_start
+            .checked_add(decoded.len())
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 output end overflow"))?;
+        output[output_start..output_end].copy_from_slice(&decoded);
+    }
+    Ok(output)
+}
+
+/// Decode only requested rows, preserving `row_indices` order and duplicates.
+///
+/// The directory is fully validated, but only microchunks containing requested
+/// rows run their inverse transform. This bounds rerank CPU by the survivor
+/// chunks rather than by the complete fetched stripe.
+pub fn decode_u8_rows_selected(data: &[u8], row_indices: &[usize]) -> Result<Vec<Vec<u8>>> {
+    let parsed = parse_clustered_u8(data)?;
+    for &row in row_indices {
+        if row >= parsed.row_count {
+            bail!("clustered u8 selected row exceeds declared row count");
+        }
+    }
+    let mut output = vec![Vec::new(); row_indices.len()];
+    for chunk in &parsed.chunks {
+        let chunk_end = chunk
+            .row_start
+            .checked_add(chunk.row_count)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 chunk row overflow"))?;
+        if !row_indices
+            .iter()
+            .any(|&row| row >= chunk.row_start && row < chunk_end)
+        {
+            continue;
+        }
+        let decoded = decode_chunk(data, &parsed, chunk)?;
+        for (output_index, &row) in row_indices.iter().enumerate() {
+            if row < chunk.row_start || row >= chunk_end {
+                continue;
+            }
+            let local_row = row - chunk.row_start;
+            let start = local_row
+                .checked_mul(parsed.dimension)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 selected row offset overflow"))?;
+            let end = start
+                .checked_add(parsed.dimension)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 selected row end overflow"))?;
+            output[output_index].extend_from_slice(&decoded[start..end]);
+        }
+    }
+    if output.iter().any(|row| row.len() != parsed.dimension) {
+        bail!("clustered u8 selected rows were not covered by directory");
+    }
+    Ok(output)
+}
+
+fn parse_clustered_u8(data: &[u8]) -> Result<ParsedClusteredU8> {
     if data.len() < HEADER_LEN {
         bail!("clustered u8 payload shorter than header");
     }
@@ -194,12 +275,9 @@ pub fn decode_u8_rows(data: &[u8]) -> Result<Vec<u8>> {
         "clustered u8 truncated directory",
     )?;
 
-    let output_len = row_count
-        .checked_mul(dimension)
-        .ok_or_else(|| anyhow::anyhow!("clustered u8 output length overflow"))?;
-    let mut output = vec![0u8; output_len];
     let mut expected_row = 0usize;
     let mut expected_payload_offset = 0usize;
+    let mut chunks = Vec::with_capacity(chunk_count);
 
     for _ in 0..chunk_count {
         let row_start = read_u32(data, &mut pos)? as usize;
@@ -229,19 +307,16 @@ pub fn decode_u8_rows(data: &[u8]) -> Result<Vec<u8>> {
             payload_len,
             "clustered u8 chunk payload is truncated",
         )?;
-        let payload = &data[absolute_payload..absolute_payload + payload_len];
-        let decoded = match kind {
-            CHUNK_RAW => decode_raw_chunk(payload, dimension, chunk_rows)?,
-            CHUNK_FOR_BITPACK => decode_for_chunk(payload, dimension, chunk_rows)?,
-            other => bail!("clustered u8 unknown chunk kind {other}"),
-        };
-        let output_start = row_start
-            .checked_mul(dimension)
-            .ok_or_else(|| anyhow::anyhow!("clustered u8 output start overflow"))?;
-        let output_end = chunk_end
-            .checked_mul(dimension)
-            .ok_or_else(|| anyhow::anyhow!("clustered u8 output end overflow"))?;
-        output[output_start..output_end].copy_from_slice(&decoded);
+        if !matches!(kind, CHUNK_RAW | CHUNK_FOR_BITPACK) {
+            bail!("clustered u8 unknown chunk kind {kind}");
+        }
+        chunks.push(ChunkDirectoryEntry {
+            row_start,
+            row_count: chunk_rows,
+            kind,
+            payload_start: absolute_payload,
+            payload_len,
+        });
 
         expected_row = chunk_end;
         expected_payload_offset = expected_payload_offset
@@ -258,7 +333,28 @@ pub fn decode_u8_rows(data: &[u8]) -> Result<Vec<u8>> {
     if expected_end != data.len() {
         bail!("clustered u8 payload has trailing bytes");
     }
-    Ok(output)
+    Ok(ParsedClusteredU8 {
+        dimension,
+        row_count,
+        chunks,
+    })
+}
+
+fn decode_chunk(
+    data: &[u8],
+    parsed: &ParsedClusteredU8,
+    chunk: &ChunkDirectoryEntry,
+) -> Result<Vec<u8>> {
+    let payload_end = chunk
+        .payload_start
+        .checked_add(chunk.payload_len)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 chunk payload end overflow"))?;
+    let payload = &data[chunk.payload_start..payload_end];
+    match chunk.kind {
+        CHUNK_RAW => decode_raw_chunk(payload, parsed.dimension, chunk.row_count),
+        CHUNK_FOR_BITPACK => decode_for_chunk(payload, parsed.dimension, chunk.row_count),
+        other => bail!("clustered u8 unknown chunk kind {other}"),
+    }
 }
 
 fn validate_runs(runs: &[ClusterRun], row_count: usize) -> Result<()> {
@@ -298,36 +394,79 @@ fn row_slice(rows: &[u8], dimension: usize, row_start: usize, row_count: usize) 
 }
 
 fn encode_for_chunk(raw: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
-    let metadata_len = dimension
-        .checked_mul(2)
-        .ok_or_else(|| anyhow::anyhow!("clustered u8 metadata length overflow"))?;
-    let mut metadata = Vec::with_capacity(metadata_len);
-    let mut lanes = Vec::new();
+    const LANE_HEADER_LEN: usize = 6;
+    const EXCEPTION_LEN: usize = 5;
+    let mut output = Vec::new();
 
     for dimension_index in 0..dimension {
         let mut minimum = u8::MAX;
-        let mut maximum = u8::MIN;
         for row_index in 0..row_count {
             let value = raw[row_index * dimension + dimension_index];
             minimum = minimum.min(value);
-            maximum = maximum.max(value);
         }
-        let max_delta = maximum - minimum;
-        let width = if max_delta == 0 {
-            0
-        } else {
-            (u8::BITS - max_delta.leading_zeros()) as u8
-        };
-        metadata.push(minimum);
-        metadata.push(width);
-
         let deltas: Vec<u32> = (0..row_count)
             .map(|row_index| u32::from(raw[row_index * dimension + dimension_index] - minimum))
             .collect();
-        lanes.extend_from_slice(&bitpack_u32(&deltas, width)?);
+
+        // PFOR-style selection: one outlier must not force every value in the
+        // lane to width 8. Choose the exact width whose packed bytes plus sparse
+        // `(row, delta)` exceptions are smallest.
+        let mut best_width = 8u8;
+        let mut best_size = LANE_HEADER_LEN
+            .checked_add(row_count)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 lane size overflow"))?;
+        for width in 0u8..=8 {
+            let threshold = if width == 8 { 256 } else { 1u32 << width };
+            let exception_count = deltas.iter().filter(|&&delta| delta >= threshold).count();
+            let packed_len = row_count
+                .checked_mul(width as usize)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 packed length overflow"))?
+                .div_ceil(8);
+            let candidate_size = LANE_HEADER_LEN
+                .checked_add(packed_len)
+                .and_then(|size| {
+                    exception_count
+                        .checked_mul(EXCEPTION_LEN)
+                        .and_then(|exceptions| size.checked_add(exceptions))
+                })
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 exception size overflow"))?;
+            if candidate_size < best_size {
+                best_size = candidate_size;
+                best_width = width;
+            }
+        }
+
+        let threshold = if best_width == 8 {
+            256
+        } else {
+            1u32 << best_width
+        };
+        let mut packed_deltas = Vec::with_capacity(deltas.len());
+        let mut exceptions = Vec::new();
+        for (row_index, &delta) in deltas.iter().enumerate() {
+            if delta >= threshold {
+                packed_deltas.push(0);
+                exceptions.push((row_index, delta));
+            } else {
+                packed_deltas.push(delta);
+            }
+        }
+        let exception_count = u32::try_from(exceptions.len())
+            .map_err(|_| anyhow::anyhow!("clustered u8 exception count exceeds u32"))?;
+        output.push(minimum);
+        output.push(best_width);
+        output.extend_from_slice(&exception_count.to_le_bytes());
+        output.extend_from_slice(&bitpack_u32(&packed_deltas, best_width)?);
+        for (row_index, delta) in exceptions {
+            let row_index = u32::try_from(row_index)
+                .map_err(|_| anyhow::anyhow!("clustered u8 exception row exceeds u32"))?;
+            let delta = u8::try_from(delta)
+                .map_err(|_| anyhow::anyhow!("clustered u8 exception delta exceeds u8"))?;
+            output.extend_from_slice(&row_index.to_le_bytes());
+            output.push(delta);
+        }
     }
-    metadata.extend_from_slice(&lanes);
-    Ok(metadata)
+    Ok(output)
 }
 
 fn decode_raw_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
@@ -341,24 +480,16 @@ fn decode_raw_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Resul
 }
 
 fn decode_for_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
-    let metadata_len = dimension
-        .checked_mul(2)
-        .ok_or_else(|| anyhow::anyhow!("clustered u8 metadata length overflow"))?;
-    ensure_remaining(
-        payload,
-        0,
-        metadata_len,
-        "clustered u8 transformed chunk lacks lane metadata",
-    )?;
     let output_len = row_count
         .checked_mul(dimension)
         .ok_or_else(|| anyhow::anyhow!("clustered u8 transformed output overflow"))?;
     let mut output = vec![0u8; output_len];
-    let mut lane_pos = metadata_len;
+    let mut lane_pos = 0usize;
 
     for dimension_index in 0..dimension {
-        let minimum = payload[dimension_index * 2];
-        let width = payload[dimension_index * 2 + 1];
+        let minimum = read_u8(payload, &mut lane_pos)?;
+        let width = read_u8(payload, &mut lane_pos)?;
+        let exception_count = read_u32(payload, &mut lane_pos)? as usize;
         if width > 8 {
             bail!("clustered u8 lane bit width exceeds 8");
         }
@@ -384,6 +515,29 @@ fn decode_for_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Resul
         lane_pos = lane_pos
             .checked_add(lane_len)
             .ok_or_else(|| anyhow::anyhow!("clustered u8 lane offset overflow"))?;
+        if exception_count > payload.len().saturating_sub(lane_pos) / 5 {
+            bail!("clustered u8 exception count exceeds lane payload");
+        }
+        let mut exception_rows = vec![false; row_count];
+        let threshold = if width == 8 { 256 } else { 1u32 << width };
+        for _ in 0..exception_count {
+            let exception_row = read_u32(payload, &mut lane_pos)? as usize;
+            let delta = read_u8(payload, &mut lane_pos)?;
+            if exception_row >= row_count {
+                bail!("clustered u8 exception row exceeds chunk");
+            }
+            if exception_rows[exception_row] {
+                bail!("clustered u8 duplicate exception row");
+            }
+            if u32::from(delta) < threshold {
+                bail!("clustered u8 exception fits declared lane width");
+            }
+            exception_rows[exception_row] = true;
+            let value = minimum
+                .checked_add(delta)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 exception value overflow"))?;
+            output[exception_row * dimension + dimension_index] = value;
+        }
     }
     if lane_pos != payload.len() {
         bail!("clustered u8 transformed chunk has trailing bytes");
@@ -501,7 +655,9 @@ fn read_u32(data: &[u8], pos: &mut usize) -> Result<u32> {
 mod tests {
     use anyhow::Result;
 
-    use super::{ClusterRun, ClusteredU8Config, decode_u8_rows, encode_u8_rows};
+    use super::{
+        ClusterRun, ClusteredU8Config, decode_u8_rows, decode_u8_rows_selected, encode_u8_rows,
+    };
 
     #[test]
     fn clustered_u8_round_trip_is_byte_exact() -> Result<()> {
@@ -576,6 +732,62 @@ mod tests {
         assert_eq!(encoded.profile().raw_chunks, 0);
         assert!(encoded.profile().encoded_bytes < encoded.profile().raw_bytes);
         assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_sparse_outliers_do_not_force_eight_bit_lanes() -> Result<()> {
+        let dimension = 16usize;
+        let row_count = 128usize;
+        let mut rows = Vec::with_capacity(dimension * row_count);
+        for row in 0..row_count {
+            for lane in 0..dimension {
+                let value = if row == lane {
+                    255
+                } else {
+                    100 + ((row + lane) % 4) as u8
+                };
+                rows.push(value);
+            }
+        }
+        let encoded = encode_u8_rows(
+            &rows,
+            dimension,
+            &[ClusterRun::new(0, row_count)],
+            ClusteredU8Config {
+                max_rows_per_chunk: row_count,
+                min_savings_bytes: 0,
+            },
+        )?;
+
+        assert!(encoded.profile().encoded_bytes < rows.len() / 2);
+        assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_selected_decode_preserves_order_and_duplicates() -> Result<()> {
+        let dimension = 8usize;
+        let row_count = 24usize;
+        let rows: Vec<u8> = (0..row_count)
+            .flat_map(|row| (0..dimension).map(move |lane| (40 + row + lane) as u8))
+            .collect();
+        let encoded = encode_u8_rows(
+            &rows,
+            dimension,
+            &[ClusterRun::new(0, 12), ClusterRun::new(12, 12)],
+            ClusteredU8Config {
+                max_rows_per_chunk: 6,
+                min_savings_bytes: 0,
+            },
+        )?;
+        let selected = [19usize, 2, 19, 7];
+        let decoded = decode_u8_rows_selected(encoded.as_bytes(), &selected)?;
+        let expected: Vec<Vec<u8>> = selected
+            .iter()
+            .map(|&row| rows[row * dimension..(row + 1) * dimension].to_vec())
+            .collect();
+        assert_eq!(decoded, expected);
         Ok(())
     }
 

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/clustered_for_bitpack.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/clustered_for_bitpack.rs
@@ -1,0 +1,633 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Exact clustered frame-of-reference transform for fixed-dimension u8 rows.
+
+use anyhow::{Result, bail};
+
+use super::bitpack::{bitpack_u32, unbitpack_u32};
+
+const MAGIC: &[u8; 4] = b"CFU8";
+const VERSION: u8 = 1;
+const HEADER_LEN: usize = 17;
+const DIRECTORY_ENTRY_LEN: usize = 17;
+const CHUNK_RAW: u8 = 0;
+const CHUNK_FOR_BITPACK: u8 = 1;
+
+/// One contiguous cluster run in row order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClusterRun {
+    /// First row in the run.
+    pub start_row: usize,
+    /// Number of rows in the run.
+    pub row_count: usize,
+}
+
+impl ClusterRun {
+    /// Construct a contiguous cluster run.
+    pub const fn new(start_row: usize, row_count: usize) -> Self {
+        Self {
+            start_row,
+            row_count,
+        }
+    }
+}
+
+/// Selection and decode-amplification bounds for clustered u8 encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClusteredU8Config {
+    /// Maximum independently encoded rows per microchunk.
+    pub max_rows_per_chunk: usize,
+    /// Required byte saving before selecting FOR/bit-pack over raw bytes.
+    pub min_savings_bytes: usize,
+}
+
+impl Default for ClusteredU8Config {
+    fn default() -> Self {
+        Self {
+            max_rows_per_chunk: 256,
+            min_savings_bytes: 8,
+        }
+    }
+}
+
+/// Realized-size accounting for one encoded u8 matrix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClusteredU8Profile {
+    /// Row count.
+    pub rows: usize,
+    /// Fixed row dimension.
+    pub dimension: usize,
+    /// Input payload bytes.
+    pub raw_bytes: usize,
+    /// Complete encoded bytes, including header and directory.
+    pub encoded_bytes: usize,
+    /// Number of independently decodable microchunks.
+    pub chunk_count: usize,
+    /// Number of chunks using FOR/bit-pack.
+    pub transformed_chunks: usize,
+    /// Number of chunks stored raw.
+    pub raw_chunks: usize,
+}
+
+/// Serialized clustered-u8 payload plus realized-size profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedClusteredU8 {
+    bytes: Vec<u8>,
+    profile: ClusteredU8Profile,
+}
+
+impl EncodedClusteredU8 {
+    /// Borrow the complete serialized payload.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Consume the result and return the serialized payload.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Return realized byte and chunk accounting.
+    pub const fn profile(&self) -> &ClusteredU8Profile {
+        &self.profile
+    }
+}
+
+#[derive(Debug)]
+struct EncodedChunk {
+    row_start: usize,
+    row_count: usize,
+    kind: u8,
+    payload: Vec<u8>,
+}
+
+/// Encode row-major fixed-dimension u8 data using cluster-local FOR/bit-pack.
+///
+/// The transform is exact. Each cluster run is split into independently
+/// described microchunks, and each microchunk falls back to raw row-major bytes
+/// unless the transformed payload clears the configured saving threshold.
+pub fn encode_u8_rows(
+    rows: &[u8],
+    dimension: usize,
+    runs: &[ClusterRun],
+    config: ClusteredU8Config,
+) -> Result<EncodedClusteredU8> {
+    if dimension == 0 {
+        bail!("clustered u8 dimension must be non-zero");
+    }
+    if config.max_rows_per_chunk == 0 {
+        bail!("clustered u8 max_rows_per_chunk must be non-zero");
+    }
+    if !rows.len().is_multiple_of(dimension) {
+        bail!("clustered u8 payload length is not divisible by dimension");
+    }
+
+    let row_count = rows.len() / dimension;
+    validate_runs(runs, row_count)?;
+
+    let mut chunks = Vec::new();
+    for run in runs {
+        let run_end = run
+            .start_row
+            .checked_add(run.row_count)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 run end overflow"))?;
+        let mut chunk_start = run.start_row;
+        while chunk_start < run_end {
+            let chunk_rows = (run_end - chunk_start).min(config.max_rows_per_chunk);
+            let raw = row_slice(rows, dimension, chunk_start, chunk_rows)?.to_vec();
+            let transformed = encode_for_chunk(&raw, dimension, chunk_rows)?;
+            let transformed_with_savings = transformed
+                .len()
+                .checked_add(config.min_savings_bytes)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 saving threshold overflow"))?;
+            let (kind, payload) = if transformed_with_savings <= raw.len() {
+                (CHUNK_FOR_BITPACK, transformed)
+            } else {
+                (CHUNK_RAW, raw)
+            };
+            chunks.push(EncodedChunk {
+                row_start: chunk_start,
+                row_count: chunk_rows,
+                kind,
+                payload,
+            });
+            chunk_start = chunk_start
+                .checked_add(chunk_rows)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 chunk start overflow"))?;
+        }
+    }
+
+    serialize_chunks(rows.len(), dimension, row_count, chunks)
+}
+
+/// Decode a complete payload produced by [`encode_u8_rows`].
+pub fn decode_u8_rows(data: &[u8]) -> Result<Vec<u8>> {
+    if data.len() < HEADER_LEN {
+        bail!("clustered u8 payload shorter than header");
+    }
+    if &data[..4] != MAGIC {
+        bail!("clustered u8 payload has invalid magic");
+    }
+    if data[4] != VERSION {
+        bail!("clustered u8 payload has unsupported version {}", data[4]);
+    }
+
+    let mut pos = 5;
+    let dimension = read_u32(data, &mut pos)? as usize;
+    let row_count = read_u32(data, &mut pos)? as usize;
+    let chunk_count = read_u32(data, &mut pos)? as usize;
+    if dimension == 0 {
+        bail!("clustered u8 payload declares zero dimension");
+    }
+
+    let directory_bytes = chunk_count
+        .checked_mul(DIRECTORY_ENTRY_LEN)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 directory length overflow"))?;
+    let payload_start = HEADER_LEN
+        .checked_add(directory_bytes)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 payload offset overflow"))?;
+    ensure_remaining(
+        data,
+        HEADER_LEN,
+        directory_bytes,
+        "clustered u8 truncated directory",
+    )?;
+
+    let output_len = row_count
+        .checked_mul(dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 output length overflow"))?;
+    let mut output = vec![0u8; output_len];
+    let mut expected_row = 0usize;
+    let mut expected_payload_offset = 0usize;
+
+    for _ in 0..chunk_count {
+        let row_start = read_u32(data, &mut pos)? as usize;
+        let chunk_rows = read_u32(data, &mut pos)? as usize;
+        let kind = read_u8(data, &mut pos)?;
+        let payload_offset = read_u32(data, &mut pos)? as usize;
+        let payload_len = read_u32(data, &mut pos)? as usize;
+
+        if row_start != expected_row || chunk_rows == 0 {
+            bail!("clustered u8 directory has non-contiguous or empty chunk");
+        }
+        if payload_offset != expected_payload_offset {
+            bail!("clustered u8 directory has non-contiguous payload offsets");
+        }
+        let chunk_end = row_start
+            .checked_add(chunk_rows)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 chunk row overflow"))?;
+        if chunk_end > row_count {
+            bail!("clustered u8 chunk exceeds declared row count");
+        }
+        let absolute_payload = payload_start
+            .checked_add(payload_offset)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 absolute payload offset overflow"))?;
+        ensure_remaining(
+            data,
+            absolute_payload,
+            payload_len,
+            "clustered u8 chunk payload is truncated",
+        )?;
+        let payload = &data[absolute_payload..absolute_payload + payload_len];
+        let decoded = match kind {
+            CHUNK_RAW => decode_raw_chunk(payload, dimension, chunk_rows)?,
+            CHUNK_FOR_BITPACK => decode_for_chunk(payload, dimension, chunk_rows)?,
+            other => bail!("clustered u8 unknown chunk kind {other}"),
+        };
+        let output_start = row_start
+            .checked_mul(dimension)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 output start overflow"))?;
+        let output_end = chunk_end
+            .checked_mul(dimension)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 output end overflow"))?;
+        output[output_start..output_end].copy_from_slice(&decoded);
+
+        expected_row = chunk_end;
+        expected_payload_offset = expected_payload_offset
+            .checked_add(payload_len)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 payload length overflow"))?;
+    }
+
+    if expected_row != row_count {
+        bail!("clustered u8 directory does not cover every row");
+    }
+    let expected_end = payload_start
+        .checked_add(expected_payload_offset)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 final payload offset overflow"))?;
+    if expected_end != data.len() {
+        bail!("clustered u8 payload has trailing bytes");
+    }
+    Ok(output)
+}
+
+fn validate_runs(runs: &[ClusterRun], row_count: usize) -> Result<()> {
+    if row_count == 0 {
+        if runs.is_empty() {
+            return Ok(());
+        }
+        bail!("clustered u8 empty input must not declare runs");
+    }
+    let mut expected_start = 0usize;
+    for run in runs {
+        if run.row_count == 0 || run.start_row != expected_start {
+            bail!("clustered u8 runs must be non-empty and exactly contiguous");
+        }
+        expected_start = expected_start
+            .checked_add(run.row_count)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 run coverage overflow"))?;
+        if expected_start > row_count {
+            bail!("clustered u8 runs exceed row count");
+        }
+    }
+    if expected_start != row_count {
+        bail!("clustered u8 runs do not cover every row");
+    }
+    Ok(())
+}
+
+fn row_slice(rows: &[u8], dimension: usize, row_start: usize, row_count: usize) -> Result<&[u8]> {
+    let start = row_start
+        .checked_mul(dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 row offset overflow"))?;
+    let len = row_count
+        .checked_mul(dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 row length overflow"))?;
+    ensure_remaining(rows, start, len, "clustered u8 row slice exceeds input")?;
+    Ok(&rows[start..start + len])
+}
+
+fn encode_for_chunk(raw: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
+    let metadata_len = dimension
+        .checked_mul(2)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 metadata length overflow"))?;
+    let mut metadata = Vec::with_capacity(metadata_len);
+    let mut lanes = Vec::new();
+
+    for dimension_index in 0..dimension {
+        let mut minimum = u8::MAX;
+        let mut maximum = u8::MIN;
+        for row_index in 0..row_count {
+            let value = raw[row_index * dimension + dimension_index];
+            minimum = minimum.min(value);
+            maximum = maximum.max(value);
+        }
+        let max_delta = maximum - minimum;
+        let width = if max_delta == 0 {
+            0
+        } else {
+            (u8::BITS - max_delta.leading_zeros()) as u8
+        };
+        metadata.push(minimum);
+        metadata.push(width);
+
+        let deltas: Vec<u32> = (0..row_count)
+            .map(|row_index| u32::from(raw[row_index * dimension + dimension_index] - minimum))
+            .collect();
+        lanes.extend_from_slice(&bitpack_u32(&deltas, width)?);
+    }
+    metadata.extend_from_slice(&lanes);
+    Ok(metadata)
+}
+
+fn decode_raw_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
+    let expected = row_count
+        .checked_mul(dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 raw chunk length overflow"))?;
+    if payload.len() != expected {
+        bail!("clustered u8 raw chunk has invalid length");
+    }
+    Ok(payload.to_vec())
+}
+
+fn decode_for_chunk(payload: &[u8], dimension: usize, row_count: usize) -> Result<Vec<u8>> {
+    let metadata_len = dimension
+        .checked_mul(2)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 metadata length overflow"))?;
+    ensure_remaining(
+        payload,
+        0,
+        metadata_len,
+        "clustered u8 transformed chunk lacks lane metadata",
+    )?;
+    let output_len = row_count
+        .checked_mul(dimension)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 transformed output overflow"))?;
+    let mut output = vec![0u8; output_len];
+    let mut lane_pos = metadata_len;
+
+    for dimension_index in 0..dimension {
+        let minimum = payload[dimension_index * 2];
+        let width = payload[dimension_index * 2 + 1];
+        if width > 8 {
+            bail!("clustered u8 lane bit width exceeds 8");
+        }
+        let lane_bits = row_count
+            .checked_mul(width as usize)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 lane bit length overflow"))?;
+        let lane_len = lane_bits.div_ceil(8);
+        ensure_remaining(
+            payload,
+            lane_pos,
+            lane_len,
+            "clustered u8 transformed lane is truncated",
+        )?;
+        let deltas = unbitpack_u32(&payload[lane_pos..lane_pos + lane_len], width, row_count)?;
+        for (row_index, delta) in deltas.into_iter().enumerate() {
+            let value = u32::from(minimum)
+                .checked_add(delta)
+                .ok_or_else(|| anyhow::anyhow!("clustered u8 decoded value overflow"))?;
+            let value = u8::try_from(value)
+                .map_err(|_| anyhow::anyhow!("clustered u8 decoded value exceeds u8"))?;
+            output[row_index * dimension + dimension_index] = value;
+        }
+        lane_pos = lane_pos
+            .checked_add(lane_len)
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 lane offset overflow"))?;
+    }
+    if lane_pos != payload.len() {
+        bail!("clustered u8 transformed chunk has trailing bytes");
+    }
+    Ok(output)
+}
+
+fn serialize_chunks(
+    raw_bytes: usize,
+    dimension: usize,
+    row_count: usize,
+    chunks: Vec<EncodedChunk>,
+) -> Result<EncodedClusteredU8> {
+    let chunk_count = chunks.len();
+    let directory_bytes = chunk_count
+        .checked_mul(DIRECTORY_ENTRY_LEN)
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 directory length overflow"))?;
+    let payload_bytes = chunks.iter().try_fold(0usize, |total, chunk| {
+        total
+            .checked_add(chunk.payload.len())
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 payload length overflow"))
+    })?;
+    let encoded_bytes = HEADER_LEN
+        .checked_add(directory_bytes)
+        .and_then(|value| value.checked_add(payload_bytes))
+        .ok_or_else(|| anyhow::anyhow!("clustered u8 encoded length overflow"))?;
+
+    let dimension_u32 = u32::try_from(dimension)
+        .map_err(|_| anyhow::anyhow!("clustered u8 dimension exceeds u32"))?;
+    let row_count_u32 = u32::try_from(row_count)
+        .map_err(|_| anyhow::anyhow!("clustered u8 row count exceeds u32"))?;
+    let chunk_count_u32 = u32::try_from(chunk_count)
+        .map_err(|_| anyhow::anyhow!("clustered u8 chunk count exceeds u32"))?;
+
+    let mut bytes = Vec::with_capacity(encoded_bytes);
+    bytes.extend_from_slice(MAGIC);
+    bytes.push(VERSION);
+    bytes.extend_from_slice(&dimension_u32.to_le_bytes());
+    bytes.extend_from_slice(&row_count_u32.to_le_bytes());
+    bytes.extend_from_slice(&chunk_count_u32.to_le_bytes());
+
+    let mut payload_offset = 0usize;
+    for chunk in &chunks {
+        let row_start = u32::try_from(chunk.row_start)
+            .map_err(|_| anyhow::anyhow!("clustered u8 chunk row start exceeds u32"))?;
+        let chunk_rows = u32::try_from(chunk.row_count)
+            .map_err(|_| anyhow::anyhow!("clustered u8 chunk row count exceeds u32"))?;
+        let offset = u32::try_from(payload_offset)
+            .map_err(|_| anyhow::anyhow!("clustered u8 payload offset exceeds u32"))?;
+        let len = u32::try_from(chunk.payload.len())
+            .map_err(|_| anyhow::anyhow!("clustered u8 chunk payload exceeds u32"))?;
+        bytes.extend_from_slice(&row_start.to_le_bytes());
+        bytes.extend_from_slice(&chunk_rows.to_le_bytes());
+        bytes.push(chunk.kind);
+        bytes.extend_from_slice(&offset.to_le_bytes());
+        bytes.extend_from_slice(&len.to_le_bytes());
+        payload_offset = payload_offset
+            .checked_add(chunk.payload.len())
+            .ok_or_else(|| anyhow::anyhow!("clustered u8 payload offset overflow"))?;
+    }
+    for chunk in &chunks {
+        bytes.extend_from_slice(&chunk.payload);
+    }
+
+    let transformed_chunks = chunks
+        .iter()
+        .filter(|chunk| chunk.kind == CHUNK_FOR_BITPACK)
+        .count();
+    Ok(EncodedClusteredU8 {
+        bytes,
+        profile: ClusteredU8Profile {
+            rows: row_count,
+            dimension,
+            raw_bytes,
+            encoded_bytes,
+            chunk_count,
+            transformed_chunks,
+            raw_chunks: chunk_count - transformed_chunks,
+        },
+    })
+}
+
+fn ensure_remaining(data: &[u8], start: usize, len: usize, message: &str) -> Result<()> {
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("{message}: length overflow"))?;
+    if end > data.len() {
+        bail!("{message}");
+    }
+    Ok(())
+}
+
+fn read_u8(data: &[u8], pos: &mut usize) -> Result<u8> {
+    ensure_remaining(data, *pos, 1, "clustered u8 payload ended while reading u8")?;
+    let value = data[*pos];
+    *pos += 1;
+    Ok(value)
+}
+
+fn read_u32(data: &[u8], pos: &mut usize) -> Result<u32> {
+    ensure_remaining(
+        data,
+        *pos,
+        4,
+        "clustered u8 payload ended while reading u32",
+    )?;
+    let end = *pos + 4;
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&data[*pos..end]);
+    *pos = end;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::{ClusterRun, ClusteredU8Config, decode_u8_rows, encode_u8_rows};
+
+    #[test]
+    fn clustered_u8_round_trip_is_byte_exact() -> Result<()> {
+        let rows = vec![
+            100, 101, 102, 103, // cluster 0
+            101, 100, 103, 102, // cluster 0
+            99, 102, 101, 104, // cluster 0
+            200, 202, 201, 203, // cluster 1
+            201, 203, 200, 202, // cluster 1
+            202, 201, 203, 200, // cluster 1
+        ];
+        let runs = [ClusterRun::new(0, 3), ClusterRun::new(3, 3)];
+        let encoded = encode_u8_rows(
+            &rows,
+            4,
+            &runs,
+            ClusteredU8Config {
+                max_rows_per_chunk: 2,
+                min_savings_bytes: 0,
+            },
+        )?;
+
+        assert_eq!(encoded.profile().rows, 6);
+        assert_eq!(encoded.profile().dimension, 4);
+        assert_eq!(encoded.profile().chunk_count, 4);
+        assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_handles_zero_and_eight_bit_widths() -> Result<()> {
+        let rows = vec![
+            7, 0, 255, // width 0, 0, 0 for first row
+            7, 1, 0, // width 0, 1, 8 across rows
+            7, 0, 128,
+        ];
+        let encoded = encode_u8_rows(
+            &rows,
+            3,
+            &[ClusterRun::new(0, 3)],
+            ClusteredU8Config {
+                max_rows_per_chunk: 3,
+                min_savings_bytes: 0,
+            },
+        )?;
+
+        assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_selects_transform_for_tight_long_runs() -> Result<()> {
+        let dimension = 16;
+        let row_count = 128;
+        let mut rows = Vec::with_capacity(dimension * row_count);
+        for row in 0..row_count {
+            for lane in 0..dimension {
+                rows.push(96 + ((row + lane) % 4) as u8);
+            }
+        }
+        let encoded = encode_u8_rows(
+            &rows,
+            dimension,
+            &[ClusterRun::new(0, row_count)],
+            ClusteredU8Config {
+                max_rows_per_chunk: row_count,
+                min_savings_bytes: 8,
+            },
+        )?;
+
+        assert_eq!(encoded.profile().transformed_chunks, 1);
+        assert_eq!(encoded.profile().raw_chunks, 0);
+        assert!(encoded.profile().encoded_bytes < encoded.profile().raw_bytes);
+        assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_every_byte_value_round_trips() -> Result<()> {
+        let rows: Vec<u8> = (u8::MIN..=u8::MAX).collect();
+        let encoded = encode_u8_rows(
+            &rows,
+            8,
+            &[ClusterRun::new(0, rows.len() / 8)],
+            ClusteredU8Config {
+                max_rows_per_chunk: 7,
+                min_savings_bytes: 0,
+            },
+        )?;
+
+        assert_eq!(decode_u8_rows(encoded.as_bytes())?, rows);
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_u8_rejects_incomplete_or_overlapping_runs() {
+        let rows = vec![1, 2, 3, 4, 5, 6];
+        let config = ClusteredU8Config::default();
+
+        assert!(encode_u8_rows(&rows, 2, &[ClusterRun::new(0, 2)], config).is_err());
+        assert!(
+            encode_u8_rows(
+                &rows,
+                2,
+                &[ClusterRun::new(0, 2), ClusterRun::new(1, 2)],
+                config,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn clustered_u8_corruption_fails_closed() -> Result<()> {
+        let rows = vec![10, 11, 12, 13, 14, 15];
+        let encoded = encode_u8_rows(
+            &rows,
+            2,
+            &[ClusterRun::new(0, 3)],
+            ClusteredU8Config::default(),
+        )?;
+        let mut corrupt = encoded.into_bytes();
+        if let Some(version) = corrupt.get_mut(4) {
+            *version = version.saturating_add(1);
+        }
+
+        assert!(decode_u8_rows(&corrupt).is_err());
+        Ok(())
+    }
+}

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/lossless_compression.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/lossless_compression.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reversible compression of bytes already produced by a value codec.
+
+use anyhow::Result;
+use proximadb_compression::{CompressionAlgorithm, CompressionContext};
+
+/// LZ4-compress encoded bytes when the compressed payload clears `min_savings`.
+///
+/// The returned bytes are the shared compressor's normal size-prefixed LZ4
+/// payload. The owning layout records the compressor tag alongside its existing
+/// value-encoding tag; no nested envelope or additional format version exists.
+pub fn compress_lz4_if_smaller(bytes: &[u8], min_savings: usize) -> Result<Option<Vec<u8>>> {
+    let compressed = proximadb_compression::compress(
+        bytes,
+        CompressionAlgorithm::Lz4,
+        1,
+        CompressionContext::Column,
+    )?;
+    let required = compressed
+        .len()
+        .checked_add(min_savings)
+        .ok_or_else(|| anyhow::anyhow!("lossless compression saving threshold overflow"))?;
+    Ok((required <= bytes.len()).then_some(compressed))
+}
+
+/// Exactly reverse [`compress_lz4_if_smaller`].
+pub fn decompress_lz4(bytes: &[u8]) -> Result<Vec<u8>> {
+    proximadb_compression::decompress(bytes, CompressionAlgorithm::Lz4, CompressionContext::Column)
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::{compress_lz4_if_smaller, decompress_lz4};
+
+    #[test]
+    fn lossless_compression_round_trips_exact_encoded_bytes() -> Result<()> {
+        let bytes = vec![0xff; 16 * 1024];
+        let compressed = compress_lz4_if_smaller(&bytes, 8)?
+            .ok_or_else(|| anyhow::anyhow!("repetitive payload did not compress"))?;
+        assert!(compressed.len() < bytes.len());
+        assert_eq!(decompress_lz4(&compressed)?, bytes);
+        Ok(())
+    }
+
+    #[test]
+    fn lossless_compression_keeps_incompressible_small_payload_flat() -> Result<()> {
+        let bytes: Vec<u8> = (0u8..=u8::MAX).collect();
+        assert!(compress_lz4_if_smaller(&bytes, 8)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn lossless_compression_corruption_fails_closed() -> Result<()> {
+        let bytes = vec![7u8; 4096];
+        let mut compressed = compress_lz4_if_smaller(&bytes, 0)?
+            .ok_or_else(|| anyhow::anyhow!("repetitive payload did not compress"))?;
+        compressed.truncate(compressed.len() / 2);
+        assert!(decompress_lz4(&compressed).is_err());
+        Ok(())
+    }
+}

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/mod.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod adaptive;
 pub mod bitpack;
+pub mod clustered_for_bitpack;
 pub mod delta;
 pub mod double_delta;
 pub mod frame_of_ref;

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/mod.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/mod.rs
@@ -33,6 +33,7 @@ pub mod double_delta;
 pub mod frame_of_ref;
 pub mod gorilla;
 pub(crate) mod helpers;
+pub mod lossless_compression;
 pub mod patched_base;
 pub mod pfor_delta;
 pub mod pfor_double_delta;

--- a/crates/horizontal/proximadb-codec/src/types.rs
+++ b/crates/horizontal/proximadb-codec/src/types.rs
@@ -594,13 +594,14 @@ impl ProximaScheme {
         }
     }
 
-    /// Check if scheme is lossless
-    pub fn is_lossless(&self) -> bool {
-        match self {
-            // Gorilla (XOR) and SQ8/RaBitQ (quantization) are lossy.
-            Self::Gorilla | Self::Sq8 | Self::RaBitQ => false,
-            _ => true,
-        }
+    /// Return whether this scheme preserves every value bit for `type_id`.
+    ///
+    /// This is deliberately type-aware: bit-packed and frame-of-reference
+    /// schemes are lossless only when their configured width covers the input
+    /// type. Durable canonical writers must use this method rather than a
+    /// parameter-blind scheme classification.
+    pub fn is_lossless_for(&self, type_id: TypeId) -> bool {
+        !self.is_lossy(type_id)
     }
 
     /// Check if scheme is suitable for sparse data
@@ -671,10 +672,27 @@ mod tests {
 
     #[test]
     fn test_scheme_properties() {
-        assert!(ProximaScheme::Delta { base: 0 }.is_lossless());
+        assert!(ProximaScheme::Delta { base: 0 }.is_lossless_for(TypeId::F32));
         assert!(ProximaScheme::Delta { base: 0 }.is_integer_scheme());
-        assert!(!ProximaScheme::Gorilla.is_lossless());
+        assert!(!ProximaScheme::Gorilla.is_lossless_for(TypeId::F32));
         assert!(ProximaScheme::SparseBitmap.is_sparse_scheme());
+
+        assert!(!ProximaScheme::BitPacked { bits: 8 }.is_lossless_for(TypeId::F32));
+        assert!(ProximaScheme::BitPacked { bits: 32 }.is_lossless_for(TypeId::F32));
+        assert!(
+            !ProximaScheme::FrameOfReference {
+                reference: 0,
+                bits: 16,
+            }
+            .is_lossless_for(TypeId::I32)
+        );
+        assert!(
+            ProximaScheme::FrameOfReference {
+                reference: 0,
+                bits: 32,
+            }
+            .is_lossless_for(TypeId::I32)
+        );
     }
 
     #[test]
@@ -685,14 +703,14 @@ mod tests {
         assert_eq!(recovered, ProximaScheme::Sq8);
         assert_eq!(s.name(), "SQ8");
         // SQ8 is lossy for every type and never reported lossless.
-        assert!(!s.is_lossless());
+        assert!(!s.is_lossless_for(TypeId::F32));
         assert!(s.is_lossy(TypeId::F32));
         // 0x71 is now the RaBitQ binary-quantization marker.
         let rq = ProximaScheme::from_marker(0x71).unwrap();
         assert_eq!(rq, ProximaScheme::RaBitQ);
         assert_eq!(ProximaScheme::RaBitQ.to_marker(), 0x71);
         assert_eq!(ProximaScheme::RaBitQ.name(), "RaBitQ");
-        assert!(!ProximaScheme::RaBitQ.is_lossless());
+        assert!(!ProximaScheme::RaBitQ.is_lossless_for(TypeId::F32));
         assert!(ProximaScheme::RaBitQ.is_lossy(TypeId::F32));
     }
 

--- a/crates/storage/proximadb-block-format/src/ranged.rs
+++ b/crates/storage/proximadb-block-format/src/ranged.rs
@@ -26,7 +26,7 @@ use anyhow::{Result, bail};
 use crate::{
     reader::{
         RankMetric, decode_f32_vec_v2, decode_i64_with_encoding, decode_str_with_encoding,
-        parse_rabitq_codes, score_rerank_row,
+        decode_vector_payload, parse_rabitq_codes, score_rerank_row,
     },
     record::col_id,
     rowgroup::RowGroupBlock,
@@ -180,6 +180,12 @@ impl BlockLayout {
         end_row: u32,
     ) -> Option<Range<u64>> {
         let entry = self.vparams.get(column_id)?;
+        if self.vparams.transform(column_id).is_some() {
+            // Transformed stripes are microchunk-addressable rather than
+            // fixed-stride. Until the planner consumes the codec directory,
+            // callers must fetch the full (smaller) stripe.
+            return None;
+        }
         let m = self.meta(column_id)?;
         let n = self.footer.n_rows;
         if start_row > end_row || end_row > n {
@@ -212,7 +218,12 @@ impl BlockLayout {
             .vparams
             .get(column_id)
             .ok_or_else(|| anyhow::anyhow!("no vector params for column {column_id}"))?;
-        decode_f32_vec_v2(stripe_bytes, self.footer.n_rows as usize, entry)
+        decode_f32_vec_v2(
+            stripe_bytes,
+            self.footer.n_rows as usize,
+            entry,
+            self.vparams.transform(column_id),
+        )
     }
 
     /// Decode a string column (e.g. `col_id::OID`) from its range-fetched stripe
@@ -301,12 +312,8 @@ impl BlockLayout {
         }
         let n = self.footer.n_rows as usize;
         let dim = entry.dim as usize;
-        let bm_len = n.div_ceil(8);
-        if stripe_bytes.len() < bm_len {
-            return None;
-        }
-        let bitmap = &stripe_bytes[..bm_len];
-        let payload = &stripe_bytes[bm_len..];
+        let (bitmap, payload) =
+            decode_vector_payload(stripe_bytes, n, self.vparams.transform(column_id)).ok()?;
         let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
         let stride = if entry.quant_kind == QUANT_FP16 {
             dim * 2

--- a/crates/storage/proximadb-block-format/src/ranged.rs
+++ b/crates/storage/proximadb-block-format/src/ranged.rs
@@ -26,7 +26,7 @@ use anyhow::{Result, bail};
 use crate::{
     reader::{
         RankMetric, decode_f32_vec_v2, decode_i64_with_encoding, decode_str_with_encoding,
-        decode_vector_payload, parse_rabitq_codes, score_rerank_row,
+        parse_rabitq_codes, score_rerank_rows_from_stripe,
     },
     record::col_id,
     rowgroup::RowGroupBlock,
@@ -310,39 +310,16 @@ impl BlockLayout {
         if entry.quant_kind != QUANT_SQ8 && entry.quant_kind != QUANT_FP16 {
             return None;
         }
-        let n = self.footer.n_rows as usize;
-        let dim = entry.dim as usize;
-        let (bitmap, payload) =
-            decode_vector_payload(stripe_bytes, n, self.vparams.transform(column_id)).ok()?;
-        let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
-        let stride = if entry.quant_kind == QUANT_FP16 {
-            dim * 2
-        } else {
-            dim
-        };
-        let mut scored: Vec<(usize, f32)> = Vec::with_capacity(rows.len());
-        let mut scratch: Vec<f32> = Vec::with_capacity(dim);
-        for &row in rows {
-            if row >= n || !is_present(row) {
-                continue;
-            }
-            let off = row * stride;
-            let end = off + stride;
-            if end > payload.len() {
-                continue;
-            }
-            let dist = score_rerank_row(
-                entry.quant_kind,
-                &entry.params,
-                &payload[off..end],
-                query,
-                metric,
-                &mut scratch,
-            );
-            scored.push((row, dist));
-        }
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-        Some(scored)
+        score_rerank_rows_from_stripe(
+            entry,
+            self.vparams.transform(column_id),
+            stripe_bytes,
+            self.footer.n_rows as usize,
+            query,
+            rows,
+            metric,
+        )
+        .ok()
     }
 }
 

--- a/crates/storage/proximadb-block-format/src/ranged.rs
+++ b/crates/storage/proximadb-block-format/src/ranged.rs
@@ -35,7 +35,7 @@ use crate::{
     writer::{BLOCK_FOOTER_SIZE, BlockFooter},
 };
 use proximadb_codec::functions::rabitq;
-use proximadb_codec::{RaBitQCode, RaBitQParams};
+use proximadb_codec::{RaBitQCode, RaBitQParams, functions};
 
 /// Byte range of the trailing [`BlockFooter`] for an object of `object_size`.
 pub fn footer_tail_range(object_size: u64) -> Result<Range<u64>> {
@@ -205,7 +205,16 @@ impl BlockLayout {
         let m = self
             .meta(column_id)
             .ok_or_else(|| anyhow::anyhow!("column {column_id} not in block"))?;
-        decode_i64_with_encoding(stripe_bytes, m.encoding_id, self.footer.n_rows as usize)
+        let row_count = self.footer.n_rows as usize;
+        if m.stripe_len == 0 && m.null_count as usize == row_count {
+            return Ok(vec![i64::MIN; row_count]);
+        }
+        let payload = if m.is_lz4_compressed {
+            functions::lossless_compression::decompress_lz4(stripe_bytes)?
+        } else {
+            stripe_bytes.to_vec()
+        };
+        decode_i64_with_encoding(&payload, m.encoding_id, row_count)
     }
 
     /// Decode an f32 vector column from its (range-fetched) stripe bytes.
@@ -235,7 +244,16 @@ impl BlockLayout {
         stripe_bytes: &[u8],
     ) -> Option<Vec<Option<String>>> {
         let meta = self.meta(column_id)?;
-        decode_str_with_encoding(stripe_bytes, meta.encoding_id, self.footer.n_rows as usize).ok()
+        let row_count = self.footer.n_rows as usize;
+        if meta.stripe_len == 0 && meta.null_count as usize == row_count {
+            return Some(vec![None; row_count]);
+        }
+        let payload = if meta.is_lz4_compressed {
+            functions::lossless_compression::decompress_lz4(stripe_bytes).ok()?
+        } else {
+            stripe_bytes.to_vec()
+        };
+        decode_str_with_encoding(&payload, meta.encoding_id, row_count).ok()
     }
 
     // ── Ranged RaBitQ cascade (ADR-057 / TD-RDSTRAT-3 S1b) ──────────────────────

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -399,7 +399,11 @@ impl<'a> PaxBlockReader<'a> {
         let raw = self.read_stripe_raw(column_id)?;
         let meta = self.columns.iter().find(|m| m.column_id == column_id)?;
         let n = self.row_count() as usize;
-        let decoded = decode_i64_with_encoding(raw, meta.encoding_id, n).ok()?;
+        if meta.stripe_len == 0 && meta.null_count as usize == n {
+            return Some(vec![None; n]);
+        }
+        let payload = decode_scalar_payload(meta, raw).ok()?;
+        let decoded = decode_i64_with_encoding(&payload, meta.encoding_id, n).ok()?;
         Some(
             decoded
                 .into_iter()
@@ -413,7 +417,11 @@ impl<'a> PaxBlockReader<'a> {
         let raw = self.read_stripe_raw(column_id)?;
         let n = self.row_count() as usize;
         let meta = self.columns.iter().find(|m| m.column_id == column_id)?;
-        decode_str_with_encoding(raw, meta.encoding_id, n).ok()
+        if meta.stripe_len == 0 && meta.null_count as usize == n {
+            return Some(vec![None; n]);
+        }
+        let payload = decode_scalar_payload(meta, raw).ok()?;
+        decode_str_with_encoding(&payload, meta.encoding_id, n).ok()
     }
 
     /// Decode all f64 values from a scalar double column stripe.
@@ -421,7 +429,11 @@ impl<'a> PaxBlockReader<'a> {
         let raw = self.read_stripe_raw(column_id)?;
         let meta = self.columns.iter().find(|m| m.column_id == column_id)?;
         let n = self.row_count() as usize;
-        let decoded = decode_f64_with_encoding(raw, meta.encoding_id, n).ok()?;
+        if meta.stripe_len == 0 && meta.null_count as usize == n {
+            return Some(vec![None; n]);
+        }
+        let payload = decode_scalar_payload(meta, raw).ok()?;
+        let decoded = decode_f64_with_encoding(&payload, meta.encoding_id, n).ok()?;
         Some(
             decoded
                 .into_iter()
@@ -716,6 +728,12 @@ impl<'a> PaxBlockReader<'a> {
     pub fn decode_bytes_stripe(&self, column_id: i32) -> Option<Vec<Option<Vec<u8>>>> {
         let raw = self.read_stripe_raw(column_id)?;
         let n = self.row_count() as usize;
+        let meta = self.columns.iter().find(|m| m.column_id == column_id)?;
+        if meta.stripe_len == 0 && meta.null_count as usize == n {
+            return Some(vec![None; n]);
+        }
+        let payload = decode_scalar_payload(meta, raw).ok()?;
+        let raw = payload.as_ref();
         let mut out = Vec::with_capacity(n);
         let mut pos = 0usize;
         for _ in 0..n {
@@ -737,6 +755,16 @@ impl<'a> PaxBlockReader<'a> {
             pos = val_end;
         }
         Some(out)
+    }
+}
+
+fn decode_scalar_payload<'a>(meta: &ColumnMeta, raw: &'a [u8]) -> Result<Cow<'a, [u8]>> {
+    if meta.is_lz4_compressed {
+        Ok(Cow::Owned(functions::lossless_compression::decompress_lz4(
+            raw,
+        )?))
+    } else {
+        Ok(Cow::Borrowed(raw))
     }
 }
 
@@ -1138,6 +1166,65 @@ mod tests {
     }
 
     #[test]
+    fn lossless_scalar_pages_compress_in_place_and_round_trip() -> Result<()> {
+        const ROWS: usize = 1024;
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 0)
+            .with_lossless_scalar(true);
+        for row in 0..ROWS {
+            writer.add_record(&make_record(
+                &format!("record-{row:08}"),
+                "tenant",
+                1_000 + row as i64,
+            ))?;
+        }
+        let block = writer.flush()?;
+        let reader = PaxBlockReader::open(&block)?;
+
+        let oid_meta = reader
+            .column_metas()
+            .iter()
+            .find(|meta| meta.column_id == col_id::OID)
+            .ok_or_else(|| anyhow::anyhow!("OID metadata missing"))?;
+        assert!(oid_meta.is_lz4_compressed);
+        let actor_meta = reader
+            .column_metas()
+            .iter()
+            .find(|meta| meta.column_id == col_id::ACTOR)
+            .ok_or_else(|| anyhow::anyhow!("actor metadata missing"))?;
+        assert_eq!(actor_meta.null_count as usize, ROWS);
+        assert_eq!(actor_meta.stripe_len, 0);
+
+        let oids = reader
+            .decode_str_stripe(col_id::OID)
+            .ok_or_else(|| anyhow::anyhow!("compressed OID decode failed"))?;
+        assert_eq!(
+            oids.first().and_then(Option::as_deref),
+            Some("record-00000000")
+        );
+        assert_eq!(
+            oids.last().and_then(Option::as_deref),
+            Some("record-00001023")
+        );
+        assert_eq!(
+            reader.decode_str_stripe(col_id::ACTOR),
+            Some(vec![None; ROWS])
+        );
+        assert_eq!(
+            reader.decode_i64_stripe(col_id::VALID_FROM),
+            Some(vec![None; ROWS])
+        );
+        assert_eq!(
+            reader.decode_f64_stripe(col_id::EDGE_WEIGHT),
+            Some(vec![None; ROWS])
+        );
+        assert_eq!(
+            reader.decode_bytes_stripe(col_id::PROPS),
+            Some(vec![None; ROWS])
+        );
+        Ok(())
+    }
+
+    #[test]
     fn reader_pruning() {
         let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 0);
         writer
@@ -1454,9 +1541,15 @@ mod tests {
         let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
             .with_quant(crate::writer::VectorQuant::Sq8)
             .with_clustered_sq8_lossless(true);
+        let mut state = 0x9e37_79b9u32;
         for row in 0..8usize {
             let embedding: Vec<f32> = (0..DIM)
-                .map(|lane| ((row * DIM + lane) % 256) as f32)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 17;
+                    state ^= state << 5;
+                    (state & 0xff) as f32
+                })
                 .collect();
             writer.add_record(&make_record_with_embedding(
                 &format!("r{row}"),

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -1434,6 +1434,52 @@ mod tests {
     }
 
     #[test]
+    fn clustered_sq8_rerank_is_metric_neutral() -> Result<()> {
+        const ROWS_PER_CLUSTER: usize = 128;
+        const DIM: usize = 32;
+        let mut flat = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::RaBitQ);
+        let mut clustered =
+            PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+                .with_quant(crate::writer::VectorQuant::RaBitQ)
+                .with_clustered_sq8_lossless(true);
+        for row in 0..(ROWS_PER_CLUSTER * 2) {
+            if row == ROWS_PER_CLUSTER {
+                clustered.start_cluster_run();
+            }
+            let center = if row < ROWS_PER_CLUSTER { -4.0 } else { 7.0 };
+            let embedding: Vec<f32> = (0..DIM)
+                .map(|lane| center + ((row + lane) % 4) as f32 * 0.01)
+                .collect();
+            let record =
+                make_record_with_embedding(&format!("r{row}"), "t", 1_000 + row as i64, embedding);
+            flat.add_record(&record)?;
+            clustered.add_record(&record)?;
+        }
+        let flat_block = flat.flush()?;
+        let clustered_block = clustered.flush()?;
+        let flat_reader = PaxBlockReader::open(&flat_block)?;
+        let clustered_reader = PaxBlockReader::open(&clustered_block)?;
+        assert!(
+            clustered_reader
+                .vector_params()
+                .transform(col_id::RERANK_BASE)
+                .is_some()
+        );
+
+        let rows: Vec<usize> = (0..ROWS_PER_CLUSTER * 2).collect();
+        let query: Vec<f32> = (0..DIM).map(|lane| 7.0 + lane as f32 * 0.001).collect();
+        for metric in [RankMetric::L2, RankMetric::Cosine, RankMetric::DotProduct] {
+            assert_eq!(
+                clustered_reader.rerank_rows(0, &query, &rows, metric),
+                flat_reader.rerank_rows(0, &query, &rows, metric),
+                "lossless transform changed {metric:?} rerank"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn f32_vec_stripe_no_per_row_dim_header() {
         // v2 vector stripes are fixed-stride with no per-row dim prefix: an SQ8
         // stripe is exactly ceil(n/8) validity bytes + n*dim code bytes.

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -113,6 +113,88 @@ pub fn score_rerank_row(
     }
 }
 
+pub(crate) fn score_rerank_rows_from_stripe(
+    entry: &crate::vparam::VectorParamEntry,
+    transform: Option<&VectorTransformColumn>,
+    stripe: &[u8],
+    row_count: usize,
+    query: &[f32],
+    rows: &[usize],
+    metric: RankMetric,
+) -> Result<Vec<(usize, f32)>> {
+    if entry.quant_kind != QUANT_SQ8 && entry.quant_kind != QUANT_FP16 {
+        bail!("rerank stripe is neither SQ8 nor FP16");
+    }
+    let bitmap_len = row_count.div_ceil(8);
+    if stripe.len() < bitmap_len {
+        bail!("rerank stripe shorter than validity bitmap");
+    }
+    let bitmap = &stripe[..bitmap_len];
+    let stored_payload = &stripe[bitmap_len..];
+    let valid_rows: Vec<usize> = rows
+        .iter()
+        .copied()
+        .filter(|&row| row < row_count && bitmap[row / 8] & (1u8 << (row % 8)) != 0)
+        .collect();
+    let transformed_rows = match transform {
+        None => None,
+        Some(transform) if transform.transform_kind == TRANSFORM_CLUSTERED_FOR_U8 => {
+            if entry.quant_kind != QUANT_SQ8 {
+                bail!("clustered u8 transform declared for non-SQ8 rerank stripe");
+            }
+            Some(functions::clustered_for_bitpack::decode_u8_rows_selected(
+                stored_payload,
+                &valid_rows,
+            )?)
+        }
+        Some(transform) => bail!(
+            "unknown vector transform kind 0x{:02x}",
+            transform.transform_kind
+        ),
+    };
+
+    let dim = entry.dim as usize;
+    let stride = if entry.quant_kind == QUANT_FP16 {
+        dim * 2
+    } else {
+        dim
+    };
+    let mut scored = Vec::with_capacity(valid_rows.len());
+    let mut scratch = Vec::with_capacity(dim);
+    for (selected_index, &row) in valid_rows.iter().enumerate() {
+        let row_bytes = if let Some(decoded) = &transformed_rows {
+            decoded
+                .get(selected_index)
+                .map(Vec::as_slice)
+                .ok_or_else(|| anyhow::anyhow!("decoded rerank row missing"))?
+        } else {
+            let start = row
+                .checked_mul(stride)
+                .ok_or_else(|| anyhow::anyhow!("rerank row offset overflow"))?;
+            let end = start
+                .checked_add(stride)
+                .ok_or_else(|| anyhow::anyhow!("rerank row end overflow"))?;
+            stored_payload
+                .get(start..end)
+                .ok_or_else(|| anyhow::anyhow!("rerank row exceeds stripe payload"))?
+        };
+        if row_bytes.len() != stride {
+            bail!("rerank row has wrong decoded stride");
+        }
+        let distance = score_rerank_row(
+            entry.quant_kind,
+            &entry.params,
+            row_bytes,
+            query,
+            metric,
+            &mut scratch,
+        );
+        scored.push((row, distance));
+    }
+    scored.sort_by(|a, b| a.1.total_cmp(&b.1));
+    Ok(scored)
+}
+
 impl<'a> PaxBlockReader<'a> {
     /// Parse the block header and footer from `data`.
     ///
@@ -444,48 +526,16 @@ impl<'a> PaxBlockReader<'a> {
         if entry.quant_kind != QUANT_SQ8 && entry.quant_kind != QUANT_FP16 {
             return None;
         }
-        let raw = self.read_stripe_raw(column_id)?;
-        let n = self.row_count() as usize;
-        let dim = entry.dim as usize;
-        let bm_len = n.div_ceil(8);
-        if raw.len() < bm_len {
-            return None;
-        }
-        let (bitmap, payload) =
-            decode_vector_payload(raw, n, self.vparams.transform(column_id)).ok()?;
-        let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
-        // FP16: 2 bytes/value; SQ8: 1 byte/value.
-        let stride = if entry.quant_kind == QUANT_FP16 {
-            dim * 2
-        } else {
-            dim
-        };
-
-        let mut scored: Vec<(usize, f32)> = Vec::with_capacity(rows.len());
-        let mut decoded: Vec<f32> = Vec::with_capacity(dim);
-        for &row in rows {
-            if row >= n || !is_present(row) {
-                continue;
-            }
-            let off = row * stride;
-            let end = off + stride;
-            if end > payload.len() {
-                continue;
-            }
-            // Per-row decode+score via the shared primitive (the ranged Stage-2
-            // reader scores its `vector_row_range`-fetched rows with the same fn).
-            let dist = score_rerank_row(
-                entry.quant_kind,
-                &entry.params,
-                &payload[off..end],
-                query,
-                metric,
-                &mut decoded,
-            );
-            scored.push((row, dist));
-        }
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-        Some(scored)
+        score_rerank_rows_from_stripe(
+            entry,
+            self.vparams.transform(column_id),
+            self.read_stripe_raw(column_id)?,
+            self.row_count() as usize,
+            query,
+            rows,
+            metric,
+        )
+        .ok()
     }
 
     /// Stage-2.5 EXACT rerank: like [`rerank_rows`] but reads the OPTIONAL exact-f32

--- a/crates/storage/proximadb-block-format/src/reader.rs
+++ b/crates/storage/proximadb-block-format/src/reader.rs
@@ -15,6 +15,8 @@
 //! locate a row by its id_hash and retrieve its row_index; then all column
 //! stripes are read at that index position.
 
+use std::borrow::Cow;
+
 use anyhow::{Result, bail};
 use crc32fast::Hasher as Crc32;
 use proximadb_codec::{ProximaScheme, functions};
@@ -24,7 +26,10 @@ use crate::{
     row_dir::{ROW_ENTRY_SIZE, RowDirectory},
     rowgroup::RowGroupBlock,
     stripe::{COLUMN_META_SIZE, ColumnMeta},
-    vparam::{QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock},
+    vparam::{
+        QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn,
+        TRANSFORM_CLUSTERED_FOR_U8, VectorParamBlock, VectorTransformColumn,
+    },
     writer::{BLOCK_FOOTER_SIZE, BlockFooter},
 };
 use proximadb_codec::functions::{rabitq, sq8};
@@ -368,7 +373,7 @@ impl<'a> PaxBlockReader<'a> {
             let col = self.vparams.rabitq_column(column_id)?;
             return decode_rabitq_reconstruct(raw, n, entry, col).ok();
         }
-        decode_f32_vec_v2(raw, n, entry).ok()
+        decode_f32_vec_v2(raw, n, entry, self.vparams.transform(column_id)).ok()
     }
 
     /// Return the per-row RaBitQ codes for a binary-quantized vector column,
@@ -446,8 +451,8 @@ impl<'a> PaxBlockReader<'a> {
         if raw.len() < bm_len {
             return None;
         }
-        let bitmap = &raw[..bm_len];
-        let payload = &raw[bm_len..];
+        let (bitmap, payload) =
+            decode_vector_payload(raw, n, self.vparams.transform(column_id)).ok()?;
         let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
         // FP16: 2 bytes/value; SQ8: 1 byte/value.
         let stride = if entry.quant_kind == QUANT_FP16 {
@@ -928,14 +933,10 @@ pub(crate) fn decode_f32_vec_v2(
     data: &[u8],
     count: usize,
     entry: &crate::vparam::VectorParamEntry,
+    transform: Option<&VectorTransformColumn>,
 ) -> Result<Vec<Option<Vec<f32>>>> {
     let dim = entry.dim as usize;
-    let bm_len = count.div_ceil(8);
-    if data.len() < bm_len {
-        bail!("vector stripe shorter than validity bitmap");
-    }
-    let bitmap = &data[..bm_len];
-    let payload = &data[bm_len..];
+    let (bitmap, payload) = decode_vector_payload(data, count, transform)?;
     let is_present = |i: usize| bitmap[i / 8] & (1u8 << (i % 8)) != 0;
 
     let mut out = Vec::with_capacity(count);
@@ -977,6 +978,30 @@ pub(crate) fn decode_f32_vec_v2(
         other => bail!("unknown vector quant_kind: {other}"),
     }
     Ok(out)
+}
+
+pub(crate) fn decode_vector_payload<'a>(
+    data: &'a [u8],
+    count: usize,
+    transform: Option<&VectorTransformColumn>,
+) -> Result<(&'a [u8], Cow<'a, [u8]>)> {
+    let bitmap_len = count.div_ceil(8);
+    if data.len() < bitmap_len {
+        bail!("vector stripe shorter than validity bitmap");
+    }
+    let bitmap = &data[..bitmap_len];
+    let stored_payload = &data[bitmap_len..];
+    let payload = match transform {
+        None => Cow::Borrowed(stored_payload),
+        Some(transform) if transform.transform_kind == TRANSFORM_CLUSTERED_FOR_U8 => Cow::Owned(
+            functions::clustered_for_bitpack::decode_u8_rows(stored_payload)?,
+        ),
+        Some(transform) => bail!(
+            "unknown vector transform kind 0x{:02x}",
+            transform.transform_kind
+        ),
+    };
+    Ok((bitmap, payload))
 }
 
 const PAX_BLOOM_SALTS: [u64; 3] = [
@@ -1304,6 +1329,108 @@ mod tests {
                 assert!((g - o).abs() <= bound + 1e-6, "got {g}, orig {o}");
             }
         }
+    }
+
+    #[test]
+    fn clustered_sq8_transform_is_exact_smaller_and_metadata_driven() -> Result<()> {
+        const ROWS_PER_CLUSTER: usize = 256;
+        const DIM: usize = 32;
+
+        let mut flat = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::Sq8);
+        let mut clustered =
+            PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+                .with_quant(crate::writer::VectorQuant::Sq8)
+                .with_clustered_sq8_lossless(true);
+
+        for row in 0..(ROWS_PER_CLUSTER * 2) {
+            if row == ROWS_PER_CLUSTER {
+                clustered.start_cluster_run();
+            }
+            let center = if row < ROWS_PER_CLUSTER { -10.0 } else { 10.0 };
+            let embedding: Vec<f32> = (0..DIM)
+                .map(|lane| center + ((row + lane) % 3) as f32 * 0.01)
+                .collect();
+            let record =
+                make_record_with_embedding(&format!("r{row}"), "t", 1_000 + row as i64, embedding);
+            flat.add_record(&record)?;
+            clustered.add_record(&record)?;
+        }
+
+        let flat_block = flat.flush()?;
+        let clustered_block = clustered.flush()?;
+        let flat_reader = PaxBlockReader::open(&flat_block)?;
+        let clustered_reader = PaxBlockReader::open(&clustered_block)?;
+        let flat_meta = flat_reader
+            .column_metas()
+            .iter()
+            .find(|meta| meta.column_id == col_id::EMBED_BASE)
+            .ok_or_else(|| anyhow::anyhow!("flat SQ8 stripe metadata missing"))?;
+        let clustered_meta = clustered_reader
+            .column_metas()
+            .iter()
+            .find(|meta| meta.column_id == col_id::EMBED_BASE)
+            .ok_or_else(|| anyhow::anyhow!("clustered SQ8 stripe metadata missing"))?;
+
+        assert!(
+            clustered_meta.stripe_len < flat_meta.stripe_len,
+            "clustered {} bytes is not smaller than flat {} bytes",
+            clustered_meta.stripe_len,
+            flat_meta.stripe_len
+        );
+        assert!(
+            flat_reader
+                .vector_params()
+                .transform(col_id::EMBED_BASE)
+                .is_none()
+        );
+        assert_eq!(
+            clustered_reader
+                .vector_params()
+                .transform(col_id::EMBED_BASE)
+                .map(|transform| transform.transform_kind),
+            Some(crate::vparam::TRANSFORM_CLUSTERED_FOR_U8)
+        );
+        assert_eq!(
+            clustered_reader.decode_f32_vec_stripe(col_id::EMBED_BASE),
+            flat_reader.decode_f32_vec_stripe(col_id::EMBED_BASE)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn clustered_sq8_transform_falls_back_when_not_smaller() -> Result<()> {
+        const DIM: usize = 16;
+        let mut writer = PaxBlockWriter::new(BlockMode::Pax, BlockCompression::None, "col", 0, 1)
+            .with_quant(crate::writer::VectorQuant::Sq8)
+            .with_clustered_sq8_lossless(true);
+        for row in 0..8usize {
+            let embedding: Vec<f32> = (0..DIM)
+                .map(|lane| ((row * DIM + lane) % 256) as f32)
+                .collect();
+            writer.add_record(&make_record_with_embedding(
+                &format!("r{row}"),
+                "t",
+                1_000 + row as i64,
+                embedding,
+            ))?;
+        }
+
+        let block = writer.flush()?;
+        let reader = PaxBlockReader::open(&block)?;
+        assert!(
+            reader
+                .vector_params()
+                .transform(col_id::EMBED_BASE)
+                .is_none()
+        );
+        let meta = reader
+            .column_metas()
+            .iter()
+            .find(|meta| meta.column_id == col_id::EMBED_BASE)
+            .ok_or_else(|| anyhow::anyhow!("SQ8 stripe metadata missing"))?;
+        assert_eq!(meta.stripe_len as usize, 1 + 8 * DIM);
+        Ok(())
     }
 
     #[test]
@@ -2085,7 +2212,7 @@ mod tests {
                 vmax: 0.4,
             },
         };
-        let decoded = decode_f32_vec_v2(&data, rows.len(), &entry).unwrap();
+        let decoded = decode_f32_vec_v2(&data, rows.len(), &entry, None).unwrap();
         assert_eq!(decoded[0], Some(vec![0.1, 0.2]));
         assert_eq!(decoded[1], None);
         assert_eq!(decoded[2], Some(vec![0.3, 0.4]));

--- a/crates/storage/proximadb-block-format/src/stripe.rs
+++ b/crates/storage/proximadb-block-format/src/stripe.rs
@@ -69,7 +69,7 @@ impl ColumnRole {
 /// [4]      role           ColumnRole as u8
 /// [5]      data_type_id   proximadb_codec::TypeId as u8 (0xff = variable/string/bytes)
 /// [6]      encoding_id    ProximaScheme stable marker (0 accepted as legacy raw)
-/// [7]      flags          bit0=nullable, bit1=has_bloom, bit2=sorted
+/// [7]      flags          bit0=nullable, bit1=has_bloom, bit2=sorted, bit3=LZ4
 /// [8..12]  stripe_offset  u32 from body start (after row directory)
 /// [12..16] stripe_len     u32 encoded byte count
 /// [16..20] null_count     u32
@@ -94,6 +94,8 @@ pub struct ColumnMeta {
     pub nullable: bool,
     pub has_bloom: bool,
     pub is_sorted: bool,
+    /// Stripe payload is LZ4-compressed after the value codec.
+    pub is_lz4_compressed: bool,
     /// Byte offset of this column's stripe from the start of the block body
     /// (i.e., from `HEADER_SIZE + row_dir_size`).
     pub stripe_offset: u32,
@@ -118,8 +120,10 @@ impl ColumnMeta {
         b[4] = self.role as u8;
         b[5] = self.data_type_id;
         b[6] = self.encoding_id;
-        b[7] =
-            (self.nullable as u8) | ((self.has_bloom as u8) << 1) | ((self.is_sorted as u8) << 2);
+        b[7] = (self.nullable as u8)
+            | ((self.has_bloom as u8) << 1)
+            | ((self.is_sorted as u8) << 2)
+            | ((self.is_lz4_compressed as u8) << 3);
         b[8..12].copy_from_slice(&self.stripe_offset.to_le_bytes());
         b[12..16].copy_from_slice(&self.stripe_len.to_le_bytes());
         b[16..20].copy_from_slice(&self.null_count.to_le_bytes());
@@ -151,6 +155,7 @@ impl ColumnMeta {
             nullable: flags & 0x01 != 0,
             has_bloom: flags & 0x02 != 0,
             is_sorted: flags & 0x04 != 0,
+            is_lz4_compressed: flags & 0x08 != 0,
             stripe_offset: u32::from_le_bytes(b[8..12].try_into()?),
             stripe_len: u32::from_le_bytes(b[12..16].try_into()?),
             null_count: u32::from_le_bytes(b[16..20].try_into()?),
@@ -398,6 +403,7 @@ mod tests {
             nullable: false,
             has_bloom: false,
             is_sorted: true,
+            is_lz4_compressed: true,
             stripe_offset: 1024,
             stripe_len: 512,
             null_count: 0,

--- a/crates/storage/proximadb-block-format/src/vparam.rs
+++ b/crates/storage/proximadb-block-format/src/vparam.rs
@@ -44,6 +44,9 @@ pub const QUANT_RABITQ: u8 = 2;
 /// Vector stripe is stored as FP16 (2 bytes/value, near-lossless).
 pub const QUANT_FP16: u8 = 3;
 
+/// Exact clustered frame-of-reference/bit-pack transform over SQ8 code bytes.
+pub const TRANSFORM_CLUSTERED_FOR_U8: u8 = 1;
+
 /// Bytes per [`VectorParamEntry`] on the wire.
 pub const ENTRY_SIZE: usize = 28;
 
@@ -102,6 +105,52 @@ pub struct RaBitQColumn {
     pub centroid: Vec<f32>,
 }
 
+/// Block-local reversible transform applied after the value codec.
+///
+/// This optional trailer is absent from legacy `VectorParamBlock` payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorTransformColumn {
+    pub column_id: i32,
+    pub transform_kind: u8,
+    pub transform_version: u8,
+}
+
+impl VectorTransformColumn {
+    const SIZE: usize = 8;
+
+    fn to_bytes(self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        bytes[0..4].copy_from_slice(&self.column_id.to_le_bytes());
+        bytes[4] = self.transform_kind;
+        bytes[5] = self.transform_version;
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < Self::SIZE {
+            bail!("VectorTransformColumn slice too short: {}", bytes.len());
+        }
+        let transform = Self {
+            column_id: i32::from_le_bytes(bytes[0..4].try_into()?),
+            transform_kind: bytes[4],
+            transform_version: bytes[5],
+        };
+        if transform.transform_kind != TRANSFORM_CLUSTERED_FOR_U8 {
+            bail!(
+                "unknown vector transform kind 0x{:02x}",
+                transform.transform_kind
+            );
+        }
+        if transform.transform_version != 1 {
+            bail!(
+                "unsupported vector transform version {}",
+                transform.transform_version
+            );
+        }
+        Ok(transform)
+    }
+}
+
 impl RaBitQColumn {
     fn to_bytes(&self) -> Vec<u8> {
         let mut b = Vec::with_capacity(16 + self.centroid.len() * 4);
@@ -148,6 +197,7 @@ impl RaBitQColumn {
 pub struct VectorParamBlock {
     pub entries: Vec<VectorParamEntry>,
     pub rabitq: Vec<RaBitQColumn>,
+    pub transforms: Vec<VectorTransformColumn>,
 }
 
 impl VectorParamBlock {
@@ -165,6 +215,14 @@ impl VectorParamBlock {
         buf.extend_from_slice(&(self.rabitq.len() as u32).to_le_bytes());
         for r in &self.rabitq {
             buf.extend_from_slice(&r.to_bytes());
+        }
+        // Optional lossless-transform trailer. Omit it when empty so default-OFF
+        // writers retain the legacy VectorParamBlock bytes exactly.
+        if !self.transforms.is_empty() {
+            buf.extend_from_slice(&(self.transforms.len() as u32).to_le_bytes());
+            for transform in &self.transforms {
+                buf.extend_from_slice(&transform.to_bytes());
+            }
         }
         buf
     }
@@ -196,7 +254,41 @@ impl VectorParamBlock {
                 cur += consumed;
             }
         }
-        Ok(Self { entries, rabitq })
+        let mut transforms = Vec::new();
+        if cur < b.len() {
+            if b.len() - cur < 4 {
+                bail!("VectorParamBlock truncated at transform count");
+            }
+            let transform_count = u32::from_le_bytes(b[cur..cur + 4].try_into()?) as usize;
+            cur += 4;
+            if transform_count > b.len().saturating_sub(cur) / VectorTransformColumn::SIZE {
+                bail!("VectorParamBlock transform count exceeds remaining bytes");
+            }
+            transforms.reserve(transform_count);
+            for _ in 0..transform_count {
+                let end = cur + VectorTransformColumn::SIZE;
+                let transform = VectorTransformColumn::from_bytes(&b[cur..end])?;
+                let Some(entry) = entries
+                    .iter()
+                    .find(|entry| entry.column_id == transform.column_id)
+                else {
+                    bail!("vector transform references unknown column");
+                };
+                if entry.quant_kind != QUANT_SQ8 {
+                    bail!("clustered u8 transform requires an SQ8 vector column");
+                }
+                transforms.push(transform);
+                cur = end;
+            }
+        }
+        if cur != b.len() {
+            bail!("VectorParamBlock has trailing bytes");
+        }
+        Ok(Self {
+            entries,
+            rabitq,
+            transforms,
+        })
     }
 
     /// Find the entry for `column_id`, if present.
@@ -207,6 +299,13 @@ impl VectorParamBlock {
     /// Find the RaBitQ side data for `column_id`, if present.
     pub fn rabitq_column(&self, column_id: i32) -> Option<&RaBitQColumn> {
         self.rabitq.iter().find(|r| r.column_id == column_id)
+    }
+
+    /// Find a reversible transform declaration for `column_id`.
+    pub fn transform(&self, column_id: i32) -> Option<&VectorTransformColumn> {
+        self.transforms
+            .iter()
+            .find(|transform| transform.column_id == column_id)
     }
 }
 
@@ -242,15 +341,27 @@ mod tests {
                 },
             ],
             rabitq: Vec::new(),
+            transforms: vec![VectorTransformColumn {
+                column_id: 20,
+                transform_kind: TRANSFORM_CLUSTERED_FOR_U8,
+                transform_version: 1,
+            }],
         };
         let bytes = block.to_bytes();
-        // entries + the (empty) RaBitQ trailer count.
-        assert_eq!(bytes.len(), 4 + 2 * ENTRY_SIZE + 4);
+        // Entries + empty RaBitQ count + one transform-trailer entry.
+        assert_eq!(
+            bytes.len(),
+            4 + 2 * ENTRY_SIZE + 4 + 4 + VectorTransformColumn::SIZE
+        );
         let back = VectorParamBlock::from_bytes(&bytes).unwrap();
         assert_eq!(back, block);
         assert_eq!(back.get(20).unwrap().dim, 384);
         assert_eq!(back.get(20).unwrap().quant_kind, QUANT_SQ8);
         assert_eq!(back.get(21).unwrap().quant_kind, QUANT_RAW_F32);
+        assert_eq!(
+            back.transform(20).map(|transform| transform.transform_kind),
+            Some(TRANSFORM_CLUSTERED_FOR_U8)
+        );
         assert!(back.get(99).is_none());
     }
 
@@ -273,6 +384,7 @@ mod tests {
                 seed: 0xDEAD_BEEF_1234_5678,
                 centroid: vec![0.1, -0.2, 0.3, -0.4],
             }],
+            transforms: Vec::new(),
         };
         let back = VectorParamBlock::from_bytes(&block.to_bytes()).unwrap();
         assert_eq!(back, block);
@@ -289,5 +401,47 @@ mod tests {
         // entries count (0) + RaBitQ trailer count (0).
         assert_eq!(bytes.len(), 8);
         assert!(VectorParamBlock::from_bytes(&bytes).unwrap().is_empty());
+    }
+
+    #[test]
+    fn legacy_vparam_without_transform_trailer_remains_readable() -> Result<()> {
+        let entry = VectorParamEntry {
+            column_id: 20,
+            dim: 4,
+            quant_kind: QUANT_SQ8,
+            params: Sq8Params {
+                scale: 1.0,
+                offset: 0.0,
+                vmin: 0.0,
+                vmax: 255.0,
+            },
+        };
+        let mut legacy = Vec::new();
+        legacy.extend_from_slice(&1u32.to_le_bytes());
+        legacy.extend_from_slice(&entry.to_bytes());
+        legacy.extend_from_slice(&0u32.to_le_bytes());
+
+        let parsed = VectorParamBlock::from_bytes(&legacy)?;
+        assert!(parsed.transforms.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_vector_transform_fails_closed() {
+        let block = VectorParamBlock {
+            entries: Vec::new(),
+            rabitq: Vec::new(),
+            transforms: vec![VectorTransformColumn {
+                column_id: 20,
+                transform_kind: TRANSFORM_CLUSTERED_FOR_U8,
+                transform_version: 1,
+            }],
+        };
+        let mut bytes = block.to_bytes();
+        let transform_kind_offset = 4 + 4 + 4 + 4;
+        if let Some(kind) = bytes.get_mut(transform_kind_offset) {
+            *kind = 0xfe;
+        }
+        assert!(VectorParamBlock::from_bytes(&bytes).is_err());
     }
 }

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -162,6 +162,8 @@ pub struct PaxBlockWriter {
     /// its realized payload is smaller. Default OFF; readers key off the
     /// VectorParamBlock transform trailer rather than inspecting payload magic.
     clustered_sq8_lossless: bool,
+    /// Apply exact all-null elision and shared LZ4 to scalar stripes when smaller.
+    lossless_scalar: bool,
     /// Row offsets at which a new producer-defined cluster starts. Row zero is
     /// implicit. These boundaries are block-local and reset by [`Self::clear`].
     cluster_run_starts: Vec<usize>,
@@ -225,6 +227,7 @@ impl PaxBlockWriter {
             include_f32_tier: false,
             rerank_quant: VectorQuant::Sq8,
             clustered_sq8_lossless: false,
+            lossless_scalar: false,
             cluster_run_starts: Vec::new(),
             oids: Vec::new(),
             tenant_ids: Vec::new(),
@@ -286,6 +289,12 @@ impl PaxBlockWriter {
     /// still stores flat SQ8 unless the complete encoded payload is smaller.
     pub fn with_clustered_sq8_lossless(mut self, enabled: bool) -> Self {
         self.clustered_sq8_lossless = enabled;
+        self
+    }
+
+    /// Enable exact Parquet-style all-null pages and post-codec scalar LZ4.
+    pub fn with_lossless_scalar(mut self, enabled: bool) -> Self {
+        self.lossless_scalar = enabled;
         self
     }
 
@@ -787,6 +796,8 @@ impl PaxBlockWriter {
     ) -> ColumnStripe {
         let scheme = select_str_scheme(role, nullable, vals);
         let (data, null_count) = encode_str_with_scheme(vals, &scheme);
+        let (data, is_lz4_compressed) =
+            self.encode_lossless_scalar(data, null_count as usize, vals.len());
         let stats = string_stats(vals);
         let meta = ColumnMeta {
             column_id: id,
@@ -796,6 +807,7 @@ impl PaxBlockWriter {
             nullable,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -872,6 +884,7 @@ impl PaxBlockWriter {
             nullable: true,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed: false,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -930,6 +943,7 @@ impl PaxBlockWriter {
             nullable: true,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed: false,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1008,6 +1022,7 @@ impl PaxBlockWriter {
             nullable: true,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed: false,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1071,6 +1086,7 @@ impl PaxBlockWriter {
             nullable: true,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed: false,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1103,6 +1119,8 @@ impl PaxBlockWriter {
         let (raw_values, null_count) = flatten_f64_values(vals);
         let scheme = select_f64_scheme(role, nullable, vals);
         let data = encode_f64_with_scheme(&raw_values, &scheme)?;
+        let (data, is_lz4_compressed) =
+            self.encode_lossless_scalar(data, null_count as usize, vals.len());
         let mut meta = ColumnMeta {
             column_id: id,
             role,
@@ -1111,6 +1129,7 @@ impl PaxBlockWriter {
             nullable,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1198,6 +1217,8 @@ impl PaxBlockWriter {
         let (raw_values, null_count) = flatten_i64_values(vals);
         let scheme = select_i64_scheme(role, nullable, vals);
         let data = encode_i64_with_scheme(&raw_values, &scheme)?;
+        let (data, is_lz4_compressed) =
+            self.encode_lossless_scalar(data, null_count as usize, vals.len());
         let mut meta = ColumnMeta {
             column_id: id,
             role,
@@ -1206,6 +1227,7 @@ impl PaxBlockWriter {
             nullable,
             has_bloom: false,
             is_sorted: is_i64_sorted(vals),
+            is_lz4_compressed,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1249,6 +1271,8 @@ impl PaxBlockWriter {
                 }
             }
         }
+        let (data, is_lz4_compressed) =
+            self.encode_lossless_scalar(data, null_count as usize, vals.len());
         let _ = refs; // suppress warning
         let meta = ColumnMeta {
             column_id: id,
@@ -1258,6 +1282,7 @@ impl PaxBlockWriter {
             nullable: true,
             has_bloom: false,
             is_sorted: false,
+            is_lz4_compressed,
             stripe_offset: 0,
             stripe_len: data.len() as u32,
             null_count,
@@ -1268,6 +1293,28 @@ impl PaxBlockWriter {
             bloom_len: 0,
         };
         ColumnStripe::new(meta, data)
+    }
+
+    /// Apply the exact post-codec storage layer selected for this block.
+    /// All-null pages use the existing `null_count` as their definition level
+    /// and need no value payload. Other pages retain the encoded bytes unless
+    /// shared LZ4 clears the realized-size threshold.
+    fn encode_lossless_scalar(
+        &self,
+        data: Vec<u8>,
+        null_count: usize,
+        row_count: usize,
+    ) -> (Vec<u8>, bool) {
+        if !self.lossless_scalar {
+            return (data, false);
+        }
+        if row_count > 0 && null_count == row_count {
+            return (Vec::new(), false);
+        }
+        match functions::lossless_compression::compress_lz4_if_smaller(&data, 8) {
+            Ok(Some(compressed)) => (compressed, true),
+            Ok(None) | Err(_) => (data, false),
+        }
     }
 }
 

--- a/crates/storage/proximadb-block-format/src/writer.rs
+++ b/crates/storage/proximadb-block-format/src/writer.rs
@@ -35,8 +35,8 @@ use crate::{
     rowgroup::{RowGroupBlock, RowGroupEntry, f64_bounds, i64_bounds},
     stripe::{COLUMN_META_SIZE, ColumnMeta, ColumnRole, ColumnStripe},
     vparam::{
-        QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn, VectorParamBlock,
-        VectorParamEntry,
+        QUANT_FP16, QUANT_RABITQ, QUANT_RAW_F32, QUANT_SQ8, RaBitQColumn,
+        TRANSFORM_CLUSTERED_FOR_U8, VectorParamBlock, VectorParamEntry, VectorTransformColumn,
     },
 };
 
@@ -158,6 +158,13 @@ pub struct PaxBlockWriter {
     /// Only used when tier 1 is RaBitQ (the rerank column is emitted alongside
     /// RaBitQ; non-RaBitQ tier 1 doesn't need a separate rerank column).
     rerank_quant: VectorQuant,
+    /// Apply the exact clustered FOR/bit-pack transform to SQ8 code bytes when
+    /// its realized payload is smaller. Default OFF; readers key off the
+    /// VectorParamBlock transform trailer rather than inspecting payload magic.
+    clustered_sq8_lossless: bool,
+    /// Row offsets at which a new producer-defined cluster starts. Row zero is
+    /// implicit. These boundaries are block-local and reset by [`Self::clear`].
+    cluster_run_starts: Vec<usize>,
 
     // Accumulated column data
     oids: Vec<String>,
@@ -217,6 +224,8 @@ impl PaxBlockWriter {
             drop_tenant_col: drop_tenant_col_enabled(),
             include_f32_tier: false,
             rerank_quant: VectorQuant::Sq8,
+            clustered_sq8_lossless: false,
+            cluster_run_starts: Vec::new(),
             oids: Vec::new(),
             tenant_ids: Vec::new(),
             created_at: Vec::new(),
@@ -271,6 +280,24 @@ impl PaxBlockWriter {
     pub fn with_rerank_quant(mut self, quant: VectorQuant) -> Self {
         self.rerank_quant = quant;
         self
+    }
+
+    /// Enable the exact clustered transform for SQ8 code bytes. The writer
+    /// still stores flat SQ8 unless the complete encoded payload is smaller.
+    pub fn with_clustered_sq8_lossless(mut self, enabled: bool) -> Self {
+        self.clustered_sq8_lossless = enabled;
+        self
+    }
+
+    /// Mark the next appended row as the start of a new cluster run.
+    ///
+    /// The clustering producer calls this at ordering boundaries. Calls before
+    /// the first row or repeated at the same boundary are harmless.
+    pub fn start_cluster_run(&mut self) {
+        let start = self.row_count();
+        if start > 0 && self.cluster_run_starts.last().copied() != Some(start) {
+            self.cluster_run_starts.push(start);
+        }
     }
 
     /// P-Shred (ADR-055): shred the given props keys into typed user-columns
@@ -418,6 +445,8 @@ impl PaxBlockWriter {
         let mut vparam_entries: Vec<VectorParamEntry> = Vec::new();
         // RaBitQ side data (centroid + seed) for any binary-quantized columns.
         let mut vparam_rabitq: Vec<RaBitQColumn> = Vec::new();
+        // Exact post-quantization transforms selected by realized byte size.
+        let mut vparam_transforms: Vec<VectorTransformColumn> = Vec::new();
 
         if mode.has_column_stripes() {
             stripes.push(
@@ -526,7 +555,7 @@ impl PaxBlockWriter {
 
             for (i, col) in self.embeddings.iter().enumerate() {
                 let refs: Vec<Option<&[f32]>> = col.iter().map(|v| v.as_deref()).collect();
-                let (stripe, entry, rabitq_col) =
+                let (stripe, entry, rabitq_col, transform) =
                     self.build_f32_vec_stripe(col_id::EMBED_BASE + i as i32, &refs)?;
                 let is_rabitq = rabitq_col.is_some();
                 stripes.push(stripe);
@@ -534,24 +563,34 @@ impl PaxBlockWriter {
                 if let Some(rc) = rabitq_col {
                     vparam_rabitq.push(rc);
                 }
+                if let Some(transform) = transform {
+                    vparam_transforms.push(transform);
+                }
                 // P3 cascade: every RaBitQ-coded embedding gets a co-located rerank
                 // column at `RERANK_BASE + i`. The rerank quant strategy is
                 // configurable (default SQ8; Fp16 for near-lossless; RawF32 for
                 // exact). RaBitQ codes drive the cheap candidate scan; the rerank
                 // pool is scored against this co-located copy before the final top-k.
                 if is_rabitq {
-                    let (rerank_stripe, rerank_entry) = match self.rerank_quant {
+                    let (rerank_stripe, rerank_entry, rerank_transform) = match self.rerank_quant {
                         VectorQuant::Fp16 => {
-                            self.build_fp16_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?
+                            let (stripe, entry) =
+                                self.build_fp16_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?;
+                            (stripe, entry, None)
                         }
                         VectorQuant::RawF32 => {
-                            self.build_raw_f32_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?
+                            let (stripe, entry) = self
+                                .build_raw_f32_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?;
+                            (stripe, entry, None)
                         }
                         // Default: SQ8 (the validated tier-2).
                         _ => self.build_sq8_vec_stripe(col_id::RERANK_BASE + i as i32, &refs)?,
                     };
                     stripes.push(rerank_stripe);
                     vparam_entries.push(rerank_entry);
+                    if let Some(transform) = rerank_transform {
+                        vparam_transforms.push(transform);
+                    }
                 }
                 // P3 Phase D f32 tier (opt-in): an exact-f32 copy of the embedding
                 // at `F32_TIER_BASE + i`, for an exact final rerank (→ recall ≈ 1.0)
@@ -612,6 +651,7 @@ impl PaxBlockWriter {
             let block = VectorParamBlock {
                 entries: vparam_entries,
                 rabitq: vparam_rabitq,
+                transforms: vparam_transforms,
             };
             let bytes = block.to_bytes();
             let offset = col_footer_offset + col_footer_bytes.len() as u32;
@@ -728,6 +768,7 @@ impl PaxBlockWriter {
         for col in &mut self.embeddings {
             col.clear();
         }
+        self.cluster_run_starts.clear();
         self.tenant_id_hash_set = 0;
         self.min_ts = i64::MAX;
         self.max_ts = i64::MIN;
@@ -780,7 +821,12 @@ impl PaxBlockWriter {
         &self,
         id: i32,
         vals: &[Option<&[f32]>],
-    ) -> Result<(ColumnStripe, VectorParamEntry, Option<RaBitQColumn>)> {
+    ) -> Result<(
+        ColumnStripe,
+        VectorParamEntry,
+        Option<RaBitQColumn>,
+        Option<VectorTransformColumn>,
+    )> {
         let dim = vector_column_dim(vals)?;
         let flat: Vec<f32> = vals
             .iter()
@@ -801,22 +847,19 @@ impl PaxBlockWriter {
                 (r, has_data && !r && !sq8_disabled())
             }
         };
-        let (data, scheme, quant_kind, rabitq_col) = if use_rabitq {
+        let (data, scheme, quant_kind, rabitq_col, transformed) = if use_rabitq {
             let (bytes, col) = encode_f32_vec_rabitq(vals, dim, id);
-            (bytes, ProximaScheme::RaBitQ, QUANT_RABITQ, Some(col))
+            (bytes, ProximaScheme::RaBitQ, QUANT_RABITQ, Some(col), false)
         } else if use_sq8 {
-            (
-                encode_f32_vec_sq8(vals, dim, &params),
-                ProximaScheme::Sq8,
-                QUANT_SQ8,
-                None,
-            )
+            let (bytes, transformed) = self.encode_sq8(vals, dim, &params)?;
+            (bytes, ProximaScheme::Sq8, QUANT_SQ8, None, transformed)
         } else {
             (
                 encode_f32_vec_raw_v2(vals, dim),
                 ProximaScheme::Raw,
                 QUANT_RAW_F32,
                 None,
+                false,
             )
         };
 
@@ -848,7 +891,12 @@ impl PaxBlockWriter {
             quant_kind,
             params,
         };
-        Ok((ColumnStripe::new(meta, data), entry, rabitq_col))
+        let transform = transformed.then_some(VectorTransformColumn {
+            column_id: id,
+            transform_kind: TRANSFORM_CLUSTERED_FOR_U8,
+            transform_version: 1,
+        });
+        Ok((ColumnStripe::new(meta, data), entry, rabitq_col, transform))
     }
 
     /// Build an SQ8-quantized vector stripe unconditionally (ignoring the
@@ -860,7 +908,11 @@ impl PaxBlockWriter {
         &self,
         id: i32,
         vals: &[Option<&[f32]>],
-    ) -> Result<(ColumnStripe, VectorParamEntry)> {
+    ) -> Result<(
+        ColumnStripe,
+        VectorParamEntry,
+        Option<VectorTransformColumn>,
+    )> {
         let dim = vector_column_dim(vals)?;
         let flat: Vec<f32> = vals
             .iter()
@@ -868,7 +920,7 @@ impl PaxBlockWriter {
             .flat_map(|s| s.iter().copied())
             .collect();
         let params = functions::sq8::fit_params(&flat);
-        let data = encode_f32_vec_sq8(vals, dim, &params);
+        let (data, transformed) = self.encode_sq8(vals, dim, &params)?;
         let null_count = vals.iter().filter(|v| v.is_none()).count() as u32;
         let meta = ColumnMeta {
             column_id: id,
@@ -897,7 +949,36 @@ impl PaxBlockWriter {
             quant_kind: QUANT_SQ8,
             params,
         };
-        Ok((ColumnStripe::new(meta, data), entry))
+        let transform = transformed.then_some(VectorTransformColumn {
+            column_id: id,
+            transform_kind: TRANSFORM_CLUSTERED_FOR_U8,
+            transform_version: 1,
+        });
+        Ok((ColumnStripe::new(meta, data), entry, transform))
+    }
+
+    fn encode_sq8(
+        &self,
+        vals: &[Option<&[f32]>],
+        dim: u32,
+        params: &functions::Sq8Params,
+    ) -> Result<(Vec<u8>, bool)> {
+        let (bitmap, codes) = encode_f32_vec_sq8_parts(vals, dim, params);
+        if !self.clustered_sq8_lossless || codes.is_empty() {
+            return Ok((join_vector_payload(bitmap, codes), false));
+        }
+
+        let runs = cluster_runs(vals.len(), &self.cluster_run_starts)?;
+        let encoded = functions::clustered_for_bitpack::encode_u8_rows(
+            &codes,
+            dim as usize,
+            &runs,
+            functions::clustered_for_bitpack::ClusteredU8Config::default(),
+        )?;
+        if encoded.as_bytes().len() >= codes.len() {
+            return Ok((join_vector_payload(bitmap, codes), false));
+        }
+        Ok((join_vector_payload(bitmap, encoded.into_bytes()), true))
     }
 
     /// Build a raw-f32 vector stripe unconditionally (the optional exact-f32
@@ -1751,23 +1832,66 @@ fn vector_validity_bitmap(vals: &[Option<&[f32]>]) -> Vec<u8> {
     bm
 }
 
-/// Encode an SQ8 vector stripe: validity bitmap + `n_rows * dim` u8 codes.
-/// Null rows occupy `dim` zero bytes so every row stays seekable.
-fn encode_f32_vec_sq8(vals: &[Option<&[f32]>], dim: u32, params: &functions::Sq8Params) -> Vec<u8> {
+/// Encode the two logical parts of an SQ8 vector stripe. Null rows occupy
+/// `dim` zero bytes so the decoded code matrix remains fixed-stride.
+fn encode_f32_vec_sq8_parts(
+    vals: &[Option<&[f32]>],
+    dim: u32,
+    params: &functions::Sq8Params,
+) -> (Vec<u8>, Vec<u8>) {
     let dim = dim as usize;
-    let mut buf = vector_validity_bitmap(vals);
-    buf.reserve(vals.len() * dim);
+    let bitmap = vector_validity_bitmap(vals);
+    let mut codes = Vec::with_capacity(vals.len() * dim);
     for v in vals {
         match v {
             Some(floats) => {
                 for &f in *floats {
-                    buf.push(functions::sq8::quantize_one(f, params));
+                    codes.push(functions::sq8::quantize_one(f, params));
                 }
             }
-            None => buf.extend(std::iter::repeat_n(0u8, dim)),
+            None => codes.extend(std::iter::repeat_n(0u8, dim)),
         }
     }
-    buf
+    (bitmap, codes)
+}
+
+fn join_vector_payload(mut bitmap: Vec<u8>, payload: Vec<u8>) -> Vec<u8> {
+    bitmap.reserve(payload.len());
+    bitmap.extend_from_slice(&payload);
+    bitmap
+}
+
+fn cluster_runs(
+    row_count: usize,
+    explicit_starts: &[usize],
+) -> Result<Vec<functions::clustered_for_bitpack::ClusterRun>> {
+    if row_count == 0 {
+        return Ok(Vec::new());
+    }
+    let mut starts = Vec::with_capacity(explicit_starts.len() + 1);
+    starts.push(0usize);
+    for &start in explicit_starts {
+        if start == 0 || start >= row_count {
+            anyhow::bail!("cluster run start {start} outside row count {row_count}");
+        }
+        if starts
+            .last()
+            .copied()
+            .is_some_and(|previous| start <= previous)
+        {
+            anyhow::bail!("cluster run starts must be strictly increasing");
+        }
+        starts.push(start);
+    }
+    let mut runs = Vec::with_capacity(starts.len());
+    for (index, &start) in starts.iter().enumerate() {
+        let end = starts.get(index + 1).copied().unwrap_or(row_count);
+        runs.push(functions::clustered_for_bitpack::ClusterRun::new(
+            start,
+            end - start,
+        ));
+    }
+    Ok(runs)
 }
 
 /// Encode a raw fixed-stride f32 vector stripe: validity bitmap + `n_rows *

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -53,8 +53,11 @@ use crate::engine_constants::{
     MAX_TARGET_BLOCK_SIZE_BYTES,
 };
 use crate::segment_layout::{
-    FooterBlockEntry, SEG_HEADER_PREFIX_LEN, SEG_LAYOUT_VERSION, SegmentFooterIndex,
-    SegmentHeaderPrefix, StatsKind, is_coalesced_segment, segment_tail,
+    BlockTierAssignment, EXTERNAL_CANONICAL_SOURCE_ID, FooterBlockEntry, LosslessCompressionTag,
+    LosslessTransformTag, ParameterScope, SEG_HEADER_PREFIX_LEN, SEG_LAYOUT_VERSION,
+    SegmentFooterIndex, SegmentHeaderPrefix, SourceFidelity, SourceRole, StatsKind,
+    StripeEncodingDescriptor, TierRole, VectorTransform, compression_flags, is_coalesced_segment,
+    segment_tail,
 };
 
 /// File extension for PAX segment files.
@@ -509,6 +512,9 @@ pub struct PaxSegmentWriter {
     f32_tier: bool,
     /// Tier-2 rerank quant (default Sq8) — re-applied to every block writer.
     rerank_quant: VectorQuant,
+    /// Exact clustered transform over SQ8 code bytes. Default OFF and selected
+    /// independently per stripe by realized byte size.
+    lossless_clustered: bool,
     /// P-Shred (ADR-055): `(prop_key, user_col_id)` to shred into typed user-columns —
     /// re-applied to every block writer so all blocks in the segment shred uniformly.
     shred_spec: Vec<(String, i32)>,
@@ -538,6 +544,9 @@ pub struct PaxSegmentWriter {
     /// Finalised per-block RMS radius (spread), 1:1 with `block_centroids`
     /// (`0.0` for a block with no Fp32 vector). Empty unless centroids opted in.
     block_radii: Vec<f32>,
+    /// Exact SQ8 transforms selected in each emitted block, by physical column
+    /// ID. Kept 1:1 with `index.blocks` for footer-v2 assignments.
+    block_transformed_sq8_columns: Vec<Vec<i32>>,
 
     /// ADR-062 / TD-RDSTRAT-6: emit the coalesced-RaBitQ layout — a file-level
     /// header region (cluster-ordered, single segment centroid) + self-describing
@@ -594,6 +603,7 @@ impl PaxSegmentWriter {
             quant: VectorQuant::Auto,
             f32_tier: false,
             rerank_quant: VectorQuant::Sq8,
+            lossless_clustered: false,
             shred_spec: Vec::new(),
             current_writer: writer,
             index: SegmentIndex { blocks: Vec::new() },
@@ -606,6 +616,7 @@ impl PaxSegmentWriter {
             cur_centroid_sumsq: 0.0,
             block_centroids: Vec::new(),
             block_radii: Vec::new(),
+            block_transformed_sq8_columns: Vec::new(),
             coalesced_rabitq: false,
             rabitq_vectors: Vec::new(),
             per_row_estimate: 0,
@@ -651,6 +662,18 @@ impl PaxSegmentWriter {
         self
     }
 
+    /// Enable the lossless clustered SQ8 transform for every block.
+    pub fn with_lossless_clustered(mut self, enabled: bool) -> Self {
+        self.lossless_clustered = enabled;
+        self.current_writer = self.fresh_block_writer();
+        self
+    }
+
+    /// Mark the next appended record as the start of a producer-defined cluster.
+    pub fn start_cluster_run(&mut self) {
+        self.current_writer.start_cluster_run();
+    }
+
     /// P-Shred (ADR-055): shred the given props keys `(prop_key, user_col_id)` into
     /// typed user-columns for every block in this segment. Builder form mirroring
     /// [`with_quant`]; empty ⇒ no shredding (byte-for-byte today's output).
@@ -694,6 +717,7 @@ impl PaxSegmentWriter {
         .with_quant(block_quant)
         .with_f32_tier(self.f32_tier)
         .with_rerank_quant(self.rerank_quant)
+        .with_clustered_sq8_lossless(self.lossless_clustered)
         .with_shred_spec(self.shred_spec.clone())
     }
 
@@ -846,6 +870,14 @@ impl PaxSegmentWriter {
         let offset = self.file_buf.len() as u64;
 
         let reader = PaxBlockReader::open(&block_bytes)?;
+        self.block_transformed_sq8_columns.push(
+            reader
+                .vector_params()
+                .transforms
+                .iter()
+                .map(|transform| transform.column_id)
+                .collect(),
+        );
         let stats =
             BlockStats::from_metas(row_count, block_size, min_ts, max_ts, reader.column_metas());
 
@@ -930,6 +962,158 @@ impl PaxSegmentWriter {
         })
     }
 
+    fn footer_encoding_map(
+        &self,
+    ) -> Result<(Vec<StripeEncodingDescriptor>, Vec<BlockTierAssignment>)> {
+        if !self
+            .block_transformed_sq8_columns
+            .iter()
+            .any(|columns| !columns.is_empty())
+        {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let mut descriptors = Vec::new();
+        let mut assignments = Vec::new();
+        let mut next_id = 1u16;
+        for embedding in 0..self.embedding_count {
+            let logical_field_id = col_id::EMBED_BASE + embedding as i32;
+            let physical_column_id = logical_field_id;
+            let canonical_id = if self.f32_tier {
+                let id = take_descriptor_id(&mut next_id)?;
+                let exact_column = col_id::F32_TIER_BASE + embedding as i32;
+                descriptors.push(StripeEncodingDescriptor {
+                    descriptor_id: id,
+                    logical_field_id,
+                    physical_column_id: exact_column,
+                    tier_role: TierRole::Exact,
+                    value_codec_tag: 0x01,
+                    value_codec_version: 1,
+                    transform_tag: LosslessTransformTag::None,
+                    transform_version: 0,
+                    compression_tag: LosslessCompressionTag::None,
+                    compression_version: 0,
+                    compression_flags: compression_flags::LOSSLESS,
+                    parameter_scope: ParameterScope::Block,
+                    vector_transform: VectorTransform::None,
+                    auxiliary_flags: 0,
+                    source_role: SourceRole::Canonical,
+                    source_fidelity: SourceFidelity::ExactBitwise,
+                    rebuild_source_id: 0,
+                    projection_generation: 0,
+                });
+                for block_ordinal in 0..self.index.blocks.len() {
+                    assignments.push(BlockTierAssignment {
+                        block_ordinal: u32::try_from(block_ordinal)
+                            .map_err(|_| anyhow::anyhow!("block ordinal exceeds u32"))?,
+                        physical_column_id: exact_column,
+                        tier_role: TierRole::Exact,
+                        descriptor_id: id,
+                    });
+                }
+                id
+            } else {
+                EXTERNAL_CANONICAL_SOURCE_ID
+            };
+
+            if embedding == 0 {
+                descriptors.push(StripeEncodingDescriptor {
+                    descriptor_id: take_descriptor_id(&mut next_id)?,
+                    logical_field_id,
+                    physical_column_id,
+                    tier_role: TierRole::Index,
+                    value_codec_tag: 0x71,
+                    value_codec_version: 1,
+                    transform_tag: LosslessTransformTag::None,
+                    transform_version: 0,
+                    compression_tag: LosslessCompressionTag::None,
+                    compression_version: 0,
+                    compression_flags: compression_flags::LOSSLESS,
+                    parameter_scope: ParameterScope::Segment,
+                    vector_transform: VectorTransform::CenteredRotated,
+                    auxiliary_flags: 0,
+                    source_role: SourceRole::IndexProjection,
+                    source_fidelity: SourceFidelity::Lossy,
+                    rebuild_source_id: canonical_id,
+                    projection_generation: 1,
+                });
+            }
+
+            let flat_id = take_descriptor_id(&mut next_id)?;
+            descriptors.push(StripeEncodingDescriptor {
+                descriptor_id: flat_id,
+                logical_field_id,
+                physical_column_id,
+                tier_role: TierRole::Rerank,
+                value_codec_tag: 0x05,
+                value_codec_version: 1,
+                transform_tag: LosslessTransformTag::None,
+                transform_version: 0,
+                compression_tag: LosslessCompressionTag::None,
+                compression_version: 0,
+                compression_flags: compression_flags::LOSSLESS,
+                parameter_scope: ParameterScope::Block,
+                vector_transform: VectorTransform::None,
+                auxiliary_flags: 0,
+                source_role: SourceRole::RerankProjection,
+                source_fidelity: SourceFidelity::Lossy,
+                rebuild_source_id: canonical_id,
+                projection_generation: 1,
+            });
+
+            let has_transformed = self
+                .block_transformed_sq8_columns
+                .iter()
+                .any(|columns| columns.contains(&physical_column_id));
+            let transformed_id = if has_transformed {
+                let id = take_descriptor_id(&mut next_id)?;
+                descriptors.push(StripeEncodingDescriptor {
+                    descriptor_id: id,
+                    logical_field_id,
+                    physical_column_id,
+                    tier_role: TierRole::Rerank,
+                    value_codec_tag: 0x05,
+                    value_codec_version: 1,
+                    transform_tag: LosslessTransformTag::ClusteredForBitpackU8,
+                    transform_version: 1,
+                    compression_tag: LosslessCompressionTag::None,
+                    compression_version: 0,
+                    compression_flags: compression_flags::LOSSLESS,
+                    parameter_scope: ParameterScope::MicroChunk,
+                    vector_transform: VectorTransform::None,
+                    auxiliary_flags: 0,
+                    source_role: SourceRole::RerankProjection,
+                    source_fidelity: SourceFidelity::Lossy,
+                    rebuild_source_id: canonical_id,
+                    projection_generation: 1,
+                });
+                Some(id)
+            } else {
+                None
+            };
+
+            for (block_ordinal, transformed_columns) in
+                self.block_transformed_sq8_columns.iter().enumerate()
+            {
+                let descriptor_id = if transformed_columns.contains(&physical_column_id) {
+                    transformed_id.ok_or_else(|| {
+                        anyhow::anyhow!("transformed block has no encoding descriptor")
+                    })?
+                } else {
+                    flat_id
+                };
+                assignments.push(BlockTierAssignment {
+                    block_ordinal: u32::try_from(block_ordinal)
+                        .map_err(|_| anyhow::anyhow!("block ordinal exceeds u32"))?,
+                    physical_column_id,
+                    tier_role: TierRole::Rerank,
+                    descriptor_id,
+                });
+            }
+        }
+        Ok((descriptors, assignments))
+    }
+
     /// ADR-062 / TD-RDSTRAT-6 coalesced layout: `[HEADER-PREFIX][RaBitQ region]
     /// [blocks][FOOTER-INDEX][footer_len][SEGMENT_MAGIC]`. The RaBitQ region is
     /// one ranged GET (keep=100% scan); the footer-index block table carries
@@ -964,6 +1148,7 @@ impl PaxSegmentWriter {
 
         // 3. Footer-index body + header-prefix offsets. The footer sits after the
         //    blocks; its length is known once serialized.
+        let (encoding_map, block_tier_assignments) = self.footer_encoding_map()?;
         let footer = SegmentFooterIndex {
             row_count: self.row_count,
             rabitq_off,
@@ -973,8 +1158,8 @@ impl PaxSegmentWriter {
             embed_quant_tag: 1, // SQ8 (the survivor-rerank data tier)
             has_f32_tier: self.f32_tier,
             blocks,
-            encoding_map: Vec::new(),
-            block_tier_assignments: Vec::new(),
+            encoding_map,
+            block_tier_assignments,
         };
         let footer_body = footer.to_bytes()?;
         let footer_off = data_offset + self.file_buf.len() as u64;
@@ -1056,6 +1241,17 @@ impl PaxSegmentWriter {
             rabitq_len: 0,
         })
     }
+}
+
+fn take_descriptor_id(next_id: &mut u16) -> Result<u16> {
+    if *next_id == EXTERNAL_CANONICAL_SOURCE_ID {
+        bail!("footer encoding descriptor id space exhausted");
+    }
+    let id = *next_id;
+    *next_id = next_id
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("footer encoding descriptor id overflow"))?;
+    Ok(id)
 }
 
 // ── Scanner ───────────────────────────────────────────────────────────────────
@@ -1351,6 +1547,63 @@ mod tests {
             updated_at_ns: ts,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn coalesced_footer_assigns_actual_clustered_sq8_encoding() -> Result<()> {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+
+        const ROWS_PER_CLUSTER: usize = 256;
+        const DIM: usize = 32;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("clustered-footer.pax");
+        let mut writer = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            Some(ROWS_PER_CLUSTER * 2 * 1024),
+        )
+        .with_quant(VectorQuant::RaBitQ)
+        .with_coalesced_rabitq(true)
+        .with_lossless_clustered(true);
+
+        for row in 0..(ROWS_PER_CLUSTER * 2) {
+            if row == ROWS_PER_CLUSTER {
+                writer.start_cluster_run();
+            }
+            let center = if row < ROWS_PER_CLUSTER { -10.0 } else { 10.0 };
+            let values: Vec<f32> = (0..DIM)
+                .map(|lane| center + ((row + lane) % 3) as f32 * 0.01)
+                .collect();
+            let mut record = make_record(&format!("r{row}"), "t", 1_000 + row as i64);
+            record.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: DIM as u32,
+                values: EmbeddingValues::Fp32(values),
+                ..Default::default()
+            });
+            writer.add_record(&record)?;
+        }
+        writer.finish()?;
+
+        let segment = std::fs::read(&path)?;
+        let footer = SegmentFooterIndex::locate_in_segment(&segment)?
+            .ok_or_else(|| anyhow::anyhow!("coalesced footer missing"))?;
+        let transformed = footer.encoding_map.iter().find(|descriptor| {
+            descriptor.physical_column_id == col_id::EMBED_BASE
+                && descriptor.transform_tag == LosslessTransformTag::ClusteredForBitpackU8
+        });
+        let transformed =
+            transformed.ok_or_else(|| anyhow::anyhow!("clustered SQ8 descriptor missing"))?;
+        assert!(footer.block_tier_assignments.iter().any(|assignment| {
+            assignment.physical_column_id == col_id::EMBED_BASE
+                && assignment.descriptor_id == transformed.descriptor_id
+        }));
+        assert_eq!(transformed.rebuild_source_id, EXTERNAL_CANONICAL_SOURCE_ID);
+        Ok(())
     }
 
     /// TD-RDSTRAT-5 S1: with `with_block_centroids(true)`, the segment writer

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -515,6 +515,8 @@ pub struct PaxSegmentWriter {
     /// Exact clustered transform over SQ8 code bytes. Default OFF and selected
     /// independently per stripe by realized byte size.
     lossless_clustered: bool,
+    /// Exact scalar all-null elision and post-codec LZ4. Default OFF.
+    lossless_scalar: bool,
     /// P-Shred (ADR-055): `(prop_key, user_col_id)` to shred into typed user-columns —
     /// re-applied to every block writer so all blocks in the segment shred uniformly.
     shred_spec: Vec<(String, i32)>,
@@ -604,6 +606,7 @@ impl PaxSegmentWriter {
             f32_tier: false,
             rerank_quant: VectorQuant::Sq8,
             lossless_clustered: false,
+            lossless_scalar: false,
             shred_spec: Vec::new(),
             current_writer: writer,
             index: SegmentIndex { blocks: Vec::new() },
@@ -669,6 +672,13 @@ impl PaxSegmentWriter {
         self
     }
 
+    /// Enable exact scalar all-null elision and post-codec LZ4 for every block.
+    pub fn with_lossless_scalar(mut self, enabled: bool) -> Self {
+        self.lossless_scalar = enabled;
+        self.current_writer = self.fresh_block_writer();
+        self
+    }
+
     /// Mark the next appended record as the start of a producer-defined cluster.
     pub fn start_cluster_run(&mut self) {
         self.current_writer.start_cluster_run();
@@ -718,6 +728,7 @@ impl PaxSegmentWriter {
         .with_f32_tier(self.f32_tier)
         .with_rerank_quant(self.rerank_quant)
         .with_clustered_sq8_lossless(self.lossless_clustered)
+        .with_lossless_scalar(self.lossless_scalar)
         .with_shred_spec(self.shred_spec.clone())
     }
 

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -973,8 +973,10 @@ impl PaxSegmentWriter {
             embed_quant_tag: 1, // SQ8 (the survivor-rerank data tier)
             has_f32_tier: self.f32_tier,
             blocks,
+            encoding_map: Vec::new(),
+            block_tier_assignments: Vec::new(),
         };
-        let footer_body = footer.to_bytes();
+        let footer_body = footer.to_bytes()?;
         let footer_off = data_offset + self.file_buf.len() as u64;
         let footer_len = footer_body.len() as u64;
 

--- a/crates/storage/proximadb-storage-common/src/segment_layout.rs
+++ b/crates/storage/proximadb-storage-common/src/segment_layout.rs
@@ -25,6 +25,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{Result, bail};
+use std::collections::HashMap;
 
 use crate::pax_block::SEGMENT_MAGIC;
 
@@ -149,6 +150,115 @@ pub struct FooterBlockEntry {
     pub stats_kind: StatsKind,
 }
 
+macro_rules! footer_tag_enum {
+    ($name:ident { $($variant:ident = $value:expr),+ $(,)? }) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[repr(u8)]
+        pub enum $name {
+            $($variant = $value),+
+        }
+
+        impl $name {
+            fn from_u8(value: u8) -> Result<Self> {
+                match value {
+                    $($value => Ok(Self::$variant),)+
+                    _ => bail!("unknown {} tag 0x{value:02x}", stringify!($name)),
+                }
+            }
+        }
+    };
+}
+
+footer_tag_enum!(TierRole {
+    Index = 0,
+    Rerank = 1,
+    Exact = 2,
+    Metadata = 3,
+});
+
+footer_tag_enum!(LosslessTransformTag {
+    None = 0,
+    ClusteredForBitpackU8 = 1,
+    ExactBaseXor = 2,
+});
+
+footer_tag_enum!(LosslessCompressionTag {
+    None = 0,
+    Lz4 = 1,
+    Zstd = 2,
+    Snappy = 3,
+});
+
+footer_tag_enum!(ParameterScope {
+    None = 0,
+    Segment = 1,
+    Block = 2,
+    ClusterRun = 3,
+    MicroChunk = 4,
+});
+
+footer_tag_enum!(VectorTransform {
+    None = 0,
+    L2Normalized = 1,
+    CenteredRotated = 2,
+});
+
+footer_tag_enum!(SourceRole {
+    Canonical = 0,
+    IndexProjection = 1,
+    RerankProjection = 2,
+});
+
+footer_tag_enum!(SourceFidelity {
+    ExactBitwise = 0,
+    Lossy = 1,
+});
+
+/// Descriptor flags for the byte-compression layer.
+pub mod compression_flags {
+    /// Compressor inverse reproduces the transform bytes exactly.
+    pub const LOSSLESS: u8 = 0b0000_0001;
+}
+
+/// One footer-v2 physical stripe descriptor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StripeEncodingDescriptor {
+    pub descriptor_id: u16,
+    pub logical_field_id: i32,
+    pub physical_column_id: i32,
+    pub tier_role: TierRole,
+    pub value_codec_tag: u8,
+    pub value_codec_version: u8,
+    pub transform_tag: LosslessTransformTag,
+    pub transform_version: u8,
+    pub compression_tag: LosslessCompressionTag,
+    pub compression_version: u8,
+    pub compression_flags: u8,
+    pub parameter_scope: ParameterScope,
+    pub vector_transform: VectorTransform,
+    pub auxiliary_flags: u16,
+    pub source_role: SourceRole,
+    pub source_fidelity: SourceFidelity,
+    pub rebuild_source_id: u16,
+    pub projection_generation: u16,
+}
+
+/// Selects one descriptor for one block-local physical tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockTierAssignment {
+    pub block_ordinal: u32,
+    pub physical_column_id: i32,
+    pub tier_role: TierRole,
+    pub descriptor_id: u16,
+}
+
+const DESCRIPTOR_SIZE: usize = 28;
+const ASSIGNMENT_SIZE: usize = 11;
+const SECTION_STRIPE_ENCODING_MAP: u8 = 2;
+const SECTION_VERSION_V1: u8 = 1;
+const FOOTER_V1: u8 = 1;
+const FOOTER_V2: u8 = 2;
+
 /// The self-describing footer-index (Parquet-style metadata hub): block table +
 /// schema snapshot + per-stripe encoding map + RaBitQ mirror + row count. Located
 /// via `[footer_index][footer_len u64][SEGMENT_MAGIC]` at the segment tail.
@@ -175,20 +285,323 @@ pub struct SegmentFooterIndex {
     pub has_f32_tier: bool,
     /// The block table (block 0..K in emission/cluster order).
     pub blocks: Vec<FooterBlockEntry>,
+    /// Footer-v2 physical encoding descriptors. Empty means emit footer v1.
+    pub encoding_map: Vec<StripeEncodingDescriptor>,
+    /// Per-block descriptor selections for footer v2.
+    pub block_tier_assignments: Vec<BlockTierAssignment>,
 }
 
 /// `[footer_len u64][SEGMENT_MAGIC 8B]` — the 16 B tail that locates the footer.
 pub const SEG_TAIL_LEN: usize = 8 + 8;
+
+impl StripeEncodingDescriptor {
+    fn write_to(&self, output: &mut Vec<u8>) {
+        output.extend_from_slice(&self.descriptor_id.to_le_bytes());
+        output.extend_from_slice(&self.logical_field_id.to_le_bytes());
+        output.extend_from_slice(&self.physical_column_id.to_le_bytes());
+        output.push(self.tier_role as u8);
+        output.push(self.value_codec_tag);
+        output.push(self.value_codec_version);
+        output.push(self.transform_tag as u8);
+        output.push(self.transform_version);
+        output.push(self.compression_tag as u8);
+        output.push(self.compression_version);
+        output.push(self.compression_flags);
+        output.push(self.parameter_scope as u8);
+        output.push(self.vector_transform as u8);
+        output.extend_from_slice(&self.auxiliary_flags.to_le_bytes());
+        output.push(self.source_role as u8);
+        output.push(self.source_fidelity as u8);
+        output.extend_from_slice(&self.rebuild_source_id.to_le_bytes());
+        output.extend_from_slice(&self.projection_generation.to_le_bytes());
+    }
+
+    fn read_from(input: &[u8], position: &mut usize) -> Result<Self> {
+        let descriptor = Self {
+            descriptor_id: read_u16(input, position)?,
+            logical_field_id: read_i32(input, position)?,
+            physical_column_id: read_i32(input, position)?,
+            tier_role: TierRole::from_u8(read_u8(input, position)?)?,
+            value_codec_tag: read_u8(input, position)?,
+            value_codec_version: read_u8(input, position)?,
+            transform_tag: LosslessTransformTag::from_u8(read_u8(input, position)?)?,
+            transform_version: read_u8(input, position)?,
+            compression_tag: LosslessCompressionTag::from_u8(read_u8(input, position)?)?,
+            compression_version: read_u8(input, position)?,
+            compression_flags: read_u8(input, position)?,
+            parameter_scope: ParameterScope::from_u8(read_u8(input, position)?)?,
+            vector_transform: VectorTransform::from_u8(read_u8(input, position)?)?,
+            auxiliary_flags: read_u16(input, position)?,
+            source_role: SourceRole::from_u8(read_u8(input, position)?)?,
+            source_fidelity: SourceFidelity::from_u8(read_u8(input, position)?)?,
+            rebuild_source_id: read_u16(input, position)?,
+            projection_generation: read_u16(input, position)?,
+        };
+        descriptor.validate()?;
+        Ok(descriptor)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.descriptor_id == 0 {
+            bail!("footer encoding descriptor id 0 is reserved");
+        }
+        if !matches!(self.value_codec_tag, 0x01 | 0x03 | 0x05 | 0x71) {
+            bail!(
+                "unknown required value codec tag 0x{:02x}",
+                self.value_codec_tag
+            );
+        }
+        if self.value_codec_version != 1 {
+            bail!(
+                "unsupported value codec version {}",
+                self.value_codec_version
+            );
+        }
+        let expected_transform_version = match self.transform_tag {
+            LosslessTransformTag::None => 0,
+            LosslessTransformTag::ClusteredForBitpackU8 | LosslessTransformTag::ExactBaseXor => 1,
+        };
+        if self.transform_version != expected_transform_version {
+            bail!("unsupported lossless transform version");
+        }
+        let expected_compression_version = match self.compression_tag {
+            LosslessCompressionTag::None => 0,
+            LosslessCompressionTag::Lz4
+            | LosslessCompressionTag::Zstd
+            | LosslessCompressionTag::Snappy => 1,
+        };
+        if self.compression_version != expected_compression_version {
+            bail!("unsupported lossless compression version");
+        }
+        if self.compression_flags & compression_flags::LOSSLESS == 0 {
+            bail!("durable stripe compressor must be declared lossless");
+        }
+        if self.source_role == SourceRole::Canonical {
+            if self.source_fidelity != SourceFidelity::ExactBitwise {
+                bail!("canonical stripe must be exact-bitwise");
+            }
+            if self.value_codec_tag != 0x01 {
+                bail!("canonical dense-vector stripe must use raw-f32 value codec");
+            }
+        }
+        match self.transform_tag {
+            LosslessTransformTag::ClusteredForBitpackU8 if self.value_codec_tag != 0x05 => {
+                bail!("clustered u8 transform requires the SQ8 value codec")
+            }
+            LosslessTransformTag::ExactBaseXor if self.value_codec_tag != 0x01 => {
+                bail!("exact base-XOR transform requires the raw-f32 value codec")
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl BlockTierAssignment {
+    fn write_to(&self, output: &mut Vec<u8>) {
+        output.extend_from_slice(&self.block_ordinal.to_le_bytes());
+        output.extend_from_slice(&self.physical_column_id.to_le_bytes());
+        output.push(self.tier_role as u8);
+        output.extend_from_slice(&self.descriptor_id.to_le_bytes());
+    }
+
+    fn read_from(input: &[u8], position: &mut usize) -> Result<Self> {
+        Ok(Self {
+            block_ordinal: read_u32(input, position)?,
+            physical_column_id: read_i32(input, position)?,
+            tier_role: TierRole::from_u8(read_u8(input, position)?)?,
+            descriptor_id: read_u16(input, position)?,
+        })
+    }
+}
+
+fn write_block_entry(output: &mut Vec<u8>, block: &FooterBlockEntry) {
+    output.extend_from_slice(&block.offset.to_le_bytes());
+    output.extend_from_slice(&block.size.to_le_bytes());
+    output.extend_from_slice(&block.row_count.to_le_bytes());
+    output.push(block.stats_kind as u8);
+    output.extend_from_slice(&0u32.to_le_bytes());
+}
+
+fn read_blocks(input: &[u8], position: &mut usize) -> Result<Vec<FooterBlockEntry>> {
+    let block_count = read_u32(input, position)? as usize;
+    if block_count > input.len().saturating_sub(*position) / 21 {
+        bail!("footer-index block count exceeds remaining bytes");
+    }
+    let mut blocks = Vec::with_capacity(block_count);
+    for _ in 0..block_count {
+        let offset = read_u64(input, position)?;
+        let size = read_u32(input, position)?;
+        let row_count = read_u32(input, position)?;
+        let stats_tag = read_u8(input, position)?;
+        let stats_len = read_u32(input, position)? as usize;
+        ensure_remaining(
+            input,
+            *position,
+            stats_len,
+            "footer-index stats payload overruns body",
+        )?;
+        *position += stats_len;
+        blocks.push(FooterBlockEntry {
+            offset,
+            size,
+            row_count,
+            stats_kind: StatsKind::from_tag(stats_tag),
+        });
+    }
+    Ok(blocks)
+}
+
+fn parse_encoding_map_payload(
+    payload: &[u8],
+) -> Result<(Vec<StripeEncodingDescriptor>, Vec<BlockTierAssignment>)> {
+    let mut position = 0usize;
+    let descriptor_count = read_u16(payload, &mut position)? as usize;
+    if descriptor_count > payload.len().saturating_sub(position) / DESCRIPTOR_SIZE {
+        bail!("stripe encoding-map descriptor count exceeds section bytes");
+    }
+    let mut descriptors = Vec::with_capacity(descriptor_count);
+    for _ in 0..descriptor_count {
+        descriptors.push(StripeEncodingDescriptor::read_from(payload, &mut position)?);
+    }
+    let assignment_count = read_u32(payload, &mut position)? as usize;
+    if assignment_count > payload.len().saturating_sub(position) / ASSIGNMENT_SIZE {
+        bail!("stripe encoding-map assignment count exceeds section bytes");
+    }
+    let mut assignments = Vec::with_capacity(assignment_count);
+    for _ in 0..assignment_count {
+        assignments.push(BlockTierAssignment::read_from(payload, &mut position)?);
+    }
+    if position != payload.len() {
+        bail!("stripe encoding-map payload has trailing bytes");
+    }
+    Ok((descriptors, assignments))
+}
+
+fn legacy_quant_tag(value_codec_tag: u8) -> u8 {
+    match value_codec_tag {
+        0x01 => 0,
+        0x03 => 3,
+        _ => 1,
+    }
+}
+
+fn ensure_remaining(input: &[u8], position: usize, len: usize, message: &str) -> Result<()> {
+    let end = position
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("{message}: length overflow"))?;
+    if end > input.len() {
+        bail!("{message}");
+    }
+    Ok(())
+}
+
+fn read_u8(input: &[u8], position: &mut usize) -> Result<u8> {
+    ensure_remaining(input, *position, 1, "footer-index truncated at u8")?;
+    let value = input[*position];
+    *position += 1;
+    Ok(value)
+}
+
+fn read_u16(input: &[u8], position: &mut usize) -> Result<u16> {
+    ensure_remaining(input, *position, 2, "footer-index truncated at u16")?;
+    let end = *position + 2;
+    let value = u16::from_le_bytes(input[*position..end].try_into()?);
+    *position = end;
+    Ok(value)
+}
+
+fn read_u32(input: &[u8], position: &mut usize) -> Result<u32> {
+    ensure_remaining(input, *position, 4, "footer-index truncated at u32")?;
+    let end = *position + 4;
+    let value = u32::from_le_bytes(input[*position..end].try_into()?);
+    *position = end;
+    Ok(value)
+}
+
+fn read_i32(input: &[u8], position: &mut usize) -> Result<i32> {
+    ensure_remaining(input, *position, 4, "footer-index truncated at i32")?;
+    let end = *position + 4;
+    let value = i32::from_le_bytes(input[*position..end].try_into()?);
+    *position = end;
+    Ok(value)
+}
+
+fn read_u64(input: &[u8], position: &mut usize) -> Result<u64> {
+    ensure_remaining(input, *position, 8, "footer-index truncated at u64")?;
+    let end = *position + 8;
+    let value = u64::from_le_bytes(input[*position..end].try_into()?);
+    *position = end;
+    Ok(value)
+}
+
+#[cfg(test)]
+fn footer_v2_first_descriptor_offset(bytes: &[u8]) -> Result<usize> {
+    if bytes.first().copied() != Some(FOOTER_V2) {
+        bail!("not a footer v2 payload");
+    }
+    let mut position = 1 + 8 * 3 + 4 * 2;
+    let block_count = read_u32(bytes, &mut position)? as usize;
+    for _ in 0..block_count {
+        let _ = read_u64(bytes, &mut position)?;
+        let _ = read_u32(bytes, &mut position)?;
+        let _ = read_u32(bytes, &mut position)?;
+        let _ = read_u8(bytes, &mut position)?;
+        let stats_len = read_u32(bytes, &mut position)? as usize;
+        ensure_remaining(bytes, position, stats_len, "footer test stats overrun")?;
+        position += stats_len;
+    }
+    let section_count = read_u16(bytes, &mut position)?;
+    if section_count == 0 {
+        bail!("footer v2 has no sections");
+    }
+    let section_tag = read_u8(bytes, &mut position)?;
+    let _ = read_u8(bytes, &mut position)?;
+    let _ = read_u32(bytes, &mut position)?;
+    if section_tag != SECTION_STRIPE_ENCODING_MAP {
+        bail!("first footer v2 section is not the encoding map");
+    }
+    let descriptor_count = read_u16(bytes, &mut position)?;
+    if descriptor_count == 0 {
+        bail!("footer v2 encoding map has no descriptors");
+    }
+    Ok(position)
+}
+
+#[cfg(test)]
+fn footer_v2_section_count_offset(bytes: &[u8]) -> Result<usize> {
+    if bytes.first().copied() != Some(FOOTER_V2) {
+        bail!("not a footer v2 payload");
+    }
+    let mut position = 1 + 8 * 3 + 4 * 2;
+    let block_count = read_u32(bytes, &mut position)? as usize;
+    for _ in 0..block_count {
+        let _ = read_u64(bytes, &mut position)?;
+        let _ = read_u32(bytes, &mut position)?;
+        let _ = read_u32(bytes, &mut position)?;
+        let _ = read_u8(bytes, &mut position)?;
+        let stats_len = read_u32(bytes, &mut position)? as usize;
+        ensure_remaining(bytes, position, stats_len, "footer test stats overrun")?;
+        position += stats_len;
+    }
+    Ok(position)
+}
 
 impl SegmentFooterIndex {
     /// Serialize the footer-index body (no tail). Layout:
     /// `[footer_version u8][row_count u64][rabitq_off u64][rabitq_len u64]`
     /// `[embed_dim u32][embed_count u32][embed_quant_tag u8][has_f32_tier u8]`
     /// `[n_blocks u32] per block: [off u64][size u32][row_count u32][stats_tag u8][stats_len u32][stats bytes]`.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        const FOOTER_VERSION: u8 = 1;
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        if self.encoding_map.is_empty() && self.block_tier_assignments.is_empty() {
+            return self.to_v1_bytes();
+        }
+        self.to_v2_bytes()
+    }
+
+    fn to_v1_bytes(&self) -> Result<Vec<u8>> {
         let mut buf = Vec::with_capacity(64 + self.blocks.len() * 24);
-        buf.push(FOOTER_VERSION);
+        buf.push(FOOTER_V1);
         buf.extend_from_slice(&self.row_count.to_le_bytes());
         buf.extend_from_slice(&self.rabitq_off.to_le_bytes());
         buf.extend_from_slice(&self.rabitq_len.to_le_bytes());
@@ -196,16 +609,121 @@ impl SegmentFooterIndex {
         buf.extend_from_slice(&self.embed_count.to_le_bytes());
         buf.push(self.embed_quant_tag);
         buf.push(if self.has_f32_tier { 1 } else { 0 });
-        buf.extend_from_slice(&(self.blocks.len() as u32).to_le_bytes());
+        let block_count = u32::try_from(self.blocks.len())
+            .map_err(|_| anyhow::anyhow!("footer-index block count exceeds u32"))?;
+        buf.extend_from_slice(&block_count.to_le_bytes());
         for b in &self.blocks {
-            buf.extend_from_slice(&b.offset.to_le_bytes());
-            buf.extend_from_slice(&b.size.to_le_bytes());
-            buf.extend_from_slice(&b.row_count.to_le_bytes());
-            buf.push(b.stats_kind as u8);
-            // PR1: no stats payload (length 0). PR3 writes the OID bloom here.
-            buf.extend_from_slice(&0u32.to_le_bytes());
+            write_block_entry(&mut buf, b);
         }
-        buf
+        Ok(buf)
+    }
+
+    fn to_v2_bytes(&self) -> Result<Vec<u8>> {
+        self.validate_encoding_map()?;
+        let mut buf = Vec::with_capacity(96 + self.blocks.len() * 24);
+        buf.push(FOOTER_V2);
+        buf.extend_from_slice(&self.row_count.to_le_bytes());
+        buf.extend_from_slice(&self.rabitq_off.to_le_bytes());
+        buf.extend_from_slice(&self.rabitq_len.to_le_bytes());
+        buf.extend_from_slice(&self.embed_dim.to_le_bytes());
+        buf.extend_from_slice(&self.embed_count.to_le_bytes());
+        let block_count = u32::try_from(self.blocks.len())
+            .map_err(|_| anyhow::anyhow!("footer-index block count exceeds u32"))?;
+        buf.extend_from_slice(&block_count.to_le_bytes());
+        for block in &self.blocks {
+            write_block_entry(&mut buf, block);
+        }
+
+        let encoding_payload = self.encoding_map_payload()?;
+        buf.extend_from_slice(&1u16.to_le_bytes());
+        buf.push(SECTION_STRIPE_ENCODING_MAP);
+        buf.push(SECTION_VERSION_V1);
+        let section_len = u32::try_from(encoding_payload.len())
+            .map_err(|_| anyhow::anyhow!("footer encoding-map section exceeds u32"))?;
+        buf.extend_from_slice(&section_len.to_le_bytes());
+        buf.extend_from_slice(&encoding_payload);
+        Ok(buf)
+    }
+
+    fn encoding_map_payload(&self) -> Result<Vec<u8>> {
+        let descriptor_count = u16::try_from(self.encoding_map.len())
+            .map_err(|_| anyhow::anyhow!("footer encoding descriptor count exceeds u16"))?;
+        let assignment_count = u32::try_from(self.block_tier_assignments.len())
+            .map_err(|_| anyhow::anyhow!("footer tier assignment count exceeds u32"))?;
+        let mut payload = Vec::with_capacity(
+            2 + self.encoding_map.len() * DESCRIPTOR_SIZE
+                + 4
+                + self.block_tier_assignments.len() * ASSIGNMENT_SIZE,
+        );
+        payload.extend_from_slice(&descriptor_count.to_le_bytes());
+        for descriptor in &self.encoding_map {
+            descriptor.write_to(&mut payload);
+        }
+        payload.extend_from_slice(&assignment_count.to_le_bytes());
+        for assignment in &self.block_tier_assignments {
+            assignment.write_to(&mut payload);
+        }
+        Ok(payload)
+    }
+
+    fn validate_encoding_map(&self) -> Result<()> {
+        if self.encoding_map.is_empty() {
+            bail!("footer v2 requires a non-empty stripe encoding map");
+        }
+        let mut descriptors = HashMap::with_capacity(self.encoding_map.len());
+        for descriptor in &self.encoding_map {
+            descriptor.validate()?;
+            if descriptors
+                .insert(descriptor.descriptor_id, descriptor)
+                .is_some()
+            {
+                bail!(
+                    "duplicate footer encoding descriptor id {}",
+                    descriptor.descriptor_id
+                );
+            }
+        }
+        for descriptor in &self.encoding_map {
+            match descriptor.source_role {
+                SourceRole::Canonical => {
+                    if descriptor.rebuild_source_id != 0 {
+                        bail!("canonical descriptor must not name a rebuild source");
+                    }
+                }
+                SourceRole::IndexProjection | SourceRole::RerankProjection => {
+                    let source =
+                        descriptors
+                            .get(&descriptor.rebuild_source_id)
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "projection descriptor {} has no canonical rebuild source {}",
+                                    descriptor.descriptor_id,
+                                    descriptor.rebuild_source_id
+                                )
+                            })?;
+                    if source.source_role != SourceRole::Canonical
+                        || source.source_fidelity != SourceFidelity::ExactBitwise
+                    {
+                        bail!("projection rebuild source is not exact canonical data");
+                    }
+                }
+            }
+        }
+        for assignment in &self.block_tier_assignments {
+            let block_ordinal = assignment.block_ordinal as usize;
+            if block_ordinal >= self.blocks.len() {
+                bail!("footer tier assignment references unknown block");
+            }
+            let descriptor = descriptors.get(&assignment.descriptor_id).ok_or_else(|| {
+                anyhow::anyhow!("footer tier assignment references unknown descriptor")
+            })?;
+            if descriptor.physical_column_id != assignment.physical_column_id
+                || descriptor.tier_role != assignment.tier_role
+            {
+                bail!("footer tier assignment disagrees with its descriptor");
+            }
+        }
+        Ok(())
     }
 
     /// Parse the footer-index body (the bytes between the data blocks and the
@@ -214,67 +732,32 @@ impl SegmentFooterIndex {
     /// footer version is a deliberate, gated change), but unknown `StatsKind`
     /// tags degrade to `None`.
     pub fn parse(body: &[u8]) -> Result<Self> {
-        const FOOTER_VERSION: u8 = 1;
         if body.is_empty() {
             bail!("empty footer-index body");
         }
-        if body[0] != FOOTER_VERSION {
-            bail!(
-                "unsupported footer-index version {} (expected {FOOTER_VERSION})",
-                body[0]
-            );
+        match body[0] {
+            FOOTER_V1 => Self::parse_v1(body),
+            FOOTER_V2 => Self::parse_v2(body),
+            version => bail!("unsupported footer-index version {version}"),
         }
+    }
+
+    fn parse_v1(body: &[u8]) -> Result<Self> {
         let mut p = 1usize;
-        let rd_u64 = |p: &mut usize| -> Result<u64> {
-            if *p + 8 > body.len() {
-                bail!("footer-index truncated at u64");
-            }
-            let v = u64::from_le_bytes(body[*p..*p + 8].try_into()?);
-            *p += 8;
-            Ok(v)
-        };
-        let rd_u32 = |p: &mut usize| -> Result<u32> {
-            if *p + 4 > body.len() {
-                bail!("footer-index truncated at u32");
-            }
-            let v = u32::from_le_bytes(body[*p..*p + 4].try_into()?);
-            *p += 4;
-            Ok(v)
-        };
-        let row_count = rd_u64(&mut p)?;
-        let rabitq_off = rd_u64(&mut p)?;
-        let rabitq_len = rd_u64(&mut p)?;
-        let embed_dim = rd_u32(&mut p)?;
-        let embed_count = rd_u32(&mut p)?;
+        let row_count = read_u64(body, &mut p)?;
+        let rabitq_off = read_u64(body, &mut p)?;
+        let rabitq_len = read_u64(body, &mut p)?;
+        let embed_dim = read_u32(body, &mut p)?;
+        let embed_count = read_u32(body, &mut p)?;
         if p + 2 > body.len() {
             bail!("footer-index truncated at encoding map");
         }
         let embed_quant_tag = body[p];
         let has_f32_tier = body[p + 1] != 0;
         p += 2;
-        let n_blocks = rd_u32(&mut p)? as usize;
-        let mut blocks = Vec::with_capacity(n_blocks);
-        for _ in 0..n_blocks {
-            let offset = rd_u64(&mut p)?;
-            let size = rd_u32(&mut p)?;
-            let rc = rd_u32(&mut p)?;
-            if p + 5 > body.len() {
-                bail!("footer-index truncated at block stats");
-            }
-            let stats_tag = body[p];
-            let stats_len = u32::from_le_bytes(body[p + 1..p + 5].try_into()?) as usize;
-            p += 5;
-            if p + stats_len > body.len() {
-                bail!("footer-index stats payload overruns body");
-            }
-            // PR1 ignores the (empty) stats payload; PR3 decodes the OID bloom.
-            p += stats_len;
-            blocks.push(FooterBlockEntry {
-                offset,
-                size,
-                row_count: rc,
-                stats_kind: StatsKind::from_tag(stats_tag),
-            });
+        let blocks = read_blocks(body, &mut p)?;
+        if p != body.len() {
+            bail!("footer-index v1 has trailing bytes");
         }
         Ok(Self {
             row_count,
@@ -285,7 +768,72 @@ impl SegmentFooterIndex {
             embed_quant_tag,
             has_f32_tier,
             blocks,
+            encoding_map: Vec::new(),
+            block_tier_assignments: Vec::new(),
         })
+    }
+
+    fn parse_v2(body: &[u8]) -> Result<Self> {
+        let mut p = 1usize;
+        let row_count = read_u64(body, &mut p)?;
+        let rabitq_off = read_u64(body, &mut p)?;
+        let rabitq_len = read_u64(body, &mut p)?;
+        let embed_dim = read_u32(body, &mut p)?;
+        let embed_count = read_u32(body, &mut p)?;
+        let blocks = read_blocks(body, &mut p)?;
+        let section_count = read_u16(body, &mut p)? as usize;
+        if section_count > body.len().saturating_sub(p) / 6 {
+            bail!("footer-index section count exceeds remaining bytes");
+        }
+        let mut encoding_map = None;
+        let mut block_tier_assignments = Vec::new();
+        for _ in 0..section_count {
+            let tag = read_u8(body, &mut p)?;
+            let version = read_u8(body, &mut p)?;
+            let section_len = read_u32(body, &mut p)? as usize;
+            ensure_remaining(body, p, section_len, "footer-index section overruns body")?;
+            let section = &body[p..p + section_len];
+            p += section_len;
+            if tag == SECTION_STRIPE_ENCODING_MAP {
+                if version != SECTION_VERSION_V1 {
+                    bail!("unsupported stripe encoding-map section version {version}");
+                }
+                if encoding_map.is_some() {
+                    bail!("duplicate stripe encoding-map section");
+                }
+                let (descriptors, assignments) = parse_encoding_map_payload(section)?;
+                encoding_map = Some(descriptors);
+                block_tier_assignments = assignments;
+            }
+        }
+        if p != body.len() {
+            bail!("footer-index v2 has trailing bytes");
+        }
+        let encoding_map =
+            encoding_map.ok_or_else(|| anyhow::anyhow!("footer v2 lacks stripe encoding map"))?;
+        let embed_quant_tag = encoding_map
+            .iter()
+            .find(|descriptor| descriptor.tier_role == TierRole::Rerank)
+            .map(|descriptor| legacy_quant_tag(descriptor.value_codec_tag))
+            .unwrap_or(1);
+        let has_f32_tier = encoding_map.iter().any(|descriptor| {
+            descriptor.source_role == SourceRole::Canonical
+                && descriptor.source_fidelity == SourceFidelity::ExactBitwise
+        });
+        let footer = Self {
+            row_count,
+            rabitq_off,
+            rabitq_len,
+            embed_dim,
+            embed_count,
+            embed_quant_tag,
+            has_f32_tier,
+            blocks,
+            encoding_map,
+            block_tier_assignments,
+        };
+        footer.validate_encoding_map()?;
+        Ok(footer)
     }
 
     /// Locate + parse the footer-index from a full segment buffer (the tail
@@ -332,6 +880,8 @@ mod tests {
             embed_count: 1,
             embed_quant_tag: 1, // SQ8
             has_f32_tier: false,
+            encoding_map: Vec::new(),
+            block_tier_assignments: Vec::new(),
             blocks: vec![
                 FooterBlockEntry {
                     offset: 24_040,
@@ -347,6 +897,79 @@ mod tests {
                 },
             ],
         }
+    }
+
+    fn sample_v2_footer() -> SegmentFooterIndex {
+        let mut footer = sample_footer();
+        footer.encoding_map = vec![
+            StripeEncodingDescriptor {
+                descriptor_id: 1,
+                logical_field_id: 20,
+                physical_column_id: 20,
+                tier_role: TierRole::Index,
+                value_codec_tag: 0x71,
+                value_codec_version: 1,
+                transform_tag: LosslessTransformTag::None,
+                transform_version: 0,
+                compression_tag: LosslessCompressionTag::None,
+                compression_version: 0,
+                compression_flags: compression_flags::LOSSLESS,
+                parameter_scope: ParameterScope::Block,
+                vector_transform: VectorTransform::CenteredRotated,
+                auxiliary_flags: 0,
+                source_role: SourceRole::IndexProjection,
+                source_fidelity: SourceFidelity::Lossy,
+                rebuild_source_id: 3,
+                projection_generation: 1,
+            },
+            StripeEncodingDescriptor {
+                descriptor_id: 2,
+                logical_field_id: 20,
+                physical_column_id: 30,
+                tier_role: TierRole::Rerank,
+                value_codec_tag: 0x05,
+                value_codec_version: 1,
+                transform_tag: LosslessTransformTag::ClusteredForBitpackU8,
+                transform_version: 1,
+                compression_tag: LosslessCompressionTag::None,
+                compression_version: 0,
+                compression_flags: compression_flags::LOSSLESS,
+                parameter_scope: ParameterScope::MicroChunk,
+                vector_transform: VectorTransform::None,
+                auxiliary_flags: 0,
+                source_role: SourceRole::RerankProjection,
+                source_fidelity: SourceFidelity::Lossy,
+                rebuild_source_id: 3,
+                projection_generation: 1,
+            },
+            StripeEncodingDescriptor {
+                descriptor_id: 3,
+                logical_field_id: 20,
+                physical_column_id: 40,
+                tier_role: TierRole::Exact,
+                value_codec_tag: 0x01,
+                value_codec_version: 1,
+                transform_tag: LosslessTransformTag::ExactBaseXor,
+                transform_version: 1,
+                compression_tag: LosslessCompressionTag::Zstd,
+                compression_version: 1,
+                compression_flags: compression_flags::LOSSLESS,
+                parameter_scope: ParameterScope::ClusterRun,
+                vector_transform: VectorTransform::None,
+                auxiliary_flags: 0,
+                source_role: SourceRole::Canonical,
+                source_fidelity: SourceFidelity::ExactBitwise,
+                rebuild_source_id: 0,
+                projection_generation: 0,
+            },
+        ];
+        footer.block_tier_assignments = vec![BlockTierAssignment {
+            block_ordinal: 0,
+            physical_column_id: 30,
+            tier_role: TierRole::Rerank,
+            descriptor_id: 2,
+        }];
+        footer
     }
 
     #[test]
@@ -412,7 +1035,7 @@ mod tests {
     #[test]
     fn footer_index_round_trips() {
         let f = sample_footer();
-        let bytes = f.to_bytes();
+        let bytes = f.to_bytes().unwrap();
         let parsed = SegmentFooterIndex::parse(&bytes).unwrap();
         assert_eq!(parsed.row_count, 1000);
         assert_eq!(parsed.rabitq_off, 40);
@@ -427,7 +1050,7 @@ mod tests {
     #[test]
     fn footer_locate_in_segment_round_trips() {
         let f = sample_footer();
-        let body = f.to_bytes();
+        let body = f.to_bytes().unwrap();
         // Pretend segment = [some data][footer body][footer_len][magic].
         let mut segment = vec![0xAAu8; 1000];
         segment.extend(segment_tail(&body));
@@ -453,7 +1076,7 @@ mod tests {
 
     #[test]
     fn footer_parse_rejects_bad_version() {
-        let mut bytes = sample_footer().to_bytes();
+        let mut bytes = sample_footer().to_bytes().unwrap();
         bytes[0] = 2; // unsupported version
         assert!(SegmentFooterIndex::parse(&bytes).is_err());
     }
@@ -462,5 +1085,54 @@ mod tests {
     fn stats_kind_unknown_tag_degrades_to_none() {
         assert_eq!(StatsKind::from_tag(99), StatsKind::None);
         assert_eq!(StatsKind::from_tag(1), StatsKind::BloomOid);
+    }
+
+    #[test]
+    fn footer_v2_encoding_map_round_trips() -> Result<()> {
+        let footer = sample_v2_footer();
+        let bytes = footer.to_bytes()?;
+        assert_eq!(bytes[0], 2);
+
+        let parsed = SegmentFooterIndex::parse(&bytes)?;
+        assert_eq!(parsed.encoding_map, footer.encoding_map);
+        assert_eq!(parsed.block_tier_assignments, footer.block_tier_assignments);
+        assert_eq!(
+            parsed.encoding_map[1].transform_tag,
+            LosslessTransformTag::ClusteredForBitpackU8
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn footer_v2_rejects_lossy_canonical_descriptor() {
+        let mut footer = sample_v2_footer();
+        footer.encoding_map[2].source_fidelity = SourceFidelity::Lossy;
+        assert!(footer.to_bytes().is_err());
+    }
+
+    #[test]
+    fn footer_v2_unknown_required_transform_fails_closed() -> Result<()> {
+        let footer = sample_v2_footer();
+        let mut bytes = footer.to_bytes()?;
+        let transform_offset = footer_v2_first_descriptor_offset(&bytes)? + 13;
+        bytes[transform_offset] = 0xfe;
+        assert!(SegmentFooterIndex::parse(&bytes).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn footer_v2_unknown_optional_section_is_skipped() -> Result<()> {
+        let footer = sample_v2_footer();
+        let mut bytes = footer.to_bytes()?;
+        let section_count_offset = footer_v2_section_count_offset(&bytes)?;
+        bytes[section_count_offset..section_count_offset + 2].copy_from_slice(&2u16.to_le_bytes());
+        bytes.push(0xfe);
+        bytes.push(1);
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&[1, 2, 3]);
+
+        let parsed = SegmentFooterIndex::parse(&bytes)?;
+        assert_eq!(parsed.encoding_map, footer.encoding_map);
+        Ok(())
     }
 }

--- a/crates/storage/proximadb-storage-common/src/segment_layout.rs
+++ b/crates/storage/proximadb-storage-common/src/segment_layout.rs
@@ -220,6 +220,11 @@ pub mod compression_flags {
     pub const LOSSLESS: u8 = 0b0000_0001;
 }
 
+/// Reserved rebuild-source ID for a projection-only object whose durable
+/// canonical authority is cataloged outside this segment (for example the WAL
+/// lineage). Such a file cannot independently serve exact reconstruction.
+pub const EXTERNAL_CANONICAL_SOURCE_ID: u16 = u16::MAX;
+
 /// One footer-v2 physical stripe descriptor.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StripeEncodingDescriptor {
@@ -691,6 +696,9 @@ impl SegmentFooterIndex {
                     }
                 }
                 SourceRole::IndexProjection | SourceRole::RerankProjection => {
+                    if descriptor.rebuild_source_id == EXTERNAL_CANONICAL_SOURCE_ID {
+                        continue;
+                    }
                     let source =
                         descriptors
                             .get(&descriptor.rebuild_source_id)

--- a/docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc
@@ -275,7 +275,7 @@ entries[] {
   auxiliary_flags:u16,       // exact-norm-sq | correction-scale
   source_role:u8,            // canonical | index-projection | rerank-projection
   source_fidelity:u8,        // exact-bitwise | lossy
-  rebuild_source_id:u16,     // 0 for canonical; canonical descriptor for projection
+  rebuild_source_id:u16,     // 0 canonical; descriptor ID, or 0xffff external authority
   projection_generation:u16
 }
 
@@ -347,6 +347,9 @@ patterns. A PAX object may omit canonical f32 only when the object is explicitly
 cataloged as a rebuildable projection and `rebuild_source_id` names durable
 canonical authority; such an object cannot serve record reconstruction,
 compaction materialization, exact vector return, or exact queries by itself.
+The reserved value `0xffff` means that authority is external to this immutable
+segment (for example WAL/catalog lineage); it is never a physical stripe ID and
+does not grant the file exact-read capability.
 
 SQ8, RaBitQ, FP16, and future quantizers are projections. Quantization is the
 sole permitted lossy boundary. Lossless transforms may reorder and recompress

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -175,6 +175,10 @@ Codec parameters needed to decode one PAX block remain in that block's
 `VectorParamBlock`, so a fetched block is self-sufficient and the segment footer does not
 duplicate parameters. The descriptor records semantics and parameter scope; it does not carry
 block-local bases, bit widths, dictionaries, or compressor payloads.
+`rebuild_source_id=0xffff` is reserved for a projection-only object whose canonical authority is
+cataloged outside the file (for example WAL lineage). It is not a stripe descriptor and cannot
+be used to claim exact reconstruction from that object; `0` remains reserved for an in-file
+canonical descriptor itself.
 
 Each immutable file also records the vector field's `metric_epoch`, the metric under which
 estimator-specific tiers were built, and its normalization contract (`none` or enforced

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -95,6 +95,22 @@ version = "flat eae1cdf4e; SQ6 base 4f0cccf30 + diff sha256 9bddadab; TQ4 3a091c
 notes = "N=100k flat/SQ6/TQ4/RaBitQ4 recall = 0.991/0.981/0.921/0.917; bytes/query = 32020233/29775220/25124981/25124830; GETs/query = 19. Verified TEXMEX N=1M: flat recall 0.968, 61 GETs, 138851704 bytes/query; SQ6 recall 0.950, 61 GETs, 128722140 bytes/query. Prototype code intentionally discarded after rejection; artifact records source states and dataset hashes. Indicative dev-machine evidence, not an SLA."
 
 [[claims]]
+id = "rdstrat7_lossless_scalar_bytes_sift"
+claim = "TD-RDSTRAT-7 lossless scalar-stripe compression (all-null page elision + post-codec LZ4 over the i64/f64/str/bytes PAX stripes, gated PROXIMADB_PAX_LOSSLESS_SCALAR=1) is bit-exact lossless and moves the deferred bytes term: on SIFT N=100k (100 queries, top-10, single-file IVF-ON, Euclidean, brute-force ground truth) recall@10 is unchanged at 0.991 and range GETs/query unchanged at 19, while bytes_read/query drops 30.5 MB to 23.9 MB (32020233 to 25067186 bytes, -21.7%) and persisted_bytes/row drops 260.7 to 200.4 (26068428 to 20035485, -23.1%) with no p95 latency regression — clearing the TD-RDSTRAT-7 bytes gate (< 31.7 MB) that the flat-SQ8 control sits above. Vector stripes are untouched (their bytes lever is the clustered transform, not LZ4)."
+metric = "recall@10 + range_gets_per_query + bytes_read_per_query + persisted_bytes_per_row"
+status = "measured"
+asserted_in = [
+  "docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc",
+]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
+bench_command = "OFF (control): PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture; ON (scalar LZ4): prepend PROXIMADB_PAX_LOSSLESS_SCALAR=1"
+artifact = "docs/_internal/status/RDSTRAT7_LOSSLESS_SCALAR_BYTES_SIFT_2026_07_16.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), serialized release runs, no competing workload"
+date = "2026-07-16"
+version = "feat/rdstrat7-lossless-pax @ 1f4a0af05 (PR #1064): lossless scalar stripe compression (LZ4 + all-null elision), default OFF"
+notes = "Same protocol as the rdstrat6_bytes_codec_bakeoff_sift flat arm (which this reproduces exactly: recall 0.991, 32020233 bytes/query, 19 GETs), differing only in PROXIMADB_PAX_LOSSLESS_SCALAR=1. Recall byte-identical ON vs OFF proves the layer is lossless (decode reconstructs exact scalar values before the value codec runs). N=100k uses the first 100k rows of sift_base.fvecs (sha256 21f66e29...) with in-test brute-force ground truth; sift_groundtruth.ivecs is not used at this scale. Default OFF, mixed-read-safe (ColumnMeta.is_lz4_compressed bit3 = 0 on legacy files). Indicative dev-machine run, not an SLA."
+
+[[claims]]
 id = "coalesced_rabitq_noivf_decisive_sift1m"
 claim = "ADR-065 gated question RESOLVED: the coalesced scan-then-rerank layout does NOT need cluster_order_pca_ivf ordering. The production flush path (sign-bit bootstrap, no IVF opt-in) measures recall@10 = 0.985 and GETs/query = 40 at full SIFT1M — both gates cleared (>=0.98 recall, <=50 GETs) — with flush wall time 35 s (~80x faster than the 47 min IVF-at-flush path). IVF's only benefit is the bytes term (250 MB with vs 430 MB without), which is precisely the block dead weight ADR-065 Region B (SQ8 hoist) removes via density, not ordering. Decision: drop IVF; regions in sign-bit row order; PR3 = Region B."
 metric = "recall@10 + range_gets_per_query + bytes_read_per_query + flush_wall_time"

--- a/docs/_internal/status/RDSTRAT7_LOSSLESS_SCALAR_BYTES_SIFT_2026_07_16.adoc
+++ b/docs/_internal/status/RDSTRAT7_LOSSLESS_SCALAR_BYTES_SIFT_2026_07_16.adoc
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-7 lossless scalar-stripe compression — SIFT N=100k bytes gate (2026-07-16)
+:toc: macro
+
+toc::[]
+
+== Decision
+
+The lossless scalar-stripe compression layer (all-null page elision + post-codec
+LZ4 over the i64/f64/str/bytes PAX stripes; `PROXIMADB_PAX_LOSSLESS_SCALAR=1`)
+is bit-exact lossless and moves the deferred TD-RDSTRAT-7 bytes term at no
+recall, GET, or latency cost.
+
+On the SIFT N=100k, 100-query, single-file, IVF-ON protocol, toggling the flag
+ON leaves recall@10 unchanged at `0.991` and range GETs/query unchanged at `19`,
+while `bytes_read/query` falls `30.5 MB -> 23.9 MB` (-21.7%) and
+`persisted_bytes/row` falls `260.7 -> 200.4` (-23.1%). This clears the
+TD-RDSTRAT-7 bytes gate (`< 31.7 MB`) that the flat-SQ8 control arm sits above.
+
+Vector stripes are untouched by this layer — their bytes lever is the separate
+clustered transform (`PROXIMADB_PAX_LOSSLESS_CLUSTERED`), not LZ4. The scalar
+win is therefore additive and composes with the vector-side work.
+
+The feature is default OFF and mixed-read-safe: the `ColumnMeta.is_lz4_compressed`
+flag (bit3) is 0 on legacy files, so old segments decode as raw; an all-null page
+(`stripe_len == 0 && null_count == n`) decodes to all-`None` unconditionally.
+
+== Protocol and provenance
+
+Both arms used the same release-profile ignored eval,
+`tests/sift_pax_recall_ratchet_test.rs::sift_coalesced_rabitq_scan_rerank_eval`:
+one flush batch, one segment, IVF ordering ON, 100 queries, top-10, Euclidean.
+Runs were serialized on the same machine; the only difference between arms is
+the `PROXIMADB_PAX_LOSSLESS_SCALAR` env var.
+
+[cols="1,1", options="header"]
+|===
+| Arm | Invocation
+
+| OFF (control)
+| `PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture`
+
+| ON (scalar LZ4)
+| as above with `PROXIMADB_PAX_LOSSLESS_SCALAR=1` prepended
+|===
+
+N=100k consumes the first 100,000 rows of `sift_base.fvecs` and computes
+brute-force ground truth in-test (the `sift_groundtruth.ivecs` file is not used
+at this scale). Dataset SHA-256 values:
+
+[cols="1,2", options="header"]
+|===
+| File | SHA-256
+
+| `sift_base.fvecs`
+| `21f66e2975057b5728ba56de1c825bac4f4d89d596609ae985741c6242631816`
+
+| `sift_query.fvecs`
+| `f7fc9be140accdfd64116c2fa2365ecdb69b8f084970c6b0532db5ff79ac8fdc`
+|===
+
+Both match the canonical hashes recorded in the 2026-07-16 bake-off artifact.
+Hardware was local macOS arm64 Apple Silicon. Results are comparative evidence,
+not an SLA. Source state: branch `feat/rdstrat7-lossless-pax` tip `1f4a0af05`
+(PR #1064).
+
+== Results
+
+[cols="2,1,1,1,1", options="header"]
+|===
+| Metric | OFF | ON (scalar LZ4) | Delta | Gate
+
+| recall@10
+| 0.991
+| 0.991
+| 0 (lossless)
+| >= 0.98
+
+| range_gets/query
+| 19
+| 19
+| 0
+| < 50, no regression
+
+| bytes_read/query
+| 32,020,233 (30.5 MB)
+| 25,067,186 (23.9 MB)
+| -21.7%
+| < 31.7 MB
+
+| persisted_bytes/row
+| 260.7 (26,068,428)
+| 200.4 (20,035,485)
+| -23.1%
+| lower
+
+| total range_gets (100 q)
+| 1,964
+| 1,950
+| ~0
+| -
+
+| mean query latency (us)
+| 11,513
+| 11,458
+| ~0
+| no regression
+
+| p95 query latency (us)
+| 14,058
+| 13,985
+| ~0
+| no regression
+
+| flush wall time (ms)
+| 155,995
+| 157,058
+| ~0
+| -
+|===
+
+== Conclusion
+
+Recall@10 is byte-identical ON vs OFF, proving the layer is lossless: decode
+reconstructs the exact SQ8 codes / scalar values before the value codec runs, so
+rerank distances, ranking, and recall are unaffected. The bytes reduction comes
+entirely from compressing the scalar stripes (OID strings, timestamps, edge
+weights, props) and eliding all-null pages. The bytes gate — the remaining
+route-cost term after PR1 moved GETs 18.5x — is cleared by this lever at fixed
+recall and GETs.

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -18,6 +18,23 @@
 
 use proximadb_records::{EmbeddingValues, ProximaRecord};
 
+/// One contiguous cluster in the reordered output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OrderedClusterRun {
+    pub start_row: usize,
+    pub row_count: usize,
+}
+
+/// Physical ordering plus the cluster boundaries that produced it.
+///
+/// Keeping both avoids reverse-engineering clusters from reordered vectors and
+/// lets the PAX writer apply cluster-local, exact storage transforms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterPlan {
+    pub order: Vec<usize>,
+    pub runs: Vec<OrderedClusterRun>,
+}
+
 /// Sort-by-code block clustering at PAX write (TD-RDSTRAT-5 S1, default ON
 /// since TD-WLP-4 / ADR-061 D3 — pre-GA "arm defaults" directive). Records are
 /// reordered by locality key at flush so blocks are spatially coherent and
@@ -85,6 +102,11 @@ fn embedding_f32(record: &ProximaRecord, idx: usize) -> Option<&[f32]> {
 /// Pure + deterministic (unit-tested). The key is a *proxy* for angular order,
 /// not an exact clustering — S4 replaces it with IVF/k-means.
 pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>> {
+    cluster_plan(records, idx).map(|plan| plan.order)
+}
+
+/// Bootstrap cluster plan: Gray-key order plus exact runs of equal keys.
+pub fn cluster_plan(records: &[ProximaRecord], idx: usize) -> Option<ClusterPlan> {
     if records.len() < 2 {
         return None;
     }
@@ -123,7 +145,9 @@ pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>
     // Precompute keys once (avoid recomputing in the comparator).
     let keys: Vec<Vec<u8>> = records.iter().map(key_of).collect();
     order.sort_by(|&a, &b| keys[a].cmp(&keys[b]).then(a.cmp(&b)));
-    Some(order)
+    let ordered_keys: Vec<&[u8]> = order.iter().map(|&row| keys[row].as_slice()).collect();
+    let runs = contiguous_runs(&ordered_keys);
+    Some(ClusterPlan { order, runs })
 }
 
 /// TD-WLP-4 (ADR-061 D3): the compaction re-cluster order — **PCA + IVF
@@ -142,6 +166,11 @@ pub fn cluster_order(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>
 /// batch-local model is discarded after ordering — persisted-model reuse
 /// (`pca_model_ref`) is the TD-WLP-4b follow-up.
 pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Vec<usize>> {
+    cluster_plan_pca_ivf(records, idx).map(|plan| plan.order)
+}
+
+/// Compaction-grade PCA+IVF plan, including the contiguous IVF-cell runs.
+pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<ClusterPlan> {
     /// Below this many usable rows a trained model can't beat the bootstrap.
     const MIN_ROWS_FOR_IVF: usize = 64;
     /// Target rows per IVF cell — approximates rows-per-PAX-block so one cell
@@ -158,11 +187,11 @@ pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Ve
         .filter_map(|(i, r)| embedding_f32(r, idx).map(|v| (i, v)))
         .collect();
     if usable.len() < MIN_ROWS_FOR_IVF {
-        return cluster_order(records, idx);
+        return cluster_plan(records, idx);
     }
     let dim = usable[0].1.len();
     if usable.iter().any(|(_, v)| v.len() != dim) {
-        return cluster_order(records, idx);
+        return cluster_plan(records, idx);
     }
 
     // Batch-local PCA (one projection serves the IVF assignment, the cell
@@ -187,7 +216,7 @@ pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Ve
         1e-3,
         PAX_IVF_KMEANS_SEED,
     ) else {
-        return cluster_order(records, idx);
+        return cluster_plan(records, idx);
     };
     let assignments = proximadb_clustering_kernel::kmeans_assign(&coords, &centroids);
 
@@ -244,7 +273,38 @@ pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Ve
     order.extend(usable_sorted.iter().map(|&u| usable[u].0));
     let in_usable: std::collections::HashSet<usize> = usable.iter().map(|(i, _)| *i).collect();
     order.extend((0..records.len()).filter(|i| !in_usable.contains(i)));
-    Some(order)
+    let mut ordered_cells: Vec<usize> = usable_sorted
+        .iter()
+        .map(|&usable_row| assignments[usable_row])
+        .collect();
+    ordered_cells.extend(std::iter::repeat_n(
+        usize::MAX,
+        records.len() - usable.len(),
+    ));
+    let runs = contiguous_runs(&ordered_cells);
+    Some(ClusterPlan { order, runs })
+}
+
+fn contiguous_runs<T: PartialEq>(ordered_labels: &[T]) -> Vec<OrderedClusterRun> {
+    if ordered_labels.is_empty() {
+        return Vec::new();
+    }
+    let mut runs = Vec::new();
+    let mut start = 0usize;
+    for row in 1..ordered_labels.len() {
+        if ordered_labels[row] != ordered_labels[row - 1] {
+            runs.push(OrderedClusterRun {
+                start_row: start,
+                row_count: row - start,
+            });
+            start = row;
+        }
+    }
+    runs.push(OrderedClusterRun {
+        start_row: start,
+        row_count: ordered_labels.len() - start,
+    });
+    runs
 }
 
 /// Binary-reflected Gray code over the sign bits of `v - mean`, packed MSB-first
@@ -330,6 +390,28 @@ mod tests {
             1,
             "negative cluster members adjacent: {oids:?}"
         );
+    }
+
+    #[test]
+    fn cluster_plan_runs_cover_reordered_rows_exactly() -> anyhow::Result<()> {
+        let recs = vec![
+            rec("p1", vec![2.0, 2.0, 2.0, 2.0]),
+            rec("n1", vec![-2.0, -2.0, -2.0, -2.0]),
+            rec("p2", vec![3.0, 1.0, 2.0, 4.0]),
+            rec("n2", vec![-3.0, -1.0, -2.0, -4.0]),
+        ];
+        let plan = cluster_plan(&recs, 0)
+            .ok_or_else(|| anyhow::anyhow!("expected a bootstrap cluster plan"))?;
+        assert_eq!(plan.order.len(), recs.len());
+        assert!(plan.runs.len() >= 2);
+        let mut expected_start = 0usize;
+        for run in &plan.runs {
+            assert_eq!(run.start_row, expected_start);
+            assert!(run.row_count > 0);
+            expected_start += run.row_count;
+        }
+        assert_eq!(expected_start, recs.len());
+        Ok(())
     }
 
     #[test]

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -266,6 +266,7 @@ fn write_pax_segment_ordered(
     plan: Option<crate::storage::engines::sst::block_cluster::ClusterPlan>,
 ) -> Result<SegmentMeta> {
     let lossless_clustered = lossless_clustered_enabled() && plan.is_some();
+    let lossless_scalar = lossless_scalar_enabled();
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,
@@ -279,6 +280,7 @@ fn write_pax_segment_ordered(
     .with_f32_tier(f32_tier)
     .with_rerank_quant(rerank_quant)
     .with_lossless_clustered(lossless_clustered)
+    .with_lossless_scalar(lossless_scalar)
     .with_block_centroids(cluster)
     // ADR-062 / TD-RDSTRAT-6: hoist the RaBitQ binary tier into a coalesced
     // file-level header region for RaBitQ-quantized writes (default ON per the
@@ -312,6 +314,18 @@ fn write_pax_segment_ordered(
 fn lossless_clustered_enabled() -> bool {
     matches!(
         std::env::var("PROXIMADB_PAX_LOSSLESS_CLUSTERED")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
+fn lossless_scalar_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_PAX_LOSSLESS_SCALAR")
             .ok()
             .as_deref()
             .map(str::trim)

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -182,15 +182,15 @@ pub fn write_pax_segment_full(
     // ranks/dedups by distance + OID). Compaction upgrades the ordering to
     // PCA+IVF via `write_pax_segment_compacted`.
     let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
-    let order = if cluster {
+    let plan = if cluster {
         // TD-WLP-4/WLP-9 eval opt-in (`PROXIMADB_PAX_FLUSH_CLUSTER=ivf`): apply
         // the compaction-grade PCA+IVF re-cluster at flush instead of the sign-bit
         // bootstrap, so clustering quality is measurable without the (unwired)
         // flush→compaction scheduler. Default OFF ⇒ bootstrap.
         if crate::storage::engines::sst::block_cluster::flush_cluster_ivf() {
-            crate::storage::engines::sst::block_cluster::cluster_order_pca_ivf(records, 0)
+            crate::storage::engines::sst::block_cluster::cluster_plan_pca_ivf(records, 0)
         } else {
-            crate::storage::engines::sst::block_cluster::cluster_order(records, 0)
+            crate::storage::engines::sst::block_cluster::cluster_plan(records, 0)
         }
     } else {
         None
@@ -205,7 +205,7 @@ pub fn write_pax_segment_full(
         f32_tier,
         target_block,
         cluster,
-        order,
+        plan,
     )
 }
 
@@ -231,8 +231,8 @@ pub fn write_pax_segment_compacted(
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
     let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
-    let order = if cluster {
-        crate::storage::engines::sst::block_cluster::cluster_order_pca_ivf(records, 0)
+    let plan = if cluster {
+        crate::storage::engines::sst::block_cluster::cluster_plan_pca_ivf(records, 0)
     } else {
         None
     };
@@ -246,7 +246,7 @@ pub fn write_pax_segment_compacted(
         f32_tier,
         target_block,
         cluster,
-        order,
+        plan,
     )
 }
 
@@ -263,8 +263,9 @@ fn write_pax_segment_ordered(
     f32_tier: bool,
     target_block: Option<usize>,
     cluster: bool,
-    order: Option<Vec<usize>>,
+    plan: Option<crate::storage::engines::sst::block_cluster::ClusterPlan>,
 ) -> Result<SegmentMeta> {
+    let lossless_clustered = lossless_clustered_enabled() && plan.is_some();
     let mut writer = PaxSegmentWriter::new(
         path,
         BlockMode::Pax,
@@ -277,15 +278,25 @@ fn write_pax_segment_ordered(
     .with_quant(quant)
     .with_f32_tier(f32_tier)
     .with_rerank_quant(rerank_quant)
+    .with_lossless_clustered(lossless_clustered)
     .with_block_centroids(cluster)
     // ADR-062 / TD-RDSTRAT-6: hoist the RaBitQ binary tier into a coalesced
     // file-level header region for RaBitQ-quantized writes (default ON per the
     // ADR-061 pre-GA in-place amendment; `PROXIMADB_PAX_COALESCED_RABITQ=0` opts
     // out to the legacy in-block RaBitQ layout for mixed-read / measurement).
     .with_coalesced_rabitq(quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled());
-    match &order {
-        Some(perm) => {
-            for &i in perm {
+    match &plan {
+        Some(plan) => {
+            let mut next_run = 1usize;
+            for (ordered_row, &i) in plan.order.iter().enumerate() {
+                if plan
+                    .runs
+                    .get(next_run)
+                    .is_some_and(|run| run.start_row == ordered_row)
+                {
+                    writer.start_cluster_run();
+                    next_run += 1;
+                }
                 writer.add_record(&records[i])?;
             }
         }
@@ -296,6 +307,18 @@ fn write_pax_segment_ordered(
         }
     }
     writer.finish()
+}
+
+fn lossless_clustered_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_PAX_LOSSLESS_CLUSTERED")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
 }
 
 /// True only when every vector row in every input `.pax` segment has an exact

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -49,12 +49,27 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
 use tempfile::TempDir;
 
 const DIMENSION: usize = 128;
 const TOP_K: usize = 10;
 const BATCH_SIZE: usize = 20_000;
 const DEFAULT_QUERIES: usize = 1000;
+
+fn directory_file_bytes(path: &Path) -> std::io::Result<u64> {
+    let mut bytes = 0u64;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            bytes = bytes.saturating_add(directory_file_bytes(&entry.path())?);
+        } else if metadata.is_file() {
+            bytes = bytes.saturating_add(metadata.len());
+        }
+    }
+    Ok(bytes)
+}
 
 // ---------------------------------------------------------------------------
 // TEXMEX .fvecs / .ivecs loader (std-only, little-endian — no native dep).
@@ -559,15 +574,21 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
         .enumerate()
         .map(|(i, v)| vector_record(i as u32, v.clone()))
         .collect();
+    let flush_started = Instant::now();
     flush_batch(&engine, &collection, batch).await;
+    let flush_ms = flush_started.elapsed().as_millis();
+    let persisted_bytes = directory_file_bytes(temp_dir.path()).expect("measure persisted bytes");
     eprintln!("[coalesced] single-file collection: N={n} vectors flushed in one batch");
 
     // Search all queries in ONE io_trace scope; range_gets accumulates over the loop.
-    let (recall, measured, snap) = proximadb::observability::io_trace::scope(async {
+    let (recall, measured, snap, mut query_us) = proximadb::observability::io_trace::scope(async {
         let mut recall_sum = 0.0f64;
         let mut measured = 0usize;
+        let mut query_us = Vec::with_capacity(queries.len());
         for (qi, query) in queries.iter().enumerate() {
+            let query_started = Instant::now();
             let got = search_topk(&engine, &collection, query.clone()).await;
+            query_us.push(query_started.elapsed().as_micros() as u64);
             if got.is_empty() {
                 continue;
             }
@@ -581,9 +602,19 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
             0.0
         };
         let snap = proximadb::observability::io_trace::snapshot().expect("io_trace scope active");
-        (recall, measured, snap)
+        (recall, measured, snap, query_us)
     })
     .await;
+    query_us.sort_unstable();
+    let mean_query_us = if query_us.is_empty() {
+        0
+    } else {
+        query_us.iter().sum::<u64>() / query_us.len() as u64
+    };
+    let p95_query_us = query_us
+        .get(query_us.len().saturating_sub(1) * 95 / 100)
+        .copied()
+        .unwrap_or(0);
 
     let per_q_gets = if measured > 0 {
         snap.range_gets / measured as u64
@@ -601,6 +632,10 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
     eprintln!(
         "  recall@{TOP_K} = {recall:.4}  range_gets/query = {per_q_gets}  bytes_read/query = {per_q_bytes}  (measured={measured}, total_gets={})",
         snap.range_gets
+    );
+    eprintln!(
+        "  persisted_bytes = {persisted_bytes}  persisted_bytes/row = {:.2}  flush_ms = {flush_ms}  mean/p95_query_us = {mean_query_us}/{p95_query_us}",
+        persisted_bytes as f64 / n as f64
     );
     eprintln!("  vs legacy block-prune ~370 GETs/query — target: < {get_budget} (≪ 370)");
 


### PR DESCRIPTION
## Summary

Lands the TD-RDSTRAT-7 "lossless bytes" work for PAX: a lossless compression layer that reduces query and persisted bytes **without touching recall**. Two orthogonal, default-OFF, mixed-read-safe levers:

1. **Clustered vector transform** (commits 1–6): `ClusteredForBitpackU8` — a reversible transform over the already-produced SQ8 code matrix (per-dimension min + bit-pack of clustered runs), wired through the segment-footer encoding map (fail-closed on unknown encodings). Gated by `PROXIMADB_PAX_LOSSLESS_CLUSTERED`.
2. **Lossless scalar-stripe compression** (tip commit): all-null page elision + post-codec LZ4 on the four scalar column types (i64/f64/str/bytes). Gated by `PROXIMADB_PAX_LOSSLESS_SCALAR`. Vector stripes are untouched — the clustered transform is their bytes lever, not LZ4.

Both are selected per-stripe by realized byte size and fall back to the raw representation when compression doesn't clear a min-savings threshold.

## Why

PR1 (#1019) moved GETs/query 18.5× (≈370 → 20); `bytes_read/query` is now the dominant remaining route-cost term (31.7 MB at recall 0.984). TD-RDSTRAT-7's 2026-07-16 bake-off rejected every lossy arm (residual SQ6 / TurboQuant4 / RaBitQ4) — **quantization remains the only permitted lossy boundary**. This PR moves bytes losslessly: decode reproduces the input SQ8 codes / f32 bits bit-for-bit, so rerank produces identical distances, ranking, and recall.

## Mixed-read safety / defaults

- New `ColumnMeta` flag `is_lz4_compressed` (bit3 of the flags byte). Old files have bit3=0 → reader treats the payload as raw. New footer encodings fail-closed on unknown tags.
- Both features **default OFF** (env-gated). No segment-magic bump.
- All-null elision read check (`stripe_len == 0 && null_count == n`) is unconditional and correct for legacy all-null pages too.
- Compression failure falls back to raw (fail-safe, not fail-closed — acceptable for a reversible optimization).

## Measurement — SIFT1M N=100k, 100-query, single-file IVF-ON (release)

| Metric | feature OFF | scalar-LZ4 ON | gate |
|---|---|---|---|
| recall@10 | 0.9910 | 0.9910 | ≥ 0.98 (beats 0.984 baseline; provably lossless) |
| range_gets/query | 19 | 19 | < 50, no regression |
| bytes_read/query | 30.5 MB | **23.9 MB (−21.7 %)** | < 31.7 MB |
| persisted_bytes/row | 260.7 | **200.4 (−23.1 %)** | lower |
| p95 query latency | ~14 ms | ~14 ms | no regression |

Recall is byte-identical with the feature ON. The bytes gate (was 30.5 MB, above the 31.7 MB cap) now clears it.

## Test coverage

- `lossless_compression`: round-trip, incompressible-fallback, corruption-fails-closed.
- `clustered_for_bitpack`: byte-exact round-trip, bit-width edges, run/chunk validation, sparse-outlier bounding, selected-decode order preservation, corruption fails-closed.
- `lossless_scalar_pages_compress_in_place_and_round_trip`: full block write→read with LZ4 + all-null across all four scalar types.
- `clustered_sq8_*`: transform exactness, rerank metric neutrality, footer encoding assignment.
- SIFT1M end-to-end recall ratchet (`sift_coalesced_rabitq_scan_rerank_eval`, `#[ignore]`, needs `PROXIMADB_SIFT_DATASET_DIR`).

## Verification done locally

`cargo fmt --check`; `cargo clippy -D warnings` (changed crates); `cargo check --tests` (lib + root); 827 unit tests green; SIFT eval run both OFF and ON; `make work-commit-check`; TD/ADR uniqueness; no-agent-attribution. Rebased onto latest `develop` (0 conflicts, 7 commits).
