### PR TITLE
feat(embedding): implement OpenAI/Cohere embedding routes (direct clients) — ADR-067

### DIFF
--- a/crates/modalities/proximadb-embedding/src/config.rs
+++ b/crates/modalities/proximadb-embedding/src/config.rs
@@ -165,6 +165,15 @@ impl OpenAiModel {
             Self::Ada002 => 1536,
         }
     }
+
+    /// The model id as sent to the OpenAI `/embeddings` API.
+    pub fn api_name(&self) -> &'static str {
+        match self {
+            Self::TextEmbed3Large => "text-embedding-3-large",
+            Self::TextEmbed3Small => "text-embedding-3-small",
+            Self::Ada002 => "text-embedding-ada-002",
+        }
+    }
 }
 
 /// Cohere embedding model selection.
@@ -184,6 +193,15 @@ impl CohereModel {
         match self {
             Self::EmbedEnglishV3 | Self::EmbedMultilingualV3 => 1024,
             Self::EmbedEnglishLightV3 => 384,
+        }
+    }
+
+    /// The model id as sent to the Cohere `/v2/embed` API.
+    pub fn api_name(&self) -> &'static str {
+        match self {
+            Self::EmbedEnglishV3 => "embed-english-v3.0",
+            Self::EmbedMultilingualV3 => "embed-multilingual-v3.0",
+            Self::EmbedEnglishLightV3 => "embed-english-light-v3.0",
         }
     }
 }

