### PR TITLE
refactor: move typed graph-op model to proximadb-graph-model leaf (ORION cascade PR 1)

### DIFF
--- a/crates/foundation/proximadb-graph-model/src/model.rs
+++ b/crates/foundation/proximadb-graph-model/src/model.rs
@@ -271,3 +271,72 @@ pub struct EdgeTypeStats {
     pub edge_type: String,
     pub count: u64,
 }
+
+// ---------------------------------------------------------------------------
+// Graph write operations (moved from src/storage/memtable/implementations/
+// graph_memtable.rs — root-crate decomposition). The unified WAL's `GraphOp`
+// variant and the ORION graph engine consume these; their payload types (Node,
+// Edge, PropertyValue, EmbeddingVersion) already live in this leaf.
+// ---------------------------------------------------------------------------
+
+/// Node / edge identifier aliases (transparent to `String`). Kept here so the
+/// graph-operation model below is self-contained.
+pub type NodeId = String;
+pub type EdgeId = String;
+
+/// Graph operation for WAL integration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GraphOperation {
+    CreateNode {
+        graph_id: String,
+        node: Node,
+    },
+    UpdateNode {
+        graph_id: String,
+        node_id: NodeId,
+        update: NodeUpdate,
+    },
+    DeleteNode {
+        graph_id: String,
+        node_id: NodeId,
+    },
+    CreateEdge {
+        graph_id: String,
+        edge: Edge,
+    },
+    UpdateEdge {
+        graph_id: String,
+        edge_id: EdgeId,
+        update: EdgeUpdate,
+    },
+    DeleteEdge {
+        graph_id: String,
+        edge_id: EdgeId,
+    },
+    BatchOperation {
+        operations: Vec<GraphOperation>,
+    },
+    CreateEdgeIndex {
+        graph_id: String,
+        index_config: String,
+    },
+    DropEdgeIndex {
+        graph_id: String,
+        index_name: String,
+    },
+}
+
+/// Node update structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeUpdate {
+    pub labels: Option<Vec<String>>,
+    pub properties: Option<HashMap<String, PropertyValue>>,
+    pub embedding: Option<EmbeddingVersion>,
+}
+
+/// Edge update structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeUpdate {
+    pub properties: Option<HashMap<String, PropertyValue>>,
+    pub weight: Option<f64>,
+}

--- a/src/storage/memtable/implementations/graph_memtable.rs
+++ b/src/storage/memtable/implementations/graph_memtable.rs
@@ -31,62 +31,12 @@ use tracing::{debug, info};
 
 type Result<T> = std::result::Result<T, ProximaDBError>;
 
-/// Graph operation for WAL integration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum GraphOperation {
-    CreateNode {
-        graph_id: String,
-        node: Node,
-    },
-    UpdateNode {
-        graph_id: String,
-        node_id: NodeId,
-        update: NodeUpdate,
-    },
-    DeleteNode {
-        graph_id: String,
-        node_id: NodeId,
-    },
-    CreateEdge {
-        graph_id: String,
-        edge: Edge,
-    },
-    UpdateEdge {
-        graph_id: String,
-        edge_id: EdgeId,
-        update: EdgeUpdate,
-    },
-    DeleteEdge {
-        graph_id: String,
-        edge_id: EdgeId,
-    },
-    BatchOperation {
-        operations: Vec<GraphOperation>,
-    },
-    CreateEdgeIndex {
-        graph_id: String,
-        index_config: String, // Placeholder for index configuration
-    },
-    DropEdgeIndex {
-        graph_id: String,
-        index_name: String,
-    },
-}
-
-/// Node update structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NodeUpdate {
-    pub labels: Option<Vec<String>>,
-    pub properties: Option<std::collections::HashMap<String, crate::graph::PropertyValue>>,
-    pub embedding: Option<crate::graph::EmbeddingVersion>,
-}
-
-/// Edge update structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EdgeUpdate {
-    pub properties: Option<std::collections::HashMap<String, crate::graph::PropertyValue>>,
-    pub weight: Option<f64>,
-}
+// Graph write-operation types (GraphOperation, NodeUpdate, EdgeUpdate) moved to
+// the `proximadb-graph-model` foundation leaf (root-crate decomposition; the
+// unified WAL's `GraphOp` variant + the ORION engine consume them). Re-exported
+// here so `crate::storage::memtable::implementations::graph_memtable::*`
+// resolves unchanged.
+pub use proximadb_graph_model::{EdgeUpdate, GraphOperation, NodeUpdate};
 
 /// Graph snapshot for persistence
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
**PR 1 of the ORION extraction cascade** (root-crate decomposition; follows the 3 merged hermetic-leaf unlocks #1071/#1075/#1079).

Moves the typed graph write-operation model — `GraphOperation`, `NodeUpdate`, `EdgeUpdate` (+ `NodeId`/`EdgeId` aliases) — from `src/storage/memtable/implementations/graph_memtable.rs` into the `proximadb-graph-model` foundation leaf, where their payload types (`Node`, `Edge`, `PropertyValue`, `EmbeddingVersion`) already live.

`graph_memtable.rs` re-exports them so every existing path resolves unchanged — notably the unified WAL's `GraphOp` variant (`wal_operations.rs`) and the ORION graph engine.

### Why
ORION's WAL extraction (the next cohort) requires a `GraphWalPort` trait that names `GraphOperation`. That type was root-internal, forcing a cyclic root dependency. Moving it to the leaf unblocks the port. Type-compatible: root's `crate::graph::{Node,Edge,...}` already resolve to this leaf via the `src/graph/model.rs` re-export shim; `NodeId`/`EdgeId` are transparent `String` aliases.

## Change
- `graph-model/src/model.rs`: + `GraphOperation`, `NodeUpdate`, `EdgeUpdate`, `NodeId`, `EdgeId`
- `graph_memtable.rs`: 3 type defs -> `pub use proximadb_graph_model::{...}` re-export

Pure relocation + re-export, **no behavior change**. (The separate flat `GraphOperation` in `proximadb-storage-transaction` is a different transaction-DSL type, intentionally untouched.)

## Verification (all local, green)
- `cargo clippy -p proximadb-graph-model --all-targets -- -D warnings` (30s)
- `cargo clippy -p proximadb --lib -- -D warnings` (8m29s - re-export resolves for WAL + ORION)
- panic-policy 0 | fmt | layering | workspace-boundaries ("No findings") | no-agent-attribution - all clean

## Cascade roadmap
PR 1 (this): graph-op model -> leaf. PR 2: GraphWalPort trait + impl. PR 3: DI-refactor OrionPersistence. PR 4+: move 14 ORION files; pgwire follows.