### PR TITLE
fix(objstore): staged segment I/O — kill the URL-string-strip class in flush/compaction/reads (TDD)

### DIFF
--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -475,15 +475,6 @@ async fn cold_recall_ratchet_survives_restart() -> anyhow::Result<()> {
     const PROBES: usize = 8;
     const MIN_RECALL: f32 = 0.9;
 
-/// TD-OBJSTORE-4 defect-6 redux (task: normal-flush string-strip): a GRACEFUL
-/// flush on a cloud base must persist the segment INTO the object store — and
-/// must NOT write it to a literal local `adls:...` directory (the
-/// URL-as-local-path artifact). #1061 fixed the RECOVERY staging path only;
-/// the normal flush retained the false-success class (masked by WAL replay).
-/// RED on that state: no segment blob in the store + artifact dir on disk.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "requires PROXIMADB_OBJECT_STORE_URL (adls://Azurite, s3://MinIO, gs://fake-gcs, or real cloud)"]
-async fn graceful_flush_persists_segment_to_object_store() -> anyhow::Result<()> {
     let base = std::env::var("PROXIMADB_OBJECT_STORE_URL")?;
     anyhow::ensure!(
         base.starts_with("s3://")
@@ -494,7 +485,6 @@ async fn graceful_flush_persists_segment_to_object_store() -> anyhow::Result<()>
     );
     let root = format!(
         "{}/td-objstore-5-recall/{}",
-        "{}/td-objstore-flush-strip/{}",
         base.trim_end_matches('/'),
         uuid::Uuid::new_v4().simple()
     );
@@ -602,6 +592,33 @@ async fn graceful_flush_persists_segment_to_object_store() -> anyhow::Result<()>
         recall >= MIN_RECALL,
         "cold recall@{K} on the object store = {recall:.3} < {MIN_RECALL} — \
          backend must be recall-neutral; a delta vs file:// is a read-path bug"
+    );
+    Ok(())
+}
+
+/// TD-OBJSTORE-4 defect-6 redux (task: normal-flush string-strip): a GRACEFUL
+/// flush on a cloud base must persist the segment INTO the object store — and
+/// must NOT write it to a literal local `adls:...` directory (the
+/// URL-as-local-path artifact). #1061 fixed the RECOVERY staging path only;
+/// the normal flush retained the false-success class (masked by WAL replay).
+/// RED on that state: no segment blob in the store + artifact dir on disk.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires PROXIMADB_OBJECT_STORE_URL (adls://Azurite, s3://MinIO, gs://fake-gcs, or real cloud)"]
+async fn graceful_flush_persists_segment_to_object_store() -> anyhow::Result<()> {
+    let base = std::env::var("PROXIMADB_OBJECT_STORE_URL")?;
+    anyhow::ensure!(
+        base.starts_with("s3://")
+            || base.starts_with("adls://")
+            || base.starts_with("az://")
+            || base.starts_with("gs://"),
+        "test URL must use s3://, adls://, az:// or gs:// (got {base})"
+    );
+    let root = format!(
+        "{}/td-objstore-flush-strip/{}",
+        base.trim_end_matches('/'),
+        uuid::Uuid::new_v4().simple()
+    );
+    let tmp = tempfile::tempdir()?;
     let collection = format!("flushseg_{}", uuid::Uuid::new_v4().simple());
     let vm1 = tmp.path().join("vm1");
     std::fs::create_dir_all(&vm1)?;

--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -475,6 +475,15 @@ async fn cold_recall_ratchet_survives_restart() -> anyhow::Result<()> {
     const PROBES: usize = 8;
     const MIN_RECALL: f32 = 0.9;
 
+/// TD-OBJSTORE-4 defect-6 redux (task: normal-flush string-strip): a GRACEFUL
+/// flush on a cloud base must persist the segment INTO the object store — and
+/// must NOT write it to a literal local `adls:...` directory (the
+/// URL-as-local-path artifact). #1061 fixed the RECOVERY staging path only;
+/// the normal flush retained the false-success class (masked by WAL replay).
+/// RED on that state: no segment blob in the store + artifact dir on disk.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires PROXIMADB_OBJECT_STORE_URL (adls://Azurite, s3://MinIO, gs://fake-gcs, or real cloud)"]
+async fn graceful_flush_persists_segment_to_object_store() -> anyhow::Result<()> {
     let base = std::env::var("PROXIMADB_OBJECT_STORE_URL")?;
     anyhow::ensure!(
         base.starts_with("s3://")
@@ -485,6 +494,7 @@ async fn cold_recall_ratchet_survives_restart() -> anyhow::Result<()> {
     );
     let root = format!(
         "{}/td-objstore-5-recall/{}",
+        "{}/td-objstore-flush-strip/{}",
         base.trim_end_matches('/'),
         uuid::Uuid::new_v4().simple()
     );
@@ -592,6 +602,62 @@ async fn cold_recall_ratchet_survives_restart() -> anyhow::Result<()> {
         recall >= MIN_RECALL,
         "cold recall@{K} on the object store = {recall:.3} < {MIN_RECALL} — \
          backend must be recall-neutral; a delta vs file:// is a read-path bug"
+    let collection = format!("flushseg_{}", uuid::Uuid::new_v4().simple());
+    let vm1 = tmp.path().join("vm1");
+    std::fs::create_dir_all(&vm1)?;
+
+    // The URL-as-local-path artifact appears under the server process CWD.
+    let scheme_dir =
+        std::path::PathBuf::from(format!("{}:", base.split("://").next().unwrap_or("adls")));
+    let artifact_preexisted = scheme_dir.exists();
+
+    // Seed dim-8 records, then SIGINT: the graceful stop flushes the segment.
+    let first = ServerProcess::start(&root, &vm1, &tmp.path().join("vm1.toml")).await?;
+    create_and_insert(&first.base_url, &collection, "sst").await?;
+    first.graceful()?;
+
+    // 1) The flushed segment must exist IN the object store under the
+    //    collection data prefix (production FileSystem, same emulator env).
+    let factory = std::sync::Arc::new(
+        proximadb::storage::persistence::filesystem::FilesystemFactory::create(
+            proximadb::storage::persistence::filesystem::FilesystemConfig::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("filesystem factory: {e}"))?,
+    );
+    let collections_prefix = format!("{root}/collections");
+    let fs = factory
+        .get_filesystem(&collections_prefix)
+        .map_err(|e| anyhow::anyhow!("get_filesystem: {e}"))?;
+    // LIST the whole collections prefix (flat keyspace) and look for a
+    // flushed vector segment object under a .../data/ key.
+    let entries = fs
+        .list(&collections_prefix)
+        .await
+        .map_err(|e| anyhow::anyhow!("LIST {collections_prefix}: {e}"))?;
+    let segment_blobs: Vec<&str> = entries
+        .iter()
+        .map(|e| e.url.as_str())
+        .filter(|u| u.contains("/data/") && (u.ends_with(".pax") || u.ends_with(".sst")))
+        .collect();
+    anyhow::ensure!(
+        !segment_blobs.is_empty(),
+        "graceful flush must persist a segment INTO the object store under \
+         {collections_prefix}/**/data/ — found none (URLs: {:?}). The segment \
+         was written to a literal local path instead (defect-6 class).",
+        entries
+            .iter()
+            .map(|e| e.url.as_str())
+            .take(10)
+            .collect::<Vec<_>>()
+    );
+
+    // 2) No URL-as-local-path artifact directory may appear.
+    anyhow::ensure!(
+        artifact_preexisted || !scheme_dir.exists(),
+        "flush created a literal local '{}' directory — the staging URL was \
+         string-stripped into a local path (defect-6 class)",
+        scheme_dir.display()
     );
     Ok(())
 }

--- a/docs/10-quality/td/TD-OBJSTORE-4-list-authority-wal-recovery.adoc
+++ b/docs/10-quality/td/TD-OBJSTORE-4-list-authority-wal-recovery.adoc
@@ -160,3 +160,23 @@ fallback, external-collections operational registry, collection-pinning registry
 primary-pod `SidecarOnly` default, legacy document WAL, observability WAL audit) — file
 separate TDs per surface as they are prioritized. Env-var bootstrap consolidation stays
 TD-OBJSTORE-3.
+
+From the staged-segment-I/O review (defect-6 class close-out):
+
+* *Streaming/multipart segment upload* — `StagedSegmentWrite::finalize` buffers the
+  whole segment in RAM; bounded for flush (memtable-sized) but a compaction output
+  merges N inputs. Needs a streaming `FileSystem` upload shape.
+* *Segment cache for cloud reads* — `search_arrow_file` and the exact PAX scan are
+  per-query full-object GETs on cloud bases (previously they read a broken local
+  artifact); round-trips are the dominant cost term, so front them with the
+  footer/segment cache.
+* *Scratch sweep* — `StagedSegmentWrite`/`LocalizedSegment` now carry Drop guards,
+  but crash-stranded files in `proximadb-flush-staging`/`proximadb-segment-scratch`
+  need an age-based startup sweep (uuid names make it cross-process safe).
+* *`sst/extraction.rs` audit* — retains a `file://` strip with a SILENT-skip failure
+  mode (cloud URL survives the strip, `Path::exists()` false, file quietly dropped
+  from AXIS extraction). Same class, different blast radius; also `nova`/`swift`
+  extraction + the DataFusion `pax_adapter` (local-input paths today).
+* *Cloud-compaction e2e* — the compaction staged-write arm is emulator-covered only
+  transitively; add an armed-compaction restart proof on Azurite (flush ×2 →
+  compaction:on → restart → verify) to the QA tier.

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1341,7 +1341,10 @@ impl Compaction {
 
             // Promote the locally staged merged segment to the (possibly remote)
             // staging URL so the atomic commit has a real file to move.
-            staged
+            // finalize returns the byte count — do NOT probe the scratch path
+            // afterwards (finalize removes it; the old post-finalize local
+            // metadata probe made cloud compaction fail at 100%).
+            let written_bytes = staged
                 .finalize(&self.filesystem_factory)
                 .await
                 .map_err(|e| {
@@ -1349,15 +1352,6 @@ impl Compaction {
                         "upload staged compaction segment: {e}"
                     ))
                 })?;
-
-            // Get file size for stats
-            let metadata = fs
-                .metadata(&staging_file_path.to_string_lossy())
-                .await
-                .map_err(|e| {
-                    crate::core::StorageError::DiskIO(std::io::Error::other(e.to_string()))
-                })?;
-            let written_bytes = metadata.size;
 
             // Finalize atomic operation - this moves the file from staging to final location
             coordinator

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1217,17 +1217,25 @@ impl Compaction {
                 .to_string_lossy()
                 .to_string();
 
-            // Write SSTable directly to staging path
-            // Strip file:// prefix if present for local filesystem operations
-            let staging_path = if atomic_op.staging_url.starts_with("file://") {
-                atomic_op
-                    .staging_url
-                    .strip_prefix("file://")
-                    .unwrap_or(&atomic_op.staging_url)
-            } else {
-                &atomic_op.staging_url
-            };
-            let staging_file_path = PathBuf::from(format!("{}/{}", staging_path, staging_filename));
+            // Write the merged segment via a staged write (TD-OBJSTORE-4
+            // defect-6 class): the writers below are LOCAL-file writers, and a
+            // CLOUD staging URL string-stripped into a "path" writes the output
+            // to a literal local `az:...` directory — the promote then stages
+            // nothing, compaction false-succeeds, and the INPUT segments (the
+            // only copies) get deleted. Stage locally, upload on finalize.
+            let staging_file_url = format!(
+                "{}/{}",
+                atomic_op.staging_url.trim_end_matches('/'),
+                staging_filename
+            );
+            let staged = crate::storage::engines::sst::staged_write::StagedSegmentWrite::begin(
+                &staging_file_url,
+            )
+            .await
+            .map_err(|e| {
+                crate::core::StorageError::SstEngine(format!("staged compaction write: {e}"))
+            })?;
+            let staging_file_path = PathBuf::from(staged.local_path());
             debug!("Writing to staging path: {}", staging_file_path.display());
 
             // Check block format and use appropriate writer
@@ -1330,6 +1338,17 @@ impl Compaction {
                     );
                 }
             }
+
+            // Promote the locally staged merged segment to the (possibly remote)
+            // staging URL so the atomic commit has a real file to move.
+            staged
+                .finalize(&self.filesystem_factory)
+                .await
+                .map_err(|e| {
+                    crate::core::StorageError::SstEngine(format!(
+                        "upload staged compaction segment: {e}"
+                    ))
+                })?;
 
             // Get file size for stats
             let metadata = fs

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -505,7 +505,7 @@ impl SstEngine {
 
         // Promote the locally staged bytes to the (possibly remote) staging URL
         // so the atomic commit has a real file to move.
-        staged
+        let _staged_bytes = staged
             .finalize(self.filesystem())
             .await
             .context("Failed to upload staged segment to the staging URL")?;

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -349,6 +349,18 @@ impl SstEngine {
         };
         tracing::debug!(staging_path = %staging_url, "Full staging path constructed");
 
+        // TD-OBJSTORE-4 defect 6 (normal-flush arm): the segment writers below are
+        // LOCAL-file writers. Stage through `StagedSegmentWrite` so a CLOUD staging
+        // URL gets a real local scratch file + an upload on finalize — instead of a
+        // literal local `az:...` directory, a promote that stages nothing, and a
+        // false-success that lets WAL deletion destroy the only durable copy. The
+        // recovery path's `file://{tempdir}` and plain local bases take the direct
+        // zero-copy arm (finalize is a no-op).
+        let staged =
+            crate::storage::engines::sst::staged_write::StagedSegmentWrite::begin(&staging_url)
+                .await
+                .context("Failed to prepare staged segment write")?;
+
         // Count entries for writing
         let entries_written = sorted_vectors.len() as u64;
 
@@ -386,8 +398,9 @@ impl SstEngine {
 
                 tracing::debug!(entries_written, dimension, "Writing vectors to Arrow block");
 
-                // Convert staging URL to local path for ArrowBlockWriter
-                let staging_path = staging_url.strip_prefix("file://").unwrap_or(&staging_url);
+                // Local write path from the staged write (uploaded on finalize
+                // when the staging URL is remote).
+                let staging_path = staged.local_path();
 
                 // Ensure parent directory exists
                 if let Some(parent) = std::path::Path::new(staging_path).parent() {
@@ -424,7 +437,9 @@ impl SstEngine {
                 // `segment_format::read_segment_records` (magic-byte detection), so no
                 // manifest/reader change is required for this segment to be read back.
                 use crate::storage::engines::sst::segment_format::write_pax_segment_full;
-                let staging_path = staging_url.strip_prefix("file://").unwrap_or(&staging_url);
+                // Local write path from the staged write (uploaded on finalize
+                // when the staging URL is remote).
+                let staging_path = staged.local_path();
                 if let Some(parent) = std::path::Path::new(staging_path).parent() {
                     tokio::fs::create_dir_all(parent)
                         .await
@@ -487,6 +502,13 @@ impl SstEngine {
                 }
             }
         }
+
+        // Promote the locally staged bytes to the (possibly remote) staging URL
+        // so the atomic commit has a real file to move.
+        staged
+            .finalize(self.filesystem())
+            .await
+            .context("Failed to upload staged segment to the staging URL")?;
 
         // Get actual bytes written from the filesystem
         let fs = self.filesystem().get_filesystem(&staging_url)?;

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -228,6 +228,7 @@ pub mod error;
 pub mod extraction;
 pub mod filter_methods;
 pub mod flush_eventlog_integration;
+pub(crate) mod staged_write;
 // Quantization now handled by unified compute module
 pub mod compactor_impl;
 pub mod indexed_reader;

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -607,8 +607,14 @@ impl SstEngine {
         use crate::storage::engines::sst::block_format::BlockFormat;
         match format {
             BlockFormat::ArrowBlock => {
-                let local = file.strip_prefix("file://").unwrap_or(file);
-                let reader = ArrowBlockReader::open(local)
+                // Cloud URLs download to a scratch file for the path-based reader
+                // (defect-6 read class); local paths pass through.
+                let seg = crate::storage::engines::sst::staged_write::LocalizedSegment::fetch(
+                    self.filesystem(),
+                    file,
+                )
+                .await?;
+                let reader = ArrowBlockReader::open(seg.path())
                     .map_err(|e| anyhow::anyhow!("open arrow segment {file}: {e}"))?;
                 reader
                     .read_all()
@@ -622,10 +628,12 @@ impl SstEngine {
             BlockFormat::PaxBlock => {
                 // P3: read a PAX segment via the mixed-format primitive (magic-detected,
                 // reuses PaxSegmentScanner). Best-effort schema keys (empty) for now.
-                let local = file.strip_prefix("file://").unwrap_or(file);
-                let bytes = tokio::fs::read(local)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("read pax segment {file}: {e}"))?;
+                let bytes = crate::storage::engines::sst::staged_write::read_object_bytes(
+                    self.filesystem(),
+                    file,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("read pax segment {file}: {e}"))?;
                 // tenant_ctx None: the AXIS rebuild indexes vectors per-collection and
                 // does not consume record.tenant_id. (Deriving the owning tenant from
                 // the DrPathBuilder segment path is a follow-up for when the
@@ -1567,11 +1575,16 @@ impl SstEngine {
 
         debug!("🏹 Searching Arrow file: {}", arrow_path);
 
-        // Convert file:// URL to local path
-        let local_path = arrow_path.strip_prefix("file://").unwrap_or(arrow_path);
+        // Cloud URLs download to a scratch file for the path-based reader
+        // (defect-6 read class); local paths pass through.
+        let seg = crate::storage::engines::sst::staged_write::LocalizedSegment::fetch(
+            self.filesystem(),
+            arrow_path,
+        )
+        .await?;
 
         // Open the Arrow file reader
-        let reader = ArrowBlockReader::open(local_path)
+        let reader = ArrowBlockReader::open(seg.path())
             .map_err(|e| anyhow::anyhow!("Failed to open Arrow file {}: {}", arrow_path, e))?;
 
         // Read all records from the Arrow file
@@ -1655,10 +1668,12 @@ impl SstEngine {
 
         debug!("📦 Exact PAX scan: {}", pax_path);
 
-        let local_path = pax_path.strip_prefix("file://").unwrap_or(pax_path);
-        let bytes = tokio::fs::read(local_path)
-            .await
-            .map_err(|e| anyhow::anyhow!("read pax segment {pax_path}: {e}"))?;
+        let bytes = crate::storage::engines::sst::staged_write::read_object_bytes(
+            self.filesystem(),
+            pax_path,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("read pax segment {pax_path}: {e}"))?;
         let records = crate::storage::engines::sst::segment_format::read_segment_records(
             &bytes,
             &[],

--- a/src/storage/engines/sst/staged_write.rs
+++ b/src/storage/engines/sst/staged_write.rs
@@ -1,0 +1,191 @@
+//! Local-scratch staging for segment writers that target object-store URLs.
+//!
+//! The SST segment writers (`write_pax_segment_full`, `ArrowBlockWriter`) are
+//! LOCAL-file writers. String-stripping a cloud staging URL into a "path"
+//! creates a literal local `az:...` directory: the atomic promote then LISTs
+//! the REMOTE staging prefix, finds nothing, moves nothing, and the operation
+//! **false-succeeds** — on the flush path that let WAL deletion destroy the
+//! only durable copy (TD-OBJSTORE-4 defect 6); on the compaction path it
+//! would drop the merged output while the inputs get deleted. This primitive
+//! makes the write coherent for BOTH bases: write locally, then upload the
+//! bytes to the remote staging URL so the coordinator promotes a file that
+//! actually exists. `file://`/bare-local bases keep the zero-copy direct
+//! write (`remote_url = None`, finalize is a no-op).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use crate::storage::persistence::filesystem::FilesystemFactory;
+
+/// A segment write staged for a possibly-remote target URL.
+pub(crate) struct StagedSegmentWrite {
+    /// Remote URL to upload to on finalize (`None` ⇒ direct local write).
+    remote_url: Option<String>,
+    /// Path the local-file segment writer must write to.
+    local_path: String,
+}
+
+impl StagedSegmentWrite {
+    /// Prepare a staged write for `target_url` (the full staging FILE url,
+    /// e.g. `az://c/…/__flush/L0_x.pax` or `file:///…/__flush/L0_x.pax`).
+    pub(crate) async fn begin(target_url: &str) -> Result<Self> {
+        let is_remote = target_url.contains("://") && !target_url.starts_with("file://");
+        if is_remote {
+            let scratch = std::env::temp_dir().join("proximadb-flush-staging");
+            tokio::fs::create_dir_all(&scratch)
+                .await
+                .context("create local segment-staging scratch dir")?;
+            let name = target_url.rsplit('/').next().unwrap_or("segment.bin");
+            let local = scratch.join(format!("{}-{}", uuid::Uuid::new_v4().simple(), name));
+            Ok(Self {
+                remote_url: Some(target_url.to_string()),
+                local_path: local.to_string_lossy().into_owned(),
+            })
+        } else {
+            let local = target_url
+                .strip_prefix("file://")
+                .unwrap_or(target_url)
+                .to_string();
+            if let Some(parent) = std::path::Path::new(&local).parent() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .context("create local staging parent dir")?;
+            }
+            Ok(Self {
+                remote_url: None,
+                local_path: local,
+            })
+        }
+    }
+
+    /// The local path the segment writer must write to.
+    pub(crate) fn local_path(&self) -> &str {
+        &self.local_path
+    }
+
+    /// Promote the staged bytes to the remote staging URL (no-op for local
+    /// bases). The scratch file is removed BEFORE the upload so an upload
+    /// failure cannot leak it (segment bytes are bounded by the flush size).
+    pub(crate) async fn finalize(self, factory: &Arc<FilesystemFactory>) -> Result<()> {
+        if let Some(remote) = self.remote_url {
+            let bytes = tokio::fs::read(&self.local_path)
+                .await
+                .context("read locally staged segment for upload")?;
+            let _ = tokio::fs::remove_file(&self.local_path).await;
+            let fs = factory
+                .get_filesystem(&remote)
+                .map_err(|e| anyhow::anyhow!("staging filesystem for {remote}: {e}"))?;
+            fs.write(&remote, &bytes, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("upload staged segment to {remote}: {e}"))?;
+            tracing::debug!(remote = %remote, bytes = bytes.len(), "staged segment uploaded");
+        }
+        Ok(())
+    }
+}
+
+/// Read a whole segment object, routing cloud URLs through the `FileSystem`
+/// (the defect-6 READ class: string-stripping a cloud URL and `tokio::fs::read`ing
+/// the result can never find the object).
+pub(crate) async fn read_object_bytes(
+    factory: &Arc<FilesystemFactory>,
+    url: &str,
+) -> Result<Vec<u8>> {
+    if url.contains("://") && !url.starts_with("file://") {
+        let fs = factory
+            .get_filesystem(url)
+            .map_err(|e| anyhow::anyhow!("segment filesystem for {url}: {e}"))?;
+        fs.read(url)
+            .await
+            .map_err(|e| anyhow::anyhow!("read segment object {url}: {e}"))
+    } else {
+        let local = url.strip_prefix("file://").unwrap_or(url);
+        tokio::fs::read(local)
+            .await
+            .with_context(|| format!("read local segment {url}"))
+    }
+}
+
+/// A segment made readable at a LOCAL path for path-based readers
+/// (`ArrowBlockReader::open`). Cloud objects download to a scratch file that is
+/// removed on drop; local paths pass through untouched.
+pub(crate) struct LocalizedSegment {
+    path: String,
+    scratch: bool,
+}
+
+impl LocalizedSegment {
+    pub(crate) async fn fetch(factory: &Arc<FilesystemFactory>, url: &str) -> Result<Self> {
+        if url.contains("://") && !url.starts_with("file://") {
+            let bytes = read_object_bytes(factory, url).await?;
+            let dir = std::env::temp_dir().join("proximadb-segment-scratch");
+            tokio::fs::create_dir_all(&dir)
+                .await
+                .context("create segment scratch dir")?;
+            let name = url.rsplit('/').next().unwrap_or("segment.bin");
+            let path = dir.join(format!("{}-{}", uuid::Uuid::new_v4().simple(), name));
+            tokio::fs::write(&path, &bytes)
+                .await
+                .context("stage segment for local reader")?;
+            Ok(Self {
+                path: path.to_string_lossy().into_owned(),
+                scratch: true,
+            })
+        } else {
+            Ok(Self {
+                path: url.strip_prefix("file://").unwrap_or(url).to_string(),
+                scratch: false,
+            })
+        }
+    }
+
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl Drop for LocalizedSegment {
+    fn drop(&mut self) {
+        if self.scratch {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_target_writes_direct_and_finalize_is_noop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = format!("file://{}/coll/data/__flush/L0_x.pax", tmp.path().display());
+        let staged = StagedSegmentWrite::begin(&target).await.expect("begin");
+        // Direct local path (parent pre-created), no scratch indirection.
+        assert!(staged.local_path().ends_with("/coll/data/__flush/L0_x.pax"));
+        assert!(!staged.local_path().contains("proximadb-flush-staging"));
+        std::fs::write(staged.local_path(), b"segment").expect("write");
+        let factory = Arc::new(
+            FilesystemFactory::create(Default::default())
+                .await
+                .expect("factory"),
+        );
+        staged.finalize(&factory).await.expect("finalize");
+        assert!(
+            tmp.path().join("coll/data/__flush/L0_x.pax").exists(),
+            "local write must land at the target path"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_target_stages_to_scratch_never_a_literal_scheme_dir() {
+        let staged = StagedSegmentWrite::begin("az://container/coll/data/__flush/L0_y.pax")
+            .await
+            .expect("begin");
+        // The writer path must be a REAL local scratch file — never a literal
+        // `az:...` path (the URL-as-local-path artifact class).
+        assert!(staged.local_path().contains("proximadb-flush-staging"));
+        assert!(!staged.local_path().contains("az:"));
+    }
+}

--- a/src/storage/engines/sst/staged_write.rs
+++ b/src/storage/engines/sst/staged_write.rs
@@ -65,10 +65,14 @@ impl StagedSegmentWrite {
     }
 
     /// Promote the staged bytes to the remote staging URL (no-op for local
-    /// bases). The scratch file is removed BEFORE the upload so an upload
-    /// failure cannot leak it (segment bytes are bounded by the flush size).
-    pub(crate) async fn finalize(self, factory: &Arc<FilesystemFactory>) -> Result<()> {
-        if let Some(remote) = self.remote_url {
+    /// bases) and return the segment's byte count — callers must NOT probe the
+    /// scratch path afterwards (it is removed here; the post-finalize size
+    /// probe reading the deleted scratch file made cloud compaction fail 100%
+    /// of the time in review round 1 of this fix). Sidecar-aware: an Arrow
+    /// segment's `{path}.idx` (required by `ArrowBlockReader::open`) is
+    /// uploaded alongside as `{remote}.idx` and its scratch removed too.
+    pub(crate) async fn finalize(mut self, factory: &Arc<FilesystemFactory>) -> Result<u64> {
+        if let Some(remote) = self.remote_url.take() {
             let bytes = tokio::fs::read(&self.local_path)
                 .await
                 .context("read locally staged segment for upload")?;
@@ -79,9 +83,37 @@ impl StagedSegmentWrite {
             fs.write(&remote, &bytes, None)
                 .await
                 .map_err(|e| anyhow::anyhow!("upload staged segment to {remote}: {e}"))?;
+            // Arrow sidecar pair (best-effort presence, mandatory upload if present).
+            let sidecar = format!("{}.idx", self.local_path);
+            if tokio::fs::try_exists(&sidecar).await.unwrap_or(false) {
+                let idx_bytes = tokio::fs::read(&sidecar)
+                    .await
+                    .context("read staged Arrow .idx sidecar")?;
+                let _ = tokio::fs::remove_file(&sidecar).await;
+                fs.write(&format!("{remote}.idx"), &idx_bytes, None)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("upload Arrow sidecar to {remote}.idx: {e}"))?;
+            }
             tracing::debug!(remote = %remote, bytes = bytes.len(), "staged segment uploaded");
+            Ok(bytes.len() as u64)
+        } else {
+            let meta = tokio::fs::metadata(&self.local_path)
+                .await
+                .context("stat locally written segment")?;
+            Ok(meta.len())
         }
-        Ok(())
+    }
+}
+
+impl Drop for StagedSegmentWrite {
+    /// Leak guard: a writer failure between `begin` and `finalize` must not
+    /// strand the scratch file (+ possible Arrow sidecar). After a successful
+    /// `finalize` (which takes `remote_url`) this is a no-op.
+    fn drop(&mut self) {
+        if self.remote_url.is_some() {
+            let _ = std::fs::remove_file(&self.local_path);
+            let _ = std::fs::remove_file(format!("{}.idx", self.local_path));
+        }
     }
 }
 
@@ -128,6 +160,14 @@ impl LocalizedSegment {
             tokio::fs::write(&path, &bytes)
                 .await
                 .context("stage segment for local reader")?;
+            // Sidecar pair: Arrow readers hard-require `{path}.idx` — fetch it
+            // when the remote has one (absent for PAX; best-effort probe).
+            if let Ok(fs) = factory.get_filesystem(url) {
+                let remote_idx = format!("{url}.idx");
+                if let Ok(idx_bytes) = fs.read(&remote_idx).await {
+                    let _ = tokio::fs::write(format!("{}.idx", path.display()), &idx_bytes).await;
+                }
+            }
             Ok(Self {
                 path: path.to_string_lossy().into_owned(),
                 scratch: true,
@@ -149,6 +189,7 @@ impl Drop for LocalizedSegment {
     fn drop(&mut self) {
         if self.scratch {
             let _ = std::fs::remove_file(&self.path);
+            let _ = std::fs::remove_file(format!("{}.idx", self.path));
         }
     }
 }

--- a/tests/objstore_segment_path_guard_test.rs
+++ b/tests/objstore_segment_path_guard_test.rs
@@ -1,0 +1,26 @@
+//! Source-guard (TD-OBJSTORE-4 defect-6 class): SST segment writers/readers must
+//! never derive a local path by string-stripping a URL — a CLOUD URL stripped
+//! into a "path" becomes a literal local `az:...` directory (write side: the
+//! atomic promote stages nothing and the operation false-succeeds, letting WAL
+//! deletion destroy the only durable copy; read side: the object can never be
+//! found). The ONE sanctioned home for the file:// strip is
+//! `sst/staged_write.rs` (`StagedSegmentWrite` / `read_object_bytes` /
+//! `LocalizedSegment`), which routes cloud URLs through the FileSystem.
+
+#[test]
+fn sst_flush_compaction_search_never_strip_urls_to_paths() {
+    for file in [
+        "src/storage/engines/sst/flush/mod.rs",
+        "src/storage/engines/sst/compaction.rs",
+        "src/storage/engines/sst/search/mod.rs",
+    ] {
+        let src = std::fs::read_to_string(format!("{}/{}", env!("CARGO_MANIFEST_DIR"), file))
+            .unwrap_or_else(|e| panic!("read {file}: {e}"));
+        assert!(
+            !src.contains("strip_prefix(\"file://\")"),
+            "{file} must not strip URLs into local paths — use \
+             sst::staged_write (StagedSegmentWrite / read_object_bytes / \
+             LocalizedSegment), the single sanctioned URL→path boundary"
+        );
+    }
+}


### PR DESCRIPTION
## What

Comprehensively closes the URL-as-local-path (string-strip) defect class in SST segment I/O, TDD-first. Found via the #1080 QA-run artifact: the **normal** flush on cloud bases still wrote segments to a literal local `adls:/` path (#1061 fixed recovery staging only), and the sweep found the same class in **compaction** (armed-by-default; false-success would delete the input segments) and **four segment-read sites**.

- **RED first**: `graceful_flush_persists_segment_to_object_store` (Azurite process test) — WAL+manifest in the store, segment absent, artifact dir present.
- **One sanctioned boundary**: `sst/staged_write.rs` — `StagedSegmentWrite` (write: local scratch → upload on finalize; zero-copy for local bases incl. #1061's recovery tempdir), `read_object_bytes` + `LocalizedSegment` (read: FileSystem-routed; scratch removed on Drop).
- Applied to both flush arms, the compaction output write, and all four search read sites.
- **Source-guard**: zero `strip_prefix("file://")` in flush/compaction/search — the class cannot silently return.

## Verified (Azurite, identical local/CI script path)

New test RED→GREEN · full restart suite 3/3 (3-boot, zero-vector batch-3 gate, graceful-flush) · clean re-run leaves **no** `adls:/` artifact · primitive units + source-guard green · clippy `-D warnings` + fmt clean.

## Notes

Composes with #1065 (gates) and #1080 (QA/nightly tiers). `nova`/`swift` extraction + DataFusion `pax_adapter` file:// strips are genuinely-local input paths today — flagged in the TD for audit, not segment-I/O load-bearing.