### PR TITLE
feat(trace): harden io trace delivery across crashes

### DIFF
--- a/crates/storage/proximadb-object-store/src/lib.rs
+++ b/crates/storage/proximadb-object-store/src/lib.rs
@@ -256,6 +256,28 @@ impl ProximaObjectStore {
             .map_err(|e| os_err("put_if_absent", e))
     }
 
+    /// Atomically create `path` at the requested access tier. This combines the
+    /// collision safety of [`Self::put_if_absent`] with the provider-native
+    /// storage-class mapping of [`Self::put_with_tier`]. Untiered stores simply
+    /// use create-only mode.
+    pub async fn put_if_absent_with_tier(
+        &self,
+        path: &Path,
+        bytes: Bytes,
+        tier: ObjectAccessTier,
+    ) -> Result<(), StorageError> {
+        let mut opts = PutOptions::from(PutMode::Create);
+        if let Some(native) = self.backend.native_tier(tier) {
+            opts.attributes
+                .insert(Attribute::StorageClass, native.into());
+        }
+        self.store
+            .put_opts(&self.full_path(path), bytes.into(), opts)
+            .await
+            .map(|_| ())
+            .map_err(|e| os_err("put_if_absent_with_tier", e))
+    }
+
     /// Read the whole object at `path`.
     pub async fn get(&self, path: &Path) -> Result<Bytes, StorageError> {
         let result = self
@@ -493,6 +515,21 @@ mod tests {
             b"first",
             "rejected create must not overwrite"
         );
+    }
+
+    #[tokio::test]
+    async fn put_if_absent_with_tier_is_create_only_on_untiered_store() {
+        let os = ProximaObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let p = Path::from("trace/segment.jsonl.zst");
+
+        os.put_if_absent_with_tier(&p, Bytes::from_static(b"first"), ObjectAccessTier::Cold)
+            .await
+            .unwrap();
+        let err = os
+            .put_if_absent_with_tier(&p, Bytes::from_static(b"second"), ObjectAccessTier::Cold)
+            .await;
+        assert!(matches!(err, Err(StorageError::AlreadyExists(_))));
+        assert_eq!(&os.get(&p).await.unwrap()[..], b"first");
     }
 
     /// The canonical tier maps to each cloud's native storage-class spelling; an

--- a/docs/10-quality/td/TD-TRACE-2-structured-io-trace-etl-sink.adoc
+++ b/docs/10-quality/td/TD-TRACE-2-structured-io-trace-etl-sink.adoc
@@ -5,10 +5,10 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open; S1 shipped #1084, S2 shipped #1087.** Current code serializes a flat snapshot into a bounded in-memory queue, seals JSONL+zstd, and PUTs directly to `_operator/io_trace/` with local-file fallback. Remaining: S2b delivery hardening, S3 envelope, S4 Iceberg-managed Parquet warehouse. The current sink is best-effort observability, not billing/audit authority.
+| Status | **Open; S1 shipped #1084, S2 shipped #1087, S2b implemented.** The sink now seals immutable pending files before conditional create, verifies digest collisions, retries on startup, and exposes bounded-delivery metrics. Remaining: S3 envelope, governance/tenant-root integration, and S4 Iceberg-managed Parquet warehouse. Ingress remains best-effort observability, not billing/audit authority.
 | Priority | P2 — leverage multiplier for fleet observability + cost analytics (which routes regress, which tenants pay the most GET round-trips, where the cost model mis-attributes). Not on any hot path; default-OFF.
 | Component | `crates/modalities/proximadb-observability-engine` (`io_trace.rs` — a new `set_trace_observer` seam + spool writer), `crates/storage/proximadb-object-store` + `DrPathBuilder` (dispatch), the server config (`config.toml` `[observability.io_trace_sink]` + `Config` struct), a background seal/upload task, and (later) a JSONL→Parquet compactor.
-| Evidence | #1084/#1087 close the “log-only” gap but expose the next correctness boundary: `Spool` is memory, drops records, and loses its `dropped` counter on shutdown; direct PUT failures write local files that startup never inventories/retries; filenames use wall-clock `run_nonce`; errors are warnings only; `partition_by`/`retention_days` are parsed but ignored. `IoTraceSnapshot` remains the flat widening source shape. ADR-066 §1/§6.
+| Evidence | #1084/#1087 exposed the delivery gap now closed by S2b: immutable pending seal, UUID+sequence+digest identity, conditional create/verification, startup retry, hard pending cap, and delivery metrics. Remaining evidence gaps are representative hot-path cost, structural tenant/operator governance, S3 envelope compatibility, and S4 warehouse commit. `partition_by`/`retention_days` remain reserved and `IoTraceSnapshot` remains the flat widening source shape. ADR-066 §1/§6.
 |===
 
 == The finding
@@ -32,13 +32,13 @@ crash-aware. Billing stays always-on/untouched (ADR-027).
   exists); a bounded memory queue and background JSONL+zstd sealer; config + env overrides;
   default-OFF. It serializes the existing flat snapshot on query completion. “Local spool” in the
   original slice name is not a durability claim.
-* **S2 — shipped #1087: direct object-store dispatch.** Background task seals on
+* **S2 — shipped #1087: initial object-store dispatch (superseded by S2b delivery).** Background task sealed on
   `segment_bytes` OR `flush_interval_s` (whichever first), zstd-compress, PUT via
   `proximadb-object-store` under `DrPathBuilder` keys
-  `_operator/io_trace/` with `ObjectAccessTier = Cold`; PUT failure writes a local fallback.
+  `_operator/io_trace/` with `ObjectAccessTier = Cold`; PUT failure wrote a local fallback.
   Compression/PUT remain off the query path. Tenant/date/host partitioning and retention are not
   implemented.
-* **S2b — delivery hardening (next).** Seal an immutable pending file before upload; startup retry;
+* **S2b — delivery hardening (implemented).** Seal an immutable pending file before upload; startup retry;
   writer-incarnation UUID + monotonic sequence + content digest; conditional create and
   AlreadyExists digest verification; retire local pending only after verified PUT. Add counters/gauges
   for dropped records/bytes, seal/upload failures, retries, pending files/bytes, and last success.

--- a/docs/12-design/adr/ADR-066-structured-io-trace-etl-sink.adoc
+++ b/docs/12-design/adr/ADR-066-structured-io-trace-etl-sink.adoc
@@ -5,7 +5,7 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | **Proposed; partially implemented** (reconciled 2026-07-17). S1 local sealing shipped in #1084 and S2 direct object-store dispatch in #1087. The current path is best-effort observability, not a durable/billing-grade ledger; acceptance is gated on the delivery, identity, governance, and warehouse-commit amendments below. Implemented under link:../../10-quality/td/TD-TRACE-2-structured-io-trace-etl-sink.adoc[TD-TRACE-2].
+| Status | **Proposed; partially implemented** (reconciled 2026-07-18). S1 local sealing shipped in #1084, S2 dispatch in #1087, and S2b crash-aware delivery is implemented. Ingress remains best-effort and is not a billing/audit ledger; acceptance is still gated on hot-path evidence, governance/tenant-root integration, the S3 envelope, and S4 warehouse commit. Implemented under link:../../10-quality/td/TD-TRACE-2-structured-io-trace-etl-sink.adoc[TD-TRACE-2].
 | Decider | Vijaykumar Singh (2026-07-17)
 | Date | 2026-07-17
 | Relates to | link:ADR-064-query-engine-pipeline-decision-dispatch-lowering-trace.adoc[ADR-064] (the per-query TRACE this makes durable), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine — meter every dimension, measured-not-asserted), link:ADR-036-azure-objectstore-orientation.adoc[ADR-036] (per-object access tier = the at-rest GB-month cost lever this ADR pulls), link:ADR-027-unified-storage-and-metering-substrate.adoc[ADR-027] (metering substrate — billing never gated; this sink is a *separate* observer). Deliberately stays OFF the sampled `predicate_diagnostics` **quality/eval** bus (a distinct concern — see D2).
@@ -183,16 +183,16 @@ access_tier      = "cool"         # Cool/Cold — GB-month lever (ADR-036)
 partition_by     = "date"         # date | tenant | host
 retention_days   = 30
 spool_max_bytes  = 268435456      # bounded spool; drop-oldest on overflow
-pending_max_bytes = 1073741824    # S2b target; never evict already-sealed pending files
+pending_max_bytes = 1073741824    # hard cap; never evict already-sealed pending files
 ----
 
 **Current code contact.** `enabled`, `local_dir`, `segment_bytes`, `flush_interval_s`,
