### PR TITLE
feat(trace): TD-TRACE-2 S1 — durable io_trace sink (local JSONL+zstd spool)

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -164,6 +164,21 @@ log_level = "info"
 # Dashboard refresh interval in seconds (default: 60, minimum: 15)
 dashboard_refresh_interval_seconds = 60
 
+# Durable per-query io_trace ETL sink (TD-TRACE-2 / ADR-066). Default OFF.
+# When enabled, each query's IoTraceSnapshot is enqueued to a bounded in-memory
+# spool and a background worker writes JSONL+zstd segments to `local_dir`, sealing
+# on `segment_bytes` OR `flush_interval_s` (whichever first). Object-store dispatch
+# (object_store_uri / access_tier / partition_by / retention_days) arrives in S2.
+# Per-field env overrides: PROXIMADB_IO_TRACE_SINK[_LOCAL_DIR|_SEGMENT_BYTES|...].
+[observability.io_trace_sink]
+enabled = false
+# local_dir = "./log/io_trace"
+# segment_bytes = 4194304          # 4 MiB
+# flush_interval_s = 60
+# compression = "zstd"
+# format = "jsonl"
+# spool_max_bytes = 268435456      # 256 MiB; drop-oldest on overflow
+
 # ==============================================================================
 # LLM Integration Configuration (Q4 2025)
 # ==============================================================================

--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -255,6 +255,11 @@ pub struct IoTrace {
     /// available on the snapshot for the cost model / billing (per-op detail; the
     /// KRU meter itself still sums `compute_ms`, so this never double-charges).
     exec_ops: Mutex<Vec<ExecOpTrace>>,
+    /// Stable per-query id (UUID v4), minted at `instrument()` entry (TD-TRACE-2 /
+    /// ADR-066). Identifies this query's record in the durable trace sink and is the
+    /// join key for the future warehouse header↔satellite tables. `None` until
+    /// stamped (e.g. a raw `IoTrace::new()` outside `instrument`).
+    query_id: Mutex<Option<String>>,
 }
 
 /// Neutral primitive tuple carrying one operator's metered actuals into
@@ -289,6 +294,19 @@ impl IoTrace {
     /// Create an empty trace.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Stamp the stable per-query id (TD-TRACE-2). Set once at `instrument()` entry.
+    pub fn set_query_id(&self, id: String) {
+        *self.query_id.lock().unwrap_or_else(|p| p.into_inner()) = Some(id);
+    }
+
+    /// The stamped per-query id, if any.
+    pub fn query_id(&self) -> Option<String> {
+        self.query_id
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
     }
 
     /// Stamp the route this query is served on (`shape_class`, `backend_label`).
@@ -588,6 +606,7 @@ impl IoTrace {
                 .lock()
                 .unwrap_or_else(|p| p.into_inner())
                 .clone(),
+            query_id: self.query_id(),
         }
     }
 }
@@ -655,6 +674,11 @@ pub struct IoTraceSnapshot {
     /// query read under (ADR-061 D6 / TD-WLP-6). `None` if unstamped.
     #[serde(default)]
     pub storage_profile: Option<String>,
+    /// Stable per-query id (UUID v4), minted at `instrument()` entry (TD-TRACE-2 /
+    /// ADR-066) — the durable trace sink's record id + future warehouse join key.
+    /// `None` for a raw snapshot taken outside `instrument`.
+    #[serde(default)]
+    pub query_id: Option<String>,
     /// pgwire relational-pipeline setup wall ms — pre-execution xCatalog schema
     /// resolution + route classification, DataFusion route only (TD-OLAP-4).
     #[serde(default)]
@@ -1099,6 +1123,37 @@ fn notify_billing_observer(snap: &IoTraceSnapshot, tenant_id: Option<&str>) {
     }
 }
 
