### PR TITLE
refactor: decouple ORION cache-hint onto GraphCacheHintPort (ORION move 6e)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -344,3 +344,42 @@ pub trait GraphWalFactory: Send + Sync {
     /// single composition-root seam that does (mirrors make_writer/make_reader).
     async fn make_filesystem(&self) -> Result<Arc<dyn FilesystemPort>>;
 }
+
+/// Graph-engine cache-hint surface (ORION extraction). A graph engine (ORION)
+/// emits best-effort access-tracking + prefetch hints to the root-owned cache
+/// orchestrator through this port, registered once at startup, so the engine
+/// never names the concrete `CrossCacheOrchestrator` / `CacheType`. Mirrors the
+/// distance-kernel GPU-factory global-registration pattern (#162). The
+/// [`CacheKind`] enum (the storage-engine subset) intentionally omits graph
+/// kinds, so this enum carries the graph variants the engine tracks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GraphCacheKind {
+    GraphNode,
+    GraphEdge,
+    GraphAdjacency,
+}
+
+/// Global graph cache-hint port (write-once, set at server startup by the
+/// composition root; read by graph engines).
+#[async_trait::async_trait]
+pub trait GraphCacheHintPort: Send + Sync {
+    /// Record an access for the access-pattern tracker (best-effort, fire-and-forget).
+    fn track_access(&self, key: String, kind: GraphCacheKind);
+    /// Request a predictive prefetch (best-effort; queue-size-guarded internally).
+    async fn request_prefetch(&self, key: &str, kind: GraphCacheKind);
+}
+
+static GLOBAL_GRAPH_CACHE_HINT: std::sync::OnceLock<Arc<dyn GraphCacheHintPort>> =
+    std::sync::OnceLock::new();
+
+/// Register the global graph cache-hint port. Called once by the composition
+/// root at startup (alongside `CrossCacheOrchestrator::register_global`).
+pub fn register_graph_cache_hint(hint: Arc<dyn GraphCacheHintPort>) {
+    let _ = GLOBAL_GRAPH_CACHE_HINT.set(hint);
+}
+
+/// Access the registered graph cache-hint port, if any. Graph engines call this
+/// and treat `None` as a no-op (e.g. before startup registration or in tests).
+pub fn graph_cache_hint() -> Option<&'static Arc<dyn GraphCacheHintPort>> {
+    GLOBAL_GRAPH_CACHE_HINT.get()
+}

--- a/src/graph/engines/orion/traversal.rs
+++ b/src/graph/engines/orion/traversal.rs
@@ -34,7 +34,7 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 // Using HashSet instead of BitVec for visited tracking
 // This provides better performance for sparse graphs
-use crate::storage::cache::orchestrator::{CacheType, CrossCacheOrchestrator};
+use proximadb_storage_ports::GraphCacheKind;
 
 /// Traversal results containing nodes, paths, and statistics
 #[derive(Debug, Clone)]
