### PR TITLE
feat(metering): meter embedding KEU from real provider usage + emit neutral usage event (TD-SANDHI-1 / ADR-067)

### DIFF
--- a/crates/modalities/proximadb-embedding/src/lib.rs
+++ b/crates/modalities/proximadb-embedding/src/lib.rs
@@ -55,7 +55,7 @@ pub mod service;
 pub mod tokenizer;
 
 pub use config::{ChunkConfig, EmbedRoute, EmbedRouteIdentity, EmbeddingConfig};
-pub use models::{BatchConversionSummary, ModelRegistry};
+pub use models::{BatchConversionSummary, EmbedUsage, ModelRegistry};
 // INT-1 (mini-phase): typed embedding values for native-precision
 // inference output. Re-exported from proximadb-records so callers don't
 // need to add the records crate as a direct dep just to consume

--- a/crates/modalities/proximadb-embedding/src/models/azure_openai.rs
+++ b/crates/modalities/proximadb-embedding/src/models/azure_openai.rs
@@ -11,6 +11,7 @@
 //! - `AZURE_OPENAI_DEPLOYMENT_SMALL`  — deployment name for text-embedding-3-small
 
 use crate::config::AzureModel;
+use crate::models::EmbedUsage;
 use crate::{EmbeddingError, Result};
 
 pub struct AzureOpenAiClient {
@@ -44,7 +45,15 @@ impl AzureOpenAiClient {
         })
     }
 
