### PR TITLE
refactor: introduce GraphWalPort seam + leaf MarkerKind (ORION cascade PR 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8280,6 +8280,7 @@ dependencies = [
  "async-trait",
  "proximadb-distance-kernel",
  "proximadb-filter-expression",
+ "proximadb-graph-model",
  "proximadb-kernel",
  "proximadb-proto",
  "proximadb-quantization-model",

--- a/crates/foundation/proximadb-graph-model/src/model.rs
+++ b/crates/foundation/proximadb-graph-model/src/model.rs
@@ -340,3 +340,15 @@ pub struct EdgeUpdate {
     pub properties: Option<HashMap<String, PropertyValue>>,
     pub weight: Option<f64>,
 }
+
+/// Non-data marker kinds carried in a graph engine's WAL stream (the payload of
+/// a `GraphMarker` frame). Moved here from the root WAL module so the
+/// `GraphWalPort` contract (storage-ports) — and the ORION graph engine — can
+/// name it without a cyclic root dependency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MarkerKind {
+    /// "Every engine-WAL frame after this marker was emitted after the canonical
+    /// layer durably checkpointed at `lsn`." Recovery skips frames at/before the
+    /// latest such marker whose `lsn` ≤ the recovered canonical checkpoint LSN.
+    CanonicalEmission(u64),
+}

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -38,6 +38,9 @@ proximadb-quantization-model.workspace = true
 # Storage-tier: the FilesystemPort names FileSystem / FileOptions / FsResult from
 # this crate (the existing filesystem abstraction). Same-tier dep (storage→storage).
 proximadb-storage-filesystem-types.workspace = true
+# Foundation-tier: the GraphWalPort names GraphOperation + MarkerKind (graph
+# write-op model) — pure-data leaf types (downward dep, facade-free).
+proximadb-graph-model.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -13,6 +13,7 @@
 
 use anyhow::Result;
 use proximadb_distance_kernel::DistanceMetric;
+use proximadb_graph_model::{GraphOperation, MarkerKind};
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
@@ -263,4 +264,22 @@ pub trait AxisClusteringPort: Send + Sync {
         distance_metric: DistanceMetric,
         boosting_weights: &[f32],
     ) -> Result<Vec<(usize, f32)>>;
+}
+
+/// Dependency-inversion port for a graph engine's WAL sink (ORION extraction).
+///
+/// ORION (and future graph engines) append graph operations + canonical-sync
+/// markers through this port rather than naming the concrete unified WAL
+/// writer/operation types, so the engine can be extracted to a crate without a
+/// cyclic dependency on the root crate's storage layer. The composition root
+/// injects a concrete impl (e.g. the unified WAL writer, which wraps
+/// [`GraphOperation`] / [`MarkerKind`] into the unified operation enum).
+#[async_trait::async_trait]
+pub trait GraphWalPort: Send + Sync {
+    /// Append a graph operation; returns the assigned sequence number (LSN).
+    async fn append_graph_op(&mut self, op: GraphOperation) -> Result<u64>;
+
+    /// Append a non-data canonical-sync marker; returns the assigned sequence
+    /// number (LSN).
+    async fn append_graph_marker(&mut self, marker: MarkerKind) -> Result<u64>;
 }

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -24,6 +24,7 @@ use crate::storage::document::DocumentRecord;
 use crate::storage::memtable::implementations::graph_memtable::GraphOperation;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_records::ProximaRecord;
+use proximadb_storage_ports::GraphWalPort;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -84,13 +85,12 @@ pub enum UnifiedWALOperation {
 }
 
 /// Non-data marker kinds carried in [`UnifiedWALOperation::GraphMarker`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MarkerKind {
-    /// "Every engine-WAL frame after this marker was emitted after the canonical
-    /// layer durably checkpointed at `lsn`." Recovery skips frames at/before the
-    /// latest such marker whose `lsn` ≤ the recovered canonical checkpoint LSN.
-    CanonicalEmission(u64),
-}
+///
+/// Definition moved to the `proximadb-graph-model` foundation leaf (named by
+/// the `GraphWalPort` contract + the ORION graph engine); re-exported here so
+/// existing `crate::storage::persistence::write_ahead_log::...::MarkerKind`
+/// references resolve unchanged.
+pub use proximadb_graph_model::MarkerKind;
 
 /// TD-066 (c) Part 2 feature gate (default OFF per the storage-format-migration
 /// mandate). When enabled, `flush_wal` emits `CanonicalEmission` marker frames
@@ -756,6 +756,21 @@ impl UnifiedWALWriter {
     #[cfg(test)]
     pub fn set_max_segment_size_for_test(&mut self, bytes: usize) {
         self.max_segment_size = bytes;
+    }
+}
+
+/// The unified WAL writer is the composition-root-provided sink for the ORION
+/// graph engine: it implements [`GraphWalPort`] by wrapping graph operations /
+/// markers into the unified operation enum, so ORION can append through the
+/// port without naming the concrete writer or the unified operation type.
+#[async_trait::async_trait]
+impl GraphWalPort for UnifiedWALWriter {
+    async fn append_graph_op(&mut self, op: GraphOperation) -> anyhow::Result<u64> {
+        self.append(UnifiedWALOperation::GraphOp(op)).await
+    }
+
+    async fn append_graph_marker(&mut self, marker: MarkerKind) -> anyhow::Result<u64> {
+        self.append(UnifiedWALOperation::GraphMarker(marker)).await
     }
 }
 


### PR DESCRIPTION
## Summary
**PR 2 of the ORION extraction cascade** (follows merged #1083: graph-op model → graph-model leaf).

Introduces the dependency-inversion seam for the graph-engine WAL sink, so the ORION engine can be extracted without a cyclic root dependency through the unified WAL.

- **graph-model**: + `MarkerKind` (moved from root `wal_operations`; root re-exports it so `UnifiedWALOperation::GraphMarker` resolves unchanged).
- **storage-ports**: + `GraphWalPort` trait (`append_graph_op(GraphOperation)` / `append_graph_marker(MarkerKind)`); + graph-model dep for those leaf types.
- **root `wal_operations`**: + `impl GraphWalPort for UnifiedWALWriter` — wraps graph ops/markers into the unified operation enum (the composition-root-provided sink).

Pure additive seam (contract + impl). ORION still appends via the concrete path for now; **PR 3** applies the seam — retargets `OrionPersistence`'s 10 WAL append sites to the port (`dyn GraphWalPort` field), severing ORION's coupling to `UnifiedWALOperation`. No behavior change.

## Verification (all local, green; stacked-then-rebased onto develop)
- `cargo clippy -p proximadb-storage-ports -p proximadb-graph-model --all-targets -- -D warnings` ✓
- `cargo clippy -p proximadb --lib -- -D warnings` ✓ (6m12s)
- `cargo fmt --check` (rustfmt 1.95.0) ✓ | panic-policy 0 ✓ | layering ✓ | workspace-boundaries "No findings" ✓ | no-agent-attribution ✓

## Cascade status
1. #1083 graph-op model → leaf ✅ **merged**
2. **this** — GraphWalPort seam + leaf MarkerKind
3. ORION 10-site WAL retarget → `dyn GraphWalPort`
4. move 14 ORION files → `proximadb-orion-engine`