### PR TITLE
refactor: retarget ORION WAL recovery onto GraphWalReaderPort (ORION cascade PR 4)

### DIFF
--- a/crates/foundation/proximadb-graph-model/src/model.rs
+++ b/crates/foundation/proximadb-graph-model/src/model.rs
@@ -352,3 +352,27 @@ pub enum MarkerKind {
     /// latest such marker whose `lsn` ≤ the recovered canonical checkpoint LSN.
     CanonicalEmission(u64),
 }
+
+/// A graph-relevant record projected from a unified WAL stream — the read-side
+/// counterpart to the graph operations / markers written through
+/// [`GraphWalPort`]. A reader port (e.g. `GraphWalReaderPort`) yields these so a
+/// graph engine can replay its WAL without naming the concrete unified WAL
+/// entry/operation types (the remaining decoupling needed to extract the engine
+/// into its own crate). Non-graph unified ops are filtered out by the reader.
+#[derive(Debug, Clone)]
+pub enum GraphWalRecord {
+    /// A graph data operation (CreateNode/CreateEdge/Update*/Delete*/Batch/…).
+    Op(GraphOperation),
+    /// A non-data canonical-sync marker.
+    Marker(MarkerKind),
+}
+
+/// One projected graph WAL frame: its sequence number (LSN) plus the graph
+/// record it carries.
+#[derive(Debug, Clone)]
+pub struct GraphWalEntry {
+    /// Monotonic WAL sequence number assigned at append.
+    pub sequence_number: u64,
+    /// The graph operation or marker.
+    pub record: GraphWalRecord,
+}

