### PR TITLE
docs(adr): ADR-067 — consume Sandhi AI usage gateway for egress metering

### DIFF
--- a/docs/10-quality/td/TD-SANDHI-1-gateway-egress-metering-wiring.adoc
+++ b/docs/10-quality/td/TD-SANDHI-1-gateway-egress-metering-wiring.adoc
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-SANDHI-1: External-provider egress → shared usage event (ADR-067 wiring)
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Open — gated.** Waits on the `anvai-labs/sandhi` OSS repo (AnvaiOps ADR-0047) publishing a stable neutral usage-event schema ProximaDB can pin. No blocking work today; the KEU meter already functions (on a heuristic).
+| Priority | **P2** — correctness/quality improvement (meter from real usage) + cross-repo billing alignment; not a live defect.
+| Component | `src/services/embedding_drainer.rs` (`record_embedding_consumption`, ~L483), `crates/modalities/proximadb-embedding/src/models/{azure_openai.rs,byo.rs,openai.rs,cohere.rs}`, `src/metrics/consumption_metrics.rs` (`record_keu_units`).
+| Governs | link:../../12-design/adr/ADR-067-consume-ai-usage-gateway-egress-metering.adoc[ADR-067], link:../../12-design/adr/ADR-060-commercial-rust-crate-extension-seam-open-core.adoc[ADR-060], link:../../12-design/OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc[OSS_ENTERPRISE_BOUNDARY].
+| Relates to | AnvaiOps ADR-0047 (authoritative wire contract), Victor FEP-0020 (sibling consumer).
+|===
+
+== The two fixes (per ADR-067)
+
+. **Meter KEU from the provider's real usage response, not a heuristic.** Today
+  `record_embedding_consumption` estimates `input_tokens = count * 512` and
+  `output_tokens = count * dim`. The real egress clients
+  (`AzureOpenAiClient::embed_batch`, `ByoClient`, the OpenAI/Cohere paths) receive an actual
+  usage/token count in the provider response — thread that through so
+  `record_keu_units(tenant, provider, model, "embed_batch", input_tokens, output_tokens)` is
+  fed measured values. Local BGE ONNX (`bge.rs`) has no provider usage and keeps its
+  compute-based accrual.
+
+. **Emit the shared neutral usage event at the external-provider boundary.** At the same
+  seam, emit the AnvaiOps ADR-0047 D3 event (tokens + cache split, `provider`/`model`/tenant
+  labels, **no dollars, no tier/SKU names**). Transport is operator's choice (ADR-067): an
+  in-process neutral emit alongside the existing meter, **or** routing the egress through the
+  `sandhi` proxy. Behind the existing seams; default-inert until configured.
+
+== Boundary invariants to hold
+
+* **Neutral units only** — OSS emits tokens/units; AnvaiOps prices. No `$`, no SKU/tier names
+  in the event or in `proximadb-embedding` public types (neutral-naming rule; same discipline
+  as the `StoragePoolClass` remediation).
+* **KEU stays authoritative + server-side** — the gateway complements, never replaces, the KEU
+  meter (AnvaiOps ADR-0020 D6). `consumption_metrics` remains the OSS meter of record.
+* **Dependency direction one-way** — ProximaDB depends on the `sandhi` wire schema, never the
+  reverse (ADR-060).
+* **No engine-mechanism change** — additive to the drainer's egress clients only; `io_trace` /
+  `DurableMeteringWriter` contracts untouched.
+
+== Gate
+
+* `anvai-labs/sandhi` exists with a tagged neutral usage-event schema to pin.
+* Prefer the in-process emit first (no new network hop on the drainer hot path); adopt proxy
+  routing only if an operator needs the language-agnostic shared-key path.
+
+== Notes
+
+The provider-label vocabulary (`victor` / `azure_openai` / `openai` / `cohere` / `byo`) that
+keys attribution **already exists** in `record_embedding_consumption` — this TD feeds it real
+numbers and mirrors the label set into the shared event, rather than inventing a new taxonomy.

