### PR TITLE
fix(sdk): facade round-trip fixes — short names (S2a) + search transport delegation (S2b) [TD-SDK-1]

### DIFF
--- a/clients/python/src/proximadb_sdk/models.py
+++ b/clients/python/src/proximadb_sdk/models.py
@@ -890,8 +890,12 @@ class CollectionConfig(BaseModel):
 
     # CORE CONFIGURATION (Required)
     name: str = Field(
-        min_length=8
-    )  # Minimum 8 characters to prevent collision with 7-char base62 IDs
+        min_length=1
+    )  # Non-empty only — the server resolves collections by name OR id and accepts
+    # short names (relational-DDL tables: part/orders/region). The former 8-char
+    # minimum (to avoid colliding with 7-char base62 IDs) was a vector-collection-
+    # era constraint the server relaxed; the SDK must not be stricter than the
+    # server. See ADR-068 / TD-SDK-1 S2a.
     dimension: int = Field(
         ge=1, le=65536
     )  # Server default maximum is 65536 (configurable)
@@ -955,15 +959,17 @@ class CollectionConfig(BaseModel):
 
     @field_validator("name")
     def validate_name_length(cls, v):
-        """Validate collection name is at least 8 characters to prevent collision with 7-char base62 IDs"""
+        """Collection name must be non-empty.
+
+        The former >=8-char floor (to avoid colliding with 7-char base62 IDs)
+        was a vector-collection-era constraint the server relaxed for relational
+        DDL (tables like `part`/`orders`/`region`). The server resolves
+        collections by name OR id, so the SDK must not be stricter than the
+        server. See ADR-068 / TD-SDK-1 S2a.
+        """
         if not v or not v.strip():
             raise ValueError("Collection name cannot be empty")
-        v = v.strip()
-        if len(v) < 8:
-            raise ValueError(
-                "Collection name must be at least 8 characters long to prevent collision with 7-character base62 collection IDs"
-            )
-        return v
+        return v.strip()
 
     def model_post_init(self, __context):
         """Post-initialization validation to align compression config with storage engine"""

--- a/clients/python/tests/test_collection_name_validation.py
+++ b/clients/python/tests/test_collection_name_validation.py
@@ -1,0 +1,42 @@
+"""Regression: short collection names must be accepted (TD-SDK-1 S2a / ADR-068).
+
+The SDK's ``CollectionConfig`` used to reject names shorter than 8 characters
+(``min_length=8`` + a ``validate_name_length`` field validator) to avoid
+colliding with 7-char base62 collection IDs. The server long since relaxed that
+vector-collection-era constraint for relational DDL (tables like ``part``,
+``orders``, ``region``) and resolves collections by name OR id — so the SDK was
+strictly stricter than the server and blocked valid creates. A local Azurite
+round-trip (2026-07-20) caught it: ``create_collection("aztest")`` succeeded on
+the server but the SDK rejected ``sdktest`` (7 chars) client-side.
+
+This is the kind of facade bug the codegen-drift gate cannot see; it is owned by
+the round-trip correctness gate (ADR-068 D5). These tests pin the relaxed
+contract so it does not regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from proximadb_sdk.models import CollectionConfig
+
+
+@pytest.mark.parametrize("name", ["ab", "part", "orders", "region", "sdktest"])
+def test_short_collection_names_are_accepted(name: str) -> None:
+    """Names shorter than the old 8-char floor must validate (server allows them)."""
+    cfg = CollectionConfig(name=name, dimension=4)
+    assert cfg.name == name
+
+
+def test_empty_collection_name_is_still_rejected() -> None:
+    """The non-empty floor stays — only the >=8 floor was lifted."""
+    with pytest.raises(ValidationError):
+        CollectionConfig(name="", dimension=4)
+    with pytest.raises(ValidationError):
+        CollectionConfig(name="   ", dimension=4)
+
+
+def test_whitespace_only_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CollectionConfig(name="\t\n", dimension=4)


### PR DESCRIPTION
Updated — both facade bugs found in the 2026-07-20 local Azurite round-trip are now fixed under the SDK codegen doctrine (ADR-068 / TD-SDK-1, #1112 merged).

## S2a — short collection names ✅
`CollectionConfig` rejected <8-char names (stale vector-collection-era constraint); the server relaxed it for relational DDL. Relax to non-empty + 7-case regression test (green).

## S2b — `search()` silent local-fallback ✅
`RestAdapter.search` called the REST transport with the wrong kwargs (`query_vector`/`metadata_filters` vs `vector`/`metadata_filter`) → `TypeError` → `search_single` silently flipped on local fallback → `[]` though the server returned results. Fix: pass the transport's actual kwargs. Fixture-replay test (mocked transport) was **RED before the rename, GREEN after** (asserts the call reaches the transport + results pass through, no local fallback). No recursion — the adapter holds the leaf httpx transport, not the unified facade.

## Tests
`clients/python/tests/test_collection_name_validation.py` (7) + `test_search_delegates_to_transport.py` (2) — **9 passed** locally (pydantic 2.13). Both are server-less (S2a is pure validation; S2b is fixture-replay of a recorded transport response) — exactly ADR-068 D5's differential/fixture pattern.
