### PR TITLE
docs(td-sandhi-2): part (a) adopts sandhi-core parsers (not hand-rolled); rides on TD-0001 W1

### DIFF
--- a/docs/10-quality/td/TD-SANDHI-2-generation-llm-consolidation.adoc
+++ b/docs/10-quality/td/TD-SANDHI-2-generation-llm-consolidation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | **Open — ready.** This is ADR-0047 **D10a step 1** (the *same-language* consolidation): a Rust→Rust crate link, no FFI. Sequenced, not urgent — the generation path is config-gated off by default (`[llm]` block absent ⇒ dormant). Two independently-shippable parts; part (a) is the higher-value, un-gated one.
+| Status | **Open — ready.** This is ADR-0047 **D10a step 1** (the *same-language* consolidation): a Rust→Rust crate link, no FFI. Sequenced, not urgent — the generation path is config-gated off by default (`[llm]` block absent ⇒ dormant). Two parts; part (a) (emit the neutral event, *adopting* `sandhi-core` parsers) is the higher-value one — it rides on Sandhi **TD-0001 W1** (parser-QA corpus, in progress in a parallel session); part (b) (link `sandhi-providers` transport) is low-urgency.
 | Priority | **P2** — correctness (metering gap) + de-duplication + capability parity; not a live defect.
 | Component | `src/ai/llm_integration/providers/{anthropic,openai,azure_openai,bedrock,cohere,ollama,vllm,huggingface}.rs` (8 hand-rolled clients), `engine.rs` (`LLMIntegrationEngine`), `metrics.rs` (`LLMMetrics`); a new neutral-event emit (mirror `src/metrics/usage_event.rs` from TD-SANDHI-1).
 | Governs | link:../../12-design/adr/ADR-067-consume-ai-usage-gateway-egress-metering.adoc[ADR-067] (sibling: embedding egress), link:../../12-design/adr/ADR-060-commercial-rust-crate-extension-seam-open-core.adoc[ADR-060].
@@ -31,13 +31,21 @@ engine as an unused `_llm_engine`. So this is de-duplication + gap-closing, not 
 
 == The two parts (independently shippable)
 
-. **(a) Emit the neutral usage event — do this first, un-gated.** Mirror TD-SANDHI-1's
-  `src/metrics/usage_event.rs`: emit `usage-event.v1` from the generation path (from
+. **(a) Emit the neutral usage event, *adopting* the shared parsers — do this first.** Mirror
+  TD-SANDHI-1's `src/metrics/usage_event.rs`: emit `usage-event.v1` from the generation path (from
   `LLMIntegrationEngine` where usage is finalized), default-inert behind
-  `PROXIMADB_EMIT_USAGE_EVENTS`, `backend=external`. This is the higher-value half — it closes the
-  metering gap **without** any dependency change, using the exact pattern already shipped for
-  embeddings. It also requires deserializing the provider cache-split usage (the Anthropic DTO
-  currently drops it).
+  `PROXIMADB_EMIT_USAGE_EVENTS`, `backend=external`. The generation path currently drops the
+  **cache split** (the Anthropic DTO deserializes only `input_tokens`/`output_tokens`) — so this
+  needs a correct cache-split extractor. **Do not hand-roll a fourth one.** Per AnvaiOps ADR-0047
+  **D10a** (steps 0–1) and Sandhi **ADR-0003**, the metering-critical extractors are single-sourced
+  in `sandhi-core::usage::parse_*` (`parse_anthropic_usage` etc. → `ParsedUsage` with the cache
+  split). ProximaDB is Rust, so **adopt those directly (Rust→Rust link to `sandhi-core`)** rather
+  than reimplementing the cache-split parse. This makes part (a) an *instance of parser-sharing*
+  (D10a step 2), not a new extractor. **Sequence it after Sandhi TD-0001 W1** (the recorded-fixture
+  usage-parser QA corpus, in progress in a parallel session) so the adopted parsers are proven on
+  real fixtures — incl. the cache split — before ProximaDB depends on them. (Linking only
+  `sandhi-core` for the parsers is much lighter than part (b)'s `sandhi-providers` transport link,
+  and stays a git/path dep until Sandhi publishes to crates.io.)
 . **(b) Link `sandhi-providers`, retire the hand-rolled clients — D10a step 1.** Replace the 8
   `providers/*.rs` transport clients with `sandhi-providers` (`OpenAiCompat` covers
   OpenAI/Azure/vLLM/Ollama; plus `Anthropic`, `Cohere`, `Gemini`) wrapped in a thin adapter that
@@ -60,9 +68,13 @@ one-way dependency (ProximaDB → Sandhi); KEU/consumption meters stay authorita
 
 == Sequencing
 
-* Ship **(a)** independently and soon — it is cheap, un-gated, and closes a real cross-repo
-  inconsistency. It does **not** require the `sandhi` crate (emit via a local struct, like
-  TD-SANDHI-1).
+* Ship **(a)** soon — it is cheap and closes a real cross-repo inconsistency. The neutral *event*
+  is emitted via a local struct (like TD-SANDHI-1); the *cache-split parsing* it needs is taken
+  from `sandhi-core::usage::parse_*` (a light Rust→Rust link to **only** `sandhi-core`, not the
+  transport crate), **not** hand-rolled. Its one sequencing dependency: **Sandhi TD-0001 W1** (the
+  fixture-QA that proves those parsers on real streams, incl. the cache split) should land first, so
+  ProximaDB adopts a verified extractor rather than an unproven one. TD-0001 W1 is being driven in a
+  parallel session.
 * Ship **(b)** when convenient — it is a clean Rust link (only a `reqwest` `0.11 → 0.12` bump +
   pulling `sandhi-core`). Because the generation path is default-off and single-consumer, there is
   no urgency; but it is the endorsed D10a direction, so new generation-provider work should prefer


### PR DESCRIPTION
Reconciles TD-SANDHI-2 with Sandhi **ADR-0003 / TD-0001** + AnvaiOps **ADR-0047 D10a** (parallel PR anvaiops #395). Part (a) — the generation neutral-event emit — needs a cache-split extractor; instead of hand-rolling a 4th one it **adopts `sandhi-core::usage::parse_*`** (a light Rust→Rust link to `sandhi-core` only), making it an instance of parser-sharing. **Sequenced after Sandhi TD-0001 W1** (the recorded-fixture parser-QA corpus, driven by a parallel session) so ProximaDB adopts a proven extractor. Event still emitted via a local struct; part (b) transport link unchanged. Docs-only.