### PR TITLE
refactor: decouple ORION distance + filesystem deps (ORION move 6b+6c)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -16,7 +16,7 @@ use proximadb_distance_kernel::DistanceMetric;
 use proximadb_graph_model::{GraphOperation, GraphWalEntry, MarkerKind};
 use proximadb_proto::proximadb_v1::Collection;
 use proximadb_storage_common::StorageEngineType;
-use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FsResult};
+use proximadb_storage_filesystem_types::{DirEntry, FileOptions, FileSystem, FsResult};
 use std::sync::Arc;
 
 pub mod capabilities;
@@ -200,6 +200,10 @@ pub trait FilesystemPort: Send + Sync {
     async fn move_atomic(&self, from_url: &str, to_url: &str) -> FsResult<()>;
     /// Delete the file/dir at `url`.
     async fn delete(&self, url: &str) -> FsResult<()>;
+    /// Read the full contents of the file at `url` (scheme-routed).
+    async fn read(&self, url: &str) -> FsResult<Vec<u8>>;
+    /// List the directory entries at `url` (scheme-routed).
+    async fn list(&self, url: &str) -> FsResult<Vec<DirEntry>>;
 }
 
 /// Cache-kind for access-pattern tracking — the engine-facing subset of the root
@@ -334,4 +338,9 @@ pub trait GraphWalFactory: Send + Sync {
     /// Build a graph WAL reader backed by `wal_path`. Opens no files until a
     /// read is issued; tolerant of an absent/empty WAL.
     async fn make_reader(&self, wal_path: &str) -> Result<Arc<dyn GraphWalReaderPort>>;
+
+    /// Build the filesystem port the engine uses for snapshot I/O (read/list).
+    /// The engine never names the concrete filesystem factory; this is the
+    /// single composition-root seam that does (mirrors make_writer/make_reader).
+    async fn make_filesystem(&self) -> Result<Arc<dyn FilesystemPort>>;
 }

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -44,8 +44,6 @@
 use crate::core::serialization::CompressionAlgorithm;
 use crate::graph::engines::orion::OrionGraphEngine;
 use crate::graph::{Edge, EdgeId, Node, NodeId};
