### PR TITLE
refactor: decouple ORION canonical-WAL + cold-payload (ORION move 6f)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -343,6 +343,10 @@ pub trait GraphWalFactory: Send + Sync {
     /// The engine never names the concrete filesystem factory; this is the
     /// single composition-root seam that does (mirrors make_writer/make_reader).
     async fn make_filesystem(&self) -> Result<Arc<dyn FilesystemPort>>;
+
+    /// Build the canonical-WAL reader the engine uses for TD-066 checkpoint-LSN
+    /// correlation on recovery. The engine never names the concrete appender.
+    async fn make_canonical_wal_reader(&self) -> Result<Arc<dyn CanonicalWalReaderPort>>;
 }
 
 /// Graph-engine cache-hint surface (ORION extraction). A graph engine (ORION)
@@ -382,4 +386,18 @@ pub fn register_graph_cache_hint(hint: Arc<dyn GraphCacheHintPort>) {
 /// and treat `None` as a no-op (e.g. before startup registration or in tests).
 pub fn graph_cache_hint() -> Option<&'static Arc<dyn GraphCacheHintPort>> {
     GLOBAL_GRAPH_CACHE_HINT.get()
+}
+
+/// Dependency-injection port for reading the shared canonical WAL (ORION
+/// extraction). The engine reads canonical-WAL entries through this port — to
+/// correlate the latest checkpoint LSN during recovery (TD-066 Part 2) — rather
+/// than naming the concrete framed-table appender. Entries are the leaf
+/// [`CanonicalWalEntry`] type.
+#[async_trait::async_trait]
+pub trait CanonicalWalReaderPort: Send + Sync {
+    /// Read every entry from the canonical WAL at `canonical_wal_path`.
+    async fn read_entries(
+        &self,
+        canonical_wal_path: &std::path::Path,
+    ) -> Result<Vec<proximadb_storage_common::wal_entry::CanonicalWalEntry>>;
 }

--- a/src/graph/engines/orion/persistence.rs
+++ b/src/graph/engines/orion/persistence.rs
@@ -53,6 +53,15 @@ use tracing::{debug, info, warn};
 
 type Result<T> = std::result::Result<T, ProximaDBError>;
 