-    pub fn embed_batch(&self, model: &AzureModel, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    /// Embed a batch and return the provider's **real** token usage alongside the vectors
+    /// (TD-SANDHI-1 / ADR-067). Azure OpenAI's embeddings response carries
+    /// `usage.{prompt_tokens,total_tokens}`; this parses it so KEU is metered from measured
+    /// values instead of a `count*512` heuristic. `None` only if the provider omits `usage`.
+    pub fn embed_batch_with_usage(
+        &self,
+        model: &AzureModel,
+        texts: &[String],
+    ) -> Result<(Vec<Vec<f32>>, Option<EmbedUsage>)> {
         let deployment = match model {
             AzureModel::TextEmbed3Large => &self.deployment_large,
             AzureModel::TextEmbed3Small => &self.deployment_small,
@@ -73,13 +82,35 @@ impl AzureOpenAiClient {
         let body: AzureEmbedResponse = resp
             .json()
             .map_err(|e| EmbeddingError::Other(anyhow::anyhow!(e)))?;
-        Ok(body.data.into_iter().map(|d| d.embedding).collect())
+        let usage = body.usage.map(|u| EmbedUsage {
+            input_tokens: u.prompt_tokens,
+            total_tokens: u.total_tokens,
+        });
+        let vectors = body.data.into_iter().map(|d| d.embedding).collect();
+        Ok((vectors, usage))
+    }
+
+    /// Vectors only — thin delegate over [`Self::embed_batch_with_usage`] for callers that
+    /// don't need the token usage.
+    pub fn embed_batch(&self, model: &AzureModel, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.embed_batch_with_usage(model, texts)
+            .map(|(vectors, _)| vectors)
     }
 }
 
 #[derive(serde::Deserialize)]
 struct AzureEmbedResponse {
     data: Vec<AzureEmbedDatum>,
+    #[serde(default)]
+    usage: Option<AzureUsage>,
+}
+
+#[derive(serde::Deserialize)]
+struct AzureUsage {
+    #[serde(default)]
+    prompt_tokens: u64,
+    #[serde(default)]
+    total_tokens: u64,
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/modalities/proximadb-embedding/src/models/mod.rs
+++ b/crates/modalities/proximadb-embedding/src/models/mod.rs
@@ -26,6 +26,17 @@ use crate::config::EmbedRoute;
 use crate::{EmbeddingError, Result};
 use proximadb_records::EmbeddingScalarType;
 
+/// Real token usage reported by an **external** provider's embedding response (TD-SANDHI-1 /
+/// ADR-067). `None` when the backend is local (BGE ONNX has no provider usage) or the provider's
+/// contract carries no usage (BYO). Measured units only — pricing is downstream (ADR-060).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EmbedUsage {
+    /// Provider `prompt_tokens` — the real input-token count for the whole batch.
+    pub input_tokens: u64,
+    /// Provider `total_tokens` (for embeddings, typically equal to `input_tokens`).
+    pub total_tokens: u64,
+}
+
 pub struct ModelRegistry {
     bge_small: OnceLock<Arc<bge::BgeModel>>,
     bge_large: OnceLock<Arc<bge::BgeModel>>,
@@ -67,10 +78,32 @@ impl ModelRegistry {
     /// responsible for ensuring all texts share the same route (the
     /// `EmbeddingService::resolve_route` cache makes this trivial in practice).
     pub fn embed_batch(&self, route: &EmbedRoute, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.embed_batch_with_usage(route, texts)
+            .map(|(vectors, _)| vectors)
+    }
+
+    /// Like [`Self::embed_batch`] but also returns the provider's real token usage when the
+    /// backend reports it (TD-SANDHI-1 / ADR-067). External providers that expose usage (Azure
+    /// OpenAI) return `Some`; local BGE and BYO (no usage in its contract) return `None`, so
+    /// callers keep the compute-based estimate for those.
+    pub fn embed_batch_with_usage(
+        &self,
+        route: &EmbedRoute,
+        texts: &[String],
+    ) -> Result<(Vec<Vec<f32>>, Option<EmbedUsage>)> {
         match route {
-            EmbedRoute::BgeSmall => self.bge(bge::Variant::Small)?.embed_batch(texts),
-            EmbedRoute::BgeLarge => self.bge(bge::Variant::Large)?.embed_batch(texts),
-            EmbedRoute::BgeM3 => self.bge(bge::Variant::M3)?.embed_batch(texts),
+            EmbedRoute::BgeSmall => self
+                .bge(bge::Variant::Small)?
+                .embed_batch(texts)
+                .map(|v| (v, None)),
+            EmbedRoute::BgeLarge => self
+                .bge(bge::Variant::Large)?
+                .embed_batch(texts)
+                .map(|v| (v, None)),
+            EmbedRoute::BgeM3 => self
+                .bge(bge::Variant::M3)?
+                .embed_batch(texts)
+                .map(|v| (v, None)),
             EmbedRoute::AzureOpenAi { model } => self
                 .azure_openai
                 .as_ref()
@@ -81,7 +114,7 @@ impl ModelRegistry {
                             .into(),
                     )
                 })?
-                .embed_batch(model, texts),
+                .embed_batch_with_usage(model, texts),
             EmbedRoute::OpenAi { model } => Err(EmbeddingError::ModelUnavailable(format!(
                 "Direct OpenAI route (model={model:?}) is declared but the HTTP client is not yet \
                  implemented; configure as Azure OpenAI or BYO endpoint in the meantime."
@@ -103,7 +136,8 @@ impl ModelRegistry {
                 // EmbedRoute for catalog audit but doesn't change the call.
                 declared_precision: _,
             } => byo::ByoClient::new(url.clone(), auth.clone(), *batch_size, *timeout_ms)
-                .embed_batch(texts, *declared_dim),
+                .embed_batch(texts, *declared_dim)
+                .map(|v| (v, None)),
         }
     }
 

--- a/crates/modalities/proximadb-embedding/src/service.rs
+++ b/crates/modalities/proximadb-embedding/src/service.rs
@@ -41,6 +41,10 @@ pub struct EmbedBatch {
 pub struct EmbedResult {
     pub vectors: Vec<Vec<f32>>,
     pub route: EmbedRoute,
+    /// The external provider's **real** token usage for this batch, when reported
+    /// (TD-SANDHI-1 / ADR-067). `None` for local BGE and BYO — callers keep the
+    /// compute-based estimate for those.
+    pub usage: Option<crate::models::EmbedUsage>,
 }
 
 /// INT-2.5c result for the precision-aware embed path
@@ -192,10 +196,14 @@ impl EmbeddingService {
         let route_inner = route.clone();
         let rx = self
             .scheduler
-            .submit_sync(move || service.models.embed_batch(&route_inner, &texts))?;
+            .submit_sync(move || service.models.embed_batch_with_usage(&route_inner, &texts))?;
         rx.await
             .map_err(|_| EmbeddingError::Other(anyhow::anyhow!("scheduler dropped")))?
-            .map(|vectors| EmbedResult { vectors, route })
+            .map(|(vectors, usage)| EmbedResult {
+                vectors,
+                route,
+                usage,
+            })
     }
 
     /// INT-2.5c: synchronous embed at a caller-declared canonical
@@ -259,8 +267,12 @@ impl EmbeddingService {
             let texts: Vec<String> = batch.records.iter().map(|r| r.text.clone()).collect();
             let outcome = service
                 .models
-                .embed_batch(&route_inner, &texts)
-                .map(|vectors| EmbedResult { vectors, route });
+                .embed_batch_with_usage(&route_inner, &texts)
+                .map(|(vectors, usage)| EmbedResult {
+                    vectors,
+                    route,
+                    usage,
+                });
             on_complete(outcome);
             Ok(())
         })

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -31,6 +31,7 @@ pub mod store;
 mod tests;
 pub mod tier_migration_metrics;
 pub mod updater;
+pub mod usage_event;
 
 // Top-level type re-exports (preserve `crate::metrics::X` paths).
 pub use cache::{CacheMetricsCollector, CacheMetricsSnapshot, CacheOptimizationHints};

--- a/src/metrics/usage_event.rs
+++ b/src/metrics/usage_event.rs
@@ -1,0 +1,170 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Neutral usage-event emission (ADR-067 / TD-SANDHI-1).
+//!
+//! Serializes to the AnvaiOps/`sandhi` `usage-event.v1` schema — the neutral, cross-repo
+//! boundary object emitted once per external model call. **Measured units only: NO dollars,
+//! NO tier/SKU names** (OSS emits units, AnvaiOps prices — ADR-067 / ADR-060).
+//!
+//! Transport is the ADR-067 "in-process emit": a direct crate call that logs the event through
+//! `tracing` (operators ship logs to their sink of record). It **complements** the KEU meter
+//! (`consumption_metrics`), never replaces it (AnvaiOps ADR-0020 D6), and is **default-inert** —
+//! nothing is emitted unless `PROXIMADB_EMIT_USAGE_EVENTS` is set truthy. Local BGE ONNX has no
+//! external egress and does not emit (it keeps its compute-based KEU accrual).
+//!
+//! Dependency direction is one-way: ProximaDB pins the `sandhi` wire *schema* (this struct), never
+//! the `sandhi` crate (ADR-060).
+
+use serde::Serialize;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The `tracing` target external tooling filters on to collect neutral usage events.
+pub const USAGE_EVENT_TARGET: &str = "proximadb::usage_event";
+
+/// Env flag gating emission. Unset/false ⇒ fully inert (no allocation, no log).
+const EMIT_FLAG_ENV: &str = "PROXIMADB_EMIT_USAGE_EVENTS";
+
+/// Backend classification (schema `backend` enum).
+pub const BACKEND_EXTERNAL: &str = "external";
+
+fn emission_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var(EMIT_FLAG_ENV)
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    })
+}
+
+fn next_request_id() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let millis = chrono::Utc::now().timestamp_millis();
+    format!("keu-emb-{millis}-{n}")
+}
+
+/// The neutral usage event — `sandhi` `usage-event.v1`. `additionalProperties:false`, so this
+/// struct carries exactly the schema's fields. Optional attribution fields are omitted when
+/// `None` (a valid encoding of the nullable schema fields).
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageEvent {
+    pub schema_version: &'static str,
+    pub request_id: String,
+    /// RFC 3339, set when the usage was finalized.
+    pub occurred_at: String,
+    /// Neutral provider slug (`azure_openai` / `openai` / `cohere` / `byo`). Never a tier/SKU.
+    pub provider: String,
+    /// Model id as sent to the provider.
+    pub model: String,
+    /// `external` for provider APIs (billed in tokens).
+    pub backend: &'static str,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub virtual_key_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    /// The team/tenant the call is attributed to. ProximaDB maps its `tenant_id` here (the drainer
+    /// knows the tenant/account, not the individual user).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+
+    /// Fresh (non-cached) input tokens — the provider's real usage count.
+    pub tokens_in: u64,
+    /// Completion tokens. Always 0 for embeddings (they emit vectors, not completion tokens).
+    pub tokens_out: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_seconds: Option<f64>,
+}
+
+impl UsageEvent {
+    /// Build the event for one external **embedding** call, metered from the provider's real
+    /// input-token count. `route` is the operation label (e.g. `"embed_batch"`).
+    pub fn external_embedding(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        tenant_id: Option<&str>,
+        tokens_in: u64,
+        route: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: "1",
+            request_id: next_request_id(),
+            occurred_at: chrono::Utc::now().to_rfc3339(),
+            provider: provider.into(),
+            model: model.into(),
+            backend: BACKEND_EXTERNAL,
+            virtual_key_id: None,
+            subject_id: None,
+            group_id: tenant_id.map(str::to_string),
+            route: Some(route.into()),
+            session_id: None,
+            tokens_in,
+            tokens_out: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            gpu_seconds: None,
+        }
+    }
+
+    /// Emit the event through `tracing` — **best-effort, off the hot path, default-inert**. No-op
+    /// unless `PROXIMADB_EMIT_USAGE_EVENTS` is truthy. Never fails the caller.
+    pub fn emit(&self) {
+        if !emission_enabled() {
+            return;
+        }
+        match serde_json::to_string(self) {
+            Ok(json) => tracing::info!(target: USAGE_EVENT_TARGET, usage_event = %json),
+            Err(e) => tracing::debug!("usage-event serialize failed (ignored): {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_to_neutral_schema_shape() {
+        let ev = UsageEvent::external_embedding(
+            "azure_openai",
+            "text-embedding-3-small",
+            Some("tenant-abc"),
+            1234,
+            "embed_batch",
+        );
+        let v: serde_json::Value = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v["schema_version"], "1");
+        assert_eq!(v["backend"], "external");
+        assert_eq!(v["provider"], "azure_openai");
+        assert_eq!(v["tokens_in"], 1234);
+        assert_eq!(v["tokens_out"], 0);
+        assert_eq!(v["group_id"], "tenant-abc");
+        assert_eq!(v["route"], "embed_batch");
+        // Neutral contract: units only, never dollars/tiers.
+        assert!(v.get("cost").is_none() && v.get("usd").is_none() && v.get("tier").is_none());
+        // Omitted optional attribution is absent (a valid nullable encoding).
+        assert!(v.get("subject_id").is_none());
+        assert!(v["request_id"].as_str().unwrap().starts_with("keu-emb-"));
+    }
+
+    #[test]
+    fn emit_is_inert_without_flag() {
+        // Just assert it never panics when the flag is unset (default posture).
+        UsageEvent::external_embedding("openai", "text-embedding-3-large", None, 10, "embed_batch")
+            .emit();
+    }
+}

--- a/src/services/embedding_drainer.rs
+++ b/src/services/embedding_drainer.rs
@@ -406,15 +406,21 @@ impl EmbeddingDrainer {
             )
             .await
             .map_err(|e| anyhow::anyhow!("drainer embed failed: {e}"))?;
-        if result.vectors.len() != batch_record_count(&payload_ranges) {
+        let batch_records_total = batch_record_count(&payload_ranges);
+        if result.vectors.len() != batch_records_total {
             anyhow::bail!(
                 "drainer: provider returned {} vectors for {} records",
                 result.vectors.len(),
-                batch_record_count(&payload_ranges)
+                batch_records_total
             );
         }
         let dimension = u32::try_from(route.dimension())
             .map_err(|_| anyhow::anyhow!("drainer: route dimension exceeds u32"))?;
+        // TD-SANDHI-1: the provider's real token usage is batch-level (all payloads in this
+        // route group). Split it across payloads proportionally by record count so each tenant
+        // is metered its share of the measured tokens.
+        let batch_usage = result.usage;
+        let total_records = batch_records_total as u64;
 
         for (payload, range) in payloads.iter().zip(payload_ranges) {
             let vectors = result
@@ -432,7 +438,11 @@ impl EmbeddingDrainer {
                 );
             }
 
-            record_embedding_consumption(payload, &route);
+            let payload_records = payload.records.len() as u64;
+            let real_input_tokens = batch_usage.map(|usage| {
+                split_input_tokens(usage.input_tokens, payload_records, total_records)
+            });
+            record_embedding_consumption(payload, &route, real_input_tokens);
             let target_precision = self.resolve_target_precision(payload).await;
             let embedded = payload
                 .records
@@ -480,27 +490,63 @@ fn batch_record_count(ranges: &[std::ops::Range<usize>]) -> usize {
     ranges.last().map_or(0, |range| range.end)
 }
 
-fn record_embedding_consumption(payload: &EmbedIngestPayload, route: &EmbedRoute) {
+/// Split a batch's total input-token count across one payload, proportionally by its record
+/// share (TD-SANDHI-1). A route group can batch several tenants' payloads into one provider
+/// call, whose usage is reported batch-wide; this attributes each tenant its slice. Returns 0
+/// for an empty batch (guards div-by-zero).
+fn split_input_tokens(batch_input_tokens: u64, payload_records: u64, total_records: u64) -> u64 {
+    if total_records == 0 {
+        return 0;
+    }
+    ((u128::from(batch_input_tokens) * u128::from(payload_records)) / u128::from(total_records))
+        as u64
+}
+
+/// Meter one payload's embedding consumption (TD-SANDHI-1 / ADR-067).
+///
+/// `real_input_tokens` carries the provider's **measured** input-token count for this payload
+/// (external providers that report `usage`); when `None` the count*512 heuristic is used (local
+/// BGE, or BYO whose contract has no usage). For external routes, also emits the neutral
+/// usage event at the egress boundary (default-inert unless `PROXIMADB_EMIT_USAGE_EVENTS`).
+fn record_embedding_consumption(
+    payload: &EmbedIngestPayload,
+    route: &EmbedRoute,
+    real_input_tokens: Option<u64>,
+) {
     let embedding_count = payload.records.len() as u64;
-    let estimated_input_tokens = embedding_count.saturating_mul(512);
-    let estimated_output_tokens = embedding_count.saturating_mul(route.dimension() as u64);
-    let (provider, model): (&'static str, String) = match route {
-        EmbedRoute::BgeSmall => ("victor", "bge-small-en-v1.5".to_string()),
-        EmbedRoute::BgeLarge => ("victor", "bge-large-en-v1.5".to_string()),
-        EmbedRoute::BgeM3 => ("victor", "bge-m3".to_string()),
-        EmbedRoute::AzureOpenAi { model } => ("azure_openai", format!("azure_{model:?}")),
-        EmbedRoute::OpenAi { model } => ("openai", format!("openai_{model:?}")),
-        EmbedRoute::Cohere { model } => ("cohere", format!("cohere_{model:?}")),
-        EmbedRoute::Byo { url, .. } => ("byo", url.clone()),
+    let input_tokens = real_input_tokens.unwrap_or_else(|| embedding_count.saturating_mul(512));
+    // Output tokens stay a compute proxy (count × dimension) — embeddings emit no completion
+    // tokens, so no provider reports them; this is ProximaDB's own KEU storage unit.
+    let output_tokens = embedding_count.saturating_mul(route.dimension() as u64);
+    let (provider, model, external): (&'static str, String, bool) = match route {
+        EmbedRoute::BgeSmall => ("victor", "bge-small-en-v1.5".to_string(), false),
+        EmbedRoute::BgeLarge => ("victor", "bge-large-en-v1.5".to_string(), false),
+        EmbedRoute::BgeM3 => ("victor", "bge-m3".to_string(), false),
+        EmbedRoute::AzureOpenAi { model } => ("azure_openai", format!("azure_{model:?}"), true),
+        EmbedRoute::OpenAi { model } => ("openai", format!("openai_{model:?}"), true),
+        EmbedRoute::Cohere { model } => ("cohere", format!("cohere_{model:?}"), true),
+        EmbedRoute::Byo { url, .. } => ("byo", url.clone(), true),
     };
     crate::metrics::consumption_metrics::record_keu_units(
         Some(&payload.tenant_id),
         provider,
         &model,
         "embed_batch",
-        estimated_input_tokens,
-        estimated_output_tokens,
+        input_tokens,
+        output_tokens,
     );
+    // ADR-067 Fix 2: emit the shared neutral usage event at the external-provider boundary.
+    // Local BGE is self-hosted (no external egress) → no event.
+    if external {
+        crate::metrics::usage_event::UsageEvent::external_embedding(
+            provider,
+            model.as_str(),
+            Some(payload.tenant_id.as_str()),
+            input_tokens,
+            "embed_batch",
+        )
+        .emit();
+    }
 }
 
 // ── tests ───────────────────────────────────────────────────────────
@@ -750,6 +796,20 @@ mod tests {
             "malformed payload must NOT invoke sink",
         );
         queue.shutdown().await.expect("shutdown");
+    }
+
+    #[test]
+    fn split_input_tokens_attributes_by_record_share() {
+        // 300 real batch tokens across 30 records → a 10-record payload gets 100.
+        assert_eq!(split_input_tokens(300, 10, 30), 100);
+        // Single-tenant batch keeps the whole count.
+        assert_eq!(split_input_tokens(1234, 5, 5), 1234);
+        // Integer division floors (no panic, no over-attribution).
+        assert_eq!(split_input_tokens(100, 1, 3), 33);
+        // Empty batch → 0, never a div-by-zero.
+        assert_eq!(split_input_tokens(100, 0, 0), 0);
+        // Large counts do not overflow (u128 intermediate).
+        assert_eq!(split_input_tokens(u64::MAX, 1, 1), u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## What

Implements **TD-SANDHI-1 / ADR-067**: meter embedding **KEU from the provider's real usage response** instead of the `count*512` heuristic, and **emit the neutral `usage-event.v1`** (AnvaiOps/`sandhi` wire contract) at the external-provider egress boundary. The gate is cleared — `anvai-labs/sandhi` v0.1.0 is published with a tagged `usage-event.v1` schema.

Additive and behind existing seams. The KEU meter stays authoritative (ADR-0020 D6); local BGE and the `io_trace` / `DurableMeteringWriter` contracts are untouched.

## Fix 1 — meter from real usage

Only **Azure OpenAI** has a real usage-bearing response today (OpenAI/Cohere routes are unimplemented stubs; BYO's contract has no usage; BGE is local ONNX). So Azure is threaded through; the rest keep the compute estimate.

- **`azure_openai.rs`** — parse `usage.{prompt_tokens,total_tokens}` (previously **discarded**) via a new `embed_batch_with_usage`; `embed_batch` kept as a thin delegate.
- **`models/mod.rs`** — `EmbedUsage` type + `embed_batch_with_usage` registry method (Azure → `Some`, BGE/BYO → `None`); `embed_batch` delegates, so **no existing caller changes**.
- **`service.rs`** — `EmbedResult.usage: Option<EmbedUsage>` threaded through both construction sites.
- **`embedding_drainer.rs`** — a route group can batch several tenants into one provider call, so the batch's real usage is **split proportionally by record share** per tenant/payload; real tokens feed `record_keu_units`, else the estimate. New pure `split_input_tokens` helper + unit test (share split, rounding, empty-batch, overflow).

## Fix 2 — emit the neutral usage event

- **`src/metrics/usage_event.rs`** (new) — `UsageEvent` serializing to sandhi `usage-event.v1` (**measured units only — no dollars, no tier/SKU names**); a **default-inert** `tracing` emit gated by `PROXIMADB_EMIT_USAGE_EVENTS` (mirrors the repo's `io_trace_sink` pattern). Emitted for **external routes only** (local BGE is self-hosted → no event), carrying the same token count fed to the authoritative KEU meter. Unit tests for the neutral shape + inert-by-default.

## Boundary invariants held (ADR-067 / ADR-060)

- Neutral units only; KEU stays the OSS meter of record (the event complements it).
- **One-way dependency**: pins the `sandhi` **wire schema** as a local struct, **not** the `sandhi` crate (not yet on crates.io). ADR-067's "link `sandhi-core` directly, no FFI" is noted as a deferred follow-up.
- No change to `io_trace` / `DurableMeteringWriter`; local BGE untouched.

## Verification

- `cargo check -p proximadb-embedding` and `-p proximadb` — clean.
- `cargo clippy` — clean on both crates.
- New unit tests: `split_input_tokens_attributes_by_record_share`, `serializes_to_neutral_schema_shape`, `emit_is_inert_without_flag`. (A local full test re-run was interrupted by a disk-space limit after fixing a test-only assertion typo; CI runs the suite.)

## Notes

- Decision docs (ADR-067 + TD-SANDHI-1) land via the docs PR on `docs/sandhi-ai-gateway`; this is the code wiring they govern.