+/// Observer invoked at trace flush with `snapshot` + `tenant_id` for the durable
+/// **trace ETL sink** (TD-TRACE-2 / ADR-066). The sink layer registers a sink that
+/// enqueues the completed per-query snapshot to a bounded spool for background
+/// export. Dependency-inversion seam: io_trace feeds the sink *without depending on
+/// it*, exactly like the billing observer — but this is a SEPARATE, default-OFF
+/// observer, so billing stays always-on / never-gated (ADR-027) and the sink can be
+/// gated without touching it. The registered sink MUST only enqueue (no I/O on the
+/// query path).
+type TraceObserver = dyn Fn(&IoTraceSnapshot, Option<&str>) + Send + Sync;
+
+static TRACE_OBSERVER: Mutex<Option<Box<TraceObserver>>> = Mutex::new(None);
+
+/// Install (or clear with `None`) the trace-sink observer. Called once at startup by
+/// the sink layer when the sink is enabled; replaceable in tests. Default: none
+/// installed ⇒ zero cost.
+pub fn set_trace_observer(observer: Option<Box<TraceObserver>>) {
+    *TRACE_OBSERVER.lock().unwrap_or_else(|p| p.into_inner()) = observer;
+}
+
+/// Feed the registered trace-sink observer, if any, with a completed query's trace
+/// and the owning tenant. Called last in the `instrument()` fan-out.
+fn notify_trace_observer(snap: &IoTraceSnapshot, tenant_id: Option<&str>) {
+    if let Some(obs) = TRACE_OBSERVER
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .as_ref()
+    {
+        obs(snap, tenant_id);
+    }
+}
+
 /// Bind a fresh [`IoTrace`] to `future` and await it. Lower-level than
 /// [`instrument`]; use when the caller wants to read the snapshot itself before
 /// the scope ends.