--- a/crates/modalities/proximadb-embedding/src/models/cohere.rs
+++ b/crates/modalities/proximadb-embedding/src/models/cohere.rs
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Direct Cohere embeddings client (blocking `reqwest`), mirroring [`super::azure_openai`].
+//!
+//! Enabled when `COHERE_API_KEY` is set (optionally `COHERE_BASE_URL`). Uses the Cohere v2
+//! `/v2/embed` API (`input_type` + `embedding_types:[float]`) and parses
+//! `meta.billed_units.input_tokens` so KEU is metered from the provider's **real** usage
+//! (TD-SANDHI-1 / ADR-067).
+
+use crate::config::CohereModel;
+use crate::models::EmbedUsage;
+use crate::{EmbeddingError, Result};
+
+pub struct CohereClient {
+    base_url: String,
+    key: String,
+    client: reqwest::blocking::Client,
+}
+
+impl CohereClient {
+    /// Read env config; `None` when Cohere embeddings are not configured.
+    pub fn from_env() -> Option<Self> {
+        let key = std::env::var("COHERE_API_KEY").ok()?;
+        let base_url = std::env::var("COHERE_BASE_URL")
+            .unwrap_or_else(|_| "https://api.cohere.com".to_string());
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .ok()?;
+        Some(Self {
+            base_url,
+            key,
+            client,
+        })
+    }
+
+    /// Embed a batch, returning vectors + the provider's real token usage.
+    pub fn embed_batch(
+        &self,
+        model: &CohereModel,
+        texts: &[String],
+    ) -> Result<(Vec<Vec<f32>>, Option<EmbedUsage>)> {
+        let url = format!("{}/v2/embed", self.base_url.trim_end_matches('/'));
+        // The drainer indexes corpora → search_document.
+        let body = serde_json::json!({
+            "model": model.api_name(),
+            "texts": texts,
+            "input_type": "search_document",
+            "embedding_types": ["float"],
+        });
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.key)
+            .json(&body)
+            .send()
+            .map_err(|e| EmbeddingError::Other(anyhow::anyhow!(e)))?;
+        if !resp.status().is_success() {
+            return Err(EmbeddingError::Inference(format!(
+                "cohere embeddings {} status {}",
+                model.api_name(),
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .map_err(|e| EmbeddingError::Other(anyhow::anyhow!(e)))?;
+        Ok(parse_embed_response(&body))
+    }
+}
+
+/// Pure parse of the Cohere v2 embed response → (vectors, usage). Shape:
+/// `{ "embeddings": { "float": [[...]] }, "meta": { "billed_units": { "input_tokens": N } } }`.
+pub(crate) fn parse_embed_response(
+    body: &serde_json::Value,
+) -> (Vec<Vec<f32>>, Option<EmbedUsage>) {
+    let vectors = body
+        .pointer("/embeddings/float")
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(serde_json::Value::as_array)
+                .map(|nums| {
+                    nums.iter()
+                        .filter_map(|n| n.as_f64().map(|f| f as f32))
+                        .collect()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let input_tokens = body
+        .pointer("/meta/billed_units/input_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let usage = (input_tokens > 0).then_some(EmbedUsage {
+        input_tokens,
+        total_tokens: input_tokens,
+    });
+    (vectors, usage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_float_vectors_and_billed_input_tokens() {
+        let body = serde_json::json!({
+            "id": "abc",
+            "embeddings": { "float": [[1.0, 2.0], [3.0, 4.0]] },
+            "texts": ["a", "b"],
+            "meta": { "billed_units": { "input_tokens": 17 } }
+        });
+        let (vectors, usage) = parse_embed_response(&body);
+        assert_eq!(vectors, vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+        assert_eq!(usage.unwrap().input_tokens, 17);
+    }
+
+    #[test]
+    fn missing_billed_units_is_none() {
+        let body = serde_json::json!({ "embeddings": { "float": [[1.0]] } });
+        let (_vectors, usage) = parse_embed_response(&body);
+        assert!(usage.is_none());
+    }
+}

--- a/crates/modalities/proximadb-embedding/src/models/mod.rs
+++ b/crates/modalities/proximadb-embedding/src/models/mod.rs
@@ -18,6 +18,8 @@
 pub mod azure_openai;
 pub mod bge;
 pub mod byo;
+pub mod cohere;
+pub mod openai;
 
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -42,6 +44,10 @@ pub struct ModelRegistry {
     bge_large: OnceLock<Arc<bge::BgeModel>>,
     bge_m3: OnceLock<Arc<bge::BgeModel>>,
     azure_openai: Option<azure_openai::AzureOpenAiClient>,
+    // Direct OpenAI / Cohere embedding clients (blocking reqwest, like azure_openai). `None`
+    // when the provider key is not configured — the route then returns ModelUnavailable.
+    openai: Option<openai::OpenAiClient>,
+    cohere: Option<cohere::CohereClient>,
     // BYO endpoints are stored per-tenant in EmbeddingService::tenant_cache;
     // the route variant carries the endpoint URL + auth.
 }
@@ -53,6 +59,8 @@ impl ModelRegistry {
             bge_large: OnceLock::new(),
             bge_m3: OnceLock::new(),
             azure_openai: azure_openai::AzureOpenAiClient::from_env(),
+            openai: openai::OpenAiClient::from_env(),
+            cohere: cohere::CohereClient::from_env(),
         })
     }
 
@@ -115,14 +123,26 @@ impl ModelRegistry {
                     )
                 })?
                 .embed_batch_with_usage(model, texts),
-            EmbedRoute::OpenAi { model } => Err(EmbeddingError::ModelUnavailable(format!(
-                "Direct OpenAI route (model={model:?}) is declared but the HTTP client is not yet \
-                 implemented; configure as Azure OpenAI or BYO endpoint in the meantime."
-            ))),
-            EmbedRoute::Cohere { model } => Err(EmbeddingError::ModelUnavailable(format!(
-                "Cohere route (model={model:?}) is declared but the HTTP client is not yet \
-                 implemented; use BYO endpoint pointing at the Cohere proxy in the meantime."
-            ))),
+            EmbedRoute::OpenAi { model } => {
+                let client = self.openai.as_ref().ok_or_else(|| {
+                    EmbeddingError::ModelUnavailable(
+                        "OpenAI embeddings not configured — set OPENAI_API_KEY \
+                         (optionally OPENAI_BASE_URL)"
+                            .into(),
+                    )
+                })?;
+                client.embed_batch(model, texts)
+            }
+            EmbedRoute::Cohere { model } => {
+                let client = self.cohere.as_ref().ok_or_else(|| {
+                    EmbeddingError::ModelUnavailable(
+                        "Cohere embeddings not configured — set COHERE_API_KEY \
+                         (optionally COHERE_BASE_URL)"
+                            .into(),
+                    )
+                })?;
+                client.embed_batch(model, texts)
+            }
             EmbedRoute::Byo {
                 url,
                 auth,

--- a/crates/modalities/proximadb-embedding/src/models/openai.rs
+++ b/crates/modalities/proximadb-embedding/src/models/openai.rs
@@ -1,0 +1,126 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Direct OpenAI embeddings client (blocking `reqwest`), mirroring [`super::azure_openai`].
+//!
+//! Enabled when `OPENAI_API_KEY` is set (optionally `OPENAI_BASE_URL` for OpenAI-compatible
+//! gateways). Parses `usage.{prompt_tokens,total_tokens}` so KEU is metered from the provider's
+//! **real** usage, not the `count*512` heuristic (TD-SANDHI-1 / ADR-067).
+
+use crate::config::OpenAiModel;
+use crate::models::EmbedUsage;
+use crate::{EmbeddingError, Result};
+
+pub struct OpenAiClient {
+    base_url: String,
+    key: String,
+    client: reqwest::blocking::Client,
+}
+
+impl OpenAiClient {
+    /// Read env config; `None` when OpenAI embeddings are not configured.
+    pub fn from_env() -> Option<Self> {
+        let key = std::env::var("OPENAI_API_KEY").ok()?;
+        let base_url = std::env::var("OPENAI_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com/v1".to_string());
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .ok()?;
+        Some(Self {
+            base_url,
+            key,
+            client,
+        })
+    }
+
+    /// Embed a batch, returning vectors + the provider's real token usage.
+    pub fn embed_batch(
+        &self,
+        model: &OpenAiModel,
+        texts: &[String],
+    ) -> Result<(Vec<Vec<f32>>, Option<EmbedUsage>)> {
+        let url = format!("{}/embeddings", self.base_url.trim_end_matches('/'));
+        let body = serde_json::json!({ "model": model.api_name(), "input": texts });
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.key)
+            .json(&body)
+            .send()
+            .map_err(|e| EmbeddingError::Other(anyhow::anyhow!(e)))?;
+        if !resp.status().is_success() {
+            return Err(EmbeddingError::Inference(format!(
+                "openai embeddings {} status {}",
+                model.api_name(),
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .map_err(|e| EmbeddingError::Other(anyhow::anyhow!(e)))?;
+        Ok(parse_embed_response(&body))
+    }
+}
+
+/// Pure parse of the OpenAI embeddings response → (vectors, usage). Split out so it is testable
+/// without a live HTTP call.
+pub(crate) fn parse_embed_response(
+    body: &serde_json::Value,
+) -> (Vec<Vec<f32>>, Option<EmbedUsage>) {
+    let vectors = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.get("embedding").and_then(|e| e.as_array()))
+                .map(|nums| {
+                    nums.iter()
+                        .filter_map(|n| n.as_f64().map(|f| f as f32))
+                        .collect()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let usage = body.get("usage").map(|u| EmbedUsage {
+        input_tokens: u
+            .get("prompt_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        total_tokens: u
+            .get("total_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+    });
+    (vectors, usage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_vectors_and_real_usage() {
+        let body = serde_json::json!({
+            "object": "list",
+            "data": [
+                { "index": 0, "embedding": [0.1, 0.2, 0.3] },
+                { "index": 1, "embedding": [0.4, 0.5, 0.6] }
+            ],
+            "usage": { "prompt_tokens": 42, "total_tokens": 42 }
+        });
+        let (vectors, usage) = parse_embed_response(&body);
+        assert_eq!(vectors, vec![vec![0.1, 0.2, 0.3], vec![0.4, 0.5, 0.6]]);
+        let u = usage.unwrap();
+        assert_eq!(u.input_tokens, 42);
+        assert_eq!(u.total_tokens, 42);
+    }
+
+    #[test]
+    fn missing_usage_is_none() {
+        let body = serde_json::json!({ "data": [{ "embedding": [1.0] }] });
+        let (vectors, usage) = parse_embed_response(&body);
+        assert_eq!(vectors, vec![vec![1.0]]);
+        assert!(usage.is_none());
+    }
+}


### PR DESCRIPTION
## What

The **OpenAI** and **Cohere** embedding routes were unimplemented stubs (`ModelUnavailable`). This implements them as **direct blocking-`reqwest` clients** mirroring the existing `azure_openai.rs`, so KEU is metered from the provider's **real** usage and the neutral usage event is emitted for these routes too (TD-SANDHI-1). This is exactly **ADR-067 point 2** — "wrap ProximaDB's own OpenAI/Cohere egress clients."

> **Design note.** A first pass delegated to `sandhi-providers` in-process. A first-principles design review found that premature: a **single-consumer** shared abstraction that ADR-067 explicitly deprioritized ("optional, lower-priority, a follow-up, not required by this ADR"), landing the embed path **outside** sandhi's resilience/metering decorators (so no retry/circuit-breaker/timeout — weaker than the Azure client), and importing a git dependency + an async→sync bridge to replace ~40 lines that already had an in-repo template. Reverted to direct clients. The sandhi embedding modality is **deferred** to the ≥2-consumer trigger ([sandhi #13](https://github.com/anvai-labs/sandhi/pull/13), closed).

## Changes

- **`config.rs`** — `api_name()` on `OpenAiModel` / `CohereModel` → the provider model ids.
- **`models/openai.rs`** (new) — blocking OpenAI `/embeddings` client + a pure response parser (`usage.prompt_tokens`); 30s timeout; `from_env()` (`OPENAI_API_KEY`, optional `OPENAI_BASE_URL`).
- **`models/cohere.rs`** (new) — blocking Cohere `/v2/embed` client (`input_type=search_document`, `embedding_types:[float]`) + a pure parser (`meta.billed_units.input_tokens`); 30s timeout; `from_env()`.
- **`models/mod.rs`** — the OpenAi/Cohere arms of `embed_batch_with_usage` call the clients, returning `Some(real usage)`. Not configured → `ModelUnavailable`, exactly like Azure. **No new external dependency.**

## Verification

- `cargo check -p proximadb-embedding` — clean.
- `cargo clippy -p proximadb-embedding --lib` — clean.
- 4 parse unit tests pass (vectors + real usage; missing-usage → None) for both providers.

## Merge order

Stacked on **TD-SANDHI-1 (#1105)** — base `feat/td-sandhi-1-egress-metering`; auto-retargets to `develop` once #1105 merges. Merge order: **#1105 → this**. (No longer depends on any sandhi PR.)