### PR TITLE
docs(adr): ADR-068 SDK codegen doctrine + TD-SDK-1 migration

### DIFF
--- a/docs/10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc
+++ b/docs/10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-SDK-1: SDK codegen-doctrine migration — round-trip correctness gate + facade fixes + generated-client oracle
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** S0 (this ADR + TD) in progress on `feat/sdk-codegen-doctrine`. S1–S5 below sequence the migration incrementally — no flag day; the legacy `<lang>-sdk-codegen-drift` gates keep enforcing the old contract until S4 lands.
+| Priority | P1 — the SDK is the customer-facing seam; two facade bugs (8-char name, broken `search()`) already escape the current gate to the VM. Unblocks spec-evolution PRs (the progenitor-panic class) and moves SDK correctness to a gate that actually catches customer-visible failures.
+| Component | `clients/{python,go,rust,nodejs-embedded}` (facades + generated dirs), `src/network/rest/openapi.rs` (spec gen), `.github/workflows/*sdk-codegen-drift*` (the gates), a new in-process/Azurite round-trip test harness.
+| Evidence | 2026-07-20 local Azurite round-trip: server endpoints clean (create/insert/search + 7 blobs persisted); Python SDK facade buggy — `CollectionConfig` rejects <8-char names (`models.py:893 min_length=8` + `:958` validator) while the server accepts `aztest` (6); `unified_client.search()` (`:3015 search_single`) routes to `_search_local_vectors` (`:665`) whenever the REST adapter raises, returning `[]` though the server logs "2 results". Also: #1103 progenitor 0.14 panic (`response_types.len() <= 1`) on inline-structured responses blocked the Rust SDK. ADR-068 §1.
+|===
+
+== The finding
+
+The SDK correctness gate is **codegen conformance** ("does the committed client match a fresh
+regeneration"), which (a) red-PRs on generator *tooling* limits (progenitor panics) unrelated to
+real drift, and (b) is blind to **facade** bugs — the ones customers hit. Two such bugs ship today
+and reached the qa VM undetected. The spec-driven mandate (#15) is right about the *contract* but
+wrong about *what is generated and how correctness is gated*.
+
+== Direction (per ADR-068)
+
+Keep the first-party spec as the contract; ship **hand-maintained facades** over **narrow generated
+types**; demote the full generated client to a **CI oracle**; make the **blocking** SDK gate a
+**behavioral round-trip** (create → insert → search → read against a live server + fixtures), with
+regeneration demoted to advisory.
+
+== Slices
+
+=== S0 — ADR + TD (this PR)
+File ADR-068 + this TD; add the ADR row to `adr/README.adoc`; `scripts/check_td_adr_unique.py` green.
+_Status: in progress._
+
+=== S1 — SDK round-trip correctness harness (the new gate)
+A per-language round-trip test that, against the in-process server (`build_router_for_unified`
+assembly, as `all_openapi_spec_paths_resolve_to_a_route` already does) and/or Azurite, asserts the
+*shipped facade* does: create collection (incl. a short name), insert records, **search returns them
+with correct ranking**, get-by-id, CDC changes. This is the gate that catches facade bugs. Start
+with Python (the client with the known bugs), then Go/TS/Rust. Template = the 2026-07-20 Azurite
+script. _Status: not started._
+
+=== S2 — Fix the two facade bugs under the doctrine (round-trip first, then fix)
+Write the S1 round-trip test that **reproduces** each bug (red), then fix:
+
+* **S2a — collection-name length.** Drop the stale `min_length=8` + the `:958` "7-char base62 ID
+  collision" validator (`clients/python/.../models.py`) and the `unified_client_async.py:77`
+  guard; the server relaxed this for relational DDL (TPC-H `part`/`orders`/`region`). The round-trip
+  test creates a 4-char collection and asserts success.
+* **S2b — REST `search()` local-fallback.** `search_single` (`unified_client.py:3015`) falls to
+  `_search_local_vectors` (`:665`) when the REST adapter raises, silently returning `[]`. Root-cause
+  why `self._adapter.search()` raises/mis-parses (the server returns correct results), fix the
+  adapter, and stop letting a remote failure degrade to a local-only read without a loud error. The
+  round-trip test asserts `search()` hits the server and returns the inserted records.
+
+_Status: not started._
+
+=== S3 — Demote the generated client to a CI oracle
+Move the full generated client in each language to a dev/CI-only path (not linked into the shipped
+package). A generator tooling failure (progenitor panic on a spec shape) becomes a **non-blocking**
+oracle warning, not a merge blocker. _Status: not started._
+
+=== S4 — Convert the `<lang>-sdk-codegen-drift` gates
+Change the four drift gates from "regenerate + `git diff --exit-code` (blocking)" to:
+(1) the S1 round-trip is **blocking**; (2) regeneration is **advisory** (keeps the oracle + narrow
+types current). A spec change PR passes when the round-trip is green + the SDKs are regenerated
+when the change is intended to reach customers. _Status: not started._
+
+=== S5 — Narrow generated types + overlay discipline (D2/D4)
+Generate only the hot-path request/response types (collection/record/search/query); keep the
+hand-maintained facade as the shipped surface; never hand-edit generated code (changes live in the
+adjacent overlay). _Status: not started._
+
+== Acceptance
+
+* The two facade bugs (S2a/S2b) are fixed with red→green round-trip tests.
+* A spec-evolution PR (e.g. the deferred #1103 docs) merges without red-PRing on a progenitor
+  tooling panic.
+* The blocking SDK gate is the round-trip; regeneration is advisory.

--- a/docs/12-design/adr/ADR-068-sdk-codegen-doctrine-hand-facade-generated-oracle.adoc
+++ b/docs/12-design/adr/ADR-068-sdk-codegen-doctrine-hand-facade-generated-oracle.adoc
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-068: SDK codegen doctrine — hand-maintained facade over narrow generated types; generated client as a CI oracle, not the shipped artifact
+
+[cols="1,3",options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (2026-07-20). Adopted as the target doctrine; the existing `<lang>-sdk-codegen-drift` gates continue to enforce the *legacy* "regenerate-and-diff" contract until link:../../10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc[TD-SDK-1] S4 lands the new behavioral gate. Migration is incremental — no flag day.
+| Decider | Vijaykumar Singh (2026-07-20)
+| Date | 2026-07-20
+| Relates to | link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design — the SDK is the customer-facing seam; correctness is measured, not asserted), link:ADR-060-oss-commercial-boundary.adoc[ADR-060] (the SDK is an OSS surface; neutral, stable), CLAUDE.md mandates #15/#16 (the spec-driven-SDK rule this ADR *refines*, not repeals). Inspired by Sandhi ADR-0003 (provider-adapter authoring — hand-written transport, generated types as a narrow reference + test oracle).
+| Refines | CLAUDE.md mandate #15 ("SDK REST transport is spec-driven, generated, never hand-rolled") — this ADR keeps the **spec as the contract** but demotes the **generated client** from the shipped product to a CI oracle, and makes the **shipped SDK** a hand-maintained facade over narrow generated types.
+| Tracked under | link:../../10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc[TD-SDK-1]
+| Non-goals | Removing the OpenAPI spec (it stays the canonical contract — first-party, `utoipa`-emitted, `verify-openapi-spec`-gated); changing the server's handler annotations; abandoning SDK generation tooling (it remains the bootstrap + the oracle); a multi-language typed-client SDK *product* strategy beyond REST (gRPC/proto and Arrow Flight are unchanged).
+|===
+
+== 1. Context — first principles
+
+From first principles, an SDK is the **customer-facing contract over the API surface**. The
+question this ADR settles is not "spec-driven or hand-written?" but **which artifact is the
+source of truth for SDK *correctness*, and where the human-ownership cost actually lands.**
+The answer CLAUDE.md mandates #15/#16 currently encode is: *the spec is generated from the
+handlers (`utoipa`), every SDK's REST surface is generated from that spec, and a `<lang>-sdk-
+codegen-drift` gate asserts the committed generated client matches a fresh regeneration —
+so every spec change must regenerate every SDK client in the same PR.* A thin hand-written
+facade sits in front of the generated transport.
+
+**What the code actually does today** (verified, not intended):
+
+* The OpenAPI spec (`docs/openapi/proximadb-openapi.yaml`) is `utoipa`-emitted from the axum
+  handlers (`src/network/rest/openapi.rs` `ApiDoc` + `openapi_supplement.yaml`), and
+  `verify-openapi-spec` (`make verify-openapi-spec`) gates handler↔spec drift.
+* Each SDK's REST transport is generated: Python (`openapi-python-client` →
+  `_generated/rest`), TypeScript (`openapi-typescript` → `schema.ts`), Go (`oapi-codegen` →
+  `genrest.gen.go`), Rust (`progenitor` → `genrest.rs`). A hand-written ergonomic facade
+  sits in front (e.g. `clients/python/.../unified_client.py`).
+* Four `<lang>-sdk-codegen-drift` CI gates assert each committed client matches a fresh
+  regeneration (`git diff --exit-code` on the generated dir).
+
+**The two failure classes that force this ADR** (both hit on 2026-07-20):
+
+. *The generation treadmill blocks PRs on tooling limits, not real drift.* Adding 11 spec
+  paths (#1103, deferred) made `progenitor` 0.14 panic (`assertion failed:
+  response_types.len() <= 1`) — the Rust SDK *cannot be generated* from inline-structured
+  OpenAPI responses. The Python/TS/Go clients then drift and must all be regenerated in the
+  same PR. The cost of a spec change is owning + verifying four generated clients, even when
+  the server is correct and the SDK surface barely moved.
+
+. *The gate that matters — does the SDK actually work against the server? — is not enforced.*
+  A local Azurite round-trip (2026-07-20) found two **facade bugs the codegen gate cannot
+  see**: (a) `CollectionConfig` rejects collection names shorter than 8 characters
+  (`models.py` `min_length=8` + the `:958` validator) while the **server** accepts short
+  names (relational-DDL relaxation); (b) `unified_client.search()` routes to
+  `_search_local_vectors` (a client-side store) whenever the REST adapter raises, then
+  returns `[]` — the server returns correct results (curl + server logs confirm). These are
+  **facade-quality bugs**, invisible to "does the generated code match the spec," and they
+  are exactly what bites a customer.
+
+**The ecosystem fact that frames it.** ProximaDB's spec is **first-party** — `utoipa`-emitted
+from its own handlers — *unlike* the third-party/unofficial provider specs that drove Sandhi
+ADR-0003 to hand-write transport. So the strongest Sandhi argument ("the spec is unreliable")
+does **not** transfer. What *does* transfer is the deeper point: **the cost that matters is
+never generation; it is ownership + verification** (Sandhi §6), and the QA that retires SDK
+risk is **behavioral round-trip + differential testing**, not codegen conformance (Sandhi §5).
+
+== 2. Decision
+
+=== D1. The OpenAPI spec remains the canonical contract (unchanged)
+
+The spec is first-party and is the server↔SDK contract. `utoipa` annotation, the
+`openapi_supplement.yaml` for dynamic-JSON surfaces, and `verify-openapi-spec` all stay. This
+ADR does **not** repeal mandate #15's "spec is the source of truth"; it refines *what is
+generated from it and how correctness is gated*.
+
+=== D2. Shipped SDKs are hand-maintained facades over *narrow* generated types
+
+The shipped client in each language is a **hand-maintained facade** (the ergonomic surface
+customers call) over a **narrow set of generated types** for the hot path (collection /
+record / search / query request+response shapes). The full generated client is **not** the
+shipped transport. Rationale:
+
+* ProximaDB's SDK is a **broad typed client** (45+ paths × CRUD) — broader than Sandhi's
+  ~40-line transport adapters — so "hand-write everything" does not scale. But the
+  *variance that customers actually depend on* (the core CRUD/search/query round-trip) is
+  narrow and benefits from co-designed, hand-owned ergonomics + first-principles correctness
+  (the two bugs above live in the facade; owning the facade is owning the risk).
+* The facade is where the bugs are. Generating the transport does not retire them; **owning
+  + verifying the facade does.**
+
+=== D3. A full generated client per language is a CI *test oracle*, never shipped
+
+A full client generated from the spec is valuable as a **check**, not as production code.
+In CI, run the generated client and the shipped facade against the **same recorded fixtures
++ a live server** and assert they agree on the fields customers depend on. Agreement raises
+confidence for free; divergence flags either spec drift, an extractor bug, or a facade bug.
+The generated client lives in dev/CI only and is **never linked into the shipped package**.
+This is the direct transfer of Sandhi ADR-0003 §3.
+
+Consequence for tooling limits: a `progenitor`/`oapi-codegen` panic on the oracle is no
+longer a **merge blocker** — the oracle is best-effort, feature-gated, and allowed to lag.
+It blocks only when it *runs* and diverges.
+
+=== D4. Generated code is never hand-edited — generated core + adjacent overlay
+
+Any generated artifact (the narrow types of D2, the oracle of D3) is regenerated from its
+pinned source and **never hand-edited**; all human changes live in an *adjacent* layer
+(newtype wrappers, extension traits, the hand-maintained facade). The first manual edit to
+generated code kills regeneration; the overlay rule prevents that. (Sandhi §4 / AnvaiOps
+`types.generated.ts` beside `types.ts` discipline.)
+
+=== D5. The SDK correctness gate is behavioral round-trip + differential, not codegen-diff
+
+The QA that retires SDK risk is a corpus of **round-trip tests against a live server +
+recorded fixtures**, asserting the facade produces correct results end-to-end (create →
+insert → search returns the right records with the right scores; short collection names
+accepted; tenant-scoped reads correct). The Azurite-backed local round-trip (2026-07-20) is
+the template; CI runs it against the in-process server (the `build_router_for_unified`
+assembly) and/or Azurite. Auditing the lines of a generated client is **not** the QA that
+matters and does not substitute for this. (Sandhi §5.)
+
+=== D6. The `<lang>-sdk-codegen-drift` gates transition from "must-regenerate" to "must agree with the oracle + server"
+
+Today the four drift gates assert `git diff --exit-code` against a fresh regeneration, which
+makes regeneration the primary gate (and a `progenitor` panic a merge blocker). Under this
+ADR they become **secondary**: regeneration is encouraged (keeps the oracle + generated
+types current) but the *blocking* gate is the D5 round-trip. Concretely, a spec change PR
+must (a) pass the round-trip suite and (b) regenerate the SDKs when the change is intended
+to reach customers — but a generator tooling failure on the oracle degrades to a non-blocking
+warning, not a red PR.
+
+=== D7. Why "generate-then-own" is scoped the way it is (Sandhi §6, retuned)
+
+Generate-first-then-hand-maintain is fastest **only where generated ≈ hand-written**: the
+narrow core types of D2. For the **full client** it *inverts* — owning and verifying four
+whole generated SDKs to ship a CRUD facade is more cost than value, and it is the cost that
+blocked #1103. So generate-then-own is admitted for the narrow types (D2) and the oracle
+(D3), and the full-client-as-product is excluded from the shipped transport. The cost that
+matters is **ownership + verification**; this scoping keeps that surface minimal and pinned
+to exactly what customers call.
+
+== 3. Consequences
+
+* **Positive:** a spec change no longer red-PRs on a generator tooling limit; SDK correctness
+  is gated on the thing that actually bites customers (the round-trip); facade bugs become
+  first-class CI failures instead of escaping to the VM; the first-party spec contract is
+  preserved (no server↔SDK drift regression).
+* **Cost:** the ergonomic facades are hand-maintained across languages — mitigated by the D5
+  round-trip suite + D3 differential oracle, which catch drift at the fields customers use.
+  Initial migration effort is bounded by TD-SDK-1 (the four existing drift gates convert in
+  place; no client rewrite).
+* **Neutral:** ratifies that the spec is the contract while demoting generation from product
+  to oracle; adds the codegen-admission rule (D2–D4) + QA doctrine (D5) so the next "just
+  generate the full SDKs" proposal has a settled bar.
+
+== 4. References
+
+* link:../../10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc[TD-SDK-1] — migration tracker (round-trip harness, facade-bug fixes, oracle demotion, gate conversion).
+* link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] — co-design spine (measured, not asserted).
+* link:ADR-060-oss-commercial-boundary.adoc[ADR-060] — SDK as an OSS-neutral surface.
+* CLAUDE.md mandates #15 (spec-driven SDK transport) / #16 (read/write correctness) — this ADR refines #15.
+* Sandhi `docs/adr/0003-provider-adapter-authoring-and-codegen.md` (ADR-0003) — the hand-written-transport + generated-oracle doctrine this ADR adapts.
+* Tooling: `oxidecomputer/progenitor`, `Deep embassy/oapi-codegen`, `openapi-python-client`, `openapi-typescript`, `oxidecomputer/typify`.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -262,6 +262,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Consume the `sandhi` AI usage gateway for external-provider egress metering
 | Proposed
 | Thin **consumer** decision (authoritative: AnvaiOps ADR-0047). The Rust drainer's external egress (`AzureOpenAiClient::embed_batch`, BYO, OpenAI/Cohere) emits the shared neutral usage event; KEU stays authoritative + server-side (AnvaiOps ADR-0020 D6); OSS emits units, AnvaiOps prices. Wiring: TD-SANDHI-1.
+| link:ADR-068-sdk-codegen-doctrine-hand-facade-generated-oracle.adoc[ADR-068]
+| SDK codegen doctrine — hand-maintained facade over narrow generated types; generated client as a CI oracle, not the shipped artifact
+| Proposed
+| Refines mandate #15 (spec-driven SDK transport) without repealing it: the first-party `utoipa` spec stays the contract, but the **shipped** SDK becomes a hand-maintained facade over narrow generated types, the full generated client is demoted to a **CI test oracle** (a `progenitor` panic stops being a merge blocker), and the **blocking** SDK gate becomes a behavioral **round-trip** (create → insert → search) instead of codegen-diff. Motivated by two facade bugs that escaped the codegen gate to the qa VM (8-char name validation; `search()` silent local-fallback) and the progenitor-0.14 panic that blocked #1103. Inspired by Sandhi ADR-0003. Migration tracked in link:../../10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc[TD-SDK-1].
 |===
 
 NOTE: ADR-010 through ADR-013 and ADR-048/ADR-049 exist in this directory but


### PR DESCRIPTION
## Summary

Adopts the **SDK codegen doctrine** (ADR-068), inspired by Sandhi ADR-0003 and tuned to ProximaDB's first-party-spec + broad-surface reality. This is the *doctrine* PR (S0 of TD-SDK-1); the facade-bug fixes land separately under it.

## The problem this settles
- **progenitor 0.14 panics** (`response_types.len() <= 1`) blocked the Rust SDK in #1103 — a generator *tooling* limit red-PRs unrelated to real drift.
- **Two facade bugs escaped the codegen gate to the qa VM** (found via the 2026-07-20 local Azurite round-trip): `CollectionConfig` rejects <8-char names while the server accepts them; `unified_client.search()` silently falls back to a client-side local store and returns `[]` though the server returns results. Codegen-conformance can't see these — only a round-trip can.

## The decision (ADR-068)
1. **Spec stays the contract** (first-party `utoipa`; mandate #15 refined, not repealed).
2. **Shipped SDK = hand-maintained facade** over **narrow** generated types; the full generated client is **not** shipped.
3. **Generated client = CI test oracle** (Sandhi §3) — a progenitor panic becomes a non-blocking warning, not a merge blocker.
4. **Generated code never hand-edited**; changes in an adjacent overlay.
5. **Blocking SDK gate = behavioral round-trip** (create→insert→search vs live server + fixtures), not codegen-diff. Regeneration → advisory.
6. **Cost = ownership + verification, not generation** — narrow the generated surface to what earns its keep.

## Migration (TD-SDK-1)
S0 this PR · S1 round-trip harness · **S2 the two facade fixes (round-trip first, then fix)** · S3 oracle demotion · S4 gate conversion · S5 narrow types.

No code changes — docs only. `check_td_adr_unique` clean (0 errors).
