### PR TITLE
ci(objstore): PR-tier Azurite restart-recovery gate (TD-OBJSTORE-5 S1, ADR-063 D8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       network_changes: ${{ steps.filter.outputs.network_changes }}
       pgwire_accuracy_changes: ${{ steps.filter.outputs.pgwire_accuracy_changes }}
       object_store_cloud_changes: ${{ steps.filter.outputs.object_store_cloud_changes }}
+      object_store_restart_changes: ${{ steps.filter.outputs.object_store_restart_changes }}
       # SDK change detection
       go_sdk: ${{ steps.filter.outputs.go_sdk }}
       nodejs_sdk: ${{ steps.filter.outputs.nodejs_sdk }}
@@ -223,6 +224,19 @@ jobs:
               - 'src/graph/cold_payload_store.rs'
               - 'scripts/run_cloud_emulator_tests.sh'
               - '.github/workflows/ci.yml'
+            # Full-server object-store RESTARTABILITY recovery (TD-OBJSTORE-5 S1,
+            # ADR-063 D8 PR tier). Any change to the WAL recovery / durable-write /
+            # object-store filesystem / catalog-restart path must prove a real
+            # process-boundary restart recovers over Azurite before merge — the exact
+            # regression class TD-OBJSTORE-1 batch 3 was.
+            object_store_restart_changes:
+              - 'src/storage/persistence/write_ahead_log/**'
+              - 'src/storage/persistence/filesystem/**'
+              - 'crates/storage/proximadb-object-store/**'
+              - 'crates/control/proximadb-catalog/**'
+              - 'src/storage/engine.rs'
+              - 'apps/proximadb-server/tests/object_store_restart_recovery.rs'
+              - 'scripts/run_cloud_emulator_tests.sh'
             graph_changes:
               - 'src/graph/**'
               - 'tests/*graph*'
@@ -1463,6 +1477,59 @@ jobs:
         # docker + aws/az CLIs are preinstalled on ubuntu-latest runners.
         run: bash scripts/run_cloud_emulator_tests.sh --fast
 
+  # TD-OBJSTORE-5 S1 (ADR-063 D8 PR tier): full-server object-store RESTARTABILITY
+  # recovery over Azurite (adls://). Spawns the real proximadb-server against one
+  # object-store prefix, SIGKILLs it, and recovers catalog + WAL-replays collections
+  # on a fresh local disk — the process-boundary proof for the TD-OBJSTORE-1 batch-3
+  # regression class. Path-gated on the WAL-recovery / durable-write / object-store
+  # filesystem / catalog code so it runs on the introducing PR (e.g. an in-flight
+  # recovery rework) — the exact churn a post-hoc gate would miss. Compiles the
+  # server binary (heavy), so it's a dedicated job: reclaim-disk + sccache +
+  # CARGO_BUILD_JOBS=1 (in the script) for the 16GB-runner OOM cliff. Path-gated
+  # (skipped otherwise) and in ci-success.needs so it gates when it runs.
+  object-store-restart-recovery:
+    name: Object-store restart recovery (Azurite)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs: [changes]
+    if: |
+      !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
+      needs.changes.outputs.object_store_restart_changes == 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
+    steps:
+      - name: Reclaim disk space
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost || true
+          echo "Disk after reclaim:"; df -h /
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-objstore-restart"
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-restart-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: sccache-restart-${{ runner.os }}-
+      - name: Prove full-server restart recovery over Azurite (adls://)
+        # docker + aws/az CLIs preinstalled on ubuntu-latest; the script starts
+        # Azurite and runs catalog_wal_and_sst_survive_fresh_local_disks.
+        run: bash scripts/run_cloud_emulator_tests.sh --restart
+
   # Targeted integration tests based on changed components
   rust-integration-test-storage:
     name: Rust Integration Tests (storage)
@@ -2166,6 +2233,7 @@ jobs:
       - rust-integration-test-graph
       - rust-integration-test-cluster
       - object-store-emulator-tests
+      - object-store-restart-recovery
       - rust-coverage
       - python-lint
       - python-test

--- a/scripts/run_cloud_emulator_tests.sh
+++ b/scripts/run_cloud_emulator_tests.sh
@@ -7,13 +7,19 @@
 # `make cloud-emulator-test` (local). Single source of truth so every CI path is
 # exactly the locally-runnable path.
 #
-# Usage: run_cloud_emulator_tests.sh [--fast|--all]
+# Usage: run_cloud_emulator_tests.sh [--fast|--all|--restart]
 #   --fast : run ONLY the cheap object-store tier tests (~3-5 min — compiles just
 #            the small object-store crate, no main-crate compile, no OOM risk).
 #            Used by the develop early-detection job so a tier regression is caught
 #            on the introducing feat→develop PR.
 #   --all  : (default) also run cold_graph_record_store_round_trips_on_real_azure,
 #            which compiles the full main crate and runs under CARGO_BUILD_JOBS=2.
+#   --restart : ONLY the full-server object-store RESTARTABILITY recovery proof
+#            (TD-OBJSTORE-5 S1, ADR-063 D8 PR tier) — spawns the real
+#            `proximadb-server` binary against an Azurite (adls://) prefix, SIGKILLs
+#            it, and recovers catalog + WAL-replays collections on a fresh local
+#            disk. Compiles the server binary, so it gets its OWN scope/job (kept
+#            off --fast/--all's compile budget).
 #
 # Requires: docker, cargo, aws CLI (MinIO bucket), az CLI (Azurite container),
 # curl (fake-gcs bucket). On GitHub ubuntu-latest all are preinstalled.
@@ -33,7 +39,8 @@ for arg in "$@"; do
   case "$arg" in
     --fast) SCOPE="fast" ;;
     --all)  SCOPE="all" ;;