--- a/docs/12-design/adr/ADR-067-consume-ai-usage-gateway-egress-metering.adoc
+++ b/docs/12-design/adr/ADR-067-consume-ai-usage-gateway-egress-metering.adoc
@@ -1,0 +1,121 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-067: Consume the `sandhi` AI usage gateway for external-provider egress metering
+
+:status: Proposed
+:date: 2026-07-18
+:deciders: architecture
+:relates-to: ADR-060 (commercial-Rust-crate open-core seam), ADR-027/030 (unified trace+meter seam), `OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc`; AnvaiOps ADR-0047 (authoritative), Victor ADR-018 / FEP-0020
+
+== Status
+
+**Proposed** — a thin **consumer** decision. The authoritative open-core split for the
+cross-repo AI usage gateway is **AnvaiOps ADR-0047**; this ADR records only ProximaDB's
+local consequence (how the Rust drainer's external egress emits the shared neutral usage
+event). No engine mechanism changes here; the wiring is tracked in
+link:../../10-quality/td/TD-SANDHI-1-gateway-egress-metering-wiring.adoc[TD-SANDHI-1].
+
+== Context
+
+ProximaDB already has a first-principles **neutral consumption-metering substrate** —
+`proximadb-metrics::consumption_metrics` (KEU/KOU/KRU/KSU/KIU counters), the always-on
+`io_trace` billing observer, and `DurableMeteringWriter` — built on the boundary principle
+*"OSS produces neutral units, never dollars; turning a metered unit into a bill is AnvaiOps
+policy"* (`OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc`, ADR-027/030).
+
+The one place ProximaDB makes **external LLM/embedding egress** today is the async
+embedding drainer's Premium/BYO path:
+
+* `src/services/embedding_drainer.rs` — `record_embedding_consumption(payload, route)`
+  (~line 483) currently meters KEU from a **heuristic**
+  (`estimated_input_tokens = count * 512`, `estimated_output_tokens = count * dim`), then
+  calls `consumption_metrics::record_keu_units(tenant, provider, model, "embed_batch", …)`.
+* `crates/modalities/proximadb-embedding/src/models/azure_openai.rs`
+  (`AzureOpenAiClient::embed_batch`), plus `byo.rs` and the OpenAI/Cohere stubs, are where
+  the actual provider HTTP egress + real usage responses happen. The provider-label
+  vocabulary already distinguishes `victor` / `azure_openai` / `openai` / `cohere` / `byo`.
+
+Two gaps: (1) KEU is estimated, not read from the provider's real token usage; (2) there is
+no *shared* usage event that lets AnvaiOps price ProximaDB's external egress the same way it
+prices Victor's and its own — each meter is repo-local.
+
+AnvaiOps ADR-0047 introduces a standalone Apache-2.0 OSS gateway, **`sandhi`**
+(`anvai-labs/sandhi`), with a **neutral usage-event wire contract** (tokens + cache split, no
+dollars) and a language-agnostic reverse-proxy — the only shape a Rust caller can share with
+the Python callers. ProximaDB is named as a consumer.
+
+== Decision
+
+**ProximaDB consumes `sandhi` as the egress-metering seam for its external LLM/embedding
+providers, and its KEU meter stays authoritative.** Concretely:
+
+. **KEU meter stays authoritative + unchanged in ownership.** The gateway *complements* the
+  KEU meter; it does **not** replace it (AnvaiOps ADR-0020 D6 — embedding metering stays
+  server-side in ProximaDB). `consumption_metrics::record_keu_units` remains the OSS meter of
+  record for embedding compute.
+. **Emit the shared neutral usage event at the external-provider boundary.** Wrap the real
+  egress clients (`AzureOpenAiClient::embed_batch`, `ByoClient`, the OpenAI/Cohere paths) so
+  each external call emits the AnvaiOps ADR-0047 D3 usage event — keyed on the existing
+  `provider`/`model` labels plus the tenant — **from the provider's actual usage response**,
+  not the `count*512` heuristic. Two viable transports, operator's choice: emit the event
+  in-process (as a new neutral field on the existing metering path) **or** route the egress
+  through the `sandhi` proxy over HTTP. Local BGE ONNX inference (`bge.rs`) has no egress and is
+  unaffected.
+. **Neutral units only (open-core boundary holds).** The event carries tokens/cache-split,
+  never dollars or tier/SKU names (neutral-naming rule). ProximaDB + `sandhi` emit units;
+  **AnvaiOps prices them** (per-`(cloud, kou_locality)` KEU/KOU $ rate). This is the same
+  mechanism-vs-policy cut ADR-060 and the boundary spec already enforce.
+. **Consumer direction, one-way.** ProximaDB (or `sandhi`) is not a dependency of AnvaiOps's
+  commercial layer in reverse; the dependency is commercial → OSS, exactly as ADR-060 fixes
+  it for the commercial Rust crate.
+
+== Note: ProximaDB is the native-Rust consumer
+
+`sandhi` is a Rust core (`sandhi-core`) with language bindings (AnvaiOps ADR-0047 D2). ProximaDB
+is the **best case**: it links `sandhi-core` **directly as a crate, no FFI** — the same
+in-process advantage the PyO3/napi bindings give Victor and the TS UIs, but without a binding
+layer. The drainer's egress path emits the neutral event through a direct crate call.
+
+Because Sandhi's transport (`sandhi-providers`, AnvaiOps ADR-0047 D10) is itself Rust,
+ProximaDB's existing 8-provider `src/ai/llm_integration/providers/mod.rs::LLMClient` is a
+**natural consolidation target** — it could delegate to `sandhi-providers` (Anthropic /
+OpenAI-compat / Gemini / Bedrock / Cohere / vLLM / Ollama already overlap) instead of keeping
+a parallel Rust adapter set. This is **optional and lower-priority** than the drainer KEU
+wiring (the embedding drainer, not `LLMClient`, is the live external-egress path today) —
+a follow-up, not required by this ADR.
+
+The embedding drainer batches are largely **session-insensitive** (stateless embed calls, no
+conversational prefix), so the ADR-0047 D9 prompt-cache/KV-affinity concern is minimal here
+today. But any **future generation-LLM egress** from the engine inherits D9 unchanged:
+preserve the per-conversation affinity key, never flatten sessions, prefix-exact
+pass-through. The KEU meter's existing `provider`/`model` labels already carry the attribution
+key, so no session identity is lost at this seam.
+
+== Non-goals
+
+* No new OSS↔commercial seam — this rides the three existing sanctioned seams + ADR-060.
+* No pricing/billing logic in the engine (that is AnvaiOps).
+* No change to the OSS `io_trace` / `DurableMeteringWriter` contracts.
+* Not the reverse-proxy build itself (that ships in `sandhi`; this is the consumer decision).
+
+== Consequences
+
+*Positive:* ProximaDB's external egress becomes metered from **real** provider usage (fixes
+the KEU estimation gap), and its usage joins the same cross-repo billing signal as Victor and
+AnvaiOps through one neutral event — no repo-local meter drift. The open-core boundary is
+unchanged: OSS emits units, AnvaiOps prices.
+
+*Negative:* a new (optional) dependency edge on the `sandhi` wire schema; the drainer's egress
+clients gain a thin emit call. Both are behind the existing seams and default-inert.
+
+*Neutral:* additive — no existing OSS meter, trace, or contract changes; local BGE inference
+is untouched.
+
+== Refs
+
+`OSS_ENTERPRISE_BOUNDARY_2026_06_17.adoc` (governing spec),
+link:ADR-060-commercial-rust-crate-extension-seam-open-core.adoc[ADR-060] (commercial→OSS
+seam + direction), ADR-027/030 (unified trace+meter),
+link:../../10-quality/td/TD-SANDHI-1-gateway-egress-metering-wiring.adoc[TD-SANDHI-1] (the wiring),
+AnvaiOps ADR-0047 (authoritative homing + wire contract), AnvaiOps ADR-0020 D6 (embedding
+metering stays server-side), Victor ADR-018 / FEP-0020 (sibling consumer + public spec).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -258,6 +258,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Structured io_trace ETL sink — versioned envelope → JSONL+zstd landing → Iceberg-managed Parquet
 | Proposed; S1 #1084 + S2 #1087 shipped
 | Takes ADR-064's trace external without touching billing. The current sink serializes flat JSON on query completion into bounded memory, seals JSONL+zstd, then direct-PUTs to `_operator/io_trace/`; failures fall back to local files. It is **best-effort observability, not billing/audit authority**. Acceptance requires S2b pending-file/restart retry, writer UUID+sequence+digest idempotency, delivery metrics/health, honest config and structural isolation; S3 adds the versioned envelope; S4 compacts to Iceberg-managed star-schema Parquet with crash/retry dedup and source watermark. Billing remains separate/fail-closed. `segment_bytes` is uncompressed bytes; 4 MiB is not a multipart claim.
