### PR TITLE
test(rdstrat): reconcile shipped bytes phase

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc
@@ -8,16 +8,14 @@
 | Field | Value
 
 | Status
-| **Lossy bake-off rejected (2026-07-16); lossless redesign active.**
-  Residual SQ6 was the only compact arm to clear recall at N=100k, but saved only
-  7.0% query bytes and was 3.4x slower. TurboQuant4 and multi-bit RaBitQ4 missed
-  recall by about six points. At genuine N=1M, flat SQ8 itself measured recall
-  `0.968` and `61` GETs/query; SQ6 fell to `0.950`. No codec/footer-v2 writer from
-  this bake-off ships. Quantization is the only permitted lossy boundary. The
-  redesign losslessly compresses the selected representation (SQ8 codes or exact
-  f32 bits), so decode reproduces it bit-for-bit; it never adds residual
-  quantization error. Adapt survivor M, wire `IopsBudget`, and scale the cluster
-  producer in parallel with this independently testable bytes lever.
+| **Partially resolved by #1064 (2026-07-17).** Footer v2, the shared exact
+  clustered-SQ8 transform, and scalar all-null/LZ4 encoding shipped default OFF.
+  The scalar arm cleared the end-to-end bytes gate (`32,020,233 -> 25,067,186`
+  bytes/query, -21.7%) with recall `0.991`, 19 GETs/query, and no p95 regression.
+  The clustered vector transform remains evidence-gated; ADR-065/#1069 hoisted
+  SQ8 into Region B for the default coalesced path, superseding inline-block SQ8
+  compression as that path's dominant lever. Exact-f32 compression and shared
+  ProximaBlocks adoption remain open and must follow current region evidence.
 
 | Severity
 | High — PR1 measured `bytes_read/query = 31.7 MB` at recall@10 `0.984` and
@@ -74,7 +72,14 @@ locality all contribute to the actual route-cost term.
 
 The 2026-07-16 equal-protocol bake-off and full N=1M follow-up are recorded in
 link:../../_internal/status/RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc[the dated evidence].
-No arm met this definition of done.
+No lossy bake-off arm met this definition of done.
+
+The subsequent lossless scalar arm did meet the bytes sub-gate and shipped in
+#1064. Its dated evidence is
+link:../../_internal/status/RDSTRAT7_LOSSLESS_SCALAR_BYTES_SIFT_2026_07_16.adoc[TD-RDSTRAT-7 lossless scalar bytes]
+and ledger claim `rdstrat7_lossless_scalar_bytes_sift`. ADR-065/#1069 later
+hoisted SQ8 into Region B, so future vector-byte measurements use the region
+layout rather than treating the pre-Region-B block baseline as current.
 
 == Settled constraints inherited from ADR-062
 
@@ -566,13 +571,21 @@ only when a supported stripe and cluster plan are present. Otherwise the writer
 emits the existing raw f32/SQ8 representation and declares no transform or byte
 compression in the encoding map.
 
+Scalar all-null elision and post-codec LZ4 use the independent
+`PROXIMADB_PAX_LOSSLESS_SCALAR=1` gate, also default OFF. This is the accepted
+#1064 bytes arm. `ColumnMeta` declares LZ4 in-place; realized non-wins remain
+flat, and all-null pages are declared by `null_count == row_count` with an empty
+payload. No additional lossy boundary or nested format version is introduced.
+
 Fallback is selected independently per micro-chunk for missing plans,
 inconsistent dimensions, undersized runs, unsupported compressor, or
 insufficient realized savings. Once a block explicitly declares a transform or
 compressor, decode errors fail closed; the reader does not guess raw/SQ8 bytes.
 
-The lossless encoding remains OFF until its bitwise, bytes, CPU, and latency
-gates are accepted. It does not change the coalesced-RaBitQ default.
+Both encodings remain default OFF. The scalar arm has accepted bitwise and
+end-to-end evidence; the clustered vector arm remains off pending evidence on a
+layout where it is still load-bearing. Neither changes the coalesced-RaBitQ or
+ADR-065 Region-B defaults.
 
 == TDD implementation sequence
 
@@ -647,9 +660,11 @@ survivor-block codec and is not tuned in the bytes PR.
 * All repository format, clippy/check, server-binary, TD uniqueness, attribution,
   and work-commit guards pass before the implementation PR targets `develop`.
 