-use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
-use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_kernel::error::ProximaDBError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -131,13 +129,10 @@ pub struct OrionPersistence {
     /// Base URL for storage (e.g., "file:///data", "s3://bucket", etc.)
     base_url: String,
 
-    /// Filesystem factory for creating appropriate filesystem
-    #[allow(dead_code)]
-    filesystem_factory: Arc<FilesystemFactory>,
-
-    /// Unified caching filesystem wrapper
-    #[allow(dead_code)]
-    filesystem: Arc<UnifiedCachingFilesystem>,
+    /// Filesystem port for snapshot I/O (read/list), injected via the
+    /// `GraphWalFactory` so the engine never names the concrete filesystem
+    /// factory.
+    filesystem_factory: Arc<dyn proximadb_storage_ports::FilesystemPort>,
 
     /// WAL path for future implementation
     wal_path: Option<PathBuf>,
@@ -222,30 +217,14 @@ impl OrionPersistence {
         enable_wal: bool,
         wal_factory: Arc<dyn proximadb_storage_ports::GraphWalFactory>,
     ) -> Result<Self> {
-        // Create filesystem factory with default configuration and initialize filesystems
-        let filesystem_factory = Arc::new(
-            FilesystemFactory::create(FilesystemConfig::default())
-                .await
-                .map_err(|e| {
-                    ProximaDBError::Storage(
-                        proximadb_kernel::error::StorageError::SerializationError(e.to_string()),
-                    )
-                })?,
-        );
-
-        // Get the underlying filesystem from the factory
-        let underlying_fs = filesystem_factory.get_filesystem(&base_url).map_err(|e| {
+        // Obtain the filesystem port (for snapshot I/O) through the injected
+        // GraphWalFactory — the engine never names the concrete filesystem
+        // factory.
+        let filesystem_factory = wal_factory.make_filesystem().await.map_err(|e| {
             ProximaDBError::Storage(proximadb_kernel::error::StorageError::SerializationError(
                 e.to_string(),
             ))
         })?;
-
-        // Wrap with UnifiedCachingFilesystem
-        let filesystem = Arc::new(UnifiedCachingFilesystem::new(
-            underlying_fs,
-            format!("graph_{}", graph_id),
-            "orion".to_string(),
-        ));
 
         // Build graph-specific path: {base_url}/graphs/{graph_id}/data
         let graph_path = format!(
@@ -316,7 +295,6 @@ impl OrionPersistence {
             graph_id,
             base_url,
             filesystem_factory,
-            filesystem,
             wal_path,
             canonical_wal_path: None,
             wal_writer,

--- a/src/graph/engines/orion/traversal.rs
+++ b/src/graph/engines/orion/traversal.rs
@@ -1275,7 +1275,7 @@ pub async fn astar_shortest_path(
 /// # Example
 ///
 /// ```rust,ignore
-/// use proximadb::compute::distance_computation::UnifiedDistanceCompute;
+/// use proximadb_distance_kernel::UnifiedDistanceCompute;
 /// use proximadb::proto::proximadb_v1::DistanceMetric;
 ///
 /// let distance_compute = Arc::new(UnifiedDistanceCompute::new(DistanceMetric::Cosine));
@@ -1298,7 +1298,7 @@ pub async fn vector_guided_astar(
     target_node_id: &NodeId,
     guide_embedding: &[f32],
     alpha: f64,
-    distance_compute: Arc<crate::compute::distance_computation::engine::UnifiedDistanceCompute>,
+    distance_compute: Arc<proximadb_distance_kernel::UnifiedDistanceCompute>,
     distance_metric: crate::proto::proximadb_v1::DistanceMetric,
     config: TraversalConfig,
 ) -> Result<Option<(Vec<NodeId>, f64)>> {
@@ -2611,10 +2611,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_guided_astar_pure_graph() {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::graph::EmbeddingVersion;
         use crate::graph::engines::GraphEngine;
         use crate::proto::proximadb_v1::DistanceMetric;
+        use proximadb_distance_kernel::UnifiedDistanceCompute;
 
         let engine = OrionGraphEngine::new();
 
@@ -2738,10 +2738,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_guided_astar_balanced_blend() {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::graph::EmbeddingVersion;
         use crate::graph::engines::GraphEngine;
         use crate::proto::proximadb_v1::DistanceMetric;
+        use proximadb_distance_kernel::UnifiedDistanceCompute;
 
         let engine = OrionGraphEngine::new();
 
@@ -2919,10 +2919,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_guided_astar_alpha_clamping() {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::graph::EmbeddingVersion;
         use crate::graph::engines::GraphEngine;
         use crate::proto::proximadb_v1::DistanceMetric;
+        use proximadb_distance_kernel::UnifiedDistanceCompute;
 
         let engine = OrionGraphEngine::new();
 
@@ -3027,10 +3027,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_guided_astar_no_path() {
-        use crate::compute::distance_computation::engine::UnifiedDistanceCompute;
         use crate::graph::EmbeddingVersion;
         use crate::graph::engines::GraphEngine;
         use crate::proto::proximadb_v1::DistanceMetric;
+        use proximadb_distance_kernel::UnifiedDistanceCompute;
 
         let engine = OrionGraphEngine::new();
 

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -1647,4 +1647,12 @@ impl proximadb_storage_ports::FilesystemPort for FilesystemFactory {
     async fn delete(&self, url: &str) -> FsResult<()> {
         FilesystemFactory::delete(self, url).await
     }
+
+    async fn read(&self, url: &str) -> FsResult<Vec<u8>> {
+        FilesystemFactory::read(self, url).await
+    }
+
+    async fn list(&self, url: &str) -> FsResult<Vec<DirEntry>> {
+        FilesystemFactory::list(self, url).await
+    }
 }

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -25,7 +25,7 @@ use crate::storage::memtable::implementations::graph_memtable::GraphOperation;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_graph_model::{GraphWalEntry, GraphWalRecord};
 use proximadb_records::ProximaRecord;
-use proximadb_storage_ports::{GraphWalFactory, GraphWalPort, GraphWalReaderPort};
+use proximadb_storage_ports::{FilesystemPort, GraphWalFactory, GraphWalPort, GraphWalReaderPort};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -836,6 +836,14 @@ impl GraphWalFactory for UnifiedWalFactory {
         let reader = UnifiedWALReader::new(wal_path.to_string()).await?;
         let reader: Arc<dyn GraphWalReaderPort> = Arc::new(reader);
         Ok(reader)
+    }
+
+    async fn make_filesystem(&self) -> anyhow::Result<Arc<dyn FilesystemPort>> {
+        let fs = FilesystemFactory::create_default()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to create default filesystem: {e}"))?;
+        let fs: Arc<dyn FilesystemPort> = Arc::new(fs);
+        Ok(fs)
     }
 }
 


### PR DESCRIPTION
## Summary

ORION **move sub-cascade, slices 6b+6c** — resolves the remaining two root-internal dependency blockers in `orion/` so the 14 files can move to a crate. Builds on `develop` (6a #1098 + the WAL decoupling #1083/#1085/#1090/#1092/#1097).

## 6b — distance (trivial; type already a leaf)
`traversal.rs` referenced `UnifiedDistanceCompute` via the root alias `crate::compute::distance_computation` — which is literally `pub use proximadb_distance_kernel as distance_computation` (`src/compute/mod.rs:168`). Rewritten to name the foundation leaf `proximadb_distance_kernel` directly (1 prod field + 4 test imports + a doc example). **Type-identical.**

## 6c — filesystem (small; no new threading)
`orion/persistence.rs` named the concrete `FilesystemFactory` (plus a **dead** `UnifiedCachingFilesystem` field) for snapshot I/O. Resolved by:
- **`FilesystemPort`** (storage-ports) gains `read()` + `list()` — the two methods orion uses (`FilesystemFactory`, the sole impl, already has them as inherent methods).
- **`GraphWalFactory`** gains `make_filesystem() -> Arc<dyn FilesystemPort>`, so `OrionPersistence::new` obtains the FS from the **already-injected** factory (no new call-site threading — reuses PR #1097's factory).
- The dead `filesystem: Arc<UnifiedCachingFilesystem>` field + construction are removed; `filesystem_factory` is now `Arc<dyn FilesystemPort>`.

## Why these were small
Both turned out simpler than the original scoping: `UnifiedDistanceCompute` was already a leaf (the root path was just an alias), and `FilesystemFactory` already implemented `FilesystemPort` (just needed `read`/`list` added to the trait). The PR #1097 `GraphWalFactory` threading paid off — the filesystem rides the same injected factory, so **zero new call-site churn**.

## After this
`orion/`'s remaining `crate::` refs are path-rewrites to **existing leaves** (graph-model, proto, storage-tenant, …) — the 6d move mechanics, no further port-inversion needed.

## Verification
- `cargo clippy --lib --bins -- -D warnings` (CI gate) — clean
- `cargo check --tests` — clean
- `rustup run 1.95.0 cargo fmt --all` — canonical
- `make work-commit-check` — fmt-check, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy, hygiene all pass
- `scripts/check-layering.sh` + `check_workspace_boundaries.py` — no boundary findings (no new storage-ports dep)
- `scripts/check_no_agent_attribution.py` — clean

## Roadmap
6a ✓ (GraphEngine trait → leaf) · **6b+6c** (this: distance + filesystem) · **6d** `git mv` 14 files + shim + Cargo + extract WAL tests to root → `proximadb-orion-engine`. Then pgwire.