### PR TITLE
refactor(route): TD-ROUTE-3 — authoritative route decision, thin match dispatch

### DIFF
--- a/docs/10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc
+++ b/docs/10-quality/td/TD-ROUTE-3-decision-dispatch-separation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open** — filed 2026-07-16 under link:../../12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (Decision 1). Phase-3 of the ADR-064 rollout; independent of the other two.
+| Status | **Done** — filed 2026-07-16, implemented 2026-07-16 under link:../../12-design/adr/ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (Decision 1). Phase-3 of the ADR-064 rollout; independent of the other two. The decision is now authoritative (`route_select_advised` folds the env master switches + ADR-058 primary eligibility + the cost-model override into `decision.backend` via `RouteFlags` + `parquet_primary_eligibility`, and `flip_eligible` refuses to flip onto an ineligible primary); dispatch is a thin `match decision.backend` where each primary owns its fall-through to the shared DataFusion floor with a single io_trace stamp. `ComputeBackend` stayed a closed enum (ADR-059).
 | Priority | P2 — maintainability + testability of the hot routing path; unblocks unit-testing routing decisions without running a query, and fixes the cost-cell mis-attribution at the source.
 | Component | `src/network/postgres/relational_pipeline.rs` (the dispatch block), `src/query/compute_scheduler.rs` (`route_select` / `route_select_advised`), per-backend execution adapters.
 | Evidence | The dispatch (relational_pipeline.rs:491-750, ~260 lines) re-decides inside the God-`if`: native-over-parquet primary (:513), DuckDB primary (:596), DataFusion floor (:682), route re-stamp "last-write-wins" (:729-732), native shadow (:739) — plus a separate PAX branch. Adding an engine edits this block (Open/Closed violation); the cost model learns the last-stamped route, not the one decided.
@@ -35,9 +35,17 @@ capability descriptor per backend (ADR-058), no duplicated coverage statements.
 == Gate
 
 No-behavior-change refactor: every current route preserved, verified by the TPC-H (22) / TPC-DS (16)
-pgwire conformance ratchets + the perf ledger (same backend served per query as before). New: unit
-tests asserting `shape → RouteDecision.backend` in isolation (no query run); a cost-attribution test
-proving a floor fall-through attributes to the floor cell, not the primary.
+pgwire conformance ratchets + the perf ledger (same backend served per query as before). New:
+
+* unit tests asserting `shape + RouteFlags → RouteDecision.backend` in isolation, no query run
+  (`compute_scheduler.rs` — `native_eligible_op_with_native_flag_decides_native`,
+  `join_bearing_with_native_flag_stays_datafusion_native_ineligible`,
+  `join_bearing_with_duckdb_flag_decides_duckdb`,
+  `route_flags_inert_on_non_parquet_shapes`,
+  `native_and_duckdb_primary_eligibility_are_disjoint`);
+* a cost-attribution e2e proving a floor fall-through attributes to the floor cell, not the declined
+  primary (`tests/native_route_pgwire_e2e.rs` —
+  `native_decline_attributes_to_datafusion_floor_not_the_declined_primary`).
 
 == Non-goals
 

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -461,11 +461,25 @@ pub async fn try_run_select(
         geometry,
         join_bearing: query_join_bearing(query),
     };