-    *) echo "::error::unknown argument: $arg"; echo "usage: $0 [--fast|--all]"; exit 2 ;;
+    --restart) SCOPE="restart" ;;
+    *) echo "::error::unknown argument: $arg"; echo "usage: $0 [--fast|--all|--restart]"; exit 2 ;;
   esac
 done
 echo "==> Scope: $SCOPE"
@@ -86,6 +93,31 @@ export AZURE_STORAGE_USE_EMULATOR=true AZURE_ALLOW_HTTP=true
 export AWS_ENDPOINT=http://127.0.0.1:9000 AWS_ALLOW_HTTP=true AWS_VIRTUAL_HOSTED_STYLE_REQUEST=false
 export AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin AWS_REGION=us-east-1
 export PROXIMADB_GCS_TEST_ENDPOINT=http://127.0.0.1:4443
+
+if [ "$SCOPE" = "restart" ]; then
+  # TD-OBJSTORE-5 S1 (ADR-063 D8 PR tier = Azurite-strict): prove full-server
+  # object-store RESTARTABILITY recovery in the runner. Spawns the real
+  # `proximadb-server` three times against ONE Azurite (adls://) prefix with a
+  # fresh local `server.data_dir` each time: CREATE+INSERT → SIGKILL → recover
+  # catalog from metadata_url + WAL-replay reattaches SST/HELIX collections →
+  # SIGINT (flush SST) → cold read on another empty disk. All durable state lives
+  # only in the object store (ADR-048 stateless catalog). Isolated scope: it
+  # compiles the proximadb-server binary (heavy, CARGO_BUILD_JOBS=1 for OOM
+  # safety), so it runs in its own path-gated CI job, not on --fast/--all's budget.
+  # (The zero-vector-KV restart arm stays OUT of the gate until TD-OBJSTORE-4
+  # greens it end-to-end — gating on a known-red test would just block PRs.)
+  echo "==> TD-OBJSTORE-5 S1: full-server restart recovery over Azurite (adls://)"
+  # Azurite = ADLS Blob emulator; the production adls:// from_url + emulator env.
+  export PROXIMADB_AZURE_EMULATOR=1 AZURE_STORAGE_USE_EMULATOR=true AZURE_ALLOW_HTTP=true
+  export AZURE_STORAGE_ACCOUNT=devstoreaccount1 AZURE_STORAGE_ACCOUNT_NAME=devstoreaccount1
+  export PROXIMADB_OBJECT_STORE_URL="adls://$CONTAINER_BUCKET/objstore-restart-recovery"
+  CARGO_BUILD_JOBS=1 cargo test -p proximadb-server --features azure \
+    --test object_store_restart_recovery \
+    catalog_wal_and_sst_survive_fresh_local_disks \
+    -- --ignored --nocapture --test-threads=1
+  echo "==> Restart-recovery validation complete (cleanup trap tears emulators down)"
+  exit 0
+fi
 
 cargo test -p proximadb-object-store --features aws,azure,gcp -- --ignored --nocapture \
   put_with_tier_accepted_by_azurite \


### PR DESCRIPTION
## What

Adds a **PR-tier CI gate** that proves full-server **object-store restartability recovery** over Azurite, on every PR that touches the recovery path. Closes the TD-OBJSTORE-5 S1 gap (the restart proof was `#[ignore]`'d and ungated).

## Why

The proof test — `object_store_restart_recovery.rs::catalog_wal_and_sst_survive_fresh_local_disks` — is `#[ignore]`'d, so a regression in the WAL-recovery / durable-write / object-store-filesystem / catalog-restart path (the **TD-OBJSTORE-1 batch-3** regression class) could only be caught by an out-of-band anvaiops VM restart. This runs it in the runner.

**Verified green first:** ran the test on current develop (`ab507e6b4`) against Azurite → `1 passed; 0 failed` (the full 3-phase recovery: catalog recovered, WAL-replayed collections on a fresh disk, cold-disk search served results). So #1061 already settled restart recovery; this gate locks it in.

## Changes (2 files)

- **`run_cloud_emulator_tests.sh`** — new `--restart` scope: reuses the Azurite startup + container, spawns the real `proximadb-server` (`--features azure`) against an `adls://` prefix, runs the 3-phase restart proof. `CARGO_BUILD_JOBS=1` for the 16 GB-runner OOM cliff.
- **`ci.yml`** — dedicated `object-store-restart-recovery` job at the **PR tier** (feat→develop), **path-gated** on `object_store_restart_changes` (WAL / filesystem / object-store / catalog / engine / the test / the script). Reclaim-disk (#1043 pattern) + sccache for the heavy server compile. Wired into `ci-success.needs` so it gates when it runs (skipped ⇒ pass).

## Design notes

- **PR tier, not qa-gate — deliberate.** It runs on the *introducing* recovery PR (e.g. the in-flight `#1065` list-authority rework), so a recovery change is proven to still restart-recover **before** merge — the exact churn a post-hoc/QA-only gate would miss. Per **ADR-063 D8**: PR = Azurite-strict; the QA Azure+S3 tier and nightly GCS best-effort are follow-ups.
- **Zero-vector-KV restart arm stays out** of the gate until TD-OBJSTORE-4 greens it end-to-end — gating on a known-red test would just block PRs.
- This PR self-validates: it changes the script (in the path filter), so its own CI runs the new job (server build + Azurite + restart proof).

Guards: `bash -n` clean, YAML valid, no-agent-attribution clean. qa-gate.yml untouched (verified no-op).