+| link:ADR-067-consume-ai-usage-gateway-egress-metering.adoc[ADR-067]
+| Consume the `sandhi` AI usage gateway for external-provider egress metering
+| Proposed
+| Thin **consumer** decision (authoritative: AnvaiOps ADR-0047). The Rust drainer's external egress (`AzureOpenAiClient::embed_batch`, BYO, OpenAI/Cohere) emits the shared neutral usage event; KEU stays authoritative + server-side (AnvaiOps ADR-0020 D6); OSS emits units, AnvaiOps prices. Wiring: TD-SANDHI-1.
 |===
 
 NOTE: ADR-010 through ADR-013 and ADR-048/ADR-049 exist in this directory but


### PR DESCRIPTION
## Summary

Thin **consumer** decision: ProximaDB consumes **Sandhi** — the AI usage gateway
(`anvai-labs/sandhi`) — for external-provider egress metering. Authoritative decision is
AnvaiOps ADR-0047; this records ProximaDB's local consequence. Docs-only.

## What's here

- **ADR-067** — ProximaDB's Rust drainer external egress (`AzureOpenAiClient::embed_batch`,
  BYO, OpenAI/Cohere) emits the shared neutral usage event. **KEU stays authoritative +
  server-side** (AnvaiOps ADR-0020 D6 — the gateway complements, never replaces the KEU meter).
  OSS emits neutral units; AnvaiOps prices — the same open-core boundary as ADR-060 /
  `OSS_ENTERPRISE_BOUNDARY`. ProximaDB links `sandhi-core` **natively (no FFI)** — the best
  case of the binding story. Notes the 8-provider `LLMClient` as an optional consolidation
  target onto `sandhi-providers` (ADR-0047 D10).
- **TD-SANDHI-1** — the wiring: meter KEU from **real provider usage** (replace the
  `count*512` heuristic in `embedding_drainer.rs`) + emit the shared schema. Behind the
  existing seams; default-inert. Gated on the `sandhi` repo publishing a stable schema.
- **README index** — adds ADR-067.

## Notes

- No engine mechanism change — additive to the drainer's egress clients only; `io_trace` /
  `DurableMeteringWriter` contracts untouched.
- ADR/TD uniqueness guard: 0 errors.
- Sibling consumer: victor FEP-0020 + ADR-018.