@@ -285,16 +285,13 @@ pub async fn breadth_first_search(
             };
             for edge in outgoing_edges {
                 // Non-blocking cache access tracking for orchestrator learning
-                if let Some(orch) = CrossCacheOrchestrator::global() {
+                if let Some(orch) = proximadb_storage_ports::graph_cache_hint() {
                     let adj_key = format!("adj::{}", current_node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(adj_key, CacheType::GraphAdjacency);
+                    orch.track_access(adj_key, GraphCacheKind::GraphAdjacency);
                     let node_key = format!("node::{}", edge.to_node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(node_key, CacheType::GraphNode);
+                    orch.track_access(node_key, GraphCacheKind::GraphNode);
                     let edge_key = format!("edge::{}->{}", current_node_id, edge.to_node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(edge_key, CacheType::GraphEdge);
+                    orch.track_access(edge_key, GraphCacheKind::GraphEdge);
                 }
                 // Filter by edge type if specified
                 if config
@@ -333,10 +330,11 @@ pub async fn breadth_first_search(
                     // Hint orchestrator to prefetch adjacency for next frontier (bounded)
                     if prefetch_budget > 0
                         && config.enable_prefetch
-                        && let Some(orch) = CrossCacheOrchestrator::global()
+                        && let Some(orch) = proximadb_storage_ports::graph_cache_hint()
                     {
                         let key = format!("adj::{}", neighbor_id);
-                        orch.request_prefetch(&key, CacheType::GraphAdjacency).await;
+                        orch.request_prefetch(&key, GraphCacheKind::GraphAdjacency)
+                            .await;
                         prefetch_budget -= 1;
                     }
                 }
@@ -480,16 +478,13 @@ pub async fn depth_first_search(
         };
         for edge in outgoing_edges.iter().rev() {
             // Non-blocking cache access tracking for orchestrator learning
-            if let Some(orch) = CrossCacheOrchestrator::global() {
+            if let Some(orch) = proximadb_storage_ports::graph_cache_hint() {
                 let adj_key = format!("adj::{}", current_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(adj_key, CacheType::GraphAdjacency);
+                orch.track_access(adj_key, GraphCacheKind::GraphAdjacency);
                 let node_key = format!("node::{}", edge.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(node_key, CacheType::GraphNode);
+                orch.track_access(node_key, GraphCacheKind::GraphNode);
                 let edge_key = format!("edge::{}->{}", current_node_id, edge.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(edge_key, CacheType::GraphEdge);
+                orch.track_access(edge_key, GraphCacheKind::GraphEdge);
             }
             // Filter by edge type if specified
             if config
@@ -522,10 +517,11 @@ pub async fn depth_first_search(
                 // Hint orchestrator to prefetch adjacency for next frontier (bounded)
                 if prefetch_budget > 0
                     && config.enable_prefetch
-                    && let Some(orch) = CrossCacheOrchestrator::global()
+                    && let Some(orch) = proximadb_storage_ports::graph_cache_hint()
                 {
                     let key = format!("adj::{}", neighbor_id);
-                    orch.request_prefetch(&key, CacheType::GraphAdjacency).await;
+                    orch.request_prefetch(&key, GraphCacheKind::GraphAdjacency)
+                        .await;
                     prefetch_budget -= 1;
                 }
             }
@@ -971,16 +967,13 @@ pub async fn dijkstra_shortest_path(
         };
         for edge in outgoing_edges {
             // Non-blocking cache access tracking for orchestrator learning (Dijkstra)
-            if let Some(orch) = CrossCacheOrchestrator::global() {
+            if let Some(orch) = proximadb_storage_ports::graph_cache_hint() {
                 let adj_key = format!("adj::{}", current.node_id);
-                orch.pattern_tracker()
-                    .track_access_async(adj_key, CacheType::GraphAdjacency);
+                orch.track_access(adj_key, GraphCacheKind::GraphAdjacency);
                 let node_key = format!("node::{}", edge.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(node_key, CacheType::GraphNode);
+                orch.track_access(node_key, GraphCacheKind::GraphNode);
                 let edge_key = format!("edge::{}->{}", current.node_id, edge.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(edge_key, CacheType::GraphEdge);
+                orch.track_access(edge_key, GraphCacheKind::GraphEdge);
             }
             // Filter by edge type if specified
             if let Some(ref allowed_types) = config.edge_types
@@ -1007,10 +1000,11 @@ pub async fn dijkstra_shortest_path(
                 // Hint orchestrator to prefetch adjacency for likely next node (bounded)
                 if prefetch_budget > 0
                     && config.enable_prefetch
-                    && let Some(orch) = CrossCacheOrchestrator::global()
+                    && let Some(orch) = proximadb_storage_ports::graph_cache_hint()
                 {
                     let key = format!("adj::{}", neighbor_id);
-                    orch.request_prefetch(&key, CacheType::GraphAdjacency).await;
+                    orch.request_prefetch(&key, GraphCacheKind::GraphAdjacency)
+                        .await;
                     prefetch_budget -= 1;
                 }
             }
@@ -1192,16 +1186,13 @@ pub async fn astar_shortest_path(
         };
         for e in neighbors {
             // Non-blocking cache access tracking for orchestrator learning (A*)
-            if let Some(orch) = CrossCacheOrchestrator::global() {
+            if let Some(orch) = proximadb_storage_ports::graph_cache_hint() {
                 let adj_key = format!("adj::{}", current.node_id);
-                orch.pattern_tracker()
-                    .track_access_async(adj_key, CacheType::GraphAdjacency);
+                orch.track_access(adj_key, GraphCacheKind::GraphAdjacency);
                 let node_key = format!("node::{}", e.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(node_key, CacheType::GraphNode);
+                orch.track_access(node_key, GraphCacheKind::GraphNode);
                 let edge_key = format!("edge::{}->{}", current.node_id, e.to_node_id);
-                orch.pattern_tracker()
-                    .track_access_async(edge_key, CacheType::GraphEdge);
+                orch.track_access(edge_key, GraphCacheKind::GraphEdge);
             }
             let neighbor = &e.to_node_id;
             if closed.contains(neighbor) {
@@ -1220,10 +1211,11 @@ pub async fn astar_shortest_path(
                 // Hint orchestrator to prefetch adjacency for likely next node (bounded)
                 if prefetch_budget > 0
                     && config.enable_prefetch
-                    && let Some(orch) = CrossCacheOrchestrator::global()
+                    && let Some(orch) = proximadb_storage_ports::graph_cache_hint()
                 {
                     let key = format!("adj::{}", neighbor);
-                    orch.request_prefetch(&key, CacheType::GraphAdjacency).await;
+                    orch.request_prefetch(&key, GraphCacheKind::GraphAdjacency)
+                        .await;
                     prefetch_budget -= 1;
                 }
             }
@@ -1559,16 +1551,13 @@ pub async fn k_shortest_paths(
             };
             for e in outgoing {
                 // Non-blocking cache access tracking for orchestrator learning (Yen's/dijkstra_with_exclusions)
-                if let Some(orch) = CrossCacheOrchestrator::global() {
+                if let Some(orch) = proximadb_storage_ports::graph_cache_hint() {
                     let adj_key = format!("adj::{}", q.node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(adj_key, CacheType::GraphAdjacency);
+                    orch.track_access(adj_key, GraphCacheKind::GraphAdjacency);
                     let node_key = format!("node::{}", e.to_node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(node_key, CacheType::GraphNode);
+                    orch.track_access(node_key, GraphCacheKind::GraphNode);
                     let edge_key = format!("edge::{}->{}", q.node_id, e.to_node_id);
-                    orch.pattern_tracker()
-                        .track_access_async(edge_key, CacheType::GraphEdge);
+                    orch.track_access(edge_key, GraphCacheKind::GraphEdge);
                 }
                 if exclude_edges.contains(&(e.from_node_id.clone(), e.to_node_id.clone())) {
                     continue;
@@ -1589,10 +1578,11 @@ pub async fn k_shortest_paths(
                     // Hint orchestrator to prefetch adjacency for likely next node (bounded)
                     if prefetch_budget > 0
                         && config.enable_prefetch
-                        && let Some(orch) = CrossCacheOrchestrator::global()
+                        && let Some(orch) = proximadb_storage_ports::graph_cache_hint()
                     {
                         let key = format!("adj::{}", e.to_node_id);
-                        orch.request_prefetch(&key, CacheType::GraphAdjacency).await;
+                        orch.request_prefetch(&key, GraphCacheKind::GraphAdjacency)
+                            .await;
                         prefetch_budget -= 1;
                     }
                 }

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1259,6 +1259,11 @@ impl SharedServices {
         };
         // Always register globally — idempotent via OnceLock
         CrossCacheOrchestrator::register_global(orchestrator.clone());
+        // Register the graph cache-hint bridge so graph engines (ORION) can hint
+        // the cache through the leaf port without naming the concrete orchestrator.
+        proximadb_storage_ports::register_graph_cache_hint(std::sync::Arc::new(
+            crate::storage::cache::orchestrator::GraphCacheHintBridge,
+        ));
 
         // =========================================================================
         // Initialize EventLog service and start AXIS consumer for async index building

--- a/src/storage/cache/orchestrator.rs
+++ b/src/storage/cache/orchestrator.rs
@@ -1695,6 +1695,42 @@ impl Default for CrossCacheOrchestrator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Graph cache-hint bridge: lets graph engines (ORION) hint the cache through the
+// leaf `GraphCacheHintPort` without naming `CrossCacheOrchestrator`/`CacheType`.
+// Registered once at startup alongside `CrossCacheOrchestrator::register_global`.
+// ---------------------------------------------------------------------------
+
+fn graph_cache_kind_to_type(kind: proximadb_storage_ports::GraphCacheKind) -> CacheType {
+    use proximadb_storage_ports::GraphCacheKind;
+    match kind {
+        GraphCacheKind::GraphNode => CacheType::GraphNode,
+        GraphCacheKind::GraphEdge => CacheType::GraphEdge,
+        GraphCacheKind::GraphAdjacency => CacheType::GraphAdjacency,
+    }
+}
+
+/// Root bridge from [`proximadb_storage_ports::GraphCacheHintPort`] to the
+/// process-global [`CrossCacheOrchestrator`]. Best-effort: a no-op when no
+/// orchestrator is registered yet.
+pub(crate) struct GraphCacheHintBridge;
+
+#[async_trait::async_trait]
+impl proximadb_storage_ports::GraphCacheHintPort for GraphCacheHintBridge {
+    fn track_access(&self, key: String, kind: proximadb_storage_ports::GraphCacheKind) {
+        if let Some(orch) = CrossCacheOrchestrator::global() {
+            orch.track_access_async(key, graph_cache_kind_to_type(kind));
+        }
+    }
+
+    async fn request_prefetch(&self, key: &str, kind: proximadb_storage_ports::GraphCacheKind) {
+        if let Some(orch) = CrossCacheOrchestrator::global() {
+            orch.request_prefetch(key, graph_cache_kind_to_type(kind))
+                .await;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

ORION **move sub-cascade, slice 6e** — resolves the cache-orchestrator blocker for moving the 14 ORION files to a crate. Builds on `develop` (6a #1098, 6b+6c #1099 merged).

`traversal.rs`'s prefetch/access hints went directly to the root `CrossCacheOrchestrator` (global singleton) + `CacheType` (~10 sites). Resolved with a **leaf port registered once at startup** (the #162 OnceLock-global pattern), so the engine never names the concrete orchestrator.

## Changes

- **storage-ports** — `GraphCacheKind` enum (GraphNode/Edge/Adjacency; the existing `CacheKind` storage-engine subset intentionally omits graph kinds) + `GraphCacheHintPort` trait (`track_access` sync + `request_prefetch` async) + OnceLock global + `register_graph_cache_hint()`/`graph_cache_hint()` accessor.
- **root (orchestrator.rs)** — `GraphCacheHintBridge` impl maps `GraphCacheKind`→`CacheType` and delegates to `CrossCacheOrchestrator::global()`; registered at startup alongside `CrossCacheOrchestrator::register_global` (`shared_services.rs`).
- **traversal.rs** — ~10 sites retargeted: `CrossCacheOrchestrator::global()`→`graph_cache_hint()`, `CacheType::GraphX`→`GraphCacheKind::X`, `pattern_tracker().track_access_async`→`track_access`.

## Why this shape
The cache hint is a best-effort optimization behind `if let Some(orch) = …::global()`. The OnceLock-registered port mirrors the distance-kernel GPU-factory pattern (#162): write-once at startup, engines read+no-op when unset. Behavior-identical — same orchestrator, same calls, behind the bridge.

## Verification
- `cargo clippy --lib --bins -- -D warnings` (CI gate) — clean
- `cargo check --tests` — clean
- `rustup run 1.95.0 cargo fmt --all` — canonical
- `make work-commit-check` + layering + workspace-boundaries — all pass (no boundary findings)
- `scripts/check_no_agent_attribution.py` — clean

## Roadmap
6a ✓ · 6b+6c ✓ · **6e** (this: cache) · **6f** (canonical-WAL `FramedTableWalAppender` + `cold_payloads_enabled` flag) · **6g** `git mv` 14 files → `proximadb-orion-engine` + shim + Cargo + extract WAL tests. After 6f, orion/'s remaining `crate::` refs are pure path-rewrites to existing leaves.