### PR TITLE
refactor: invert ORION WAL construction onto GraphWalFactory (ORION cascade PR 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8289,6 +8289,7 @@ dependencies = [
  "proximadb-storage-common",
  "proximadb-storage-filesystem-types",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/lib.rs"
 anyhow.workspace = true
 async-trait.workspace = true
 serde.workspace = true
+# tokio: GraphWalFactory returns Arc<tokio::sync::Mutex<dyn GraphWalPort>> (the
+# async-mutex the writer is shared under). Precedent: distance-kernel/records/
+# tenant/storage-common/storage-traits all depend on tokio.
+tokio = { workspace = true, features = ["sync"] }
 proximadb-proto.workspace = true
 proximadb-storage-common.workspace = true
 # Foundation-tier: FilterExpression (ScanStrategy::FilteredScan predicates) +

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -17,6 +17,7 @@ use proximadb_graph_model::{GraphOperation, GraphWalEntry, MarkerKind};
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
+use std::sync::Arc;
 
 pub mod capabilities;
 pub use capabilities::*;
@@ -307,4 +308,30 @@ pub trait GraphWalReaderPort: Send + Sync {
     /// Read every graph-relevant frame from the WAL, in append order. Returns an
     /// empty vector when the WAL is absent or empty (e.g. before the first write).
     async fn read_all_graph(&self) -> Result<Vec<GraphWalEntry>>;
+}
+
+/// Dependency-injection factory for a graph engine's WAL writer + reader (ORION
+/// extraction).
+///
+/// This is the seam that lets the engine obtain its [`GraphWalPort`] (writer)
+/// and [`GraphWalReaderPort`] (reader) WITHOUT naming the concrete unified WAL
+/// types: the engine calls `make_writer` / `make_reader` at construction, and
+/// the composition root injects a concrete factory (the unified WAL factory),
+/// which is the only place the concrete types are named. Without this, the
+/// engine would construct the writer/reader itself and could not be extracted
+/// to a crate. The factory is injected once at the composition root and threaded
+/// down through the engine constructors — the single object that crosses the
+/// engine↔root boundary.
+#[async_trait::async_trait]
+pub trait GraphWalFactory: Send + Sync {
+    /// Build a graph WAL writer backed by `wal_path`, wrapped in the async mutex
+    /// the writer is shared under (`append` & friends take `&mut self`).
+    async fn make_writer(
+        &self,
+        wal_path: &str,
+    ) -> Result<Arc<tokio::sync::Mutex<dyn GraphWalPort>>>;
+
+    /// Build a graph WAL reader backed by `wal_path`. Opens no files until a
+    /// read is issued; tolerant of an absent/empty WAL.
+    async fn make_reader(&self, wal_path: &str) -> Result<Arc<dyn GraphWalReaderPort>>;
 }

--- a/src/graph/engines/orion/mod.rs
+++ b/src/graph/engines/orion/mod.rs
@@ -94,8 +94,13 @@
 //! // Create a new ORION engine (in-memory only)
 //! let engine = OrionGraphEngine::new();
 //!
-//! // Create with WAL persistence for durability
-//! let engine = OrionGraphEngine::with_persistence("/path/to/data", true).await?;
+//! // Create with WAL persistence for durability (inject a graph WAL factory)
+//! let engine = OrionGraphEngine::with_persistence(
+//!     "/path/to/data",
+//!     true,
+//!     proximadb::graph::unified_wal_factory(),
+//! )
+//! .await?;
 //!
 //! // Insert nodes and edges
 //! engine.insert_node(node).await?;
@@ -219,13 +224,18 @@ impl OrionGraphEngine {
     }
 
     /// Create ORION engine with persistence enabled
-    pub async fn with_persistence(base_path: impl AsRef<Path>, enable_wal: bool) -> Result<Self> {
+    pub async fn with_persistence(
+        base_path: impl AsRef<Path>,
+        enable_wal: bool,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
+    ) -> Result<Self> {
         // Use default base URL if path is provided
         let base_url = format!("file:///{}", base_path.as_ref().display());
         let graph_id = "default".to_string(); // Default graph for backward compatibility
 
-        let persistence =
-            Arc::new(persistence::OrionPersistence::new(graph_id, base_url, enable_wal).await?);
+        let persistence = Arc::new(
+            persistence::OrionPersistence::new(graph_id, base_url, enable_wal, wal_factory).await?,
+        );
 
         Ok(Self {
             memory_pool: Arc::new(GraphMemoryPool::new()),
@@ -244,9 +254,16 @@ impl OrionGraphEngine {
         graph_id: String,
         base_url: String,
         enable_wal: bool,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
     ) -> Result<Self> {
-        Self::with_persistence_for_graph_and_canonical_wal(graph_id, base_url, enable_wal, None)
-            .await
+        Self::with_persistence_for_graph_and_canonical_wal(
+            graph_id,
+            base_url,
+            enable_wal,
+            None,
+            wal_factory,
+        )
+        .await
     }
 
     /// Create ORION engine with persistence AND a shared canonical WAL
@@ -261,9 +278,10 @@ impl OrionGraphEngine {
         base_url: String,
         enable_wal: bool,
         canonical_wal_path: Option<std::path::PathBuf>,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
     ) -> Result<Self> {
         let mut persistence =
-            persistence::OrionPersistence::new(graph_id, base_url, enable_wal).await?;
+            persistence::OrionPersistence::new(graph_id, base_url, enable_wal, wal_factory).await?;
         if let Some(path) = canonical_wal_path {
             persistence = persistence.with_canonical_wal_path(path);
         }
@@ -286,8 +304,9 @@ impl OrionGraphEngine {
         snapshot_path: impl AsRef<Path>,
         base_path: impl AsRef<Path>,
         enable_wal: bool,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
     ) -> Result<Self> {
-        let engine = Self::with_persistence(base_path, enable_wal).await?;
+        let engine = Self::with_persistence(base_path, enable_wal, wal_factory).await?;
 
         if let Some(persistence) = &engine.persistence {
             persistence.load_snapshot(&engine, snapshot_path).await?;
@@ -309,8 +328,10 @@ impl OrionGraphEngine {
         graph_id: String,
         base_url: String,
         enable_wal: bool,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
     ) -> Result<Self> {
-        let engine = Self::with_persistence_for_graph(graph_id, base_url, enable_wal).await?;
+        let engine =
+            Self::with_persistence_for_graph(graph_id, base_url, enable_wal, wal_factory).await?;
 
         if let Some(persistence) = &engine.persistence {
             persistence.load_snapshot(&engine, snapshot_path).await?;
@@ -1510,6 +1531,7 @@ mod td066_replay_scope_tests {
                 base_url.clone(),
                 true,
                 Some(canonical_wal.clone()),
+                crate::graph::unified_wal_factory(),
             )
             .await
             .expect("engine");
@@ -1550,6 +1572,7 @@ mod td066_replay_scope_tests {
             base_url.clone(),
             true,
             Some(canonical_wal.clone()),
+            crate::graph::unified_wal_factory(),
         )
         .await
         .expect("recovery engine");
@@ -1617,6 +1640,7 @@ mod td066_replay_scope_tests {
                 base_url.clone(),
                 true,
                 Some(canonical_wal.clone()),
+                crate::graph::unified_wal_factory(),
             )
             .await
             .expect("engine");
@@ -1663,6 +1687,7 @@ mod td066_replay_scope_tests {
             base_url.clone(),
             true,
             Some(canonical_wal.clone()),
+            crate::graph::unified_wal_factory(),
         )
         .await
         .expect("recovery engine");

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -46,9 +46,6 @@ use crate::graph::engines::orion::OrionGraphEngine;
 use crate::graph::{Edge, EdgeId, Node, NodeId};
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
-use crate::storage::persistence::write_ahead_log::wal_operations::{
-    UnifiedWALReader, UnifiedWALWriter,
-};
 use proximadb_kernel::error::ProximaDBError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -219,7 +216,12 @@ impl OrionPersistence {
     /// wiring (`src/graph/service_engine_factory.rs` →
     /// `OrionGraphEngine::with_persistence_for_graph`) reaches into
     /// the underlying persistence and sets the path via the builder.
-    pub async fn new(graph_id: String, base_url: String, enable_wal: bool) -> Result<Self> {
+    pub async fn new(
+        graph_id: String,
+        base_url: String,
+        enable_wal: bool,
+        wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
+    ) -> Result<Self> {
         // Create filesystem factory with default configuration and initialize filesystems
         let filesystem_factory = Arc::new(
             FilesystemFactory::create(FilesystemConfig::default())
@@ -287,36 +289,23 @@ impl OrionPersistence {
                     ))
                 })?;
 
-            // Initialize WAL writer + reader with path (not URL), then erase
-            // each to its dependency-inversion port. The unsizing coercions
-            // `Arc<Mutex<UnifiedWALWriter>>` -> `Arc<Mutex<dyn GraphWalPort>>`
-            // and `Arc<UnifiedWALReader>` -> `Arc<dyn GraphWalReaderPort>` are
-            // sound because both implement their ports (PRs #1085 / #1093).
+            // Obtain the WAL writer + reader through the injected GraphWalFactory
+            // port — the engine never names the concrete UnifiedWAL* types (the
+            // factory is the single composition-root seam that does). Both are
+            // tolerant of an absent/empty WAL (the reader opens no files until a
+            // read; recovery is a no-op before the first write).
             tracing::debug!("Creating WAL writer with path: {}", wal_path_str);
-            let wal_writer = UnifiedWALWriter::new(wal_path_str.clone())
-                .await
-                .map_err(|e| {
-                    ProximaDBError::Storage(
-                        proximadb_kernel::error::StorageError::SerializationError(e.to_string()),
-                    )
-                })?;
-            tracing::debug!("WAL writer created successfully");
-            let wal_writer: Arc<tokio::sync::Mutex<dyn proximadb_storage_ports::GraphWalPort>> =
-                Arc::new(tokio::sync::Mutex::new(wal_writer));
-
-            // The reader opens no files at construction (only the FS handle);
-            // segments are enumerated lazily on `read_all_graph`. Tolerant of an
-            // absent/empty WAL (e.g. before the first write) — recovery is a
-            // no-op then.
-            let wal_reader = UnifiedWALReader::new(wal_path_str.clone())
-                .await
-                .map_err(|e| {
-                    ProximaDBError::Storage(
-                        proximadb_kernel::error::StorageError::SerializationError(e.to_string()),
-                    )
-                })?;
-            let wal_reader: Arc<dyn proximadb_storage_ports::GraphWalReaderPort> =
-                Arc::new(wal_reader);
+            let wal_writer = wal_factory.make_writer(&wal_path_str).await.map_err(|e| {
+                ProximaDBError::Storage(proximadb_kernel::error::StorageError::SerializationError(
+                    e.to_string(),
+                ))
+            })?;
+            let wal_reader = wal_factory.make_reader(&wal_path_str).await.map_err(|e| {
+                ProximaDBError::Storage(proximadb_kernel::error::StorageError::SerializationError(
+                    e.to_string(),
+                ))
+            })?;
+            tracing::debug!("WAL writer + reader created successfully");
 
             (Some(wal_path), Some(wal_writer), Some(wal_reader))
         } else {
@@ -1623,9 +1612,14 @@ mod topology_only_snapshot_tests {
 
     async fn engine(graph_id: &str, base: &std::path::Path) -> OrionGraphEngine {
         let base_url = format!("file://{}", base.display());
-        OrionGraphEngine::with_persistence_for_graph(graph_id.to_string(), base_url, false)
-            .await
-            .expect("engine with persistence")
+        OrionGraphEngine::with_persistence_for_graph(
+            graph_id.to_string(),
+            base_url,
+            false,
+            crate::graph::unified_wal_factory(),
+        )
+        .await
+        .expect("engine with persistence")
     }
 
     fn node(id: &str) -> Node {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -75,6 +75,9 @@ pub mod proto_convert;
 pub mod rag;
 // Generic, engine-agnostic traversal utilities
 pub use engines::generic_traversal;
+// Default graph WAL factory (unified) for composition-root injection into the
+// ORION engine constructors (ORION cascade PR 5).
+pub use crate::storage::persistence::write_ahead_log::wal_operations::unified_wal_factory;
 pub mod hybrid;
 pub mod monitoring;
 pub mod query;

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -1056,6 +1056,7 @@ impl GraphOperationsService {
                     graph_id.to_string(),
                     self.base_storage_url.clone(),
                     true, // Enable WAL
+                    crate::graph::unified_wal_factory(),
                 )
                 .await?;
                 engine.recover().await?;

--- a/src/graph/service_engine_factory.rs
+++ b/src/graph/service_engine_factory.rs
@@ -100,6 +100,7 @@ impl super::GraphOperationsService {
                         storage_root_url,
                         true,
                         canonical_wal_path,
+                        crate::graph::unified_wal_factory(),
                     )
                     .await?;
                 crate::graph::engines::GraphEngineImpl::Orion(orion)

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -25,7 +25,7 @@ use crate::storage::memtable::implementations::graph_memtable::GraphOperation;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_graph_model::{GraphWalEntry, GraphWalRecord};
 use proximadb_records::ProximaRecord;
-use proximadb_storage_ports::{GraphWalPort, GraphWalReaderPort};
+use proximadb_storage_ports::{GraphWalFactory, GraphWalPort, GraphWalReaderPort};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -811,6 +811,40 @@ impl GraphWalReaderPort for UnifiedWALReader {
         }
         Ok(out)
     }
+}
+
+/// Composition-root factory for a graph engine's WAL writer + reader: the single
+/// place the concrete `UnifiedWALWriter` / `UnifiedWALReader` are named, so the
+/// ORION engine can obtain its [`GraphWalPort`] / [`GraphWalReaderPort`] through
+/// the [`GraphWalFactory`] port without naming these types itself.
+#[derive(Default)]
+pub struct UnifiedWalFactory;
+
+#[async_trait::async_trait]
+impl GraphWalFactory for UnifiedWalFactory {
+    async fn make_writer(
+        &self,
+        wal_path: &str,
+    ) -> anyhow::Result<Arc<tokio::sync::Mutex<dyn GraphWalPort>>> {
+        let writer = UnifiedWALWriter::new(wal_path.to_string()).await?;
+        let writer: Arc<tokio::sync::Mutex<dyn GraphWalPort>> =
+            Arc::new(tokio::sync::Mutex::new(writer));
+        Ok(writer)
+    }
+
+    async fn make_reader(&self, wal_path: &str) -> anyhow::Result<Arc<dyn GraphWalReaderPort>> {
+        let reader = UnifiedWALReader::new(wal_path.to_string()).await?;
+        let reader: Arc<dyn GraphWalReaderPort> = Arc::new(reader);
+        Ok(reader)
+    }
+}
+
+/// Convenience constructor for the default (unified) graph WAL factory, erased
+/// to the [`GraphWalFactory`] port. Composition-root callers (and tests) inject
+/// this into the ORION engine constructors; it is the only symbol outside this
+/// module that needs to name a concrete graph WAL type.
+pub fn unified_wal_factory() -> Arc<dyn GraphWalFactory> {
+    Arc::new(UnifiedWalFactory)
 }
 
 /// WAL reader for recovery

--- a/tests/graph_persistence_service_test.rs
+++ b/tests/graph_persistence_service_test.rs
@@ -146,6 +146,7 @@ async fn test_graph_persistence_with_wal_recovery() {
                 TEST_GRAPH_ID.to_string(),
                 test_dir.to_string(),
                 true, // enable WAL
+                proximadb::graph::unified_wal_factory(),
             )
             .await?;
             info!("✅ New engine instance created");

--- a/tests/orion_canonical_checkpoint_read_test.rs
+++ b/tests/orion_canonical_checkpoint_read_test.rs
@@ -65,8 +65,13 @@ fn checkpoint_op(sequence_number: u64, collection_ids: Vec<&str>) -> CanonicalOp
 async fn canonical_checkpoint_lsn_returns_none_when_no_wal_path() -> Result<()> {
     let (_tmp, base, _wal) = fresh_layout()?;
     let base_url = format!("file://{}", base.display());
-    let engine =
-        OrionGraphEngine::with_persistence_for_graph("graph-a".to_string(), base_url, true).await?;
+    let engine = OrionGraphEngine::with_persistence_for_graph(
+        "graph-a".to_string(),
+        base_url,
+        true,
+        proximadb::graph::unified_wal_factory(),
+    )
+    .await?;
 
     let lsn = engine
         .persistence()
@@ -110,6 +115,7 @@ async fn canonical_checkpoint_lsn_returns_max_for_graph() -> Result<()> {
         base_url,
         true,
         Some(wal_path.clone()),
+        proximadb::graph::unified_wal_factory(),
     )
     .await?;
 
@@ -156,6 +162,7 @@ async fn canonical_checkpoint_lsn_filters_by_graph_id() -> Result<()> {
         base_url.clone(),
         true,
         Some(wal_path.clone()),
+        proximadb::graph::unified_wal_factory(),
     )
     .await?;
     let lsn_a = engine_a
@@ -175,6 +182,7 @@ async fn canonical_checkpoint_lsn_filters_by_graph_id() -> Result<()> {
         base_url.clone(),
         true,
         Some(wal_path.clone()),
+        proximadb::graph::unified_wal_factory(),
     )
     .await?;
     let lsn_b = engine_b
@@ -194,6 +202,7 @@ async fn canonical_checkpoint_lsn_filters_by_graph_id() -> Result<()> {
         base_url,
         true,
         Some(wal_path.clone()),
+        proximadb::graph::unified_wal_factory(),
     )
     .await?;
     let lsn_c = engine_c

--- a/tests/phase3_integration_test.rs
+++ b/tests/phase3_integration_test.rs
@@ -374,6 +374,7 @@ mod graph_wal_recovery_tests {
             "insert_test".to_string(),
             base_url.clone(),
             true,
+            proximadb::graph::unified_wal_factory(),
         )
         .await
         .expect("Failed to create engine");
@@ -397,6 +398,7 @@ mod graph_wal_recovery_tests {
             "edge_test".to_string(),
             base_url.clone(),
             true,
+            proximadb::graph::unified_wal_factory(),
         )
         .await
         .expect("Failed to create engine");
@@ -431,6 +433,7 @@ mod graph_wal_recovery_tests {
             "update_test".to_string(),
             base_url.clone(),
             true,
+            proximadb::graph::unified_wal_factory(),
         )
         .await
         .expect("Failed to create engine");
@@ -462,6 +465,7 @@ mod graph_wal_recovery_tests {
             "delete_test".to_string(),
             base_url.clone(),
             true,
+            proximadb::graph::unified_wal_factory(),
         )
         .await
         .expect("Failed to create engine");
@@ -505,6 +509,7 @@ mod graph_wal_recovery_tests {
                 "recovery_test".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine");
@@ -523,6 +528,7 @@ mod graph_wal_recovery_tests {
                 "recovery_test".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine for recovery");
@@ -553,6 +559,7 @@ mod graph_wal_recovery_tests {
                 "update_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine");
@@ -577,6 +584,7 @@ mod graph_wal_recovery_tests {
                 "update_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine for recovery");
@@ -607,6 +615,7 @@ mod graph_wal_recovery_tests {
                 "delete_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine");
@@ -630,6 +639,7 @@ mod graph_wal_recovery_tests {
                 "delete_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine for recovery");
@@ -662,6 +672,7 @@ mod graph_wal_recovery_tests {
                 "edge_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine");
@@ -692,6 +703,7 @@ mod graph_wal_recovery_tests {
                 "edge_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine for recovery");
@@ -722,6 +734,7 @@ mod graph_wal_recovery_tests {
                 "traversal_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine");
@@ -752,6 +765,7 @@ mod graph_wal_recovery_tests {
                 "traversal_recovery".to_string(),
                 base_url.clone(),
                 true,
+                proximadb::graph::unified_wal_factory(),
             )
             .await
             .expect("Failed to create engine for recovery");

--- a/tests/wal_path_correctness_test.rs
+++ b/tests/wal_path_correctness_test.rs
@@ -52,9 +52,13 @@ async fn test_graph_wal_path_with_persistence() {
     tracing::info!("Test storage path: {:?}", storage_path);
 
     // Create ORION engine with persistence using the correct API
-    let engine = OrionGraphEngine::with_persistence(storage_path, true)
-        .await
-        .expect("Failed to create engine with persistence");
+    let engine = OrionGraphEngine::with_persistence(
+        storage_path,
+        true,
+        proximadb::graph::unified_wal_factory(),
+    )
+    .await
+    .expect("Failed to create engine with persistence");
 
     // Create a test node with proper proto types
     let mut properties = HashMap::new();
@@ -103,9 +107,13 @@ async fn test_delete_operations_write_to_wal() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let storage_path = temp_dir.path();
 
-    let engine = OrionGraphEngine::with_persistence(storage_path, true)
-        .await
-        .expect("Failed to create engine with persistence");
+    let engine = OrionGraphEngine::with_persistence(
+        storage_path,
+        true,
+        proximadb::graph::unified_wal_factory(),
+    )
+    .await
+    .expect("Failed to create engine with persistence");
 
     let ts = now_ms();
 
@@ -192,9 +200,13 @@ async fn test_update_operations_write_to_wal() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let storage_path = temp_dir.path();
 
-    let engine = OrionGraphEngine::with_persistence(storage_path, true)
-        .await
-        .expect("Failed to create engine with persistence");
+    let engine = OrionGraphEngine::with_persistence(
+        storage_path,
+        true,
+        proximadb::graph::unified_wal_factory(),
+    )
+    .await
+    .expect("Failed to create engine with persistence");
 
     let ts = now_ms();
 


### PR DESCRIPTION
## Summary

ORION cascade **PR 5** — the construction-site inversion. Builds on `develop` (#1083, #1085, #1090, #1092 all merged).

ORION no longer constructs the concrete `UnifiedWALWriter` / `UnifiedWALReader`: `OrionPersistence::new` obtains its writer + reader through an injected `GraphWalFactory` port. The `orion/` tree now names **only port traits** (`GraphWalPort` / `GraphWalReaderPort` / `GraphWalFactory`) + graph-model leaf types. Together with PR #1090 (append) and #1092 (read), this leaves the 14 ORION files **fully decoupled from the unified WAL types** and ready to move into `proximadb-orion-engine` (PR 6).

## Changes

- **storage-ports** — `GraphWalFactory` port (`async make_writer/make_reader` → port objects); adds `tokio["sync"]` dep (precedent: distance-kernel/records/tenant/storage-common/storage-traits).
- **wal_operations.rs** — `UnifiedWalFactory` + `impl GraphWalFactory` (the **single place** the concrete `UnifiedWAL*` types are named) + `unified_wal_factory()` convenience constructor.
- **persistence.rs** — `OrionPersistence::new` takes `Arc<dyn GraphWalFactory>`; the concrete `UnifiedWALWriter`/`UnifiedWALReader` imports are removed.
- **orion/mod.rs** — the 5 engine constructors (`with_persistence[_for_graph[_and_canonical_wal]]`, `load_from_snapshot[_for_graph]`) thread `wal_factory` down.
- **graph/mod.rs** — re-export `unified_wal_factory()` for short injection paths.
- **composition root** (`service_engine_factory.rs`, `service.rs`) + ~28 test sites inject `unified_wal_factory()`.

## Design note

The factory must be **constructed outside `orion/`** (at the composition root) and threaded down — constructing it inside `orion/mod.rs` would be a no-op for decoupling (`mod.rs` currently has zero concrete-WAL references). So this PR threads one factory object through the engine constructors. This is the chosen "Factory port" option (Option B) over full per-object DI (Option A): one object threaded, construction encapsulated in the factory impl.

## Scope & verification

Construction decoupling only — **no behavior change**.
- `cargo clippy --lib --bins -- -D warnings` (the CI gate) — clean
- `cargo check --tests` — all tests (incl. the ~28 updated call sites) compile clean
- `rustup run 1.95.0 cargo fmt --all` — canonical
- `make work-commit-check` — fmt-check, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy (`graph` 0/0/0), hygiene all pass
- `scripts/check-layering.sh` + `check_workspace_boundaries.py` — no boundary findings
- `scripts/check_no_agent_attribution.py` — clean
- Runtime: TD-066 recovery tests pass (factory-built writer+reader exercised end-to-end: construct → append → flush → marker → truncate → recover)

## Next

PR 6 — move the 14 ORION files into `proximadb-orion-engine` (now clean: the module depends only on port traits + graph-model). pgwire (12.9K) follows the same template.