-`spool_max_bytes`, `compression`, `format`, `object_store_uri`, and `access_tier` resolve today.
-Only JSONL+zstd is implemented; unsupported `format`/`compression` values must fail configuration
-instead of being accepted and ignored. `partition_by` and `retention_days` deserialize but are not
+`spool_max_bytes`, `pending_max_bytes`, `compression`, `format`, `object_store_uri`, and
+`access_tier` resolve today. Only JSONL+zstd is implemented; strict runtime resolution rejects
+unsupported `format`, `compression`, and access-tier values. `partition_by` and `retention_days` deserialize but are not
 carried into `ResolvedIoTraceSinkConfig` and have no runtime effect. They are reserved until their
 implementation and tests land; documentation must not advertise them as active controls.
-`pending_max_bytes` is an S2b target: once full, the worker preserves existing pending files and
+Once `pending_max_bytes` is full, the worker preserves existing pending files and
 stops draining memory ingress, causing measured ingress drops; it never deletes sealed pending data
 to make room.
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -117,6 +117,7 @@ pub struct ObservabilityConfig {
 /// compression = "zstd"
 /// format = "jsonl"
 /// spool_max_bytes = 268435456
+/// pending_max_bytes = 1073741824
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct IoTraceSinkConfig {
@@ -139,6 +140,9 @@ pub struct IoTraceSinkConfig {
     /// Bounded in-memory spool cap (bytes-equivalent record budget); on overflow the
     /// oldest queued record is dropped (best-effort). Default 256 MiB.
     pub spool_max_bytes: Option<u64>,
+    /// Hard durable pending-file cap. A segment that would cross it is returned
+    /// to ingress; sealed files are never evicted. Default 1 GiB.
+    pub pending_max_bytes: Option<u64>,
     /// Object-store destination URI (consumed in S2 — parsed now, unused in S1).
     pub object_store_uri: Option<String>,
     /// Per-object access tier for the object-store dispatch (S2). e.g. `cool`.
@@ -154,6 +158,15 @@ impl IoTraceSinkConfig {
     /// `None` when the sink is disabled (no observer installed, no worker spawned).
     /// Mirrors [`QueueRuntimeConfig::resolve`].
     pub fn resolve(toml_section: Option<&IoTraceSinkConfig>) -> Option<ResolvedIoTraceSinkConfig> {
+        Self::try_resolve(toml_section).unwrap_or(None)
+    }
+
+    /// Strict runtime resolution. Unlike [`Self::resolve`], this reports invalid
+    /// active settings so database startup cannot silently run a different
+    /// delivery contract than the operator requested.
+    pub fn try_resolve(
+        toml_section: Option<&IoTraceSinkConfig>,
+    ) -> Result<Option<ResolvedIoTraceSinkConfig>, String> {
         let from_toml = toml_section.cloned().unwrap_or_default();
 
         let enabled = std::env::var("PROXIMADB_IO_TRACE_SINK")
@@ -161,7 +174,7 @@ impl IoTraceSinkConfig {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(from_toml.enabled);
         if !enabled {
-            return None;
+            return Ok(None);
         }
 
         let env_u64 = |key: &str| std::env::var(key).ok().and_then(|v| v.parse::<u64>().ok());
@@ -180,14 +193,36 @@ impl IoTraceSinkConfig {
         let spool_max_bytes = env_u64("PROXIMADB_IO_TRACE_SINK_SPOOL_MAX_BYTES")
             .or(from_toml.spool_max_bytes)
             .unwrap_or(256 * 1024 * 1024);
+        let pending_max_bytes = env_u64("PROXIMADB_IO_TRACE_SINK_PENDING_MAX_BYTES")
+            .or(from_toml.pending_max_bytes)
+            .unwrap_or(1024 * 1024 * 1024);
         let compression = std::env::var("PROXIMADB_IO_TRACE_SINK_COMPRESSION")
             .ok()
             .or(from_toml.compression.clone())
-            .unwrap_or_else(|| "zstd".to_string());
+            .unwrap_or_else(|| "zstd".to_string())
+            .to_ascii_lowercase();
         let format = std::env::var("PROXIMADB_IO_TRACE_SINK_FORMAT")
             .ok()
             .or(from_toml.format.clone())
-            .unwrap_or_else(|| "jsonl".to_string());
+            .unwrap_or_else(|| "jsonl".to_string())
+            .to_ascii_lowercase();
+
+        if compression != "zstd" {
+            return Err(format!(
+                "unsupported io_trace sink compression `{compression}`; only `zstd` is implemented"
+            ));
+        }
+        if format != "jsonl" {
+            return Err(format!(
+                "unsupported io_trace sink format `{format}`; only `jsonl` is implemented"
+            ));
+        }
+        if segment_bytes == 0 || spool_max_bytes == 0 || pending_max_bytes == 0 {
+            return Err(
+                "io_trace sink segment_bytes, spool_max_bytes, and pending_max_bytes must be non-zero"
+                    .to_string(),
+            );
+        }
 
         // S2 (ADR-066 D4): optional object-store dispatch. When set, sealed segments
         // are PUT to this store; when unset, the sink stays local-only (S1). The
@@ -196,22 +231,26 @@ impl IoTraceSinkConfig {
         let object_store_uri = std::env::var("PROXIMADB_IO_TRACE_SINK_OBJECT_STORE_URI")
             .ok()
             .or(from_toml.object_store_uri.clone());
-        let access_tier = std::env::var("PROXIMADB_IO_TRACE_SINK_ACCESS_TIER")
+        let access_tier_text = std::env::var("PROXIMADB_IO_TRACE_SINK_ACCESS_TIER")
             .ok()
-            .or(from_toml.access_tier.clone())
-            .and_then(|s| ObjectAccessTier::parse(&s))
-            .unwrap_or(ObjectAccessTier::Cold);
+            .or(from_toml.access_tier.clone());
+        let access_tier = match access_tier_text {
+            Some(value) => ObjectAccessTier::parse(&value)
+                .ok_or_else(|| format!("unsupported io_trace sink access_tier `{value}`"))?,
+            None => ObjectAccessTier::Cold,
+        };
 
-        Some(ResolvedIoTraceSinkConfig {
+        Ok(Some(ResolvedIoTraceSinkConfig {
             local_dir,
             segment_bytes,
             flush_interval_s,
             spool_max_bytes,
+            pending_max_bytes,
             compression,
             format,
             object_store_uri,
             access_tier,
-        })
+        }))
     }
 }
 
@@ -224,6 +263,7 @@ pub struct ResolvedIoTraceSinkConfig {
     pub segment_bytes: u64,
     pub flush_interval_s: u64,
     pub spool_max_bytes: u64,
+    pub pending_max_bytes: u64,
     pub compression: String,
     pub format: String,
     /// Object-store dispatch target (S2). `None` ⇒ segments stay local-only.
@@ -388,6 +428,7 @@ mod queue_config_tests {
         let _g3 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_FLUSH_INTERVAL_S", None);
         let _g4 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_OBJECT_STORE_URI", None);
         let _g5 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_ACCESS_TIER", None);
+        let _g6 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_PENDING_MAX_BYTES", None);
         let toml = IoTraceSinkConfig {
             enabled: true,
             local_dir: Some("/tmp/tr".to_string()),
@@ -398,11 +439,40 @@ mod queue_config_tests {
         assert_eq!(r.segment_bytes, 4 * 1024 * 1024);
         assert_eq!(r.flush_interval_s, 60);
         assert_eq!(r.spool_max_bytes, 256 * 1024 * 1024);
+        assert_eq!(r.pending_max_bytes, 1024 * 1024 * 1024);
         assert_eq!(r.compression, "zstd");
         assert_eq!(r.format, "jsonl");
         // S2 defaults: no object store (local-only), Cold tier.
         assert_eq!(r.object_store_uri, None);
         assert_eq!(r.access_tier, ObjectAccessTier::Cold);
+    }
+
+    #[test]
+    fn io_trace_sink_strict_resolution_rejects_unsupported_active_settings() {
+        let _g0 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK", None);
+        let _g1 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_COMPRESSION", None);
+        let _g2 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_FORMAT", None);
+        let _g3 = EnvGuard::set("PROXIMADB_IO_TRACE_SINK_ACCESS_TIER", None);
+
+        for config in [
+            IoTraceSinkConfig {
+                enabled: true,
+                compression: Some("gzip".to_string()),
+                ..Default::default()
+            },
+            IoTraceSinkConfig {
+                enabled: true,
+                format: Some("parquet".to_string()),
+                ..Default::default()
+            },
+            IoTraceSinkConfig {
+                enabled: true,
+                access_tier: Some("cheapish".to_string()),
+                ..Default::default()
+            },
+        ] {
+            assert!(IoTraceSinkConfig::try_resolve(Some(&config)).is_err());
+        }
     }
 
     /// TOML-only flow: a TOML `[queue]` section with `root` set

--- a/src/database.rs
+++ b/src/database.rs
@@ -190,13 +190,15 @@ impl ProximaDB {
         // observer (the billing observer above stays always-on/never-gated, ADR-027).
         // Installed only when `[observability.io_trace_sink]` resolves enabled (env
         // `PROXIMADB_IO_TRACE_SINK` or TOML); `resolve` returns None otherwise.
-        if let Some(sink_cfg) = crate::core::config::IoTraceSinkConfig::resolve(
+        if let Some(sink_cfg) = crate::core::config::IoTraceSinkConfig::try_resolve(
             config
                 .observability
                 .as_ref()
                 .and_then(|o| o.io_trace_sink.as_ref()),
-        ) {
-            crate::observability::io_trace_sink::install(sink_cfg);
+        )
+        .map_err(anyhow::Error::msg)?
+        {
+            crate::observability::io_trace_sink::install(sink_cfg).map_err(anyhow::Error::msg)?;
         }
         // Co-design C5 (integration): register the tenant→tier Port to read the
         // header-fed tier registry (`X-Tenant-Tier` → `record_store::TENANT_TIERS`),

--- a/src/metrics/io_trace_sink_metrics.rs
+++ b/src/metrics/io_trace_sink_metrics.rs
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Low-cardinality delivery-state metrics for the ADR-066 trace sink.
+
+use lazy_static::lazy_static;
+use prometheus::{IntCounter, IntGauge, register_int_counter, register_int_gauge};
+
+fn counter(name: &str, help: &str) -> IntCounter {
+    register_int_counter!(name, help)
+        .unwrap_or_else(|_| IntCounter::new(format!("{name}_fallback"), help).unwrap())
+}
+
+fn gauge(name: &str, help: &str) -> IntGauge {
+    register_int_gauge!(name, help)
+        .unwrap_or_else(|_| IntGauge::new(format!("{name}_fallback"), help).unwrap())
+}
+
+lazy_static! {
+    pub static ref RECORDS_DROPPED_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_records_dropped_total",
+        "Trace records dropped from best-effort ingress or after an unrecoverable seal failure",
+    );
+    pub static ref BYTES_DROPPED_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_bytes_dropped_total",
+        "Uncompressed trace bytes dropped by the best-effort sink",
+    );
+    pub static ref SEAL_FAILURES_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_seal_failures_total",
+        "Trace segment compression or durable local-seal failures",
+    );
+    pub static ref UPLOAD_FAILURES_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_upload_failures_total",
+        "Trace object conditional-create or verification failures",
+    );
+    pub static ref UPLOAD_RETRIES_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_upload_retries_total",
+        "Durable pending trace files retried after their initial upload attempt",
+    );
+    pub static ref PENDING_FILES: IntGauge = gauge(
+        "proximadb_io_trace_sink_pending_files",
+        "Immutable trace files awaiting verified object-store delivery",
+    );
+    pub static ref PENDING_BYTES: IntGauge = gauge(
+        "proximadb_io_trace_sink_pending_bytes",
+        "Compressed bytes awaiting verified object-store delivery",
+    );
+    pub static ref LAST_SUCCESS_UNIX_SECONDS: IntGauge = gauge(
+        "proximadb_io_trace_sink_last_success_unix_seconds",
+        "Unix timestamp of the latest verified trace object delivery",
+    );
+    pub static ref DUPLICATE_INSTALLS_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_duplicate_installs_total",
+        "Trace sink installation attempts rejected because a worker was already live",
+    );
+    pub static ref SHUTDOWN_TIMEOUTS_TOTAL: IntCounter = counter(
+        "proximadb_io_trace_sink_shutdown_timeouts_total",
+        "Trace sink graceful shutdown attempts that exceeded the deadline",
+    );
+}
+
+pub fn record_drop(records: u64, bytes: u64) {
+    RECORDS_DROPPED_TOTAL.inc_by(records);
+    BYTES_DROPPED_TOTAL.inc_by(bytes);
+}
+
+pub fn set_pending(files: u64, bytes: u64) {
+    PENDING_FILES.set(files.min(i64::MAX as u64) as i64);
+    PENDING_BYTES.set(bytes.min(i64::MAX as u64) as i64);
+}
+
+pub fn record_delivery_success() {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    LAST_SUCCESS_UNIX_SECONDS.set(now.min(i64::MAX as u64) as i64);
+}

--- a/src/metrics/io_trace_sink_metrics.rs
+++ b/src/metrics/io_trace_sink_metrics.rs
@@ -7,13 +7,17 @@ use lazy_static::lazy_static;
 use prometheus::{IntCounter, IntGauge, register_int_counter, register_int_gauge};
 
 fn counter(name: &str, help: &str) -> IntCounter {
-    register_int_counter!(name, help)
-        .unwrap_or_else(|_| IntCounter::new(format!("{name}_fallback"), help).unwrap())
+    register_int_counter!(name, help).unwrap_or_else(|_| {
+        IntCounter::new(format!("{name}_fallback"), help)
+            .unwrap_or_else(|_| unreachable!("valid counter metric descriptor"))
+    })
 }
 
 fn gauge(name: &str, help: &str) -> IntGauge {
-    register_int_gauge!(name, help)
-        .unwrap_or_else(|_| IntGauge::new(format!("{name}_fallback"), help).unwrap())
+    register_int_gauge!(name, help).unwrap_or_else(|_| {
+        IntGauge::new(format!("{name}_fallback"), help)
+            .unwrap_or_else(|_| unreachable!("valid gauge metric descriptor"))
+    })
 }
 
 lazy_static! {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -24,6 +24,7 @@ pub mod cache;
 pub mod collection_pin_metrics;
 pub mod collectors;
 pub mod consumption_metrics;
+pub mod io_trace_sink_metrics;
 pub mod metering_writer;
 pub mod query_service;
 pub mod store;

--- a/src/observability/io_trace_sink.rs
+++ b/src/observability/io_trace_sink.rs
@@ -1,51 +1,51 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-//! Durable io_trace ETL sink — TD-TRACE-2 S1 (local JSONL+zstd spool).
+//! Crash-aware `io_trace` delivery sink (ADR-066 / TD-TRACE-2 S1–S2b).
 //!
-//! ADR-066: takes the in-process per-query [`IoTraceSnapshot`] durable + queryable.
-//! S1 is the local-spool foundation (no object-store dispatch — that is S2):
-//!
-//! ```text
-//!  instrument() exit ──set_trace_observer──▶ [serialize + enqueue]  (query path: CPU only, no I/O)
-//!                                                    │  bounded spool, drop-oldest
-//!                                                    ▼
-//!                            background worker ──interval/size seal──▶ {local_dir}/trace-{run}-{seq}.jsonl.zst
-//! ```
-//!
-//! Guarantees:
-//! * **Separate, default-OFF observer** — billing stays always-on / never-gated
-//!   (ADR-027); the sink is installed only when `[observability.io_trace_sink]`
-//!   resolves enabled.
-//! * **Never blocks the query path** — the observer only serializes one small JSON
-//!   line and pushes it to a bounded in-memory spool (O(1)); the compress + file
-//!   write happen on the background worker (via `spawn_blocking`).
-//! * **Bounded + best-effort** — the spool has a byte cap; on overflow the oldest
-//!   queued record is dropped (never blocks / OOMs the DB).
-//! * **Graceful shutdown** — a final drain + seal on the shutdown signal.
+//! The query path only serializes and enqueues into bounded memory. A background
+//! worker compresses each segment, durably seals an immutable `.pending` file,
+//! conditionally creates the object, verifies collisions, and only then retires
+//! the pending file. Startup retries every pending file.
 
 use std::collections::VecDeque;
-use std::sync::{Mutex, OnceLock};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use bytes::Bytes;
+use chrono::Utc;
 use object_store::path::Path as ObjectPath;
+use proximadb_kernel::error::StorageError;
 use proximadb_object_store::ProximaObjectStore;
 use proximadb_storage_filesystem_types::ObjectAccessTier;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::core::config::ResolvedIoTraceSinkConfig;
+use crate::metrics::io_trace_sink_metrics as delivery_metrics;
 use crate::observability::io_trace::{self, IoTraceSnapshot};
 use crate::storage::trait_components::path_resolver::DrPathBuilder;
 
-/// One serialized trace record awaiting export (a `\n`-terminated JSON line).
-type SpoolLine = Vec<u8>;
+#[derive(Debug, PartialEq, Eq)]
+struct SpoolLine {
+    bytes: Vec<u8>,
+    sequence: u64,
+}
 
-/// Bounded in-memory spool. Push is O(1) and drops the oldest record(s) when the
-/// byte cap is exceeded — observability is best-effort and must never block/OOM.
+impl SpoolLine {
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+/// Bounded, non-blocking ingress. Overflow always drops oldest and accounts the
+/// exact records and uncompressed bytes lost.
 struct Spool {
     deque: VecDeque<SpoolLine>,
     bytes: usize,
     cap: usize,
-    dropped: u64,
 }
 
 impl Spool {
@@ -54,7 +54,6 @@ impl Spool {
             deque: VecDeque::new(),
             bytes: 0,
             cap: cap.max(1),
-            dropped: 0,
         }
     }
 
@@ -62,149 +61,241 @@ impl Spool {
         self.bytes = self.bytes.saturating_add(line.len());
         self.deque.push_back(line);
         while self.bytes > self.cap {
-            match self.deque.pop_front() {
-                Some(old) => {
-                    self.bytes = self.bytes.saturating_sub(old.len());
-                    self.dropped = self.dropped.saturating_add(1);
-                }
-                None => break,
-            }
+            let Some(old) = self.deque.pop_front() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(old.len());
+            delivery_metrics::record_drop(1, old.len() as u64);
         }
     }
 
-    /// Take everything queued, resetting the buffer.
-    fn drain(&mut self) -> VecDeque<SpoolLine> {
+    /// Drain at most one target-sized segment, leaving later records queued. A
+    /// single large record is returned whole rather than split.
+    fn drain_segment(&mut self, target_bytes: usize) -> Vec<SpoolLine> {
+        let mut out = Vec::new();
+        let mut bytes = 0usize;
+        while bytes < target_bytes.max(1) {
+            let Some(line) = self.deque.pop_front() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(line.len());
+            bytes = bytes.saturating_add(line.len());
+            out.push(line);
+        }
+        out
+    }
+
+    fn prepend(&mut self, lines: Vec<SpoolLine>) {
+        for line in lines.into_iter().rev() {
+            self.bytes = self.bytes.saturating_add(line.len());
+            self.deque.push_front(line);
+        }
+        while self.bytes > self.cap {
+            let Some(oldest) = self.deque.pop_front() else {
+                break;
+            };
+            self.bytes = self.bytes.saturating_sub(oldest.len());
+            delivery_metrics::record_drop(1, oldest.len() as u64);
+        }
+    }
+
+    fn drop_all(&mut self) {
+        let records = self.deque.len() as u64;
+        let bytes = self.bytes as u64;
+        self.deque.clear();
         self.bytes = 0;
-        std::mem::take(&mut self.deque)
+        if records > 0 {
+            delivery_metrics::record_drop(records, bytes);
+        }
     }
 }
 
-/// The serialized record shape: the completed snapshot plus the owning tenant.
-/// `#[serde(flatten)]` keeps the snapshot's fields at the top level so the JSONL is
-/// a flat object per line (S3 will replace this with the envelope model).
 #[derive(serde::Serialize)]
 struct SinkRecord<'a> {
+    schema_version: u16,
+    writer_incarnation_uuid: &'a str,
+    sequence: u64,
+    event_time_unix_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     tenant: Option<&'a str>,
     #[serde(flatten)]
     snap: &'a IoTraceSnapshot,
 }
 
-/// Live sink handle: the worker's shutdown sender + join handle (for graceful stop).
 struct SinkHandle {
     shutdown: tokio::sync::watch::Sender<bool>,
     join: tokio::task::JoinHandle<()>,
 }
 
 static SINK: OnceLock<Mutex<Option<SinkHandle>>> = OnceLock::new();
+static SINK_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 fn sink_slot() -> &'static Mutex<Option<SinkHandle>> {
     SINK.get_or_init(|| Mutex::new(None))
 }
 
-/// Shared spool handle used by both the observer closure and the worker.
-type SharedSpool = std::sync::Arc<Mutex<Spool>>;
+type SharedSpool = Arc<Mutex<Spool>>;
 
-/// Install the trace-sink observer + spawn its background worker. Idempotent-ish:
-/// a second install replaces the observer and spawns a fresh worker (the previous
-/// handle, if any, is aborted). Call only when the resolved config is `Some`
-/// (enabled). Must run inside a tokio runtime (it is — `ProximaDB::new`).
-pub fn install(cfg: ResolvedIoTraceSinkConfig) {
-    // Best-effort: create the local spool directory up front.
-    if let Err(e) = std::fs::create_dir_all(&cfg.local_dir) {
-        tracing::warn!(
-            "io_trace sink: cannot create local_dir {}: {e}; sink not installed",
-            cfg.local_dir
-        );
-        return;
+/// Install exactly one sink worker. Duplicate installation is rejected without
+/// replacing the observer or aborting the live worker.
+pub fn install(cfg: ResolvedIoTraceSinkConfig) -> Result<(), String> {
+    let mut slot = sink_slot().lock().unwrap_or_else(|p| p.into_inner());
+    if SINK_ACTIVE
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        delivery_metrics::DUPLICATE_INSTALLS_TOTAL.inc();
+        return Err("io_trace sink is already installed".to_string());
     }
 
-    let spool: SharedSpool =
-        std::sync::Arc::new(Mutex::new(Spool::new(cfg.spool_max_bytes as usize)));
+    if let Err(e) = std::fs::create_dir_all(&cfg.local_dir) {
+        SINK_ACTIVE.store(false, Ordering::Release);
+        return Err(format!(
+            "io_trace sink cannot create local_dir {}: {e}",
+            cfg.local_dir
+        ));
+    }
 
-    // S2 (ADR-066 D4): build the object store ONCE (sync `from_url`) when a URI is
-    // configured; on failure, fall back to local-only rather than dropping the sink.
-    let object_store =
-        cfg.object_store_uri
-            .as_deref()
-            .and_then(|uri| match ProximaObjectStore::from_url(uri) {
-                Ok(store) => {
-                    tracing::info!("io_trace sink: dispatching sealed segments to {uri}");
-                    Some(store)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "io_trace sink: object_store_uri {uri} unusable: {e}; local-only"
-                    );
-                    None
-                }
-            });
+    let object_store = match cfg.object_store_uri.as_deref() {
+        Some(uri) => match ProximaObjectStore::from_url(uri) {
+            Ok(store) => Some(store),
+            Err(e) => {
+                SINK_ACTIVE.store(false, Ordering::Release);
+                return Err(format!(
+                    "io_trace sink object_store_uri {uri} is invalid: {e}"
+                ));
+            }
+        },
+        None => None,
+    };
+    let writer_uuid = Uuid::new_v4().to_string();
+    let next_sequence = Arc::new(AtomicU64::new(0));
+    let spool: SharedSpool = Arc::new(Mutex::new(Spool::new(cfg.spool_max_bytes as usize)));
 
-    // Observer: serialize one JSON line (cheap, per-query) and enqueue. No I/O here.
-    let spool_obs = spool.clone();
+    let spool_obs = Arc::clone(&spool);
+    let sequence_obs = Arc::clone(&next_sequence);
+    let writer_obs = writer_uuid.clone();
     io_trace::set_trace_observer(Some(Box::new(move |snap, tenant| {
-        if let Ok(mut line) = serde_json::to_vec(&SinkRecord { tenant, snap }) {
-            line.push(b'\n');
-            spool_obs
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .push(line);
+        let sequence = sequence_obs.fetch_add(1, Ordering::Relaxed);
+        let event_time_unix_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis().min(u64::MAX as u128) as u64)
+            .unwrap_or(0);
+        match serde_json::to_vec(&SinkRecord {
+            schema_version: 1,
+            writer_incarnation_uuid: &writer_obs,
+            sequence,
+            event_time_unix_ms,
+            tenant,
+            snap,
+        }) {
+            Ok(mut bytes) => {
+                bytes.push(b'\n');
+                spool_obs
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(SpoolLine { bytes, sequence });
+            }
+            Err(e) => {
+                delivery_metrics::record_drop(1, 0);
+                tracing::warn!("io_trace sink: record serialization failed: {e}");
+            }
         }
     })));
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    let worker = Worker::new(cfg, spool, object_store);
+    let worker = Worker::new(cfg, spool, object_store, writer_uuid);
     let join = tokio::spawn(worker.run(shutdown_rx));
-
-    let mut slot = sink_slot().lock().unwrap_or_else(|p| p.into_inner());
-    if let Some(prev) = slot.take() {
-        prev.join.abort();
-    }
     *slot = Some(SinkHandle {
         shutdown: shutdown_tx,
         join,
     });
-    tracing::info!("io_trace sink installed (durable per-query trace spool)");
+    tracing::info!("io_trace sink installed (best-effort ingress, crash-aware delivery)");
+    Ok(())
 }
 
-/// Signal the worker to flush + stop, awaiting it with a short timeout. Called from
-/// `ProximaDB::shutdown()` for a graceful final seal. No-op if not installed.
+/// Stop accepting records and request a final delivery cycle. Timing out is
+/// observable and detaches (rather than aborts) the worker so sealed work can
+/// still finish.
 pub async fn shutdown() {
-    let handle = {
-        let mut slot = sink_slot().lock().unwrap_or_else(|p| p.into_inner());
-        slot.take()
-    };
+    let handle = sink_slot().lock().unwrap_or_else(|p| p.into_inner()).take();
     if let Some(handle) = handle {
-        // Clear the observer so no further records are enqueued during drain.
         io_trace::set_trace_observer(None);
         let _ = handle.shutdown.send(true);
         match tokio::time::timeout(Duration::from_secs(5), handle.join).await {
-            Ok(Ok(())) => tracing::info!("io_trace sink flushed and stopped"),
-            Ok(Err(e)) => tracing::warn!("io_trace sink worker join error: {e}"),
-            Err(_) => tracing::warn!("io_trace sink flush timed out (5s)"),
+            Ok(Ok(())) => {
+                SINK_ACTIVE.store(false, Ordering::Release);
+                tracing::info!("io_trace sink flushed and stopped");
+            }
+            Ok(Err(e)) => {
+                SINK_ACTIVE.store(false, Ordering::Release);
+                tracing::warn!("io_trace sink worker join error: {e}");
+            }
+            Err(_) => {
+                delivery_metrics::SHUTDOWN_TIMEOUTS_TOTAL.inc();
+                tracing::warn!("io_trace sink flush timed out (5s); worker left running");
+            }
         }
     }
 }
 
-/// The background worker: drains the spool on an interval, buffering lines into the
-/// current segment, and seals a JSONL+zstd file when the segment reaches
-/// `segment_bytes` OR at each interval tick (whichever first) — bounding both
-/// segment size and latency-to-disk.
+#[derive(Debug, Clone)]
+struct PendingSegment {
+    path: PathBuf,
+    object_filename: String,
+    date: String,
+    digest: String,
+}
+
+impl PendingSegment {
+    fn parse(path: PathBuf) -> Result<Self, String> {
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| "pending filename is not UTF-8".to_string())?;
+        let object_filename = filename
+            .strip_suffix(".pending")
+            .ok_or_else(|| format!("not a pending trace file: {filename}"))?
+            .to_string();
+        let stem = object_filename
+            .strip_suffix(".jsonl.zst")
+            .ok_or_else(|| format!("invalid pending trace suffix: {filename}"))?;
+        let mut parts = stem.rsplitn(4, '-');
+        let digest = parts.next().unwrap_or_default().to_string();
+        let last = parts.next().unwrap_or_default();
+        let first = parts.next().unwrap_or_default();
+        let prefix = parts.next().unwrap_or_default();
+        if digest.len() != 64
+            || !digest.bytes().all(|b| b.is_ascii_hexdigit())
+            || first.parse::<u64>().is_err()
+            || last.parse::<u64>().is_err()
+            || !prefix.starts_with("trace-")
+        {
+            return Err(format!("invalid pending trace identity: {filename}"));
+        }
+        let identity = &prefix["trace-".len()..];
+        let date = identity
+            .get(..10)
+            .filter(|d| d.as_bytes().get(4) == Some(&b'-') && d.as_bytes().get(7) == Some(&b'-'))
+            .ok_or_else(|| format!("invalid pending trace date: {filename}"))?
+            .to_string();
+        Ok(Self {
+            path,
+            object_filename,
+            date,
+            digest,
+        })
+    }
+}
+
 struct Worker {
     cfg: ResolvedIoTraceSinkConfig,
     spool: SharedSpool,
-    current: Vec<u8>,
-    seq: u64,
-    run_nonce: u128,
-    /// Object-store destination for sealed segments (S2). `None` ⇒ local-only.
+    writer_uuid: String,
     object_store: Option<ProximaObjectStore>,
-    /// Access tier for the object-store PUT (S2).
     tier: ObjectAccessTier,
-    /// Object-key prefix for the trace stream — the non-tenant operator root
-    /// (`_operator/io_trace/`), built once via `DrPathBuilder` (keys are never raw).
-    /// A trace segment is intentionally cross-tenant, so it lives under the
-    /// operator control-plane root, not a per-tenant `data/{tenant}/` prefix.
     trace_prefix: String,
+    pending_bytes: u64,
 }
 
 impl Worker {
@@ -212,40 +303,39 @@ impl Worker {
         cfg: ResolvedIoTraceSinkConfig,
         spool: SharedSpool,
         object_store: Option<ProximaObjectStore>,
+        writer_uuid: String,
     ) -> Self {
-        // A per-run nonce so segment filenames never collide across restarts.
-        // Wall-clock is fine in production code (only workflow scripts forbid it).
-        let run_nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
         let tier = cfg.access_tier;
         let trace_prefix = DrPathBuilder::operator_subprefix("io_trace")
             .unwrap_or_else(|_| "_operator/io_trace/".to_string());
         Self {
             cfg,
             spool,
-            current: Vec::new(),
-            seq: 0,
-            run_nonce,
+            writer_uuid,
             object_store,
             tier,
             trace_prefix,
+            pending_bytes: 0,
         }
     }
 
     async fn run(mut self, mut shutdown_rx: tokio::sync::watch::Receiver<bool>) {
+        self.delivery_cycle().await;
         let mut interval = tokio::time::interval(Duration::from_secs(self.cfg.flush_interval_s));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Consume the immediate first tick; startup delivery above already did the work.
+        interval.tick().await;
         loop {
             tokio::select! {
-                _ = interval.tick() => {
-                    self.drain_and_seal().await;
-                }
+                _ = interval.tick() => self.delivery_cycle().await,
                 changed = shutdown_rx.changed() => {
                     if changed.is_err() || *shutdown_rx.borrow() {
-                        // Final drain + seal any remainder, then stop.
-                        self.drain_and_seal().await;
+                        self.delivery_cycle().await;
+                        if self.object_store.is_some()
+                            && self.pending_bytes >= self.cfg.pending_max_bytes
+                        {
+                            self.spool.lock().unwrap_or_else(|p| p.into_inner()).drop_all();
+                        }
                         return;
                     }
                 }
@@ -253,91 +343,309 @@ impl Worker {
         }
     }
 
-    /// Drain the spool into the current segment buffer; seal a full segment whenever
-    /// it crosses `segment_bytes`, then seal the leftover so records never sit longer
-    /// than one interval (called on each interval tick and on final shutdown flush).
-    async fn drain_and_seal(&mut self) {
-        let lines = { self.spool.lock().unwrap_or_else(|p| p.into_inner()).drain() };
-        for line in lines {
-            self.current.extend_from_slice(&line);
-            if self.current.len() as u64 >= self.cfg.segment_bytes {
-                self.seal().await;
-            }
+    async fn delivery_cycle(&mut self) {
+        if self.object_store.is_some() {
+            self.retry_pending().await;
+        } else {
+            self.refresh_pending_metrics().await;
         }
-        // Interval / shutdown seal of the remainder (bounds latency-to-disk).
-        if !self.current.is_empty() {
-            self.seal().await;
+
+        loop {
+            if self.object_store.is_some() && self.pending_bytes >= self.cfg.pending_max_bytes {
+                break;
+            }
+            let lines = self
+                .spool
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .drain_segment(self.cfg.segment_bytes as usize);
+            if lines.is_empty() {
+                break;
+            }
+            if !self.seal(lines).await {
+                break;
+            }
         }
     }
 
-    /// Seal the current buffer into one zstd-compressed segment. Compress off the
-    /// worker thread (`spawn_blocking`), then dispatch: to the object store when
-    /// configured (S2), else to a local file (S1). On an object PUT failure, fall
-    /// back to the local write so a sealed segment is never lost — this is
-    /// best-effort observability that must never block/panic the worker.
-    async fn seal(&mut self) {
-        if self.current.is_empty() {
-            return;
+    /// Returns false when the exact compressed segment would cross the durable
+    /// pending cap. In that case the original lines are returned to ingress.
+    async fn seal(&mut self, lines: Vec<SpoolLine>) -> bool {
+        let records = lines.len() as u64;
+        let first_sequence = lines.first().map(|l| l.sequence).unwrap_or(0);
+        let last_sequence = lines.last().map(|l| l.sequence).unwrap_or(first_sequence);
+        let uncompressed_bytes = lines.iter().map(SpoolLine::len).sum::<usize>() as u64;
+        let mut raw = Vec::with_capacity(uncompressed_bytes as usize);
+        for line in &lines {
+            raw.extend_from_slice(&line.bytes);
         }
-        let buf = std::mem::take(&mut self.current);
-        let seq = self.seq;
-        self.seq += 1;
-
-        // Compress off the worker's async thread.
         let compressed =
-            match tokio::task::spawn_blocking(move || zstd::encode_all(&buf[..], 3)).await {
-                Ok(Ok(c)) => c,
+            match tokio::task::spawn_blocking(move || zstd::encode_all(&raw[..], 3)).await {
+                Ok(Ok(data)) => data,
                 Ok(Err(e)) => {
-                    tracing::warn!("io_trace sink: compress failed: {e}");
-                    return;
+                    delivery_metrics::SEAL_FAILURES_TOTAL.inc();
+                    delivery_metrics::record_drop(records, uncompressed_bytes);
+                    tracing::warn!("io_trace sink: compression failed: {e}");
+                    return true;
                 }
                 Err(e) => {
-                    tracing::warn!("io_trace sink: compress task panicked: {e}");
-                    return;
+                    delivery_metrics::SEAL_FAILURES_TOTAL.inc();
+                    delivery_metrics::record_drop(records, uncompressed_bytes);
+                    tracing::warn!("io_trace sink: compression task failed: {e}");
+                    return true;
                 }
             };
-        let filename = format!("trace-{}-{:08}.jsonl.zst", self.run_nonce, seq);
+        let digest = digest_hex(&compressed);
+        let date = Utc::now().format("%Y-%m-%d").to_string();
+        let filename = format!(
+            "trace-{date}-{}-{first_sequence:020}-{last_sequence:020}-{digest}.jsonl.zst",
+            self.writer_uuid
+        );
 
-        // S2: PUT to the object store at the access tier; local fallback on failure.
-        if let Some(store) = &self.object_store {
-            let key = format!("{}{}", self.trace_prefix, filename);
-            // `Bytes::clone` is an O(1) refcount bump (shared buffer), so keeping a
-            // copy for the fallback costs no data copy on the happy path.
-            let bytes = Bytes::from(compressed);
-            match store
-                .put_with_tier(&ObjectPath::from(key.clone()), bytes.clone(), self.tier)
-                .await
+        if self.object_store.is_some() {
+            if self.pending_bytes.saturating_add(compressed.len() as u64)
+                > self.cfg.pending_max_bytes
             {
-                Ok(()) => return,
+                self.spool
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .prepend(lines);
+                return false;
+            }
+            let pending = match self.persist_pending(&filename, compressed).await {
+                Ok(pending) => pending,
                 Err(e) => {
-                    tracing::warn!(
-                        "io_trace sink: object PUT {key} failed: {e}; writing local fallback"
-                    );
-                    self.write_local(&filename, bytes.to_vec()).await;
-                    return;
+                    delivery_metrics::SEAL_FAILURES_TOTAL.inc();
+                    delivery_metrics::record_drop(records, uncompressed_bytes);
+                    tracing::warn!("io_trace sink: durable pending seal failed: {e}");
+                    return true;
                 }
+            };
+            self.refresh_pending_metrics().await;
+            self.upload_pending(pending, false).await;
+        } else if let Err(e) = self.write_local_final(&filename, compressed).await {
+            delivery_metrics::SEAL_FAILURES_TOTAL.inc();
+            delivery_metrics::record_drop(records, uncompressed_bytes);
+            tracing::warn!("io_trace sink: immutable local seal failed: {e}");
+        }
+        true
+    }
+
+    async fn persist_pending(
+        &self,
+        filename: &str,
+        data: Vec<u8>,
+    ) -> Result<PendingSegment, String> {
+        let path = Path::new(&self.cfg.local_dir).join(format!("{filename}.pending"));
+        let path_for_write = path.clone();
+        tokio::task::spawn_blocking(move || write_immutable(&path_for_write, &data))
+            .await
+            .map_err(|e| e.to_string())??;
+        PendingSegment::parse(path)
+    }
+
+    async fn write_local_final(&self, filename: &str, data: Vec<u8>) -> Result<(), String> {
+        let path = Path::new(&self.cfg.local_dir).join(filename);
+        tokio::task::spawn_blocking(move || write_immutable(&path, &data))
+            .await
+            .map_err(|e| e.to_string())?
+    }
+
+    async fn retry_pending(&mut self) {
+        let mut pending = self.inventory_pending().await;
+        pending.sort_by(|a, b| a.object_filename.cmp(&b.object_filename));
+        for segment in pending {
+            self.upload_pending(segment, true).await;
+        }
+        self.refresh_pending_metrics().await;
+    }
+
+    async fn upload_pending(&mut self, pending: PendingSegment, retry: bool) {
+        let Some(store) = self.object_store.clone() else {
+            return;
+        };
+        if retry {
+            delivery_metrics::UPLOAD_RETRIES_TOTAL.inc();
+        }
+        let path = pending.path.clone();
+        let data = match tokio::task::spawn_blocking(move || std::fs::read(path)).await {
+            Ok(Ok(data)) => data,
+            Ok(Err(e)) => {
+                delivery_metrics::UPLOAD_FAILURES_TOTAL.inc();
+                tracing::warn!("io_trace sink: pending read failed: {e}");
+                return;
+            }
+            Err(e) => {
+                delivery_metrics::UPLOAD_FAILURES_TOTAL.inc();
+                tracing::warn!("io_trace sink: pending read task failed: {e}");
+                return;
+            }
+        };
+        if digest_hex(&data) != pending.digest {
+            delivery_metrics::UPLOAD_FAILURES_TOTAL.inc();
+            tracing::error!(
+                "io_trace sink: pending digest mismatch; refusing upload: {}",
+                pending.path.display()
+            );
+            return;
+        }
+
+        let key = format!(
+            "{}{}/{}",
+            self.trace_prefix, pending.date, pending.object_filename
+        );
+        let object_path = ObjectPath::from(key.clone());
+        let verified = match store
+            .put_if_absent_with_tier(&object_path, Bytes::from(data), self.tier)
+            .await
+        {
+            Ok(()) => true,
+            Err(StorageError::AlreadyExists(_)) => match store.get(&object_path).await {
+                Ok(existing) if digest_hex(&existing) == pending.digest => true,
+                Ok(_) => {
+                    tracing::error!("io_trace sink: object collision has different content: {key}");
+                    false
+                }
+                Err(e) => {
+                    tracing::warn!("io_trace sink: cannot verify existing object {key}: {e}");
+                    false
+                }
+            },
+            Err(e) => {
+                tracing::warn!("io_trace sink: conditional object PUT {key} failed: {e}");
+                false
+            }
+        };
+        if !verified {
+            delivery_metrics::UPLOAD_FAILURES_TOTAL.inc();
+            return;
+        }
+
+        delivery_metrics::record_delivery_success();
+        let retire = pending.path.clone();
+        match tokio::task::spawn_blocking(move || std::fs::remove_file(retire)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(
+                "io_trace sink: verified object but pending retirement failed (safe to retry): {e}"
+            ),
+            Err(e) => tracing::warn!("io_trace sink: pending retirement task failed: {e}"),
+        }
+        self.refresh_pending_metrics().await;
+    }
+
+    async fn inventory_pending(&self) -> Vec<PendingSegment> {
+        let dir = self.cfg.local_dir.clone();
+        match tokio::task::spawn_blocking(move || inventory_pending_sync(Path::new(&dir))).await {
+            Ok(items) => items,
+            Err(e) => {
+                tracing::warn!("io_trace sink: pending inventory task failed: {e}");
+                Vec::new()
             }
         }
-
-        // S1 path (no object store configured): local file only.
-        self.write_local(&filename, compressed).await;
     }
 
-    /// Write one sealed segment to the local spool dir (S1 destination + the S2
-    /// object-store fallback). Runs the blocking `fs::write` off the worker thread.
-    async fn write_local(&self, filename: &str, data: Vec<u8>) {
-        let path = format!("{}/{}", self.cfg.local_dir.trim_end_matches('/'), filename);
-        match tokio::task::spawn_blocking(move || std::fs::write(&path, data)).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::warn!("io_trace sink: segment write failed: {e}"),
-            Err(e) => tracing::warn!("io_trace sink: seal task panicked: {e}"),
+    async fn refresh_pending_metrics(&mut self) {
+        let dir = self.cfg.local_dir.clone();
+        let (files, bytes) = tokio::task::spawn_blocking(move || pending_usage(Path::new(&dir)))
+            .await
+            .unwrap_or((0, 0));
+        self.pending_bytes = bytes;
+        delivery_metrics::set_pending(files, bytes);
+    }
+}
+
+fn digest_hex(data: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(data))
+}
+
+/// Commit immutable bytes with create-only semantics. A fully synced hidden temp
+/// file is atomically linked into the visible name; an existing identical file is
+/// an idempotent success, while different bytes fail closed.
+fn write_immutable(path: &Path, data: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "immutable filename is not UTF-8".to_string())?;
+    let temp = parent.join(format!(".{file_name}.{}.tmp", Uuid::new_v4()));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .map_err(|e| e.to_string())?;
+    if let Err(e) = file.write_all(data).and_then(|_| file.sync_all()) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(e.to_string());
+    }
+    drop(file);
+    match std::fs::hard_link(&temp, path) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&temp);
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let existing = std::fs::read(path).map_err(|read| read.to_string());
+            let _ = std::fs::remove_file(&temp);
+            match existing {
+                Ok(existing) if existing == data => Ok(()),
+                Ok(_) => Err(format!(
+                    "immutable path already exists with different content: {}",
+                    path.display()
+                )),
+                Err(read) => Err(read),
+            }
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp);
+            Err(e.to_string())
         }
     }
+}
+
+fn inventory_pending_sync(dir: &Path) -> Vec<PendingSegment> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.to_string_lossy().ends_with(".jsonl.zst.pending"))
+        .filter_map(|path| match PendingSegment::parse(path) {
+            Ok(segment) => Some(segment),
+            Err(e) => {
+                delivery_metrics::UPLOAD_FAILURES_TOTAL.inc();
+                tracing::error!("io_trace sink: invalid pending file left in place: {e}");
+                None
+            }
+        })
+        .collect()
+}
+
+fn pending_usage(dir: &Path) -> (u64, u64) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, 0);
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.to_string_lossy().ends_with(".pending"))
+        .fold((0u64, 0u64), |(files, bytes), path| {
+            let len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+            (files.saturating_add(1), bytes.saturating_add(len))
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static INSTALL_TEST_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 
     fn cfg(dir: &str, seg: u64, spool: u64) -> ResolvedIoTraceSinkConfig {
         ResolvedIoTraceSinkConfig {
@@ -345,6 +653,7 @@ mod tests {
             segment_bytes: seg,
             flush_interval_s: 1,
             spool_max_bytes: spool,
+            pending_max_bytes: 1 << 20,
             compression: "zstd".to_string(),
             format: "jsonl".to_string(),
             object_store_uri: None,
@@ -352,182 +661,221 @@ mod tests {
         }
     }
 
+    fn line(sequence: u64, bytes: &[u8]) -> SpoolLine {
+        SpoolLine {
+            bytes: bytes.to_vec(),
+            sequence,
+        }
+    }
+
+    fn tempdir(label: &str) -> tempfile::TempDir {
+        tempfile::Builder::new().prefix(label).tempdir().unwrap()
+    }
+
+    fn trace_files_recursive(root: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let mut dirs = vec![root.to_path_buf()];
+        while let Some(dir) = dirs.pop() {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                } else if path.to_string_lossy().ends_with(".jsonl.zst") {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
     #[test]
     fn spool_drops_oldest_on_overflow() {
-        let mut s = Spool::new(10); // 10-byte cap
-        s.push(b"aaaa".to_vec()); // 4
-        s.push(b"bbbb".to_vec()); // 8
-        s.push(b"cccc".to_vec()); // 12 > 10 → drop oldest "aaaa"
-        assert_eq!(s.dropped, 1);
-        assert!(s.bytes <= 10);
-        let drained: Vec<_> = s.drain().into_iter().collect();
-        assert_eq!(drained, vec![b"bbbb".to_vec(), b"cccc".to_vec()]);
-        assert_eq!(s.bytes, 0);
-    }
-
-    #[tokio::test]
-    async fn worker_seals_jsonl_zstd_and_round_trips() {
-        let dir = std::env::temp_dir().join(format!(
-            "iotrace_sink_test_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let dir_s = dir.to_string_lossy().to_string();
-
-        let spool: SharedSpool = std::sync::Arc::new(Mutex::new(Spool::new(1 << 20)));
-        // Enqueue two JSON records directly (bypassing the observer for determinism).
-        {
-            let mut g = spool.lock().unwrap();
-            g.push(b"{\"query_id\":\"q1\",\"range_gets\":3}\n".to_vec());
-            g.push(b"{\"query_id\":\"q2\",\"range_gets\":5}\n".to_vec());
-        }
-        let mut worker = Worker::new(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20), spool, None);
-        worker.drain_and_seal().await;
-
-        // Exactly one sealed segment; decompress → two JSONL lines round-trip.
-        let mut segs: Vec<_> = std::fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.to_string_lossy().ends_with(".jsonl.zst"))
-            .collect();
-        segs.sort();
-        assert_eq!(segs.len(), 1, "one segment sealed");
-        let compressed = std::fs::read(&segs[0]).unwrap();
-        let decoded = zstd::decode_all(&compressed[..]).unwrap();
-        let text = String::from_utf8(decoded).unwrap();
-        let lines: Vec<&str> = text.lines().collect();
-        assert_eq!(lines.len(), 2);
-        assert!(lines[0].contains("\"query_id\":\"q1\""));
-        assert!(lines[1].contains("\"query_id\":\"q2\""));
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// End-to-end (no server): install the sink → run instrumented queries →
-    /// graceful shutdown → a JSONL+zstd segment lands on disk carrying the minted
-    /// `query_id`. Exercises the full observer → spool → worker → seal wiring.
-    #[tokio::test]
-    async fn install_instrument_shutdown_writes_segment_with_query_id() {
-        use crate::observability::io_trace;
-        let dir = std::env::temp_dir().join(format!("iotrace_sink_e2e_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        let dir_s = dir.to_string_lossy().to_string();
-
-        install(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20));
-        // Two non-empty instrumented queries → two enqueued records.
-        for _ in 0..2 {
-            io_trace::instrument(Some("acme".to_string()), "test", async {
-                io_trace::record_bytes_read(128);
-            })
-            .await;
-        }
-        // Graceful shutdown drains + seals the buffered records.
-        shutdown().await;
-
-        let segs: Vec<_> = std::fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.to_string_lossy().ends_with(".jsonl.zst"))
-            .collect();
-        assert_eq!(segs.len(), 1, "one segment sealed on shutdown: {segs:?}");
-        let text =
-            String::from_utf8(zstd::decode_all(&std::fs::read(&segs[0]).unwrap()[..]).unwrap())
-                .unwrap();
-        let lines: Vec<&str> = text.lines().collect();
-        assert_eq!(lines.len(), 2, "both queries recorded");
-        assert!(
-            lines
-                .iter()
-                .all(|l| l.contains("\"query_id\"") && l.contains("\"tenant\":\"acme\"")),
-            "each record carries query_id + tenant: {text}"
-        );
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// S2: with `object_store_uri` set (a `file://` store), the sealed segment is
-    /// PUT to the object store under the `DrPathBuilder` operator key
-    /// (`_operator/io_trace/…`) — NOT the local dir. Exercises the S2 dispatch path
-    /// on every PR without an emulator (`put_with_tier` degrades to a plain put on
-    /// `file://`, so the Cold tier is a no-op locally).
-    #[tokio::test]
-    async fn install_instrument_shutdown_uploads_segment_to_object_store() {
-        use crate::observability::io_trace;
-        let base = std::env::temp_dir().join(format!(
-            "iotrace_sink_obj_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        let store_dir = base.join("objstore");
-        let local_dir = base.join("local");
-        std::fs::create_dir_all(&store_dir).unwrap();
-        let uri = format!("file://{}", store_dir.display());
-
-        let mut c = cfg(&local_dir.to_string_lossy(), 4 * 1024 * 1024, 1 << 20);
-        c.object_store_uri = Some(uri);
-        install(c);
-        for _ in 0..2 {
-            io_trace::instrument(Some("acme".to_string()), "test", async {
-                io_trace::record_bytes_read(128);
-            })
-            .await;
-        }
-        shutdown().await;
-
-        // The object landed under {store_dir}/_operator/io_trace/, decoding to the
-        // two records — not the local dir.
-        let obj_dir = store_dir.join("_operator").join("io_trace");
-        let segs: Vec<_> = std::fs::read_dir(&obj_dir)
-            .unwrap_or_else(|e| panic!("no _operator/io_trace under the store ({e}): {obj_dir:?}"))
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.to_string_lossy().ends_with(".jsonl.zst"))
-            .collect();
+        let before = delivery_metrics::RECORDS_DROPPED_TOTAL.get();
+        let mut spool = Spool::new(10);
+        spool.push(line(0, b"aaaa"));
+        spool.push(line(1, b"bbbb"));
+        spool.push(line(2, b"cccc"));
+        assert_eq!(spool.bytes, 8);
+        assert_eq!(delivery_metrics::RECORDS_DROPPED_TOTAL.get(), before + 1);
         assert_eq!(
-            segs.len(),
-            1,
-            "one segment PUT to the object store: {segs:?}"
+            spool.drain_segment(100),
+            vec![line(1, b"bbbb"), line(2, b"cccc")]
         );
-        let text =
-            String::from_utf8(zstd::decode_all(&std::fs::read(&segs[0]).unwrap()[..]).unwrap())
-                .unwrap();
-        let lines: Vec<&str> = text.lines().collect();
-        assert_eq!(lines.len(), 2, "both queries recorded");
-        assert!(
-            lines
-                .iter()
-                .all(|l| l.contains("\"query_id\"") && l.contains("\"tenant\":\"acme\"")),
-            "each record carries query_id + tenant: {text}"
-        );
-        // Local dir received nothing (the object store was the destination).
-        let local_segs = std::fs::read_dir(&local_dir)
-            .map(|rd| {
-                rd.filter_map(|e| e.ok())
-                    .filter(|e| e.path().to_string_lossy().ends_with(".jsonl.zst"))
-                    .count()
-            })
-            .unwrap_or(0);
-        assert_eq!(local_segs, 0, "object store was the destination, not local");
-        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]
-    async fn empty_drain_writes_no_segment() {
-        let dir = std::env::temp_dir().join(format!("iotrace_sink_empty_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let dir_s = dir.to_string_lossy().to_string();
-        let spool: SharedSpool = std::sync::Arc::new(Mutex::new(Spool::new(1 << 20)));
-        let mut worker = Worker::new(cfg(&dir_s, 4 * 1024 * 1024, 1 << 20), spool, None);
-        worker.drain_and_seal().await;
-        let n = std::fs::read_dir(&dir).unwrap().count();
-        assert_eq!(n, 0, "no segment written for an empty drain");
-        let _ = std::fs::remove_dir_all(&dir);
+    async fn local_segment_round_trips_with_digest_identity() {
+        let dir = tempdir("iotrace-local-");
+        let spool = Arc::new(Mutex::new(Spool::new(1 << 20)));
+        {
+            let mut guard = spool.lock().unwrap();
+            guard.push(line(7, b"{\"query_id\":\"q1\"}\n"));
+            guard.push(line(8, b"{\"query_id\":\"q2\"}\n"));
+        }
+        let mut worker = Worker::new(
+            cfg(&dir.path().to_string_lossy(), 1 << 20, 1 << 20),
+            spool,
+            None,
+            Uuid::new_v4().to_string(),
+        );
+        worker.delivery_cycle().await;
+        let files = trace_files_recursive(dir.path());
+        assert_eq!(files.len(), 1);
+        let text =
+            String::from_utf8(zstd::decode_all(&std::fs::read(&files[0]).unwrap()[..]).unwrap())
+                .unwrap();
+        assert_eq!(text.lines().count(), 2);
+        assert!(files[0].to_string_lossy().contains("00000000000000000007"));
+        assert!(files[0].to_string_lossy().contains("00000000000000000008"));
+    }
+
+    #[tokio::test]
+    async fn startup_retry_delivers_once_and_retires_pending() {
+        let base = tempdir("iotrace-retry-");
+        let local = base.path().join("local");
+        let objects = base.path().join("objects");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::create_dir_all(&objects).unwrap();
+        let store = ProximaObjectStore::from_url(&format!("file://{}", objects.display())).unwrap();
+        let spool = Arc::new(Mutex::new(Spool::new(1024)));
+        let mut worker = Worker::new(
+            cfg(&local.to_string_lossy(), 1024, 1024),
+            spool,
+            Some(store),
+            Uuid::new_v4().to_string(),
+        );
+        let compressed = zstd::encode_all(&b"{\"query_id\":\"q\"}\n"[..], 3).unwrap();
+        let digest = digest_hex(&compressed);
+        let name = format!(
+            "trace-2026-07-18-{}-{:020}-{:020}-{digest}.jsonl.zst",
+            worker.writer_uuid, 0, 0
+        );
+        let pending = worker.persist_pending(&name, compressed).await.unwrap();
+        assert!(pending.path.exists());
+
+        worker.retry_pending().await;
+        assert!(!pending.path.exists());
+        assert_eq!(trace_files_recursive(&objects).len(), 1);
+        worker.retry_pending().await;
+        assert_eq!(trace_files_recursive(&objects).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn already_exists_with_different_content_fails_closed() {
+        let base = tempdir("iotrace-collision-");
+        let local = base.path().join("local");
+        let objects = base.path().join("objects");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::create_dir_all(&objects).unwrap();
+        let store = ProximaObjectStore::from_url(&format!("file://{}", objects.display())).unwrap();
+        let mut worker = Worker::new(
+            cfg(&local.to_string_lossy(), 1024, 1024),
+            Arc::new(Mutex::new(Spool::new(1024))),
+            Some(store.clone()),
+            Uuid::new_v4().to_string(),
+        );
+        let compressed = zstd::encode_all(&b"correct\n"[..], 3).unwrap();
+        let digest = digest_hex(&compressed);
+        let name = format!(
+            "trace-2026-07-18-{}-{:020}-{:020}-{digest}.jsonl.zst",
+            worker.writer_uuid, 4, 4
+        );
+        let pending = worker.persist_pending(&name, compressed).await.unwrap();
+        let key = ObjectPath::from(format!("_operator/io_trace/2026-07-18/{name}"));
+        store
+            .put_if_absent(&key, Bytes::from_static(b"different"))
+            .await
+            .unwrap();
+
+        worker.upload_pending(pending.clone(), true).await;
+        assert!(
+            pending.path.exists(),
+            "unverified pending must be preserved"
+        );
+        assert_eq!(&store.get(&key).await.unwrap()[..], b"different");
+    }
+
+    #[tokio::test]
+    async fn pending_cap_preserves_sealed_file_and_stops_ingress_drain() {
+        let base = tempdir("iotrace-cap-");
+        let local = base.path().join("local");
+        let objects = base.path().join("objects");
+        std::fs::create_dir_all(&local).unwrap();
+        std::fs::create_dir_all(&objects).unwrap();
+        let store = ProximaObjectStore::from_url(&format!("file://{}", objects.display())).unwrap();
+        let spool = Arc::new(Mutex::new(Spool::new(1024)));
+        spool.lock().unwrap().push(line(9, b"queued\n"));
+        let mut config = cfg(&local.to_string_lossy(), 1024, 1024);
+        config.pending_max_bytes = 1;
+        let mut worker = Worker::new(
+            config,
+            Arc::clone(&spool),
+            Some(store.clone()),
+            Uuid::new_v4().to_string(),
+        );
+        let compressed = zstd::encode_all(&b"sealed\n"[..], 3).unwrap();
+        let digest = digest_hex(&compressed);
+        let name = format!(
+            "trace-2026-07-18-{}-{:020}-{:020}-{digest}.jsonl.zst",
+            worker.writer_uuid, 1, 1
+        );
+        let pending = worker.persist_pending(&name, compressed).await.unwrap();
+        let key = ObjectPath::from(format!("_operator/io_trace/2026-07-18/{name}"));
+        store
+            .put_if_absent(&key, Bytes::from_static(b"collision"))
+            .await
+            .unwrap();
+
+        worker.delivery_cycle().await;
+        assert!(
+            pending.path.exists(),
+            "sealed pending data is never evicted"
+        );
+        assert_eq!(spool.lock().unwrap().bytes, b"queued\n".len());
+    }
+
+    #[tokio::test]
+    async fn install_shutdown_emits_record_identity() {
+        let _guard = INSTALL_TEST_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        let dir = tempdir("iotrace-e2e-");
+        install(cfg(&dir.path().to_string_lossy(), 1 << 20, 1 << 20)).unwrap();
+        io_trace::instrument(Some("acme".to_string()), "test", async {
+            io_trace::record_bytes_read(128);
+        })
+        .await;
+        shutdown().await;
+        let files = trace_files_recursive(dir.path());
+        assert_eq!(files.len(), 1);
+        let text =
+            String::from_utf8(zstd::decode_all(&std::fs::read(&files[0]).unwrap()[..]).unwrap())
+                .unwrap();
+        assert!(text.contains("\"schema_version\":1"));
+        assert!(text.contains("\"writer_incarnation_uuid\""));
+        assert!(text.contains("\"sequence\":0"));
+        assert!(text.contains("\"tenant\":\"acme\""));
+        assert!(!text.contains("vector"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_install_is_rejected_without_aborting_live_worker() {
+        let _guard = INSTALL_TEST_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        let first = tempdir("iotrace-first-");
+        let second = tempdir("iotrace-second-");
+        install(cfg(&first.path().to_string_lossy(), 1024, 1024)).unwrap();
+        assert!(install(cfg(&second.path().to_string_lossy(), 1024, 1024)).is_err());
+        io_trace::instrument(None, "test", async { io_trace::record_bytes_read(1) }).await;
+        shutdown().await;
+        assert_eq!(trace_files_recursive(first.path()).len(), 1);
+        assert!(trace_files_recursive(second.path()).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- durably seal immutable pending JSONL+zstd segments before object upload
- retry pending segments on startup using writer UUID, monotonic sequence ranges, and SHA-256 object identity
- conditionally create tiered objects and verify digest on AlreadyExists before retiring local state
- enforce a hard pending-byte cap without deleting sealed data, expose delivery metrics, and reject duplicate installs without aborting a live worker
- reject unsupported active sink configuration at database startup
- reconcile ADR-066 and TD-TRACE-2 with current implementation reality

## First-principles invariants

- no filesystem, compression, or network I/O enters the query path
- the pending file is the durable handoff; it is retired only after verified object delivery
- retries are idempotent and collisions with different bytes fail closed
- pending capacity never evicts sealed data; ingress remains bounded and explicitly best-effort
- billing remains separate and untouched

## Verification

- cargo test --lib observability::io_trace_sink::tests -- --test-threads=1
- cargo test --lib core::config::queue_config_tests::io_trace_sink -- --test-threads=1
- cargo test -p proximadb-object-store put_if_absent -- --nocapture
- cargo fmt --all -- --check
- git diff --check

## Remaining ADR-066 gates

ADR-066 remains Proposed. Representative hot-path cost evidence, structural operator and tenant-root governance integration, the S3 versioned modality envelope, and S4 Iceberg-managed Parquet commit and watermark behavior remain subsequent work.