-The 2026-07-16 bake-off satisfies the evidence requirement but **does not
-satisfy the acceptance gates**. The TD remains active; none of the prototype
-codec tags or footer-v2 writes are accepted for production.
+The lossy 2026-07-16 bake-off remains rejected. The later lossless #1064 scalar
+arm **does satisfy the bytes sub-gate** and its footer-v2/shared-codec foundation
+ships default OFF. This TD remains partially open for evidence-gated exact-f32
+compression and shared ProximaBlocks adoption; clustered inline SQ8 is not a
+priority on ADR-065's default coalesced Region-B path.
 
 == History
 
@@ -667,3 +682,9 @@ codec tags or footer-v2 writes are accepted for production.
   lossy boundary. Replaced residual quantization with shared lossless
   clustered-FOR/SQ8-code and exact base-XOR/f32 transforms plus optional
   lossless byte compression, each selected by realized total bytes.
+* 2026-07-17 — #1064 shipped footer v2, the default-OFF clustered SQ8 transform,
+  and the independently gated scalar all-null/LZ4 arm. The scalar arm cleared
+  the bytes gate by 21.7% at unchanged recall/GETs/p95.
+* 2026-07-17 — ADR-065/#1069 hoisted SQ8 into Region B on the default coalesced
+  layout. Remaining vector-byte work follows the region roadmap: selective
+  Region-A/B probing (TD-RDSTRAT-8) first; exact Region C only with evidence.

--- a/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
+++ b/docs/12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc
@@ -321,6 +321,17 @@ recall `0.921` and `0.917`. At genuine N=1M the flat control itself fell to reca
 durable tag. Its evidence sizes survivor and geometry prerequisites; it does not authorize
 another lossy storage tier.
 
+**Implementation reconciliation (2026-07-17).** #1064 shipped the footer-v2 and
+shared-codec foundation plus an independently gated, lossless scalar arm. Scalar
+all-null elision and post-codec LZ4 reduced the same SIFT N=100k end-to-end
+counter from `32,020,233` to `25,067,186` bytes/query (-21.7%) at recall `0.991`,
+19 GETs/query, and unchanged p95. The clustered SQ8 transform also shipped
+default OFF but has no accepted end-to-end win. ADR-065/#1069 subsequently
+hoisted SQ8 into Region B on the default coalesced layout, so Region-B density
+and selective probing supersede inline-block SQ8 compression there. D8 remains
+applicable to scalar fields, non-coalesced layouts, and a future exact-f32
+Region C only when their own evidence gates pass.
+
 The N=1M result measures two prerequisites to D6/D8. Top-M is fixed at 1,000 for top-10
 regardless of segment rows; it shrinks from 1% of N=100k to 0.1% of N=1M and must become a
 measured segment-scale/confidence rule. `IopsBudget` exists, but PAX still cuts at a 3 MiB
@@ -416,10 +427,12 @@ leaving RaBitQ at the header.
 * **TD-RDSTRAT-7 bytes ratchet:** same end-to-end protocol, recall@10 `>= 0.98`, no material
   GET regression, bytes/query materially below `31.7 MB`, lower persisted bytes, and no material
   release-profile decode-CPU or p95 latency regression. Codec-only ratios are diagnostic.
