### PR TITLE
refactor: retarget ORION WAL appends onto GraphWalPort (ORION cascade PR 3)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -282,4 +282,13 @@ pub trait GraphWalPort: Send + Sync {
     /// Append a non-data canonical-sync marker; returns the assigned sequence
     /// number (LSN).
     async fn append_graph_marker(&mut self, marker: MarkerKind) -> Result<u64>;
+
+    /// Flush any buffered WAL frames to durable storage.
+    async fn flush(&mut self) -> Result<()>;
+
+    /// Reclaim WAL segments fully covered by a durable snapshot whose canonical
+    /// checkpoint is at `checkpoint_lsn` (every segment whose frames all precede
+    /// the matching `CanonicalEmission(checkpoint_lsn)` marker). Returns the
+    /// number of segments reclaimed.
+    async fn truncate_through_canonical_marker(&mut self, checkpoint_lsn: u64) -> Result<u64>;
 }

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -153,8 +153,12 @@ pub struct OrionPersistence {
     /// changes are the Part 2 follow-up slice).
     canonical_wal_path: Option<PathBuf>,
 
-    /// WAL writer for unified operations
-    wal_writer: Option<Arc<tokio::sync::Mutex<UnifiedWALWriter>>>,
+    /// WAL sink for graph operations. The engine appends through the
+    /// [`GraphWalPort`] dependency-inversion port (injected by the composition
+    /// root as the unified WAL writer), so it never names the concrete writer
+    /// or the unified operation type — a prerequisite for extracting ORION into
+    /// its own crate without a cyclic dependency on the root storage layer.
+    wal_writer: Option<Arc<tokio::sync::Mutex<dyn proximadb_storage_ports::GraphWalPort>>>,
 
     /// Compression configuration
     compression: CompressionAlgorithm,
@@ -171,7 +175,7 @@ impl std::fmt::Debug for OrionPersistence {
             .field("graph_id", &self.graph_id)
             .field("base_url", &self.base_url)
             .field("wal_path", &self.wal_path)
-            .field("wal_writer", &"<UnifiedWALWriter>")
+            .field("wal_writer", &"<dyn GraphWalPort>")
             .field("compression", &self.compression)
             .field("compression_level", &self.compression_level)
             .field("max_snapshots", &self.max_snapshots)
@@ -273,7 +277,10 @@ impl OrionPersistence {
                     ))
                 })?;
 
-            // Initialize WAL writer with path (not URL)
+            // Initialize WAL writer with path (not URL), then erase it to the
+            // GraphWalPort port the engine speaks. The unsizing coercion
+            // `Arc<Mutex<UnifiedWALWriter>>` -> `Arc<Mutex<dyn GraphWalPort>>`
+            // is sound because the writer implements the port (PR #1085).
             tracing::debug!("Creating WAL writer with path: {}", wal_path_str);
             let wal_writer = UnifiedWALWriter::new(wal_path_str.clone())
                 .await
@@ -283,11 +290,10 @@ impl OrionPersistence {
                     )
                 })?;
             tracing::debug!("WAL writer created successfully");
+            let wal_writer: Arc<tokio::sync::Mutex<dyn proximadb_storage_ports::GraphWalPort>> =
+                Arc::new(tokio::sync::Mutex::new(wal_writer));
 
-            (
-                Some(wal_path),
-                Some(Arc::new(tokio::sync::Mutex::new(wal_writer))),
-            )
+            (Some(wal_path), Some(wal_writer))
         } else {
             (None, None)
         };