+    // TD-ROUTE-3: read the env master switches ONCE here (both are OnceLock-cached)
+    // and thread them into the decision so `route_select_advised` — not the
+    // dispatch — decides whether a native/duckdb primary is engaged. The decision
+    // core stays env-free / unit-testable.
+    let route_flags = crate::query::compute_scheduler::RouteFlags {
+        native_route: crate::query::execution::native_engine::native_route_enabled(),
+        // `duckdb_engine` compiles only under the `duckdb` feature; without it the
+        // switch is inert (false), matching the absent DuckDB dispatch arm.
+        #[cfg(feature = "duckdb")]
+        duckdb_route: crate::query::execution::duckdb_engine::duckdb_route_enabled(),
+        #[cfg(not(feature = "duckdb"))]
+        duckdb_route: false,
+    };
     let decision = crate::query::compute_scheduler::ComputeScheduler::new().route_select_advised(
         shape,
         // C4: observe-mode advisory from the trace-driven cost model — augments
         // the reason for telemetry/EXPLAIN, never changes the backend.
         Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
+        route_flags,
     );
     tracing::debug!(
         target: "proximadb::compute_route",
@@ -477,17 +491,17 @@ pub async fn try_run_select(
         decision.explain_line()
     );
 
-    // P1 dispatch driven by the scheduler decision. The DataFusion arm exists only
-    // under the feature (and `parquet_backed` — hence a `DataFusionLocal` decision —
-    // is only reachable there), so a default build never enters it and stays Volcano.
+    // P1 dispatch driven by the AUTHORITATIVE scheduler decision (TD-ROUTE-3).
+    // `route_select_advised` has already folded eligibility (ADR-058) + the env
+    // master switches + any cost-model override into `decision.backend`, so this
+    // block does NOT re-decide — it is a thin `match decision.backend` over the
+    // parquet-OLAP engines, each PRIMARY owning its own fall-through to the shared
+    // DataFusion floor. The DataFusion arm exists only under the feature (and
+    // `parquet_backed`), so a default build never enters it and stays Volcano.
     //
-    // The block is entered for the OLAP-over-parquet route: a static `DataFusionLocal`
-    // decision, OR a cost-model override/exploration flip to `Native` on the
-    // `olap/parquet` class (the only class with two freshness-safe engines,
-    // `freshness_safe_backends_from_class`). Routing the override-`Native` case here
-    // rather than to the Volcano keeps a warmed override on the native-over-parquet
-    // path (which reads the external parquet) with DataFusion as the floor — never on
-    // the Volcano, which has no external-parquet scan wired.
+    // The outer guard restricts entry to the three parquet-OLAP backends; any
+    // other `decision.backend` (never produced for a parquet-OLAP shape) falls
+    // through to the Volcano path below — exactly as before.
     #[cfg(feature = "datafusion-integration")]
     if parquet_backed
         && matches!(
@@ -497,78 +511,15 @@ pub async fn try_run_select(
                 | crate::query::table_write_plan::ComputeBackend::DuckDbCompat
         )
     {
-        // TD-OLAP-4 "favor native by operation": for the operation classes native
-        // measurably wins — footer-elidable `COUNT(*)`/`MIN`/`MAX` (MetadataElidable)
-        // and narrow unfiltered scalar aggregates (ScalarAggregate) — run the native
-        // vectorized engine over the SAME external parquet as the PRIMARY backend and
-        // return ITS result. DataFusion stays the correctness floor: any decline
-        // (ineligible shape, wide/filtered/grouped scan, native error) falls through
-        // to the DataFusion execution below, so correctness never depends on native.
-        //
-        // Trigger (default-OFF): the explicit `PROXIMADB_NATIVE_ROUTE` master switch,
-        // OR a warmed cost-model override/exploration that advised `Native` for this
-        // operation-keyed `olap/parquet` cell (`PROXIMADB_ROUTE_COST_OVERRIDE`, with
-        // its freshness/RTT/min-advantage gating). Either way the shape gate is the
-        // same measured win-set, and DataFusion is the fallback.
-        let native_advised = matches!(
-            decision.backend,
-            crate::query::table_write_plan::ComputeBackend::Native
-        ) && matches!(
-            decision.source,
-            crate::query::compute_scheduler::RouteSource::OverrideExploit
-                | crate::query::compute_scheduler::RouteSource::OverrideExplore
-        );
-        let native_eligible_op = matches!(
-            operation_class,
-            crate::query::compute_scheduler::OperationClass::MetadataElidable
-                | crate::query::compute_scheduler::OperationClass::ScalarAggregate
-        );
-        if native_eligible_op
-            && (crate::query::execution::native_engine::native_route_enabled() || native_advised)
-        {
-            let native_snapshot = SnapshotCatalog {
-                dml: dml.clone(),
-                tables: tables.clone(),
-                tenant: tenant_ctx.clone(),
-            };
-            // Setup (planning/route) time is attributed here; the native engine records
-            // its own `native-vectorized` compute sample inside the run.
-            crate::observability::io_trace::record_setup_ms(
-                setup_start.elapsed().as_millis() as u64
-            );
-            if let Some(result) = try_native_over_parquet(
-                sql,
-                &native_snapshot,
-                &parquet_loc_by_key,
-                &parquet_trust_by_key,
-            )
-            .await
-            {
-                tracing::debug!(
-                    target: "proximadb::compute_route",
-                    "native-over-parquet served as PRIMARY (op={:?}); DataFusion floor bypassed",
-                    operation_class
-                );
-                if let Some((skey, lsn)) = &cache_ctx {
-                    populate_olap_result_cache(
-                        result_cache,
-                        skey,
-                        *lsn,
-                        result.clone(),
-                        &native_snapshot.tables,
-                    );
-                }
-                return Some(Ok(result));
-            }
-            // Native declined → fall through to the DataFusion floor below.
-        }
+        // Shared prep for the DuckDB primary + the DataFusion floor: per-table
+        // Parquet locations and (ADR-058 D5 / §9.A) per-table footer-stats trust,
+        // keyed by table_name (matching `parquet_tables`) and derived from
+        // `parquet_trust_by_key` (keyed by the canonical table key). Drives adapter
+        // elision gating.
         let parquet_tables: Vec<(String, String)> = tables
             .iter()
             .map(|(k, t)| (t.table_name.clone(), parquet_loc_by_key[k].clone()))
             .collect();
-        // ADR-058 D5/§9.A: per-table footer-stats trust, keyed by table_name
-        // (matching `parquet_tables`), derived from `parquet_trust_by_key`
-        // (keyed by the canonical table key). Drives adapter elision gating.
         let parquet_table_trust: HashMap<String, StatsTrust> = tables
             .iter()
             .filter_map(|(k, t)| {
@@ -577,42 +528,69 @@ pub async fn try_run_select(
                     .map(|tr| (t.table_name.clone(), *tr))
             })
             .collect();
-        // ADR-059 rollout step 2: DuckDB-Local as PRIMARY for the join/agg-shaped
-        // parquet OLAP route — the shapes with the measured 100–700× DataFusion
-        // join-plan gap (TD-OLAP-15/TD-OLAP-2). DataFusion remains the correctness
-        // floor: any DuckDB error falls through to the DataFusion execution below.
-        // Trigger (default-OFF): the PROXIMADB_DUCKDB_ROUTE master switch, OR a
-        // warmed cost-model override/exploration that advised DuckDbCompat (the
-        // #946 per-class staged enable). Eligibility (ADR-058: precedes selection):
-        // join-bearing or grouped shape, AND every referenced table's ADR-025
-        // post-snapshot WAL delta is EMPTY — DuckDB reads bare parquet and cannot
-        // reconcile a delta, so it serves only when base parquet == current state
-        // (the delta-merging DataFusion floor serves everything else; errors from
-        // the delta probe fail closed to the floor). The probe is the TD-OLAP-17
-        // per-collection high-water check DataFusion itself pays at table open, so
-        // the common no-writes case costs no scan. The io_trace route is
-        // re-stamped to the engine that actually served ("last write wins" by
-        // design), so cost cells never mis-attribute.
-        #[cfg(feature = "duckdb")]
-        {
-            let duckdb_advised = matches!(
-                decision.backend,
-                crate::query::table_write_plan::ComputeBackend::DuckDbCompat
-            ) && matches!(
-                decision.source,
-                crate::query::compute_scheduler::RouteSource::OverrideExploit
-                    | crate::query::compute_scheduler::RouteSource::OverrideExplore
-            );
-            let duckdb_eligible_shape = shape.join_bearing
-                || matches!(
-                    operation_class,
-                    crate::query::compute_scheduler::OperationClass::Grouped
+
+        // PRIMARY dispatch — a thin match over the authoritative backend. Each arm
+        // attempts its engine and RETURNS on success; on decline it falls through
+        // to the shared DataFusion floor below (which re-stamps the io_trace route
+        // so cost cells attribute to the engine that actually served). Eligibility
+        // + enablement were decided upstream, so reaching an arm IS the
+        // authorization to attempt it — no re-decision here (the TD-ROUTE-3 fix).
+        match decision.backend {
+            // TD-OLAP-4 "favor native by operation": the native vectorized engine
+            // over the SAME external parquet, for the footer-elidable `COUNT(*)` /
+            // `MIN` / `MAX` (MetadataElidable) and narrow unfiltered scalar
+            // aggregates (ScalarAggregate) it measurably wins on. Its own fine
+            // plan-shape gates (single-scan / width / trust) live inside
+            // `try_native_over_parquet`; any decline falls to the floor.
+            crate::query::table_write_plan::ComputeBackend::Native => {
+                let native_snapshot = SnapshotCatalog {
+                    dml: dml.clone(),
+                    tables: tables.clone(),
+                    tenant: tenant_ctx.clone(),
+                };
+                // Setup (planning/route) time is attributed here; the native engine
+                // records its own `native-vectorized` compute sample inside the run.
+                crate::observability::io_trace::record_setup_ms(
+                    setup_start.elapsed().as_millis() as u64
                 );
-            let duckdb_delta_clean =
-                if (crate::query::execution::duckdb_engine::duckdb_route_enabled()
-                    || duckdb_advised)
-                    && duckdb_eligible_shape
+                if let Some(result) = try_native_over_parquet(
+                    sql,
+                    &native_snapshot,
+                    &parquet_loc_by_key,
+                    &parquet_trust_by_key,
+                )
+                .await
                 {
+                    tracing::debug!(
+                        target: "proximadb::compute_route",
+                        "native-over-parquet served as PRIMARY (op={:?}); DataFusion floor bypassed",
+                        operation_class
+                    );
+                    if let Some((skey, lsn)) = &cache_ctx {
+                        populate_olap_result_cache(
+                            result_cache,
+                            skey,
+                            *lsn,
+                            result.clone(),
+                            &native_snapshot.tables,
+                        );
+                    }
+                    return Some(Ok(result));
+                }
+                // Native declined → fall through to the DataFusion floor below.
+            }
+            // ADR-059: DuckDB-Local as PRIMARY for the join/agg-shaped parquet route
+            // (the measured 100–700× DataFusion join-plan gap, TD-OLAP-15/TD-OLAP-2).
+            // The remaining gate is the ADR-025 TRUST probe: DuckDB reads bare
+            // parquet and cannot reconcile a post-snapshot WAL delta, so it serves
+            // only when every referenced table's delta is EMPTY (the delta-merging
+            // DataFusion floor serves everything else; a probe error fails closed to
+            // the floor). The probe is the TD-OLAP-17 per-collection high-water
+            // check DataFusion itself pays at table open, so the common no-writes
+            // case costs no scan.
+            #[cfg(feature = "duckdb")]
+            crate::query::table_write_plan::ComputeBackend::DuckDbCompat => {
+                let duckdb_delta_clean = {
                     use crate::query::execution::olap_delta_merge::OlapDeltaSource;
                     let mut clean = true;
                     for (tkey, params) in &olap_delta_tables {
@@ -628,57 +606,65 @@ pub async fn try_run_select(
                         }
                     }
                     clean
-                } else {
-                    false
                 };
-            if duckdb_delta_clean {
-                let duck_context = QueryExecutionContext {
-                    parquet_tables: parquet_tables.clone(),
-                    parquet_table_trust: parquet_table_trust.clone(),
-                    tenant_id: tenant.map(str::to_string),
-                    controls: controls.clone(),
-                    ..Default::default()
-                };
-                crate::observability::io_trace::record_setup_ms(
-                    setup_start.elapsed().as_millis() as u64
-                );
-                match execute_sql_with_backend(
-                    crate::query::table_write_plan::ComputeBackend::DuckDbCompat,
-                    sql,
-                    duck_context,
-                )
-                .await
-                {
-                    Ok(result) => {
-                        crate::observability::io_trace::record_route(
-                            &crate::query::route_cost_model::shape_class(&shape),
-                            "DuckDbCompat",
-                        );
-                        tracing::debug!(
-                            target: "proximadb::compute_route",
-                            "duckdb-local served as PRIMARY (join/agg parquet shape); \
-                             DataFusion floor bypassed"
-                        );
-                        if let Some((skey, lsn)) = &cache_ctx {
-                            populate_olap_result_cache(
-                                result_cache,
-                                skey,
-                                *lsn,
-                                result.clone(),
-                                &tables,
+                if duckdb_delta_clean {
+                    let duck_context = QueryExecutionContext {
+                        parquet_tables: parquet_tables.clone(),
+                        parquet_table_trust: parquet_table_trust.clone(),
+                        tenant_id: tenant.map(str::to_string),
+                        controls: controls.clone(),
+                        ..Default::default()
+                    };
+                    crate::observability::io_trace::record_setup_ms(
+                        setup_start.elapsed().as_millis() as u64,
+                    );
+                    match execute_sql_with_backend(
+                        crate::query::table_write_plan::ComputeBackend::DuckDbCompat,
+                        sql,
+                        duck_context,
+                    )
+                    .await
+                    {
+                        Ok(result) => {
+                            crate::observability::io_trace::record_route(
+                                &crate::query::route_cost_model::shape_class(&shape),
+                                "DuckDbCompat",
+                            );
+                            tracing::debug!(
+                                target: "proximadb::compute_route",
+                                "duckdb-local served as PRIMARY (join/agg parquet shape); \
+                                 DataFusion floor bypassed"
+                            );
+                            if let Some((skey, lsn)) = &cache_ctx {
+                                populate_olap_result_cache(
+                                    result_cache,
+                                    skey,
+                                    *lsn,
+                                    result.clone(),
+                                    &tables,
+                                );
+                            }
+                            return Some(Ok(result));
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                target: "proximadb::compute_route",
+                                "duckdb-local PRIMARY declined ({e}); DataFusion floor serves"
                             );
                         }
-                        return Some(Ok(result));
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            target: "proximadb::compute_route",
-                            "duckdb-local PRIMARY declined ({e}); DataFusion floor serves"
-                        );
                     }
                 }
+                // Not delta-clean or DuckDB declined → fall through to the floor.
             }
+            // DataFusionLocal (or a DuckDbCompat decision in a non-`duckdb` build) →
+            // the floor serves directly, no primary attempt.
+            _ => {}
         }
+
+        // === DataFusion floor (shared) ===
+        // Reached directly for a DataFusionLocal decision, or by fall-through when a
+        // Native/DuckDB PRIMARY declined. This IS the correctness floor for the
+        // OLAP-over-parquet route.
         let context = QueryExecutionContext {
             parquet_tables,
             parquet_table_trust,
@@ -705,23 +691,18 @@ pub async fn try_run_select(
             allow_engine_sql_fallback: true,
             controls: controls.clone(),
         };
-        // ADR-030 / TD-158: time the DataFusion (engine-SQL fallback) execution so
-        // the always-on billing observer can attribute KRU to this engine at scope
-        // close. `record_compute_ms` no-ops outside an `io_trace` scope.
+        // ADR-030 / TD-158: time the DataFusion execution so the always-on billing
+        // observer can attribute KRU to this engine at scope close. `record_compute_ms`
+        // no-ops outside an `io_trace` scope.
         crate::observability::io_trace::record_setup_ms(setup_start.elapsed().as_millis() as u64);
         let started = std::time::Instant::now();
-        // This block IS the DataFusion floor for the OLAP-over-parquet route, so
-        // execute on DataFusion regardless of the scheduler's advised label — a
-        // cost-model override may have set `decision.backend = Native` (routed here
-        // for the native-primary attempt above), but `execute_sql_with_backend` only
-        // serves `DataFusionLocal`; anything else errors `UnsupportedBackend`.
         let floor_backend = crate::query::table_write_plan::ComputeBackend::DataFusionLocal;
-        // Fold-attribution correctness: the decision stamp may carry an advised
-        // Native/DuckDbCompat backend whose PRIMARY attempt declined above — the
-        // floor is about to serve, so re-stamp the route to DataFusion ("last
-        // write wins"). Without this, a gap-missed flip poisons the advised
-        // engine's cost cells with DataFusion's measured quantities (the
-        // TD-ROUTE-1 §review failure mode).
+        // Fold-attribution correctness (TD-ROUTE-3): if a Native/DuckDB PRIMARY was
+        // decided but declined above, the floor is about to serve — re-stamp the
+        // route to DataFusion ("last write wins") so the declined engine's cost
+        // cells are not poisoned with DataFusion's measured quantities. A direct
+        // DataFusionLocal decision was already stamped by `finalize_route`, so the
+        // guard skips the redundant re-stamp.
         if !matches!(
             decision.backend,
             crate::query::table_write_plan::ComputeBackend::DataFusionLocal
@@ -2062,6 +2043,9 @@ pub fn classify_select_route(
                 ..Default::default()
             },
             Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
+            // `parquet_backed: false` here — the env master switches gate only the
+            // parquet-OLAP primary arm, so flags are inert; default is exact.
+            crate::query::compute_scheduler::RouteFlags::default(),
         ),
     )
 }
@@ -2409,6 +2393,15 @@ async fn route_and_plan_select(
             ..Default::default()
         },
         Some(&crate::query::route_cost_model::GLOBAL_ROUTE_COST_MODEL),
+        // EXPLAIN must disclose the SAME backend the real path picks, so thread the
+        // real env master switches (TD-ROUTE-3), not a default.
+        crate::query::compute_scheduler::RouteFlags {
+            native_route: crate::query::execution::native_engine::native_route_enabled(),
+            #[cfg(feature = "duckdb")]
+            duckdb_route: crate::query::execution::duckdb_engine::duckdb_route_enabled(),
+            #[cfg(not(feature = "duckdb"))]
+            duckdb_route: false,
+        },
     );
     let mut explanation = decision_to_explanation(&decision);
 

--- a/src/query/compute_scheduler.rs
+++ b/src/query/compute_scheduler.rs
@@ -352,6 +352,54 @@ impl RouteSource {
     }
 }
 
+/// Process-level route master switches (TD-ROUTE-3). The env-driven
+/// `PROXIMADB_NATIVE_ROUTE` / `PROXIMADB_DUCKDB_ROUTE` gates are read ONCE at the
+/// pgwire boundary and threaded in here so the decision core
+/// ([`ComputeScheduler::route_select_advised`]) stays free of `std::env` reads
+/// and is unit-testable by injecting flags. When a switch is on and the shape is
+/// the corresponding primary's eligible shape, the decision IS that engine —
+/// authoritative for the thin `match decision.backend` dispatch (no downstream
+/// re-decision). Both default-`false` (`RouteFlags::default()`), preserving the
+/// static + cost-model route.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RouteFlags {
+    /// `PROXIMADB_NATIVE_ROUTE`: force the native-over-parquet vectorized engine
+    /// as PRIMARY for the ops it is eligible for (metadata-elidable / scalar
+    /// aggregate). DataFusion remains the correctness floor (the adapter's own
+    /// fine plan-shape gates + fallback).
+    pub native_route: bool,
+    /// `PROXIMADB_DUCKDB_ROUTE`: force DuckDB-local as PRIMARY for the join/grouped
+    /// parquet shapes it is the measured win for. DataFusion remains the floor.
+    pub duckdb_route: bool,
+}
+
+/// The two parquet-OLAP PRIMARY engines' *shape* eligibility (ADR-058:
+/// eligibility precedes selection). Pure over [`QueryShape`] and unit-testable;
+/// the fine plan-shape gates (single-scan / no-predicate / width-cap / stats
+/// trust) stay inside the native adapter (`try_native_over_parquet`), which needs
+/// the lowered physical plan.
+///
+/// The two sets are **disjoint** — native is the *single-scan* ungrouped
+/// scalar-aggregate shape (a join-bearing plan is NEVER native-servable, so it is
+/// excluded here; the adapter would decline it anyway), while DuckDB is the
+/// join/grouped shape. Disjointness makes the env-force precedence unambiguous and
+/// the dispatch `match` arms mutually exclusive: a `(scalar-agg, join-bearing)`
+/// query is DuckDB's, never native's — which is exactly where the former dispatch
+/// sent it (native attempted, declined the join, fell through to DuckDB).
+///
+/// Mirrors the former dispatch gates (`native_eligible_op &&` the adapter's
+/// single-scan gate / `duckdb_eligible_shape`) so folding them into the decision
+/// changes no served engine — only makes `decision.backend` authoritative.
+fn parquet_primary_eligibility(shape: &QueryShape) -> (bool, bool) {
+    let native_ok = !shape.join_bearing
+        && matches!(
+            shape.operation_class,
+            OperationClass::MetadataElidable | OperationClass::ScalarAggregate
+        );
+    let duckdb_ok = shape.join_bearing || matches!(shape.operation_class, OperationClass::Grouped);
+    (native_ok, duckdb_ok)
+}
+
 /// Which of ADR-058's three routing axes a [`RouteReason`] explains. The router
 /// decides in this order — a backend must be *eligible* (can serve the shape
 /// soundly) before it is *selected* (cheapest by the cost cells), and an
@@ -625,10 +673,54 @@ impl ComputeScheduler {
         &self,
         shape: QueryShape,
         model: Option<&crate::query::route_cost_model::RouteCostModel>,
+        flags: RouteFlags,
     ) -> SelectRouteDecision {
         use crate::query::route_cost_model::RouteConsult;
 
         let mut decision = self.route_select_inner(shape);
+
+        // TD-ROUTE-3: env master-switch force takes precedence over the cost
+        // model — this mirrors the former dispatch order, where the native /
+        // DuckDB primary was attempted under `native_route_enabled() || advised`
+        // BEFORE the DataFusion floor. Folding it here makes `decision.backend`
+        // the engine that will actually be attempted, so dispatch is a thin
+        // `match` with no re-decision. The native/duckdb eligible shapes are
+        // disjoint, so at most one branch fires. Default-OFF: both flags false →
+        // falls straight through to the static + cost-model path unchanged. The
+        // adapter still owns the primary→floor fallback, so a forced primary that
+        // declines is still served correctly by DataFusion.
+        if shape.parquet_backed {
+            let (native_ok, duckdb_ok) = parquet_primary_eligibility(&shape);
+            if flags.native_route && native_ok {
+                let prev = backend_label(&decision.backend);
+                decision.backend = ComputeBackend::Native;
+                decision.reason = format!(
+                    "{} | PROXIMADB_NATIVE_ROUTE forces native-over-parquet PRIMARY \
+                     (op eligible; {prev} is the floor)",
+                    decision.reason
+                );
+                decision.push_reason(
+                    RouteAxis::Selection,
+                    "PROXIMADB_NATIVE_ROUTE forces native-over-parquet PRIMARY (op eligible)",
+                );
+                return finalize_route(decision, shape);
+            }
+            if flags.duckdb_route && duckdb_ok {
+                let prev = backend_label(&decision.backend);
+                decision.backend = ComputeBackend::DuckDbCompat;
+                decision.reason = format!(
+                    "{} | PROXIMADB_DUCKDB_ROUTE forces duckdb-local PRIMARY \
+                     (shape eligible; {prev} is the floor)",
+                    decision.reason
+                );
+                decision.push_reason(
+                    RouteAxis::Selection,
+                    "PROXIMADB_DUCKDB_ROUTE forces duckdb-local PRIMARY (shape eligible)",
+                );
+                return finalize_route(decision, shape);
+            }
+        }
+
         let Some(model) = model else {
             return finalize_route(decision, shape);
         };
@@ -655,16 +747,30 @@ impl ComputeScheduler {
             _ => String::new(),
         };
 
-        // TD-ROUTE-1 capability gate (ADR-058: eligibility precedes selection):
-        // the Native arm cannot serve a join-bearing plan over Parquet (no
-        // external-parquet scan for Volcano; the vectorized native path is
-        // single-scan-only) — a flip would be served by the DataFusion floor
-        // while the io_trace stamps Native, poisoning the cost cells. So a
-        // join-bearing plan is never an eligible FLIP TARGET for Native —
-        // including via ancestor-fallback consults whose coarse class carries
-        // no join signal. Static routes are untouched; override OFF = no change.
-        let flip_eligible =
-            |b: &ComputeBackend| !matches!(b, ComputeBackend::Native) || !shape.join_bearing;
+        // TD-ROUTE-1 + TD-ROUTE-3 capability gate (ADR-058: eligibility precedes
+        // selection). A cost-model flip may only target a backend that will
+        // actually serve the shape as PRIMARY — otherwise the flip stamps that
+        // engine while the DataFusion floor serves, poisoning the cost cells (the
+        // "last-write-wins" mis-attribution TD-ROUTE-3 removes). The eligible
+        // shapes are the SAME sets the former dispatch gates checked
+        // (`native_eligible_op` / `duckdb_eligible_shape`), now the single source
+        // of truth via [`parquet_primary_eligibility`]:
+        //   - Native over Parquet: only the ungrouped scalar-aggregate ops the
+        //     native-over-parquet adapter can serve, and never a join-bearing
+        //     plan (no multi-table native scan; the single-scan vectorized path).
+        //   - DuckDB-local: only the join/grouped shapes it is the measured win
+        //     for.
+        // Other backends carry no extra primary-eligibility gate here. Static
+        // routes are untouched; override OFF (default) = no change.
+        // `native_flip_ok` already excludes join-bearing plans (see
+        // `parquet_primary_eligibility`), subsuming the former standalone
+        // `!join_bearing` Native guard.
+        let (native_flip_ok, duckdb_flip_ok) = parquet_primary_eligibility(&shape);
+        let flip_eligible = |b: &ComputeBackend| match b {
+            ComputeBackend::Native => native_flip_ok,
+            ComputeBackend::DuckDbCompat => duckdb_flip_ok,
+            _ => true,
+        };
 
         // Per-class staged go-live (TD-EXEC-2 §3): the scope gate reads the
         // DECISION class (the full refined key), so enabling an ancestor prefix
@@ -929,6 +1035,133 @@ mod tests {
         assert_eq!(d.compute_route_label(), "DataFusionLocal");
     }
 
+    // ---- TD-ROUTE-3: authoritative decision (shape + RouteFlags → backend) ----
+
+    fn parquet_shape(op: OperationClass, join_bearing: bool) -> QueryShape {
+        QueryShape {
+            engages_relational: true,
+            parquet_backed: true,
+            operation_class: op,
+            join_bearing,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn native_eligible_op_with_native_flag_decides_native() {
+        // ScalarAggregate over parquet + PROXIMADB_NATIVE_ROUTE → the decision is
+        // authoritative Native (the engine dispatch will attempt as primary), no
+        // downstream re-check. `model: None` isolates the env-force fold.
+        let d = ComputeScheduler::new().route_select_advised(
+            parquet_shape(OperationClass::ScalarAggregate, false),
+            None,
+            RouteFlags {
+                native_route: true,
+                duckdb_route: false,
+            },
+        );
+        assert_eq!(d.backend, ComputeBackend::Native);
+    }
+
+    #[test]
+    fn native_eligible_op_without_flag_or_override_stays_datafusion() {
+        // Same shape, flags off, no cost model → the static parquet route
+        // (DataFusion floor). Native is NOT engaged just because the op is eligible.
+        let d = ComputeScheduler::new().route_select_advised(
+            parquet_shape(OperationClass::ScalarAggregate, false),
+            None,
+            RouteFlags::default(),
+        );
+        assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
+    }
+
+    #[test]
+    fn join_bearing_with_duckdb_flag_decides_duckdb() {
+        let d = ComputeScheduler::new().route_select_advised(
+            parquet_shape(OperationClass::Other, true),
+            None,
+            RouteFlags {
+                native_route: false,
+                duckdb_route: true,
+            },
+        );
+        assert_eq!(d.backend, ComputeBackend::DuckDbCompat);
+    }
+
+    #[test]
+    fn join_bearing_with_native_flag_stays_datafusion_native_ineligible() {
+        // A join-bearing plan is NOT native-eligible (no multi-table native scan),
+        // so the native master switch cannot force it onto Native — the decision
+        // keeps the DataFusion floor. This is the core attribution invariant.
+        let d = ComputeScheduler::new().route_select_advised(
+            parquet_shape(OperationClass::Other, true),
+            None,
+            RouteFlags {
+                native_route: true,
+                duckdb_route: false,
+            },
+        );
+        assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
+    }
+
+    #[test]
+    fn grouped_without_flags_stays_datafusion() {
+        let d = ComputeScheduler::new().route_select_advised(
+            parquet_shape(OperationClass::Grouped, false),
+            None,
+            RouteFlags::default(),
+        );
+        assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
+    }
+
+    #[test]
+    fn route_flags_inert_on_non_parquet_shapes() {
+        // The env master switches gate only the parquet-OLAP primary arm. An
+        // OLAP-on-native shape stays Volcano/Native regardless of the flags.
+        let d = ComputeScheduler::new().route_select_advised(
+            QueryShape {
+                engages_relational: true,
+                parquet_backed: false,
+                operation_class: OperationClass::ScalarAggregate,
+                ..Default::default()
+            },
+            None,
+            RouteFlags {
+                native_route: true,
+                duckdb_route: true,
+            },
+        );
+        // (true, false) → native storage OLAP → Volcano. Unchanged by flags.
+        assert_eq!(d.backend, ComputeBackend::Native);
+        assert_eq!(d.workload_profile, CatalogWorkloadProfile::Olap);
+    }
+
+    #[test]
+    fn native_and_duckdb_primary_eligibility_are_disjoint() {
+        // At most one parquet primary is ever eligible for a given query, so the
+        // env-force precedence (native-first) is unambiguous and the dispatch
+        // `match` arms are mutually exclusive. Guards against a future
+        // OperationClass change silently making both fire.
+        use OperationClass::*;
+        for op in [
+            Unknown,
+            MetadataElidable,
+            ScalarAggregate,
+            Grouped,
+            StringHeavy,
+            Other,
+        ] {
+            for join_bearing in [false, true] {
+                let (native_ok, duckdb_ok) =
+                    parquet_primary_eligibility(&parquet_shape(op, join_bearing));
+                assert!(
+                    !(native_ok && duckdb_ok),
+                    "native/duckdb eligibility overlapped for op={op:?} join_bearing={join_bearing}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn decision_records_structured_eligibility_selection_trust_reasons() {
         // ADR-064 / TD-TRACE-1: a route decision records structured, axis-tagged
@@ -1039,7 +1272,7 @@ mod tests {
         };
         let s = ComputeScheduler::new();
         let plain = s.route_select(shape);
-        let advised = s.route_select_advised(shape, None);
+        let advised = s.route_select_advised(shape, None, RouteFlags::default());
         assert_eq!(advised.backend, plain.backend);
         assert_eq!(advised.reason, plain.reason);
     }
@@ -1071,7 +1304,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let advised = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         // Backend is UNCHANGED (observe-mode) ...
         assert_eq!(advised.backend, ComputeBackend::DataFusionLocal);
         // ... but the divergence is disclosed for EXPLAIN/validation.
@@ -1095,7 +1332,11 @@ mod tests {
         for _ in 0..3 {
             model.observe("oltp/native", &ComputeBackend::Native, &io_snap(2, 8192));
         }
-        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let advised = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(advised.backend, ComputeBackend::Native);
         assert!(advised.reason.contains("cost-model concurs"));
     }
@@ -1123,7 +1364,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         // Native is far cheaper, but override is off → static DataFusion holds.
         assert_eq!(d.backend, ComputeBackend::DataFusionLocal);
         assert!(d.reason.contains("would prefer Native") && d.reason.contains("observe-mode"));
@@ -1132,9 +1377,16 @@ mod tests {
     #[test]
     fn override_on_flips_olap_parquet_to_the_cheaper_backend() {
         use crate::query::route_cost_model::RouteCostModel;
+        // TD-ROUTE-3: a Native flip is only eligible for a native-servable shape
+        // (ungrouped scalar aggregate) — an Unknown-op shape can never be served by
+        // the native-over-parquet adapter, so flipping the DECISION onto Native
+        // there would mis-attribute (the floor serves). The refined `op=agg` class
+        // consults the warmed `olap/parquet` ancestor cells via hierarchical
+        // fallback.
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            operation_class: OperationClass::ScalarAggregate,
             ..Default::default()
         }; // static => DataFusionLocal
         let model = RouteCostModel::new()
@@ -1153,7 +1405,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         // Override fires: the route is flipped to the measured-cheaper engine.
         assert_eq!(d.backend, ComputeBackend::Native);
         assert!(d.reason.contains("OVERRIDE"));
@@ -1196,10 +1452,18 @@ mod tests {
         model.set_override_scope(OverrideScope::Classes(vec![
             "olap/parquet/op=agg".to_string(),
         ]));
-        let d = ComputeScheduler::new().route_select_advised(scoped_in, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            scoped_in,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(d.backend, ComputeBackend::Native);
         assert!(d.reason.contains("OVERRIDE"), "got: {}", d.reason);
-        let d = ComputeScheduler::new().route_select_advised(scoped_out, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            scoped_out,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::DataFusionLocal,
@@ -1240,7 +1504,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::DataFusionLocal,
@@ -1275,7 +1543,11 @@ mod tests {
                 &io_snap(4, 8192),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::DataFusionLocal,
@@ -1312,7 +1584,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::DataFusionLocal,
@@ -1323,9 +1599,13 @@ mod tests {
     #[test]
     fn override_on_explores_under_explored_olap_parquet_candidate() {
         use crate::query::route_cost_model::RouteCostModel;
+        // TD-ROUTE-3: exploration may only target a native-servable shape
+        // (native-eligible op); the refined `op=agg` class consults the warmed
+        // `olap/parquet` ancestor cells via hierarchical fallback.
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            operation_class: OperationClass::ScalarAggregate,
             ..Default::default()
         }; // static => DataFusionLocal
         let model = RouteCostModel::new()
@@ -1341,7 +1621,11 @@ mod tests {
                 &io_snap(4, 8192),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::Native,
@@ -1372,7 +1656,11 @@ mod tests {
                 &io_snap(1, 4096),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(d.backend, ComputeBackend::Native);
         assert!(!d.reason.contains("EXPLORE"));
     }
@@ -1405,7 +1693,11 @@ mod tests {
                 &io_snap(1, 4096),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(
             d.backend,
             ComputeBackend::Native,
@@ -1442,7 +1734,11 @@ mod tests {
             parquet_backed: true,
             ..Default::default()
         };
-        let advised = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let advised = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(advised.backend, ComputeBackend::DataFusionLocal);
         assert_eq!(advised.source, RouteSource::Static);
         assert!(!advised.reason.contains("cost-model"));
@@ -1451,9 +1747,12 @@ mod tests {
     #[test]
     fn override_sets_decision_source_label() {
         use crate::query::route_cost_model::RouteCostModel;
+        // TD-ROUTE-3: native-eligible shape so the override→Native flip is a valid
+        // (servable) route, not a mis-attribution.
         let shape = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            operation_class: OperationClass::ScalarAggregate,
             ..Default::default()
         };
         let model = RouteCostModel::new()
@@ -1472,7 +1771,11 @@ mod tests {
                 &io_snap(300, 16 << 20),
             );
         }
-        let d = ComputeScheduler::new().route_select_advised(shape, Some(&model));
+        let d = ComputeScheduler::new().route_select_advised(
+            shape,
+            Some(&model),
+            RouteFlags::default(),
+        );
         assert_eq!(d.backend, ComputeBackend::Native);
         assert_eq!(d.source, RouteSource::OverrideExploit);
     }

--- a/src/query/route_cost_model.rs
+++ b/src/query/route_cost_model.rs
@@ -2366,13 +2366,16 @@ mod tests {
             .with_min_advantage(0.1)
             .with_recompute_every(1);
         m.set_override_enabled(true);
+        // TD-ROUTE-3: a Native flip is only eligible for a native-servable shape
+        // (ungrouped scalar aggregate); an Unknown-op shape can never be served by
+        // native, so the override must not flip its DECISION onto Native.
         let big = QueryShape {
             engages_relational: true,
             parquet_backed: true,
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
-            operation_class: Default::default(),
+            operation_class: crate::query::compute_scheduler::OperationClass::ScalarAggregate,
             geometry: Default::default(),
             join_bearing: false,
         };
@@ -2389,7 +2392,11 @@ mod tests {
                 &snap(40, 1 << 20, 8),
             );
         }
-        let decision = ComputeScheduler::new().route_select_advised(big, Some(&m));
+        let decision = ComputeScheduler::new().route_select_advised(
+            big,
+            Some(&m),
+            crate::query::compute_scheduler::RouteFlags::default(),
+        );
         // Static rule picks DataFusion for OLAP-Parquet; the warmed model
         // overrides to freshness-safe, cheaper Native.
         assert_eq!(decision.backend, ComputeBackend::Native);
@@ -2422,14 +2429,22 @@ mod tests {
                 &snap(40, 1 << 20, 8),
             );
         }
+        // TD-ROUTE-3: native-eligible op so the override→Native flip is a valid
+        // (servable) route; the geometry refinement still exercises the ancestor
+        // consult down to the warmed coarse `olap/parquet` cells.
         let refined = QueryShape {
             engages_relational: true,
             parquet_backed: true,
+            operation_class: crate::query::compute_scheduler::OperationClass::ScalarAggregate,
             geometry: GeometryClass::from_estimate(9, 4),
             ..Default::default()
         };
-        assert_eq!(shape_class(&refined), "olap/parquet/geom=mxhi");
-        let decision = ComputeScheduler::new().route_select_advised(refined, Some(&m));
+        assert_eq!(shape_class(&refined), "olap/parquet/op=agg/geom=mxhi");
+        let decision = ComputeScheduler::new().route_select_advised(
+            refined,
+            Some(&m),
+            crate::query::compute_scheduler::RouteFlags::default(),
+        );
         assert_eq!(decision.backend, ComputeBackend::Native);
         assert!(
             decision.reason.contains("OVERRIDE")

--- a/tests/native_route_pgwire_e2e.rs
+++ b/tests/native_route_pgwire_e2e.rs
@@ -268,3 +268,78 @@ async fn native_route_aggregates_equal_datafusion_over_pgwire() {
         GLOBAL_ROUTE_COST_MODEL.learned_cell_keys()
     );
 }
+
+/// TD-ROUTE-3 fold-attribution: a native PRIMARY that DECLINES must attribute its
+/// query to the DataFusion FLOOR, never to the declined native engine.
+///
+/// With the decision now authoritative (`route_select_advised` folds the native
+/// master switch + op eligibility into `decision.backend`), the dispatch is a thin
+/// `match decision.backend`. For a native-eligible op the decision selects the
+/// native primary; when `try_native_over_parquet` declines the shape (here: a
+/// FILTERED scan — native has no predicate pushdown), the shared floor serves and
+/// RE-STAMPS the io_trace route to DataFusion. This test proves the cost cells
+/// learn the engine that ACTUALLY served:
+///   * a `NativeVectorized` cell exists → native genuinely engaged as PRIMARY on
+///     the unfiltered shape (so the filtered case is a real primary→floor
+///     fall-through, not "native was never eligible"), AND
+///   * a `DataFusionLocal` cell exists → the filtered decline attributed to the
+///     floor. A broken re-stamp would leave the filtered query stamped as the
+///     native backend, so NO `DataFusionLocal` cell would appear here (every query
+///     run is a native-eligible aggregate) and this test would fail.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn native_decline_attributes_to_datafusion_floor_not_the_declined_primary() {
+    let server = PgServer::start().await.expect("server start");
+    let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
+        .await
+        .expect("tokio-postgres connect");
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("pgwire connection error: {e}");
+        }
+    });
+
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let t = format!("nrfloor_{suffix}");
+
+    client
+        .simple_query(&format!("CREATE TABLE {t} (id INT PRIMARY KEY, v INT)"))
+        .await
+        .unwrap_or_else(|e| panic!("CREATE: {}", explain_err(&e)));
+    for (id, v) in [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)] {
+        client
+            .simple_query(&format!("INSERT INTO {t} (id, v) VALUES ({id}, {v})"))
+            .await
+            .unwrap_or_else(|e| panic!("INSERT: {}", explain_err(&e)));
+    }
+    client
+        .simple_query(&format!("ALTER TABLE {t} MATERIALIZE"))
+        .await
+        .unwrap_or_else(|e| panic!("MATERIALIZE: {}", explain_err(&e)));
+    sleep(Duration::from_millis(500)).await;
+
+    // Unfiltered scalar aggregate → native PRIMARY serves (stamps NativeVectorized).
+    let _ = scalar(&client, &format!("SELECT SUM(v) FROM {t}")).await;
+    // Filtered variant of the SAME native-eligible op → the native primary is
+    // selected but DECLINES the predicate scan → DataFusion floor serves and the
+    // route is re-stamped DataFusionLocal.
+    let _ = scalar(&client, &format!("SELECT SUM(v) FROM {t} WHERE v > 25")).await;
+
+    let cells = GLOBAL_ROUTE_COST_MODEL.learned_cell_keys();
+    let served_native = cells.iter().any(|(_c, b)| b == "NativeVectorized");
+    let served_floor = cells.iter().any(|(_c, b)| b == "DataFusionLocal");
+    assert!(
+        served_native,
+        "native PRIMARY never engaged — the filtered case would not be a genuine \
+         primary→floor fall-through. Learned cells: {cells:?}"
+    );
+    assert!(
+        served_floor,
+        "the FILTERED native-eligible aggregate declined the native primary but no \
+         DataFusionLocal cost cell was learned — the TD-ROUTE-3 fold-attribution \
+         re-stamp is broken (the floor fall-through was mis-attributed to the \
+         declined native engine). Learned cells: {cells:?}"
+    );
+}

--- a/tests/route_cost_offline_eval.rs
+++ b/tests/route_cost_offline_eval.rs
@@ -140,7 +140,11 @@ fn simulate(rounds: u64) -> (Vec<(String, Regret)>, f64, f64) {
             cardinality: CardinalityClass::Large,
             partition_fanout: PartitionFanout::Many,
             pax_backed: false,
-            operation_class: Default::default(),
+            // TD-ROUTE-3: a native-eligible (single-scan scalar-aggregate) shape,
+            // so the controller flipping this case to Native reflects a route the
+            // real `route_select_advised` would actually take (Native is not an
+            // eligible flip target for a non-servable shape).
+            operation_class: proximadb::query::compute_scheduler::OperationClass::ScalarAggregate,
             geometry: Default::default(),
             join_bearing: false,
         },

--- a/tests/route_cost_override_pgwire_eval.rs
+++ b/tests/route_cost_override_pgwire_eval.rs
@@ -298,6 +298,7 @@ async fn override_eval_body() {
                 ..Default::default()
             },
             Some(&GLOBAL_ROUTE_COST_MODEL),
+            proximadb::query::compute_scheduler::RouteFlags::default(),
         );
     assert_eq!(
         decision.backend,


### PR DESCRIPTION
## What

Separate the route **DECISION** from **DISPATCH** in the pgwire SELECT path (ADR-064 Phase 3, TD-ROUTE-3). Previously `try_run_select` computed a `SelectRouteDecision`, then a ~280-line God-`if` **re-decided**: re-checking native/duckdb eligibility, running the delta-clean trust probe, trying a primary, falling to the DataFusion floor, and **re-stamping** the io_trace route ("last-write-wins"). So `decision.backend` was not authoritative and the cost model could learn the wrong route on a fall-through.

## How

**Phase A — authoritative decision (`compute_scheduler.rs`)**
- `RouteFlags { native_route, duckdb_route }` — the env master switches read **once** at the pgwire boundary and threaded in, so the decision core does no `std::env` reads and is unit-testable.
- `parquet_primary_eligibility(shape)` — single source of truth for the native (single-scan, non-join, ungrouped scalar aggregate) and duckdb (join/grouped) primary shapes. The two sets are **disjoint**, so env-force precedence is unambiguous and the dispatch match arms are mutually exclusive.
- `route_select_advised` folds env force + eligibility into `decision.backend`; `flip_eligible` is extended so a cost-model override can never flip onto an ineligible primary — the core attribution fix.

**Phase B — thin dispatch (`relational_pipeline.rs`)**
- The God-`if` becomes a `match decision.backend`. Each PRIMARY owns its fall-through to the shared DataFusion floor, which re-stamps the route **once** so cost cells attribute to the engine that actually served. The delta-clean trust probe stays as the DuckDB adapter's own gate. io_trace call placement, `record_setup_ms` (non-hoisted), cache population, the `olap_delta_tables` move/borrow, and the native shadow probe are all preserved.

**Phase C — tests**
- Unit tests: `shape + RouteFlags → backend` in isolation + native/duckdb eligibility disjointness.
- `tests/native_route_pgwire_e2e.rs`: a floor-attribution e2e proving a declined native primary attributes to `DataFusionLocal`, not the declined engine.
- Existing override/explore tests updated to native-eligible shapes (an Unknown-op shape is never native-servable, so flipping its DECISION onto Native was the exact mis-attribution this TD removes).

`ComputeBackend` stays a **closed** enum (ADR-059 — no plugin registry).

## No behavior change

Every query routes to the same engine as before (the join-bearing-with-both-flags case still lands on DuckDB after the disjointness fix), gated by the TPC-H/TPC-DS pgwire ratchets.

## Verification

- `cargo check --lib --tests` — 0 errors
- `cargo clippy --lib --bins -- -D warnings` — clean
- `cargo fmt --check`, `make work-commit-check`, `check_td_adr_unique.py` — green
- compute_scheduler + route_cost_model unit suites: 76/76
- route-cost offline/override evals + native-route e2e (incl. floor-attribution): 4/4

Closes TD-ROUTE-3.