-* **N=1M scale ratchet (measured 2026-07-16, currently failing):** flat SQ8
+* **N=1M scale ratchet (historical failure, restored by #1060):** flat SQ8
   recall@10 `0.968`, `61` GETs/query, `138,851,704` bytes/query. Restore
   recall/GET via adaptive M and actual-byte block geometry before accepting
-  another bytes codec. Evidence: `RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc`.
+  another bytes codec. #1060 subsequently measured recall `0.990` and 36
+  GETs/query; ADR-065/#1069 then replaced inline SQ8 block fetches with Region B.
+  Evidence: `RDSTRAT6_BYTES_BAKEOFF_SIFT_2026_07_16.adoc` and ADR-065.
 * Compaction test: N→1 merge yields fewer RaBitQ GETs/query + re-clustered tighter locality.
 
 == Initial open questions and resolution

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -103,7 +103,7 @@ asserted_in = [
   "docs/10-quality/td/TD-RDSTRAT-7-lossless-clustered-pax-bytes.adoc",
 ]
 bench_source = "tests/sift_pax_recall_ratchet_test.rs"
-bench_command = "OFF (control): PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture; ON (scalar LZ4): prepend PROXIMADB_PAX_LOSSLESS_SCALAR=1"
+bench_command = "OFF (control): PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 PROXIMADB_SIFT_QUERIES=100 cargo test --release --test sift_pax_recall_ratchet_test sift_coalesced_rabitq_scan_rerank_eval -- --ignored --nocapture; ON (scalar LZ4): prepend PROXIMADB_PAX_LOSSLESS_SCALAR=1 PROXIMADB_SIFT_COALESCED_BYTE_BUDGET=26000000"
 artifact = "docs/_internal/status/RDSTRAT7_LOSSLESS_SCALAR_BYTES_SIFT_2026_07_16.adoc"
 hardware = "Local macOS arm64 (Apple Silicon), serialized release runs, no competing workload"
 date = "2026-07-16"

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -19,6 +19,7 @@
 //!   - `sift_base.fvecs`       (1 000 000 × 128)  — insert set
 //!   - `sift_query.fvecs`      (10 000 × 128)     — query set
 //!   - `sift_groundtruth.ivecs`(10 000 × 100)     — true neighbours (full 1M only)
+//!
 //! Download (qa-gate `sift-pax-recall` job or local):
 //! ```text
 //! curl -L -O https://huggingface.co/datasets/qbo-odp/sift1m/resolve/main/<file>
@@ -30,6 +31,8 @@
 //!                                CI floor); unset → full 1M + provided GT
 //!   PROXIMADB_SIFT_QUERIES       cap the query count (default 1000)
 //!   PROXIMADB_SIFT_RECALL_FLOOR  ratchet threshold (default 0.90)
+//!   PROXIMADB_SIFT_COALESCED_BYTE_BUDGET optional bytes/query ceiling for the
+//!                                coalesced end-to-end eval (unset = report only)
 //!   PROXIMADB_RECALL_DATASET_REQUIRED fail instead of skip when corpus is absent
 //!
 //! nextest isolates each test in its own process, so the PAX env vars set here
@@ -537,6 +540,10 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|n| *n > 0)
         .unwrap_or(60);
+    let byte_budget: Option<u64> = std::env::var("PROXIMADB_SIFT_COALESCED_BYTE_BUDGET")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0);
 
     let base = read_vec_records_f32(&base_path, subset_n).expect("read sift_base.fvecs");
     let n = base.len();
@@ -713,4 +720,10 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
         per_q_gets < get_budget,
         "coalesced range_gets/query = {per_q_gets} >= budget {get_budget} (not ≪ 370)"
     );
+    if let Some(byte_budget) = byte_budget {
+        assert!(
+            per_q_bytes < byte_budget,
+            "coalesced bytes_read/query = {per_q_bytes} >= budget {byte_budget}"
+        );
+    }
 }


### PR DESCRIPTION
Summary:
- reconcile ADR-062 and TD-RDSTRAT-7 with shipped PRs #1064 and #1069
- record the accepted lossless scalar bytes arm while leaving the superseded inline vector arm evidence-gated
- make the SIFT coalesced evaluator enforce an optional bytes/query ceiling and wire the accepted 26 MB ceiling into the evidence command

Verified state:
- PR #1064 already shipped footer v2, shared exact clustered-SQ8 support, and scalar all-null/LZ4 encoding default OFF
- PR #1069 subsequently hoisted SQ8 into coalesced Region B, so inline SQ8 compression is no longer the default path's primary bytes lever
- existing N=100k evidence: recall@10 0.991, 19 GETs/query, 32,020,233 to 25,067,186 bytes/query (-21.7%), no p95 regression

Checks:
- cargo fmt --all --check
- cargo check --test sift_pax_recall_ratchet_test
- cargo clippy --test sift_pax_recall_ratchet_test -- -D warnings
- cargo check -p proximadb-server
- make work-commit-check
- TD/ADR uniqueness and status consistency
- no-agent-attribution range check

This PR changes no storage writer or search hot path; it makes the already-recorded end-to-end bytes evidence fail closed on rerun.