+/// Whether the cold-payload tier is enabled. Mirrors `graph::service::cold_payloads_enabled`
+/// (reads `PROXIMADB_GRAPH_COLD_PAYLOADS`) — inlined here so this module has no root
+/// `crate::graph::service` dependency (ORION crate extraction).
+fn cold_payloads_enabled() -> bool {
+    std::env::var("PROXIMADB_GRAPH_COLD_PAYLOADS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
 /// Serializable snapshot of the ORION engine state
 #[derive(Serialize, Deserialize)]
 pub struct OrionSnapshot {
@@ -147,6 +156,11 @@ pub struct OrionPersistence {
     /// changes are the Part 2 follow-up slice).
     canonical_wal_path: Option<PathBuf>,
 
+    /// Canonical-WAL reader (TD-066 checkpoint-LSN correlation), obtained
+    /// through the injected `GraphWalFactory` so the engine never names the
+    /// concrete appender. Only used when `canonical_wal_path` is `Some`.
+    canonical_wal_reader: Arc<dyn proximadb_storage_ports::CanonicalWalReaderPort>,
+
     /// WAL sink for graph operations. The engine appends through the
     /// [`GraphWalPort`] dependency-inversion port (injected by the composition
     /// root as the unified WAL writer), so it never names the concrete writer
@@ -225,6 +239,11 @@ impl OrionPersistence {
                 e.to_string(),
             ))
         })?;
+        let canonical_wal_reader = wal_factory.make_canonical_wal_reader().await.map_err(|e| {
+            ProximaDBError::Storage(proximadb_kernel::error::StorageError::SerializationError(
+                e.to_string(),
+            ))
+        })?;
 
         // Build graph-specific path: {base_url}/graphs/{graph_id}/data
         let graph_path = format!(
@@ -297,6 +316,7 @@ impl OrionPersistence {
             filesystem_factory,
             wal_path,
             canonical_wal_path: None,
+            canonical_wal_reader,
             wal_writer,
             wal_reader,
             compression: CompressionAlgorithm::Zstd,
@@ -350,20 +370,19 @@ impl OrionPersistence {
         if !tokio::fs::try_exists(path).await.unwrap_or(false) {
             return None;
         }
-        let entries =
-            match crate::services::FramedTableWalAppender::read_entries_from_path(path).await {
-                Ok(entries) => entries,
-                Err(err) => {
-                    tracing::warn!(
-                        graph_id = %self.graph_id,
-                        canonical_wal_path = %path.display(),
-                        error = %err,
-                        "ORION canonical_checkpoint_lsn: failed to read canonical WAL; \
-                         returning None and falling back to engine-WAL-only recovery"
-                    );
-                    return None;
-                }
-            };
+        let entries = match self.canonical_wal_reader.read_entries(path).await {
+            Ok(entries) => entries,
+            Err(err) => {
+                tracing::warn!(
+                    graph_id = %self.graph_id,
+                    canonical_wal_path = %path.display(),
+                    error = %err,
+                    "ORION canonical_checkpoint_lsn: failed to read canonical WAL; \
+                     returning None and falling back to engine-WAL-only recovery"
+                );
+                return None;
+            }
+        };
 
         let graph_id = self.graph_id.as_str();
         entries
@@ -394,20 +413,19 @@ impl OrionPersistence {
         if !tokio::fs::try_exists(path).await.unwrap_or(false) {
             return None;
         }
-        let entries =
-            match crate::services::FramedTableWalAppender::read_entries_from_path(path).await {
-                Ok(entries) => entries,
-                Err(err) => {
-                    tracing::warn!(
-                        graph_id = %self.graph_id,
-                        canonical_wal_path = %path.display(),
-                        error = %err,
-                        "ORION canonical_checkpoint_with_timestamp: failed to read canonical WAL; \
-                         returning None and falling back to engine-WAL-only recovery"
-                    );
-                    return None;
-                }
-            };
+        let entries = match self.canonical_wal_reader.read_entries(path).await {
+            Ok(entries) => entries,
+            Err(err) => {
+                tracing::warn!(
+                    graph_id = %self.graph_id,
+                    canonical_wal_path = %path.display(),
+                    error = %err,
+                    "ORION canonical_checkpoint_with_timestamp: failed to read canonical WAL; \
+                     returning None and falling back to engine-WAL-only recovery"
+                );
+                return None;
+            }
+        };
 
         let graph_id = self.graph_id.as_str();
         entries
@@ -438,7 +456,7 @@ impl OrionPersistence {
         // record store via the service cold-fetch path). When OFF (default), the full
         // v2 snapshot is written exactly as before. The same `OrionSnapshot` struct
         // carries both; a v3 is simply a v2 with empty `nodes`/`edges` + `version = 3`.
-        let topology_only = crate::graph::service::cold_payloads_enabled();
+        let topology_only = cold_payloads_enabled();
 
         // Collect node/edge payloads ONLY for the full (v2) snapshot. The clones are the
         // expensive part a huge graph wants to avoid, so they are skipped entirely for v3.
@@ -632,7 +650,7 @@ impl OrionPersistence {
         // cold-fetch, so get_node/get_edge would silently return None (apparent data loss).
         // Refuse the load loudly instead, so flipping the gate off after enabling it yields
         // a clear error, not silent corruption.
-        if topology_only_snapshot && !crate::graph::service::cold_payloads_enabled() {
+        if topology_only_snapshot && !cold_payloads_enabled() {
             return Err(ProximaDBError::InvalidInput(format!(
                 "graph '{}': snapshot is topology-only (empty payloads) but the cold-payload \
                  tier (PROXIMADB_GRAPH_COLD_PAYLOADS) is OFF — enable it to load this snapshot, \

--- a/src/services/canonical_wal.rs
+++ b/src/services/canonical_wal.rs
@@ -110,6 +110,19 @@ impl FramedTableWalAppender {
     }
 }
 
+/// Root bridge from [`proximadb_storage_ports::CanonicalWalReaderPort`] to
+/// [`FramedTableWalAppender::read_entries_from_path`], so graph engines can read
+/// the canonical WAL for TD-066 checkpoint-LSN correlation without naming the
+/// concrete appender.
+pub(crate) struct CanonicalWalReaderBridge;
+
+#[async_trait]
+impl proximadb_storage_ports::CanonicalWalReaderPort for CanonicalWalReaderBridge {
+    async fn read_entries(&self, canonical_wal_path: &Path) -> Result<Vec<CanonicalWalEntry>> {
+        FramedTableWalAppender::read_entries_from_path(canonical_wal_path).await
+    }
+}
+
 #[async_trait]
 impl TableWalAppender for FramedTableWalAppender {
     async fn read_all_entries(&self) -> Result<Vec<CanonicalWalEntry>> {

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -25,7 +25,9 @@ use crate::storage::memtable::implementations::graph_memtable::GraphOperation;
 use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
 use proximadb_graph_model::{GraphWalEntry, GraphWalRecord};
 use proximadb_records::ProximaRecord;
-use proximadb_storage_ports::{FilesystemPort, GraphWalFactory, GraphWalPort, GraphWalReaderPort};
+use proximadb_storage_ports::{
+    CanonicalWalReaderPort, FilesystemPort, GraphWalFactory, GraphWalPort, GraphWalReaderPort,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -844,6 +846,12 @@ impl GraphWalFactory for UnifiedWalFactory {
             .map_err(|e| anyhow::anyhow!("Failed to create default filesystem: {e}"))?;
         let fs: Arc<dyn FilesystemPort> = Arc::new(fs);
         Ok(fs)
+    }
+
+    async fn make_canonical_wal_reader(&self) -> anyhow::Result<Arc<dyn CanonicalWalReaderPort>> {
+        Ok(Arc::new(
+            crate::services::canonical_wal::CanonicalWalReaderBridge,
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

ORION **move sub-cascade, slice 6f** — the last port-inversion before the `git mv` capstone. Builds on `develop` (6e #1101 + 6a/6b+6c/#1083-#1097 all merged). Resolves `persistence.rs`'s two remaining root-internal dependencies.

## Changes

- **Canonical-WAL reading** (TD-066 checkpoint-LSN correlation): `canonical_checkpoint_lsn` + `canonical_checkpoint_with_timestamp` read the shared canonical WAL via the root `FramedTableWalAppender`. Resolved with a **`CanonicalWalReaderPort`** (storage-ports; returns the leaf `CanonicalWalEntry` so the engine keeps its scan logic) produced by `GraphWalFactory::make_canonical_wal_reader`; a root `CanonicalWalReaderBridge` (`canonical_wal.rs`) delegates to `FramedTableWalAppender`. `OrionPersistence` obtains the reader from the already-injected factory (**no new threading**).
- **`cold_payloads_enabled`**: was `crate::graph::service::cold_payloads_enabled()` (a 4-line env-var read). Inlined as a local `persistence.rs` helper reading `PROXIMADB_GRAPH_COLD_PAYLOADS` directly (no root dep, no port).

## After this
`orion/persistence.rs` has **zero** `crate::services` / `crate::graph::service` references. `orion/`'s remaining `crate::` refs are pure path-rewrites to existing leaves (graph-model, proto, storage-tenant) — the 6g move mechanics, no further port-inversion.

## Verification
- `cargo clippy --lib --bins -- -D warnings` (CI gate) — clean
- `cargo check --tests` — clean
- `rustup run 1.95.0 cargo fmt --all` — canonical
- `make work-commit-check` + layering + workspace-boundaries — all pass (no boundary findings)
- `scripts/check_no_agent_attribution.py` — clean

## Roadmap
6a ✓ · 6b+6c ✓ · 6e ✓ · **6f** (this: canonical-WAL + cold-payload) · **6g** `git mv` 14 files → `proximadb-orion-engine` (path-rewrites to existing leaves + shim + Cargo + extract WAL tests). Then pgwire.