### PR TITLE
ci: fix Feature Matrix (small-crates) referencing nonexistent crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,7 +757,9 @@ jobs:
           - { label: "embedded",             pkg: proximadb-embedded, args: "" }
           # Small extracted crates batched into one runner (each compiles in <1min;
           # the per-runner overhead — checkout + toolchain + apt + cache — dominates).
-          - { label: "small-crates",         pkg: "proximadb-mongodb-parser proximadb-catalog-introspection", args: "" }
+          # Space-separate additional small crates here as they are extracted; the
+          # step loops over every package in the list.
+          - { label: "small-crates",         pkg: "proximadb-mongodb-parser", args: "" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0


### PR DESCRIPTION
## Problem

`Feature Matrix (small-crates)` — and therefore `CI Success` — is **red on develop HEAD** (90aa582a2) for every PR, including the ADR-064 close-out #1068, independent of PR contents.

Root cause: PR #1067 batched the small-crate feature-matrix entries and listed a package that does not exist:

```
error: package ID specification `proximadb-catalog-introspection` did not match any packages
```

There is no `proximadb-catalog-introspection` crate anywhere in the workspace — the name was fabricated during the batching change.

## Fix

Drop the bogus package, leaving the valid `proximadb-mongodb-parser`. The batch-loop step is kept so real small crates can be appended later.

## Verification

- `cargo metadata` confirms every `proximadb-*` package referenced by the feature-matrix now resolves (`proximadb`, `proximadb-embedded`, `proximadb-mongodb-parser`, `proximadb-server`).
- CI-YAML-only change; no Rust source touched.