@@ -774,15 +780,12 @@ impl OrionPersistence {
     /// configured.
     pub async fn append_canonical_emission_marker(&self, lsn: u64) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::{
-                MarkerKind, UnifiedWALOperation,
-            };
+            use proximadb_graph_model::MarkerKind;
 
-            let unified_op = UnifiedWALOperation::GraphMarker(MarkerKind::CanonicalEmission(lsn));
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_marker(MarkerKind::CanonicalEmission(lsn))
                 .await
                 .map_err(|e| {
                     tracing::error!(
@@ -849,8 +852,6 @@ impl OrionPersistence {
     /// Write node operation to WAL
     pub async fn write_node_operation(&self, node: Node) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             tracing::debug!("Writing node operation to WAL for node: {}", node.id);
 
             let graph_op = GraphOperation::CreateNode {
@@ -858,11 +859,10 @@ impl OrionPersistence {
                 node,
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     tracing::error!("WAL append failed: {:?}", e);
@@ -882,18 +882,15 @@ impl OrionPersistence {
     /// Write edge operation to WAL
     pub async fn write_edge_operation(&self, edge: Edge) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             let graph_op = GraphOperation::CreateEdge {
                 graph_id: self.graph_id.clone(),
                 edge,
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     ProximaDBError::Storage(
@@ -912,8 +909,6 @@ impl OrionPersistence {
         }
 
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             // Wrap all CreateEdge operations in a single batch GraphOp to reduce WAL traffic
             let batch = GraphOperation::BatchOperation {
                 operations: edges
@@ -926,11 +921,10 @@ impl OrionPersistence {
                     .collect(),
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(batch);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(batch)
                 .await
                 .map_err(|e| {
                     ProximaDBError::Storage(
@@ -949,8 +943,6 @@ impl OrionPersistence {
         }
 
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             // Wrap all CreateNode operations in a single batch GraphOp to reduce WAL traffic
             let batch = GraphOperation::BatchOperation {
                 operations: nodes
@@ -963,11 +955,10 @@ impl OrionPersistence {
                     .collect(),
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(batch);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(batch)
                 .await
                 .map_err(|e| {
                     ProximaDBError::Storage(
@@ -983,8 +974,6 @@ impl OrionPersistence {
     /// For updates, we write the full updated node (upsert semantic)
     pub async fn write_update_node_operation(&self, node: Node) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             tracing::debug!("Writing update node operation to WAL for node: {}", node.id);
 
             // Use CreateNode with upsert semantic - during recovery, this will overwrite existing node
@@ -993,11 +982,10 @@ impl OrionPersistence {
                 node,
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     tracing::error!("WAL append failed for update node: {:?}", e);
@@ -1019,8 +1007,6 @@ impl OrionPersistence {
     /// Write node delete operation to WAL
     pub async fn write_delete_node_operation(&self, node_id: &NodeId) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             tracing::debug!("Writing delete node operation to WAL for node: {}", node_id);
 
             let graph_op = GraphOperation::DeleteNode {
@@ -1028,11 +1014,10 @@ impl OrionPersistence {
                 node_id: node_id.clone(),
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     tracing::error!("WAL append failed for delete node: {:?}", e);
@@ -1055,8 +1040,6 @@ impl OrionPersistence {
     /// For updates, we write the full updated edge (upsert semantic)
     pub async fn write_update_edge_operation(&self, edge: Edge) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             tracing::debug!("Writing update edge operation to WAL for edge: {}", edge.id);
 
             // Use CreateEdge with upsert semantic - during recovery, this will overwrite existing edge
@@ -1065,11 +1048,10 @@ impl OrionPersistence {
                 edge,
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     tracing::error!("WAL append failed for update edge: {:?}", e);
@@ -1091,8 +1073,6 @@ impl OrionPersistence {
     /// Write edge delete operation to WAL
     pub async fn write_delete_edge_operation(&self, edge_id: &EdgeId) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
             tracing::debug!("Writing delete edge operation to WAL for edge: {}", edge_id);
 
             let graph_op = GraphOperation::DeleteEdge {
@@ -1100,11 +1080,10 @@ impl OrionPersistence {
                 edge_id: edge_id.clone(),
             };
 
-            let unified_op = UnifiedWALOperation::GraphOp(graph_op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(graph_op)
                 .await
                 .map_err(|e| {
                     tracing::error!("WAL append failed for delete edge: {:?}", e);
@@ -1126,13 +1105,10 @@ impl OrionPersistence {
     /// Log a generic graph operation to WAL
     pub async fn log_operation(&self, op: GraphOperation) -> Result<()> {
         if let Some(ref wal_writer) = self.wal_writer {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation;
-
-            let unified_op = UnifiedWALOperation::GraphOp(op);
             wal_writer
                 .lock()
                 .await
-                .append(unified_op)
+                .append_graph_op(op)
                 .await
                 .map_err(|e| {
                     ProximaDBError::Storage(

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -772,6 +772,17 @@ impl GraphWalPort for UnifiedWALWriter {
     async fn append_graph_marker(&mut self, marker: MarkerKind) -> anyhow::Result<u64> {
         self.append(UnifiedWALOperation::GraphMarker(marker)).await
     }
+
+    async fn flush(&mut self) -> anyhow::Result<()> {
+        UnifiedWALWriter::flush(self).await
+    }
+
+    async fn truncate_through_canonical_marker(
+        &mut self,
+        checkpoint_lsn: u64,
+    ) -> anyhow::Result<u64> {
+        UnifiedWALWriter::truncate_through_canonical_marker(self, checkpoint_lsn).await
+    }
 }
 
 /// WAL reader for recovery


### PR DESCRIPTION
## Summary

ORION cascade PR 3 — the GraphWalPort retarget. Follows #1083 (graph-op model → `proximadb-graph-model` leaf) and #1085 (the `GraphWalPort` seam + `UnifiedWALWriter` impl), both on `develop`.

ORION's persistence layer now appends graph operations and canonical-sync markers through the `GraphWalPort` dependency-inversion port instead of constructing `UnifiedWALOperation` and naming the concrete `UnifiedWALWriter`. This severs the engine's **append-path** coupling to the unified WAL types — the prerequisite for extracting ORION into its own crate without a cyclic dependency on the root storage layer. ORION itself stays in root this PR.

## Changes

- **`GraphWalPort` gains `flush()` and `truncate_through_canonical_marker(lsn)`** — the two additional sink methods ORION calls on the writer beyond `append`. `UnifiedWALWriter` implements them by delegating to its inherent methods (fully-qualified to avoid recursion into the trait method of the same name).
- **`OrionPersistence.wal_writer`** is now `Option<Arc<Mutex<dyn GraphWalPort>>>`; the concrete writer is erased to the port at construction via the `Arc<Mutex<T>> → Arc<Mutex<dyn Trait>>` unsizing coercion.
- **9 op append sites** call `append_graph_op(..)`; the canonical-emission marker site calls `append_graph_marker(MarkerKind::CanonicalEmission(lsn))`. `MarkerKind` is imported from the `proximadb_graph_model` leaf rather than re-exported through the WAL module.
- `truncate_wal_through_checkpoint` and `flush_wal` are unchanged at their call sites (they now dispatch through the port).

## Scope

Append path only. The recovery **read** path still constructs a `UnifiedWALReader` and pattern-matches `UnifiedWALOperation` on replay; that read-path coupling is a separate reader-port follow-up (PR 4+), not in scope here.

## Why this deviates from "all changes in persistence.rs"

PR 2 introduced `GraphWalPort` with only the two append methods. ORION additionally calls `flush()` and `truncate_through_canonical_marker()` on the writer, so fully retargeting the field to `dyn GraphWalPort` required extending the port with those two methods. This is a small, coherent extension of a port introduced one PR ago — the clean dependency-inversion move (the alternative, keeping a second concrete handle for flush/truncate, would defeat the decoupling this PR exists to deliver).

## Verification

- `cargo clippy -p proximadb --lib` — clean (coercion compiles; no unused imports)
- `rustup run 1.95.0 cargo fmt --all` — canonical (pre-push hook clean)
- `make work-commit-check` — deterministic guards pass: fmt-check, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy (`graph` module 0/0/0), hygiene
- `scripts/check-layering.sh` + `scripts/check_workspace_boundaries.py` — no boundary findings
- `scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` — clean
- Runtime: ORION TD-066 checkpoint/truncate recovery tests pass
  - `recovery_scopes_engine_wal_replay_to_post_checkpoint_frames`
  - `truncate_after_snapshot_preserves_recovery`
  - (exercise the full append → flush → marker → truncate → recovery path through the retargeted `dyn GraphWalPort`; behavior unchanged)

## Next

PR 4+ — move the 14 ORION files into `proximadb-orion-engine`, gated on a reader port for the recovery path (the remaining `UnifiedWALOperation` coupling).