@@ -1121,6 +1176,10 @@ where
     let route = route.into();
     IO_TRACE
         .scope(Arc::new(IoTrace::new()), async move {
+            // TD-TRACE-2: mint a stable per-query id at scope entry so the durable
+            // trace sink can identify (and later join) every query's record. One
+            // UUID + one lock set per query — negligible, and off any row loop.
+            let _ = IO_TRACE.try_with(|t| t.set_query_id(uuid::Uuid::new_v4().to_string()));
             let out = future.await;
             // Still inside the scope: read and emit before the binding drops.
             if let Ok((snap, stamped_route)) = IO_TRACE.try_with(|t| (t.snapshot(), t.route())) {
@@ -1142,6 +1201,12 @@ where
                 // per-engine compute_ms are both in hand here.
                 if !snap.is_empty() {
                     notify_billing_observer(&snap, tenant_id.as_deref());
+                }
+                // TD-TRACE-2 durable trace sink (separate, default-OFF observer —
+                // billing above stays always-on/never-gated). Fires last; only
+                // enqueues the completed snapshot for background export.
+                if !snap.is_empty() {
+                    notify_trace_observer(&snap, tenant_id.as_deref());
                 }
             }
             out
@@ -1185,6 +1250,45 @@ mod tests {
             got,
             Some((Some("acme".to_string()), 7, 100)),
             "billing observer must receive the tenant + summed compute_ms (4+3) + bytes_read from the same snapshot"
+        );
+    }
+
+    /// TD-TRACE-2: the durable trace-sink observer fires at scope close (like
+    /// billing), with the completed snapshot carrying a minted `query_id` and the
+    /// owning tenant. An EMPTY query never fires it (the `!is_empty()` guard).
+    #[tokio::test]
+    #[allow(clippy::type_complexity)]
+    async fn trace_observer_receives_snapshot_with_query_id_and_skips_empty() {
+        use std::sync::{Arc, Mutex};
+        let captured: Arc<Mutex<Vec<(Option<String>, Option<String>)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let sink = captured.clone();
+        set_trace_observer(Some(Box::new(move |snap, tenant| {
+            sink.lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push((tenant.map(String::from), snap.query_id.clone()));
+        })));
+
+        // Non-empty query → observer fires with a minted query_id.
+        instrument(Some("acme".to_string()), "test-route", async {
+            record_bytes_read(42);
+        })
+        .await;
+        // Empty query → observer must NOT fire (no measurable I/O).
+        instrument(Some("acme".to_string()), "test-route", async {}).await;
+
+        set_trace_observer(None); // restore global state for other tests
+
+        let got = captured.lock().unwrap_or_else(|p| p.into_inner()).clone();
+        assert_eq!(
+            got.len(),
+            1,
+            "trace observer fires only for the non-empty query"
+        );
+        assert_eq!(got[0].0.as_deref(), Some("acme"));
+        assert!(
+            got[0].1.as_deref().is_some_and(|id| !id.is_empty()),
+            "the snapshot carries a minted query_id: {got:?}"
         );
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -61,6 +61,10 @@ pub struct Config {
     /// across replicas). Env vars exist for per-pod emergency tuning
     /// without rebuilding the artifact.
     pub queue: Option<QueueRuntimeConfig>,
+    /// Observability configuration (optional) — currently the durable io_trace ETL
+    /// sink (TD-TRACE-2 / ADR-066). Absent ⇒ the sink is off (default).
+    #[serde(default)]
+    pub observability: Option<ObservabilityConfig>,
 }
 
 pub use proximadb_config::{HardwareConfig, SksConfig, TlsConfig};
@@ -84,8 +88,127 @@ impl Default for Config {
             query: None, // Uses default RL planner settings when None
             llm: None,
             queue: None,
+            observability: None,
         }
     }
+}
+
+/// Observability configuration (`[observability]` TOML table). Today it carries the
+/// durable io_trace ETL sink; more observability knobs can nest here later.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ObservabilityConfig {
+    /// Durable per-query trace sink (`[observability.io_trace_sink]`, TD-TRACE-2).
+    #[serde(default)]
+    pub io_trace_sink: Option<IoTraceSinkConfig>,
+}
+
+/// Durable io_trace ETL sink configuration (`[observability.io_trace_sink]`,
+/// TD-TRACE-2 / ADR-066). The TOML is the canonical declarative source; env vars
+/// (`PROXIMADB_IO_TRACE_SINK_*`) are per-pod overrides; defaults fill the gaps —
+/// see [`IoTraceSinkConfig::resolve`]. **Default-OFF** (`enabled = false`).
+///
+/// ```toml
+/// [observability.io_trace_sink]
+/// enabled = false
+/// local_dir = "./log/io_trace"
+/// segment_bytes = 4194304
+/// flush_interval_s = 60
+/// compression = "zstd"
+/// format = "jsonl"
+/// spool_max_bytes = 268435456
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IoTraceSinkConfig {
+    /// Master switch — the sink observer is installed only when this is true.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Local directory where JSONL+zstd segments are written (S1). Default
+    /// `./log/io_trace`.
+    pub local_dir: Option<String>,
+    /// Seal a segment when its (uncompressed) size reaches this many bytes.
+    /// Default 4 MiB.
+    pub segment_bytes: Option<u64>,
+    /// Also seal + drain on this interval (seconds), whichever comes first.
+    /// Default 60.
+    pub flush_interval_s: Option<u64>,
+    /// Segment compression codec. Default (and only value in S1) `zstd`.
+    pub compression: Option<String>,
+    /// Segment record format. Default (and only value in S1) `jsonl`.
+    pub format: Option<String>,
+    /// Bounded in-memory spool cap (bytes-equivalent record budget); on overflow the
+    /// oldest queued record is dropped (best-effort). Default 256 MiB.
+    pub spool_max_bytes: Option<u64>,
+    /// Object-store destination URI (consumed in S2 — parsed now, unused in S1).
+    pub object_store_uri: Option<String>,
+    /// Per-object access tier for the object-store dispatch (S2). e.g. `cool`.
+    pub access_tier: Option<String>,
+    /// Key partitioning scheme for the object-store dispatch (S2). `date`/`tenant`/`host`.
+    pub partition_by: Option<String>,
+    /// Retention days for object-store lifecycle GC (S2).
+    pub retention_days: Option<u64>,
+}
+
+impl IoTraceSinkConfig {
+    /// Layer env (`PROXIMADB_IO_TRACE_SINK_*`) over TOML over defaults. Returns
+    /// `None` when the sink is disabled (no observer installed, no worker spawned).
+    /// Mirrors [`QueueRuntimeConfig::resolve`].
+    pub fn resolve(toml_section: Option<&IoTraceSinkConfig>) -> Option<ResolvedIoTraceSinkConfig> {
+        let from_toml = toml_section.cloned().unwrap_or_default();
+
+        let enabled = std::env::var("PROXIMADB_IO_TRACE_SINK")
+            .ok()
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(from_toml.enabled);
+        if !enabled {
+            return None;
+        }
+
+        let env_u64 = |key: &str| std::env::var(key).ok().and_then(|v| v.parse::<u64>().ok());
+
+        let local_dir = std::env::var("PROXIMADB_IO_TRACE_SINK_LOCAL_DIR")
+            .ok()
+            .or(from_toml.local_dir.clone())
+            .unwrap_or_else(|| "./log/io_trace".to_string());
+        let segment_bytes = env_u64("PROXIMADB_IO_TRACE_SINK_SEGMENT_BYTES")
+            .or(from_toml.segment_bytes)
+            .unwrap_or(4 * 1024 * 1024);
+        let flush_interval_s = env_u64("PROXIMADB_IO_TRACE_SINK_FLUSH_INTERVAL_S")
+            .or(from_toml.flush_interval_s)
+            .unwrap_or(60)
+            .max(1);
+        let spool_max_bytes = env_u64("PROXIMADB_IO_TRACE_SINK_SPOOL_MAX_BYTES")
+            .or(from_toml.spool_max_bytes)
+            .unwrap_or(256 * 1024 * 1024);
+        let compression = std::env::var("PROXIMADB_IO_TRACE_SINK_COMPRESSION")
+            .ok()
+            .or(from_toml.compression.clone())
+            .unwrap_or_else(|| "zstd".to_string());
+        let format = std::env::var("PROXIMADB_IO_TRACE_SINK_FORMAT")
+            .ok()
+            .or(from_toml.format.clone())
+            .unwrap_or_else(|| "jsonl".to_string());
+
+        Some(ResolvedIoTraceSinkConfig {
+            local_dir,
+            segment_bytes,
+            flush_interval_s,
+            spool_max_bytes,
+            compression,
+            format,
+        })
+    }
+}
+
+/// Resolved io_trace sink settings (S1 fields only; S2 object-store fields join
+/// later). All values populated — no Options.
+#[derive(Debug, Clone)]
+pub struct ResolvedIoTraceSinkConfig {
+    pub local_dir: String,
+    pub segment_bytes: u64,
+    pub flush_interval_s: u64,
+    pub spool_max_bytes: u64,
+    pub compression: String,
+    pub format: String,
 }
 
 /// Queue subsystem runtime configuration. Lives at the `[queue]` TOML