--- a/crates/foundation/proximadb-graph-model/src/model.rs
+++ b/crates/foundation/proximadb-graph-model/src/model.rs
@@ -362,7 +362,10 @@ pub enum MarkerKind {
 #[derive(Debug, Clone)]
 pub enum GraphWalRecord {
     /// A graph data operation (CreateNode/CreateEdge/Update*/Delete*/Batch/…).
-    Op(GraphOperation),
+    /// Boxed because `GraphOperation` (itself an enum over Node/Edge/Batch) is
+    /// far larger than [`MarkerKind`]; boxing the heavy variant keeps the enum
+    /// pointer-sized and `Vec<GraphWalEntry>` compact during replay.
+    Op(Box<GraphOperation>),
     /// A non-data canonical-sync marker.
     Marker(MarkerKind),
 }

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -13,7 +13,7 @@
 
 use anyhow::Result;
 use proximadb_distance_kernel::DistanceMetric;
-use proximadb_graph_model::{GraphOperation, MarkerKind};
+use proximadb_graph_model::{GraphOperation, GraphWalEntry, MarkerKind};
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
@@ -291,4 +291,20 @@ pub trait GraphWalPort: Send + Sync {
     /// the matching `CanonicalEmission(checkpoint_lsn)` marker). Returns the
     /// number of segments reclaimed.
     async fn truncate_through_canonical_marker(&mut self, checkpoint_lsn: u64) -> Result<u64>;
+}
+
+/// Dependency-inversion port for a graph engine's WAL *reader* (ORION
+/// extraction) — the read-side counterpart to [`GraphWalPort`].
+///
+/// A graph engine replays its WAL through this port rather than naming the
+/// concrete unified WAL reader/entry/operation types. The port yields only the
+/// graph-relevant frames ([`GraphWalEntry`]); non-graph unified operations are
+/// filtered out by the reader. As with [`GraphWalPort`], the composition root
+/// injects a concrete impl (e.g. the unified WAL reader), so the engine can be
+/// extracted to a crate without a cyclic dependency on the root storage layer.
+#[async_trait::async_trait]
+pub trait GraphWalReaderPort: Send + Sync {
+    /// Read every graph-relevant frame from the WAL, in append order. Returns an
+    /// empty vector when the WAL is absent or empty (e.g. before the first write).
+    async fn read_all_graph(&self) -> Result<Vec<GraphWalEntry>>;
 }

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -46,7 +46,9 @@ use crate::graph::engines::orion::OrionGraphEngine;
 use crate::graph::{Edge, EdgeId, Node, NodeId};
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
-use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALWriter;
+use crate::storage::persistence::write_ahead_log::wal_operations::{
+    UnifiedWALReader, UnifiedWALWriter,
+};
 use proximadb_kernel::error::ProximaDBError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -160,6 +162,13 @@ pub struct OrionPersistence {
     /// its own crate without a cyclic dependency on the root storage layer.
     wal_writer: Option<Arc<tokio::sync::Mutex<dyn proximadb_storage_ports::GraphWalPort>>>,
 
+    /// WAL reader for recovery. The engine replays through the
+    /// [`GraphWalReaderPort`] dependency-inversion port (injected by the
+    /// composition root as the unified WAL reader), so it never names the
+    /// concrete reader or the unified entry/operation types — the read-side
+    /// counterpart to the writer port.
+    wal_reader: Option<Arc<dyn proximadb_storage_ports::GraphWalReaderPort>>,
+
     /// Compression configuration
     compression: CompressionAlgorithm,
     compression_level: i32,
@@ -176,6 +185,7 @@ impl std::fmt::Debug for OrionPersistence {
             .field("base_url", &self.base_url)
             .field("wal_path", &self.wal_path)
             .field("wal_writer", &"<dyn GraphWalPort>")
+            .field("wal_reader", &"<dyn GraphWalReaderPort>")
             .field("compression", &self.compression)
             .field("compression_level", &self.compression_level)
             .field("max_snapshots", &self.max_snapshots)
@@ -253,7 +263,7 @@ impl OrionPersistence {
             })?;
 
         // Store WAL path and initialize WAL writer
-        let (wal_path, wal_writer) = if enable_wal {
+        let (wal_path, wal_writer, wal_reader) = if enable_wal {
             // Build WAL URL (keep as URL for filesystem operations)
             let wal_url = format!("{}/wal", graph_path);
 
@@ -277,10 +287,11 @@ impl OrionPersistence {
                     ))
                 })?;
 
-            // Initialize WAL writer with path (not URL), then erase it to the
-            // GraphWalPort port the engine speaks. The unsizing coercion
+            // Initialize WAL writer + reader with path (not URL), then erase
+            // each to its dependency-inversion port. The unsizing coercions
             // `Arc<Mutex<UnifiedWALWriter>>` -> `Arc<Mutex<dyn GraphWalPort>>`
-            // is sound because the writer implements the port (PR #1085).
+            // and `Arc<UnifiedWALReader>` -> `Arc<dyn GraphWalReaderPort>` are
+            // sound because both implement their ports (PRs #1085 / #1093).
             tracing::debug!("Creating WAL writer with path: {}", wal_path_str);
             let wal_writer = UnifiedWALWriter::new(wal_path_str.clone())
                 .await
@@ -293,9 +304,23 @@ impl OrionPersistence {
             let wal_writer: Arc<tokio::sync::Mutex<dyn proximadb_storage_ports::GraphWalPort>> =
                 Arc::new(tokio::sync::Mutex::new(wal_writer));
 
-            (Some(wal_path), Some(wal_writer))
+            // The reader opens no files at construction (only the FS handle);
+            // segments are enumerated lazily on `read_all_graph`. Tolerant of an
+            // absent/empty WAL (e.g. before the first write) — recovery is a
+            // no-op then.
+            let wal_reader = UnifiedWALReader::new(wal_path_str.clone())
+                .await
+                .map_err(|e| {
+                    ProximaDBError::Storage(
+                        proximadb_kernel::error::StorageError::SerializationError(e.to_string()),
+                    )
+                })?;
+            let wal_reader: Arc<dyn proximadb_storage_ports::GraphWalReaderPort> =
+                Arc::new(wal_reader);
+
+            (Some(wal_path), Some(wal_writer), Some(wal_reader))
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         Ok(Self {
@@ -306,6 +331,7 @@ impl OrionPersistence {
             wal_path,
             canonical_wal_path: None,
             wal_writer,
+            wal_reader,
             compression: CompressionAlgorithm::Zstd,
             compression_level: 3,
             max_snapshots: 10,
@@ -1145,20 +1171,12 @@ impl OrionPersistence {
         engine: &OrionGraphEngine,
         snapshot_lsn: Option<u64>,
     ) -> Result<()> {
-        if let Some(ref wal_path) = self.wal_path {
-            use crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALReader;
+        if let Some(ref wal_reader) = self.wal_reader {
+            use proximadb_graph_model::{GraphWalRecord, MarkerKind};
 
-            let wal_path_str = wal_path.to_string_lossy().to_string();
-            tracing::debug!("Attempting WAL recovery from path: {}", wal_path_str);
+            tracing::debug!("Attempting WAL recovery for graph {}", self.graph_id);
 
-            let reader = UnifiedWALReader::new(wal_path_str.clone())
-                .await
-                .map_err(|e| {
-                    ProximaDBError::Storage(
-                        proximadb_kernel::error::StorageError::SerializationError(e.to_string()),
-                    )
-                })?;
-            let entries = reader.read_all().await.map_err(|e| {
+            let entries = wal_reader.read_all_graph().await.map_err(|e| {
                 ProximaDBError::Storage(proximadb_kernel::error::StorageError::SerializationError(
                     e.to_string(),
                 ))
@@ -1183,13 +1201,10 @@ impl OrionPersistence {
             if let Some(snapshot_lsn) = snapshot_lsn
                 && snapshot_lsn > 0
             {
-                use crate::storage::persistence::write_ahead_log::wal_operations::{
-                    MarkerKind, UnifiedWALOperation,
-                };
                 let mut marker_idx: Option<usize> = None;
                 for (i, entry) in entries.iter().enumerate() {
-                    if let UnifiedWALOperation::GraphMarker(MarkerKind::CanonicalEmission(lsn)) =
-                        &entry.operation
+                    if let GraphWalRecord::Marker(MarkerKind::CanonicalEmission(lsn)) =
+                        &entry.record
                         && *lsn == snapshot_lsn
                     {
                         marker_idx = Some(i);
@@ -1216,11 +1231,13 @@ impl OrionPersistence {
 
             let mut replayed: u64 = 0;
             for entry in entries.into_iter().skip(start_index) {
-                if entry.is_graph_operation()
-                    && let crate::storage::persistence::write_ahead_log::wal_operations::UnifiedWALOperation::GraphOp(graph_op) = entry.operation {
-                        self.apply_graph_operation(engine, graph_op).await?;
-                        replayed += 1;
-                    }
+                // `entries` is already projected to graph records; apply the
+                // data ops and skip the canonical-sync markers (they carry no
+                // engine state to reapply).
+                if let GraphWalRecord::Op(graph_op) = entry.record {
+                    self.apply_graph_operation(engine, graph_op).await?;
+                    replayed += 1;
+                }
             }
             tracing::info!(
                 graph_id = %self.graph_id,

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -1235,7 +1235,7 @@ impl OrionPersistence {
                 // data ops and skip the canonical-sync markers (they carry no
                 // engine state to reapply).
                 if let GraphWalRecord::Op(graph_op) = entry.record {
-                    self.apply_graph_operation(engine, graph_op).await?;
+                    self.apply_graph_operation(engine, *graph_op).await?;
                     replayed += 1;
                 }
             }

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -798,7 +798,7 @@ impl GraphWalReaderPort for UnifiedWALReader {
         let mut out = Vec::with_capacity(entries.len());
         for entry in entries {
             let record = match entry.operation {
-                UnifiedWALOperation::GraphOp(op) => GraphWalRecord::Op(op),
+                UnifiedWALOperation::GraphOp(op) => GraphWalRecord::Op(Box::new(op)),
                 UnifiedWALOperation::GraphMarker(marker) => GraphWalRecord::Marker(marker),
                 // Non-graph unified ops (Document/Observability/Hybrid/…) are
                 // not part of a graph engine's stream — filtered out.

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -23,8 +23,9 @@ use crate::proto::proximadb_v1::{DocumentUpdate, LogEntry, MetricSample};
 use crate::storage::document::DocumentRecord;
 use crate::storage::memtable::implementations::graph_memtable::GraphOperation;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+use proximadb_graph_model::{GraphWalEntry, GraphWalRecord};
 use proximadb_records::ProximaRecord;
-use proximadb_storage_ports::GraphWalPort;
+use proximadb_storage_ports::{GraphWalPort, GraphWalReaderPort};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -782,6 +783,33 @@ impl GraphWalPort for UnifiedWALWriter {
         checkpoint_lsn: u64,
     ) -> anyhow::Result<u64> {
         UnifiedWALWriter::truncate_through_canonical_marker(self, checkpoint_lsn).await
+    }
+}
+
+/// The unified WAL reader is the composition-root-provided recovery source for
+/// the ORION graph engine: it implements [`GraphWalReaderPort`] by projecting
+/// graph operations / markers out of the unified entry stream, so ORION can
+/// replay through the port without naming the concrete reader or the unified
+/// operation/entry types.
+#[async_trait::async_trait]
+impl GraphWalReaderPort for UnifiedWALReader {
+    async fn read_all_graph(&self) -> anyhow::Result<Vec<GraphWalEntry>> {
+        let entries = self.read_all().await?;
+        let mut out = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let record = match entry.operation {
+                UnifiedWALOperation::GraphOp(op) => GraphWalRecord::Op(op),
+                UnifiedWALOperation::GraphMarker(marker) => GraphWalRecord::Marker(marker),
+                // Non-graph unified ops (Document/Observability/Hybrid/…) are
+                // not part of a graph engine's stream — filtered out.
+                _ => continue,
+            };
+            out.push(GraphWalEntry {
+                sequence_number: entry.sequence_number,
+                record,
+            });
+        }
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
## Summary

ORION cascade **PR 4** — the **read-side** counterpart to PR #1090 (the append-path retarget). Builds on `develop` (which has #1083 + #1085 + #1090).

ORION's recovery read path now replays through a `GraphWalReaderPort` dependency-inversion port instead of constructing `UnifiedWALReader` and pattern-matching `UnifiedWALOperation`. This **removes the last `UnifiedWALOperation` references from `persistence.rs`** (the unified operation-enum coupling), leaving ORION's read path speaking entirely in graph-model leaf types (`GraphWalEntry` / `GraphWalRecord`).

## Changes

- **graph-model leaf** — `GraphWalRecord { Op(GraphOperation) | Marker(MarkerKind) }` + `GraphWalEntry { sequence_number, record }`: a read-side projection of a graph engine's WAL stream.
- **storage-ports** — `GraphWalReaderPort` trait (`read_all_graph -> Vec<GraphWalEntry>`), the read-side counterpart to `GraphWalPort`.
- **wal_operations.rs** — `impl GraphWalReaderPort for UnifiedWALReader`: `read_all()` → project `GraphOp`/`GraphMarker` to `GraphWalEntry`, filter non-graph unified ops.
- **persistence.rs** — inject `wal_reader: Option<Arc<dyn GraphWalReaderPort>>` at construction (alongside the writer); rewrite `replay_wal` to iterate `Vec<GraphWalEntry>` (marker-scope logic preserved, now matching `GraphWalRecord::Marker`). `UnifiedWALOperation` is now fully absent from `persistence.rs`.

## Scope

**Read-path operation-enum decoupling only.** ORION still constructs the concrete `UnifiedWALWriter`/`UnifiedWALReader` at its composition root (`OrionPersistence::new`) — inverting that construction into the caller is the next PR and the actual enabler of the 14-file move into `proximadb-orion-engine`. The `wal_path` field also stays (used by `checkpoint`'s raw-FS segment truncation and `Debug`). This PR is deliberately symmetric with PR 3's shape (leaf type + port trait + root impl + engine retarget).

## Verification

- `cargo clippy -p proximadb --lib` — clean
- `rustup run 1.95.0 cargo fmt --all` — canonical (pre-push hook clean)
- `make work-commit-check` — deterministic guards pass: fmt-check, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy (`graph` 0/0/0), hygiene
- `scripts/check-layering.sh` + `scripts/check_workspace_boundaries.py` — no boundary findings
- `scripts/check_no_agent_attribution.py --range HEAD~1..HEAD` — clean
- Runtime: ORION TD-066 recovery tests pass
  - `recovery_scopes_engine_wal_replay_to_post_checkpoint_frames`
  - `truncate_after_snapshot_preserves_recovery`
  - (exercise the rewritten `replay_wal` through the new `GraphWalReaderPort` — projection + CanonicalEmission-marker scope logic; behavior unchanged)

## Next

PR 5 — invert the writer/reader **construction** out of `OrionPersistence::new` into the caller (true DI), then move the 14 ORION files into `proximadb-orion-engine`.