@@ -224,6 +347,36 @@ mod queue_config_tests {
         let _g_part = EnvGuard::set("PROXIMADB_EMBED_DRAINER_PARTITIONS", None);
         assert!(QueueRuntimeConfig::resolve(None).is_none());
         assert!(QueueRuntimeConfig::resolve(Some(&QueueRuntimeConfig::default())).is_none());
+    }
+
+    /// TD-TRACE-2: the sink is default-OFF — absent config or `enabled=false`
+    /// resolves to `None` (no observer, no worker).
+    #[test]
+    fn io_trace_sink_disabled_resolves_to_none() {
+        let _g = EnvGuard::set("PROXIMADB_IO_TRACE_SINK", None);
+        assert!(IoTraceSinkConfig::resolve(None).is_none());
+        assert!(IoTraceSinkConfig::resolve(Some(&IoTraceSinkConfig::default())).is_none());
+    }
+
+    /// TD-TRACE-2: an enabled TOML section resolves; unset fields fall to defaults.
+    #[test]
+    fn io_trace_sink_enabled_toml_fills_defaults() {
+        let _g0 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK", None);
+        let _g1 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_LOCAL_DIR", None);
+        let _g2 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_SEGMENT_BYTES", None);
+        let _g3 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_FLUSH_INTERVAL_S", None);
+        let toml = IoTraceSinkConfig {
+            enabled: true,
+            local_dir: Some("/tmp/tr".to_string()),
+            ..Default::default()
+        };
+        let r = IoTraceSinkConfig::resolve(Some(&toml)).expect("enabled → Some");
+        assert_eq!(r.local_dir, "/tmp/tr");
+        assert_eq!(r.segment_bytes, 4 * 1024 * 1024);
+        assert_eq!(r.flush_interval_s, 60);
+        assert_eq!(r.spool_max_bytes, 256 * 1024 * 1024);
+        assert_eq!(r.compression, "zstd");
+        assert_eq!(r.format, "jsonl");
     }
 
     /// TOML-only flow: a TOML `[queue]` section with `root` set

--- a/src/database.rs
+++ b/src/database.rs
@@ -186,6 +186,18 @@ impl ProximaDB {
         // `otlp-metering` feature is compiled out). Must run inside the runtime —
         // the grpc-tonic exporter's reader is driven on it.
         crate::observability::metering_otlp::init_from_env();
+        // TD-TRACE-2 / ADR-066: durable io_trace ETL sink. A SEPARATE, default-OFF
+        // observer (the billing observer above stays always-on/never-gated, ADR-027).
+        // Installed only when `[observability.io_trace_sink]` resolves enabled (env
+        // `PROXIMADB_IO_TRACE_SINK` or TOML); `resolve` returns None otherwise.
+        if let Some(sink_cfg) = crate::core::config::IoTraceSinkConfig::resolve(
+            config
+                .observability
+                .as_ref()
+                .and_then(|o| o.io_trace_sink.as_ref()),
+        ) {
+            crate::observability::io_trace_sink::install(sink_cfg);
+        }
         // Co-design C5 (integration): register the tenant→tier Port to read the
         // header-fed tier registry (`X-Tenant-Tier` → `record_store::TENANT_TIERS`),
         // so the per-tenant tier the cache LimitsResolver already sees also drives
@@ -805,6 +817,10 @@ impl ProximaDB {
         // Persist the learned route cost model so measured history survives the
         // restart (best-effort; off the hot path, on graceful shutdown only).
         crate::query::route_cost_model::persist_cost_model(&self._config.server.data_dir);
+
+        // TD-TRACE-2: flush + stop the durable io_trace sink so buffered trace
+        // segments are sealed to disk (no-op if the sink was not installed).
+        crate::observability::io_trace_sink::shutdown().await;
 
         // 1a. Stop the async-ingest drainer first so it stops consuming
         //     before we shut down the storage layer it inserts into.

--- a/src/observability/io_trace_sink.rs
+++ b/src/observability/io_trace_sink.rs
@@ -1,0 +1,383 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Durable io_trace ETL sink — TD-TRACE-2 S1 (local JSONL+zstd spool).
+//!
+//! ADR-066: takes the in-process per-query [`IoTraceSnapshot`] durable + queryable.
+//! S1 is the local-spool foundation (no object-store dispatch — that is S2):
+//!
+//! ```text
+//!  instrument() exit ──set_trace_observer──▶ [serialize + enqueue]  (query path: CPU only, no I/O)
+//!                                                    │  bounded spool, drop-oldest
+//!                                                    ▼
+//!                            background worker ──interval/size seal──▶ {local_dir}/trace-{run}-{seq}.jsonl.zst
+//! ```
+//!
+//! Guarantees:
+//! * **Separate, default-OFF observer** — billing stays always-on / never-gated
+//!   (ADR-027); the sink is installed only when `[observability.io_trace_sink]`
+//!   resolves enabled.
+//! * **Never blocks the query path** — the observer only serializes one small JSON
+//!   line and pushes it to a bounded in-memory spool (O(1)); the compress + file
+//!   write happen on the background worker (via `spawn_blocking`).
+//! * **Bounded + best-effort** — the spool has a byte cap; on overflow the oldest
+//!   queued record is dropped (never blocks / OOMs the DB).
+//! * **Graceful shutdown** — a final drain + seal on the shutdown signal.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::core::config::ResolvedIoTraceSinkConfig;
+use crate::observability::io_trace::{self, IoTraceSnapshot};
+
+/// One serialized trace record awaiting export (a `\n`-terminated JSON line).
+type SpoolLine = Vec<u8>;
+
+/// Bounded in-memory spool. Push is O(1) and drops the oldest record(s) when the
+/// byte cap is exceeded — observability is best-effort and must never block/OOM.
+struct Spool {
+    deque: VecDeque<SpoolLine>,
+    bytes: usize,
+    cap: usize,
+    dropped: u64,
+}
+
+impl Spool {
+    fn new(cap: usize) -> Self {
+        Self {
+            deque: VecDeque::new(),
+            bytes: 0,
+            cap: cap.max(1),
+            dropped: 0,
+        }
+    }
+
+    fn push(&mut self, line: SpoolLine) {
+        self.bytes = self.bytes.saturating_add(line.len());
+        self.deque.push_back(line);
+        while self.bytes > self.cap {
+            match self.deque.pop_front() {
+                Some(old) => {
+                    self.bytes = self.bytes.saturating_sub(old.len());
+                    self.dropped = self.dropped.saturating_add(1);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Take everything queued, resetting the buffer.
+    fn drain(&mut self) -> VecDeque<SpoolLine> {
+        self.bytes = 0;
+        std::mem::take(&mut self.deque)
+    }
+}
+
+/// The serialized record shape: the completed snapshot plus the owning tenant.
+/// `#[serde(flatten)]` keeps the snapshot's fields at the top level so the JSONL is
+/// a flat object per line (S3 will replace this with the envelope model).
+#[derive(serde::Serialize)]
+struct SinkRecord<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tenant: Option<&'a str>,
+    #[serde(flatten)]
+    snap: &'a IoTraceSnapshot,
+}
+
+/// Live sink handle: the worker's shutdown sender + join handle (for graceful stop).
+struct SinkHandle {
+    shutdown: tokio::sync::watch::Sender<bool>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+static SINK: OnceLock<Mutex<Option<SinkHandle>>> = OnceLock::new();
+
+fn sink_slot() -> &'static Mutex<Option<SinkHandle>> {
+    SINK.get_or_init(|| Mutex::new(None))
+}
+
+/// Shared spool handle used by both the observer closure and the worker.
+type SharedSpool = std::sync::Arc<Mutex<Spool>>;
+
+/// Install the trace-sink observer + spawn its background worker. Idempotent-ish:
+/// a second install replaces the observer and spawns a fresh worker (the previous
+/// handle, if any, is aborted). Call only when the resolved config is `Some`
+/// (enabled). Must run inside a tokio runtime (it is — `ProximaDB::new`).
+pub fn install(cfg: ResolvedIoTraceSinkConfig) {
+    // Best-effort: create the local spool directory up front.
+    if let Err(e) = std::fs::create_dir_all(&cfg.local_dir) {
+        tracing::warn!(
+            "io_trace sink: cannot create local_dir {}: {e}; sink not installed",
+            cfg.local_dir
+        );
+        return;
+    }
+
+    let spool: SharedSpool =
+        std::sync::Arc::new(Mutex::new(Spool::new(cfg.spool_max_bytes as usize)));
+
+    // Observer: serialize one JSON line (cheap, per-query) and enqueue. No I/O here.
+    let spool_obs = spool.clone();
+    io_trace::set_trace_observer(Some(Box::new(move |snap, tenant| {
+        if let Ok(mut line) = serde_json::to_vec(&SinkRecord { tenant, snap }) {
+            line.push(b'\n');
+            spool_obs
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(line);
+        }
+    })));
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let worker = Worker::new(cfg, spool);
+    let join = tokio::spawn(worker.run(shutdown_rx));
+
+    let mut slot = sink_slot().lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(prev) = slot.take() {
+        prev.join.abort();
+    }
+    *slot = Some(SinkHandle {
+        shutdown: shutdown_tx,
+        join,
+    });
+    tracing::info!("io_trace sink installed (durable per-query trace spool)");
+}
+
+/// Signal the worker to flush + stop, awaiting it with a short timeout. Called from
+/// `ProximaDB::shutdown()` for a graceful final seal. No-op if not installed.
+pub async fn shutdown() {
+    let handle = {
+        let mut slot = sink_slot().lock().unwrap_or_else(|p| p.into_inner());
+        slot.take()
+    };
+    if let Some(handle) = handle {
+        // Clear the observer so no further records are enqueued during drain.
+        io_trace::set_trace_observer(None);
+        let _ = handle.shutdown.send(true);
+        match tokio::time::timeout(Duration::from_secs(5), handle.join).await {
+            Ok(Ok(())) => tracing::info!("io_trace sink flushed and stopped"),
+            Ok(Err(e)) => tracing::warn!("io_trace sink worker join error: {e}"),
+            Err(_) => tracing::warn!("io_trace sink flush timed out (5s)"),
+        }
+    }
+}
+
+/// The background worker: drains the spool on an interval, buffering lines into the
+/// current segment, and seals a JSONL+zstd file when the segment reaches
+/// `segment_bytes` OR at each interval tick (whichever first) — bounding both
+/// segment size and latency-to-disk.
+struct Worker {
+    cfg: ResolvedIoTraceSinkConfig,
+    spool: SharedSpool,
+    current: Vec<u8>,
+    seq: u64,
+    run_nonce: u128,
+}
+
+impl Worker {
+    fn new(cfg: ResolvedIoTraceSinkConfig, spool: SharedSpool) -> Self {
+        // A per-run nonce so segment filenames never collide across restarts
+        // (S2 replaces local names with DrPathBuilder object keys). Wall-clock is
+        // fine in production code (only workflow scripts forbid it).
+        let run_nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        Self {
+            cfg,
+            spool,
+            current: Vec::new(),
+            seq: 0,
+            run_nonce,
+        }
+    }
+
+    async fn run(mut self, mut shutdown_rx: tokio::sync::watch::Receiver<bool>) {
+        let mut interval = tokio::time::interval(Duration::from_secs(self.cfg.flush_interval_s));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    self.drain_and_seal().await;
+                }
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        // Final drain + seal any remainder, then stop.
+                        self.drain_and_seal().await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Drain the spool into the current segment buffer; seal a full segment whenever
+    /// it crosses `segment_bytes`, then seal the leftover so records never sit longer
+    /// than one interval (called on each interval tick and on final shutdown flush).
+    async fn drain_and_seal(&mut self) {
+        let lines = { self.spool.lock().unwrap_or_else(|p| p.into_inner()).drain() };
+        for line in lines {
+            self.current.extend_from_slice(&line);
+            if self.current.len() as u64 >= self.cfg.segment_bytes {
+                self.seal().await;
+            }
+        }
+        // Interval / shutdown seal of the remainder (bounds latency-to-disk).
+        if !self.current.is_empty() {
+            self.seal().await;
+        }
+    }
+
+    /// Compress the current buffer with zstd and write it as one segment file.
+    /// Compress + write run on a blocking thread so the worker task never stalls.
+    async fn seal(&mut self) {
+        if self.current.is_empty() {
+            return;
+        }
+        let buf = std::mem::take(&mut self.current);
+        let path = format!(
+            "{}/trace-{}-{:08}.jsonl.zst",
+            self.cfg.local_dir.trim_end_matches('/'),
+            self.run_nonce,
+            self.seq
+        );
+        self.seq += 1;
+        let write = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let compressed = zstd::encode_all(&buf[..], 3)?;
+            std::fs::write(&path, compressed)
+        })
+        .await;
+        match write {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!("io_trace sink: segment write failed: {e}"),
+            Err(e) => tracing::warn!("io_trace sink: seal task panicked: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(dir: &str, seg: u64, spool: u64) -> ResolvedIoTraceSinkConfig {
+        ResolvedIoTraceSinkConfig {
+            local_dir: dir.to_string(),
+            segment_bytes: seg,
+            flush_interval_s: 1,
+            spool_max_bytes: spool,
+            compression: "zstd".to_string(),
+            format: "jsonl".to_string(),
+        }
+    }
+
+    #[test]
+    fn spool_drops_oldest_on_overflow() {
+        let mut s = Spool::new(10); // 10-byte cap
+        s.push(b"aaaa".to_vec()); // 4
+        s.push(b"bbbb".to_vec()); // 8
+        s.push(b"cccc".to_vec()); // 12 > 10 → drop oldest "aaaa"
+        assert_eq!(s.dropped, 1);
+        assert!(s.bytes <= 10);
+        let drained: Vec<_> = s.drain().into_iter().collect();
+        assert_eq!(drained, vec![b"bbbb".to_vec(), b"cccc".to_vec()]);
+        assert_eq!(s.bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn worker_seals_jsonl_zstd_and_round_trips() {
+        let dir = std::env::temp_dir().join(format!(
+            "iotrace_sink_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_s = dir.to_string_lossy().to_string();
+
+        let spool: SharedSpool = std::sync::Arc::new(Mutex::new(Spool::new(1 << 20)));
+        // Enqueue two JSON records directly (bypassing the observer for determinism).
+        {
+            let mut g = spool.lock().unwrap();
+            g.push(b"{\"query_id\":\"q1\",\"range_gets\":3}\n".to_vec());
+            g.push(b"{\"query_id\":\"q2\",\"range_gets\":5}\n".to_vec());
+        }
+        let mut worker = Worker::new(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20), spool);
+        worker.drain_and_seal().await;
+
+        // Exactly one sealed segment; decompress → two JSONL lines round-trip.
+        let mut segs: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.to_string_lossy().ends_with(".jsonl.zst"))
+            .collect();
+        segs.sort();
+        assert_eq!(segs.len(), 1, "one segment sealed");
+        let compressed = std::fs::read(&segs[0]).unwrap();
+        let decoded = zstd::decode_all(&compressed[..]).unwrap();
+        let text = String::from_utf8(decoded).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"query_id\":\"q1\""));
+        assert!(lines[1].contains("\"query_id\":\"q2\""));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// End-to-end (no server): install the sink → run instrumented queries →
+    /// graceful shutdown → a JSONL+zstd segment lands on disk carrying the minted
+    /// `query_id`. Exercises the full observer → spool → worker → seal wiring.
+    #[tokio::test]
+    async fn install_instrument_shutdown_writes_segment_with_query_id() {
+        use crate::observability::io_trace;
+        let dir = std::env::temp_dir().join(format!("iotrace_sink_e2e_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let dir_s = dir.to_string_lossy().to_string();
+
+        install(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20));
+        // Two non-empty instrumented queries → two enqueued records.
+        for _ in 0..2 {
+            io_trace::instrument(Some("acme".to_string()), "test", async {
+                io_trace::record_bytes_read(128);
+            })
+            .await;
+        }
+        // Graceful shutdown drains + seals the buffered records.
+        shutdown().await;
+
+        let segs: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.to_string_lossy().ends_with(".jsonl.zst"))
+            .collect();
+        assert_eq!(segs.len(), 1, "one segment sealed on shutdown: {segs:?}");
+        let text =
+            String::from_utf8(zstd::decode_all(&std::fs::read(&segs[0]).unwrap()[..]).unwrap())
+                .unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "both queries recorded");
+        assert!(
+            lines
+                .iter()
+                .all(|l| l.contains("\"query_id\"") && l.contains("\"tenant\":\"acme\"")),
+            "each record carries query_id + tenant: {text}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn empty_drain_writes_no_segment() {
+        let dir = std::env::temp_dir().join(format!("iotrace_sink_empty_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_s = dir.to_string_lossy().to_string();
+        let spool: SharedSpool = std::sync::Arc::new(Mutex::new(Spool::new(1 << 20)));
+        let mut worker = Worker::new(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20), spool);
+        worker.drain_and_seal().await;
+        let n = std::fs::read_dir(&dir).unwrap().count();
+        assert_eq!(n, 0, "no segment written for an empty drain");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -75,6 +75,10 @@ pub mod ingestion;
 /// co-design cost model minimizes. See
 /// `docs/12-design/CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` §4.1.
 pub use proximadb_observability_engine::io_trace;
+/// Durable io_trace ETL sink (TD-TRACE-2 / ADR-066) — a separate, default-OFF
+/// observer that spools each per-query snapshot to local JSONL+zstd segments (S1;
+/// object-store dispatch is S2). Billing stays untouched/always-on (ADR-027).
+pub mod io_trace_sink;
 /// Metering event builder — converts SearchPlanTrace → operator metering
 /// event JSON shape so the data plane and operator pipelines can't drift.
 pub use proximadb_observability_engine::metering_event;


### PR DESCRIPTION
## What

ADR-066 / TD-TRACE-2 **S1**: take the in-process per-query `IoTraceSnapshot` **durable** by spooling it to local JSONL+zstd segments. First slice; object-store dispatch is S2. **Default-OFF**, own single-purpose PR.

```
instrument() exit ──set_trace_observer──▶ [serialize + enqueue]   (query path: CPU only, no I/O)
                                                  │  bounded spool, drop-oldest
                                                  ▼
                          background worker ──interval/size seal──▶ {local_dir}/trace-{run}-{seq}.jsonl.zst
```

## How

- **io_trace (modality):** a **separate** `set_trace_observer` seam (mirrors the billing observer), fired last in `instrument()` on the same `!is_empty()` guard — billing stays always-on/never-gated (ADR-027). Mint a stable `query_id` (uuid v4) at `instrument()` entry, stamped on `IoTrace` + surfaced on the snapshot (the durable record id + future warehouse join key).
- **sink (`src/observability/io_trace_sink.rs`):** the installed observer serializes one JSON line and pushes it to a bounded `VecDeque` spool (O(1), **drop-oldest** on overflow — never blocks/OOMs the query path). A background tokio worker (`select!` + `watch` shutdown) drains on interval, seals JSONL+zstd segments on `segment_bytes` OR interval, compress+write **off-thread** via `spawn_blocking`. Graceful `shutdown()` does a final drain+seal (5s timeout).
- **config (`src/core/config.rs`):** `[observability.io_trace_sink]` → `IoTraceSinkConfig::resolve()` layering env (`PROXIMADB_IO_TRACE_SINK*`) > TOML > default (mirrors `QueueRuntimeConfig`; `None` when disabled). Wired at `ProximaDB::new` (install if resolved) + `ProximaDB::shutdown` (flush).

## Invariants
- **No served-result change**; sink is default-OFF (no observer, no worker until enabled).
- **Billing untouched** — separate observer; `consumption_metrics.rs` unmodified (`check_billing_never_gated` green).
- Object-store fields (`object_store_uri`/`access_tier`/`partition_by`/`retention_days`) are parsed now, **consumed in S2**.

## Verification
- `clippy --lib --bins` **and** `-p proximadb-observability-engine -D warnings`; `fmt`; `work-commit-check`; **server binary** compiles.
- Guards: `check_billing_never_gated`, `check-layering`, `check_workspace_boundaries` (no new inverted edge — the sink lives in the platform crate; the modality crate gained only leaf `uuid`, already a dep).
- Tests (9): spool drop-oldest · worker JSONL+zstd round-trip · empty-drain writes nothing · `install→instrument→shutdown` e2e-lite (segment carries `query_id` + tenant) · config resolve precedence + disabled→None · io_trace observer fires with `query_id`, skips empty. Coexists with Slice 2's `exec_ops` (both in the merged `io_trace.rs`).

Refs ADR-066, TD-TRACE-2. Follow-up: **S2** object-store dispatch (`DrPathBuilder` + `ObjectAccessTier`, Azurite-tested).