### PR TITLE
feat(wal): TD-WAL-1 — flush policy + observability + live config (ADR-069); driver deferred

### DIFF
--- a/crates/control/proximadb-metrics/src/lib.rs
+++ b/crates/control/proximadb-metrics/src/lib.rs
@@ -24,6 +24,7 @@ pub mod schema;
 pub mod td064_metrics;
 pub mod td066_metrics;
 pub mod turboquant_metrics;
+pub mod wal_flush_metrics;
 pub mod wal_scan_metrics;
 
 // Re-exports so cross-module references that resolved via the root

--- a/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
+++ b/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
@@ -1,0 +1,303 @@
+//! ADR-069 / TD-WAL-1 WAL flush observability.
+//!
+//! Exposes the operational view of the tiered WAL flush optimizer — how often
+//! the memtable→SST flush fires, *why* (its trigger), how much it moved, how
+//! long it took, and how close each collection sits to its capacity budget /
+//! backpressure line. Operators use these to confirm the RPO floor (time-based
+//! flush) is holding, to watch a collection approach `wal_max_bytes`, and to see
+//! backpressure engage before memory is exhausted.
+//!
+//! Families (all `proximadb_wal_flush_*` / `proximadb_wal_*`):
+//!   * `proximadb_wal_flush_total{collection,reason,result}`      — counter, flushes by trigger + outcome
+//!   * `proximadb_wal_flush_bytes_total{collection,reason}`       — counter, bytes moved to SST
+//!   * `proximadb_wal_flush_vectors_total{collection,reason}`     — counter, vectors flushed
+//!   * `proximadb_wal_flush_duration_seconds{reason}`             — histogram, flush wall-clock
+//!   * `proximadb_wal_size_bytes{collection}`                     — gauge, current UNflushed memtable bytes
+//!   * `proximadb_wal_budget_bytes{collection}`                   — gauge, configured `wal_max_bytes` (0 = disabled)
+//!   * `proximadb_wal_high_watermark_bytes{collection}`           — gauge, force-flush line (budget × high_pct)
+//!   * `proximadb_wal_critical_watermark_bytes{collection}`       — gauge, backpressure line (budget × critical_pct)
+//!   * `proximadb_wal_last_flush_timestamp_seconds{collection}`   — gauge, unixtime of last OK flush (age = `time()-metric`)
+//!   * `proximadb_wal_backpressure_active{collection}`            — gauge, 1 while a write is being throttled
+//!   * `proximadb_wal_backpressure_total{collection}`             — counter, backpressure engagements
+//!
+//! Wiring mirrors [`crate::wal_scan_metrics`]: a *private* Prometheus registry
+//! (no boot init required) whose [`scrape_text`] is appended to the
+//! `/metrics/prometheus` exposition. Empty until the first emit, so binaries that
+//! never flush stay valid.
+//!
+//! `reason` is a low-cardinality label ("size" | "time" | "capacity" | "manual")
+//! — this sink takes it as a plain `&str`; the closed decision enum lives with the
+//! flush *policy* in the WAL engine (`write_ahead_log::flush_policy::FlushReason`),
+//! so this foundation-level metrics crate never depends upward on engine types.
+//! `result` is "success" | "error". Never emit an unbounded label here.
+
+use lazy_static::lazy_static;
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
+    exponential_buckets,
+};
+use tracing::error;
+
+lazy_static! {
+    static ref REGISTRY: Registry = Registry::new();
+    static ref FLUSH_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_flush_total",
+        "WAL memtable→SST flushes by trigger reason and outcome (ADR-069 tiered flush)",
+        &["collection", "reason", "result"],
+    );
+    static ref FLUSH_BYTES_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_flush_bytes_total",
+        "Bytes moved from WAL memtable to SST on flush, by trigger reason (ADR-069)",
+        &["collection", "reason"],
+    );
+    static ref FLUSH_VECTORS_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_flush_vectors_total",
+        "Vector records flushed from WAL memtable to SST, by trigger reason (ADR-069)",
+        &["collection", "reason"],
+    );
+    static ref FLUSH_DURATION: HistogramVec = build_histogram(
+        "proximadb_wal_flush_duration_seconds",
+        "Wall-clock duration of a WAL flush, by trigger reason (ADR-069)",
+        &["reason"],
+    );
+    static ref WAL_SIZE_BYTES: IntGaugeVec = build_gauge(
+        "proximadb_wal_size_bytes",
+        "Current UNflushed WAL memtable size in bytes, per collection (ADR-069 capacity watermark input)",
+        &["collection"],
+    );
+    static ref BUDGET_BYTES: IntGaugeVec = build_gauge(
+        "proximadb_wal_budget_bytes",
+        "Configured per-collection WAL size budget `wal_max_bytes` in bytes; 0 = disabled (ADR-069 D6)",
+        &["collection"],
+    );
+    static ref HIGH_WATERMARK_BYTES: IntGaugeVec = build_gauge(
+        "proximadb_wal_high_watermark_bytes",
+        "Force-flush line: `wal_max_bytes` × `high_watermark_pct` in bytes (ADR-069 D3)",
+        &["collection"],
+    );
+    static ref CRITICAL_WATERMARK_BYTES: IntGaugeVec = build_gauge(
+        "proximadb_wal_critical_watermark_bytes",
+        "Backpressure line: `wal_max_bytes` × `critical_watermark_pct` in bytes (ADR-069 D3)",
+        &["collection"],
+    );
+    static ref LAST_FLUSH_TIMESTAMP: IntGaugeVec = build_gauge(
+        "proximadb_wal_last_flush_timestamp_seconds",
+        "Unix timestamp (seconds) of the last successful flush; RPO age = time() - this (ADR-069 D2)",
+        &["collection"],
+    );
+    static ref BACKPRESSURE_ACTIVE: IntGaugeVec = build_gauge(
+        "proximadb_wal_backpressure_active",
+        "1 while a write to this collection is being throttled at the critical watermark (ADR-069 D3)",
+        &["collection"],
+    );
+    static ref BACKPRESSURE_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_backpressure_total",
+        "Count of write-backpressure engagements at the critical watermark, per collection (ADR-069 D3)",
+        &["collection"],
+    );
+}
+
+/// Build + register an `IntCounterVec` into this module's private registry.
+/// Never panics: on descriptor error logs and returns a `_fallback` handle,
+/// matching the `*_safe` convention in [`crate::wal_scan_metrics`].
+fn build_counter(name: &str, help: &str, labels: &[&str]) -> IntCounterVec {
+    let m = IntCounterVec::new(Opts::new(name, help), labels).unwrap_or_else(|e| {
+        error!("failed to build {name}: {e}");
+        IntCounterVec::new(Opts::new(format!("{name}_fallback"), help), labels)
+            .unwrap_or_else(|_| unreachable!("valid counter descriptor"))
+    });
+    if let Err(e) = REGISTRY.register(Box::new(m.clone())) {
+        error!("failed to register {name}: {e}");
+    }
+    m
+}
+
+fn build_gauge(name: &str, help: &str, labels: &[&str]) -> IntGaugeVec {
+    let m = IntGaugeVec::new(Opts::new(name, help), labels).unwrap_or_else(|e| {
+        error!("failed to build {name}: {e}");
+        IntGaugeVec::new(Opts::new(format!("{name}_fallback"), help), labels)
+            .unwrap_or_else(|_| unreachable!("valid gauge descriptor"))
+    });
+    if let Err(e) = REGISTRY.register(Box::new(m.clone())) {
+        error!("failed to register {name}: {e}");
+    }
+    m
+}
+
+fn build_histogram(name: &str, help: &str, labels: &[&str]) -> HistogramVec {
+    // 1ms → ~32s, ×2 per bucket (15 buckets): covers a fast small-memtable flush
+    // through a slow object-store SST write.
+    let buckets = exponential_buckets(0.001, 2.0, 15)
+        .unwrap_or_else(|_| vec![0.001, 0.01, 0.1, 0.5, 1.0, 5.0, 30.0]);
+    let m = HistogramVec::new(
+        HistogramOpts::new(name, help).buckets(buckets.clone()),
+        labels,
+    )
+    .unwrap_or_else(|e| {
+        error!("failed to build {name}: {e}");
+        HistogramVec::new(
+            HistogramOpts::new(format!("{name}_fallback"), help).buckets(buckets),
+            labels,
+        )
+        .unwrap_or_else(|_| unreachable!("valid histogram descriptor"))
+    });
+    if let Err(e) = REGISTRY.register(Box::new(m.clone())) {
+        error!("failed to register {name}: {e}");
+    }
+    m
+}
+
+/// Record a completed flush attempt. `ok=false` records the attempt + duration
+/// under `result="error"` but does NOT advance the byte/vector counters or the
+/// last-flush timestamp (a failed flush neither moved data nor advanced the RPO).
+pub fn record_flush(
+    collection: &str,
+    reason: &str,
+    ok: bool,
+    bytes: i64,
+    vectors: i64,
+    duration_secs: f64,
+    unixtime_secs: i64,
+) {
+    let result = if ok { "success" } else { "error" };
+    FLUSH_TOTAL
+        .with_label_values(&[collection, reason, result])
+        .inc();
+    FLUSH_DURATION
+        .with_label_values(&[reason])
+        .observe(duration_secs.max(0.0));
+    if ok {
+        if bytes > 0 {
+            FLUSH_BYTES_TOTAL
+                .with_label_values(&[collection, reason])
+                .inc_by(bytes as u64);
+        }
+        if vectors > 0 {
+            FLUSH_VECTORS_TOTAL
+                .with_label_values(&[collection, reason])
+                .inc_by(vectors as u64);
+        }
+        LAST_FLUSH_TIMESTAMP
+            .with_label_values(&[collection])
+            .set(unixtime_secs);
+    }
+}
+
+/// Set the current unflushed memtable size for a collection (capacity-watermark input).
+pub fn set_wal_size(collection: &str, bytes: i64) {
+    WAL_SIZE_BYTES.with_label_values(&[collection]).set(bytes);
+}
+
+/// Publish the configured budget + derived watermark lines for a collection so
+/// operators can graph `wal_size_bytes` against them. `budget_bytes=0` means the
+/// capacity trigger is disabled; the watermark gauges are then set to 0 too.
+pub fn set_budget(collection: &str, budget_bytes: i64, high_bytes: i64, critical_bytes: i64) {
+    BUDGET_BYTES
+        .with_label_values(&[collection])
+        .set(budget_bytes);
+    HIGH_WATERMARK_BYTES
+        .with_label_values(&[collection])
+        .set(high_bytes);
+    CRITICAL_WATERMARK_BYTES
+        .with_label_values(&[collection])
+        .set(critical_bytes);
+}
+
+/// Set the backpressure gauge (1 = a write is currently throttled).
+pub fn set_backpressure_active(collection: &str, active: bool) {
+    BACKPRESSURE_ACTIVE
+        .with_label_values(&[collection])
+        .set(if active { 1 } else { 0 });
+}
+
+/// Count a backpressure engagement (paired with `set_backpressure_active(.., true)`).
+pub fn inc_backpressure(collection: &str) {
+    BACKPRESSURE_TOTAL.with_label_values(&[collection]).inc();
+}
+
+/// Prometheus text exposition for this family. Empty until the first emit,
+/// appended to `/metrics/prometheus`.
+pub fn scrape_text() -> String {
+    let mut buf = Vec::new();
+    let encoder = TextEncoder::new();
+    if encoder.encode(&REGISTRY.gather(), &mut buf).is_err() {
+        return String::new();
+    }
+    String::from_utf8(buf).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_flush_advances_counters_and_timestamp() {
+        let c = "col_flush_ok";
+        record_flush(c, "time", true, 4096, 12, 0.05, 1_700_000_000);
+        assert_eq!(
+            FLUSH_TOTAL.with_label_values(&[c, "time", "success"]).get(),
+            1
+        );
+        assert_eq!(
+            FLUSH_BYTES_TOTAL.with_label_values(&[c, "time"]).get(),
+            4096
+        );
+        assert_eq!(
+            FLUSH_VECTORS_TOTAL.with_label_values(&[c, "time"]).get(),
+            12
+        );
+        assert_eq!(
+            LAST_FLUSH_TIMESTAMP.with_label_values(&[c]).get(),
+            1_700_000_000
+        );
+    }
+
+    #[test]
+    fn failed_flush_records_attempt_but_not_progress() {
+        let c = "col_flush_err";
+        record_flush(c, "capacity", false, 9999, 5, 0.02, 1_700_000_500);
+        assert_eq!(
+            FLUSH_TOTAL
+                .with_label_values(&[c, "capacity", "error"])
+                .get(),
+            1
+        );
+        // No byte/vector progress, no RPO advance on failure.
+        assert_eq!(
+            FLUSH_BYTES_TOTAL.with_label_values(&[c, "capacity"]).get(),
+            0
+        );
+        assert_eq!(LAST_FLUSH_TIMESTAMP.with_label_values(&[c]).get(), 0);
+    }
+
+    #[test]
+    fn budget_and_backpressure_gauges_round_trip() {
+        let c = "col_budget";
+        set_wal_size(c, 8_000);
+        set_budget(c, 10_000, 8_000, 9_500);
+        set_backpressure_active(c, true);
+        inc_backpressure(c);
+        assert_eq!(WAL_SIZE_BYTES.with_label_values(&[c]).get(), 8_000);
+        assert_eq!(BUDGET_BYTES.with_label_values(&[c]).get(), 10_000);
+        assert_eq!(HIGH_WATERMARK_BYTES.with_label_values(&[c]).get(), 8_000);
+        assert_eq!(
+            CRITICAL_WATERMARK_BYTES.with_label_values(&[c]).get(),
+            9_500
+        );
+        assert_eq!(BACKPRESSURE_ACTIVE.with_label_values(&[c]).get(), 1);
+        assert_eq!(BACKPRESSURE_TOTAL.with_label_values(&[c]).get(), 1);
+        set_backpressure_active(c, false);
+        assert_eq!(BACKPRESSURE_ACTIVE.with_label_values(&[c]).get(), 0);
+    }
+
+    #[test]
+    fn scrape_exposes_emitted_families() {
+        record_flush("col_scrape", "size", true, 2048, 3, 0.01, 1_700_001_000);
+        set_wal_size("col_scrape", 2048);
+        let text = scrape_text();
+        assert!(text.contains("proximadb_wal_flush_total"), "{text}");
+        assert!(text.contains("proximadb_wal_size_bytes"), "{text}");
+        assert!(text.contains("col_scrape"), "{text}");
+        assert!(text.contains("reason=\"size\""), "{text}");
+    }
+}

--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -1050,6 +1050,18 @@ pub struct WalStorageConfig {
 
     /// Global manifest location (optional - explicit configuration).
     pub global_manifest_url: Option<String>,
+
+    /// ADR-069 D2 — time-based WAL flush interval (seconds); absent = engine default.
+    pub flush_interval_secs: Option<u64>,
+
+    /// ADR-069 D6 — per-collection WAL size budget (bytes) for capacity watermarks; absent = disabled.
+    pub wal_max_bytes: Option<usize>,
+
+    /// ADR-069 D3 — fraction of `wal_max_bytes` to force a flush at; absent = engine default.
+    pub high_watermark_pct: Option<f64>,
+
+    /// ADR-069 D3 — fraction of `wal_max_bytes` to apply write backpressure at; absent = engine default.
+    pub critical_watermark_pct: Option<f64>,
 }
 
 /// Strategy for distributing WAL segments across multiple storage directories.
@@ -1079,6 +1091,10 @@ impl Default for WalStorageConfig {
             write_buffer_size_mb: None,
             concurrent_flushes: None,
             global_shrink_factor: Some(0.4),
+            flush_interval_secs: None,
+            wal_max_bytes: None,
+            high_watermark_pct: None,
+            critical_watermark_pct: None,
         }
     }
 }
@@ -1186,6 +1202,11 @@ mod tests {
         assert_eq!(config.memory_flush_size_bytes, 10 * 1024 * 1024);
         assert_eq!(config.global_flush_threshold, 4 * 1024 * 1024 * 1024);
         assert_eq!(config.global_shrink_factor, Some(0.4));
+        // ADR-069 / TD-WAL-1 S1: new flush-control fields default to None (engine defaults apply).
+        assert_eq!(config.flush_interval_secs, None);
+        assert_eq!(config.wal_max_bytes, None);
+        assert_eq!(config.high_watermark_pct, None);
+        assert_eq!(config.critical_watermark_pct, None);
     }
 
     #[test]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1008,6 +1008,32 @@ pub struct WriteBufferUserConfig {
     pub enable_wal: bool,
     /// Global manifest location (optional)
     pub global_manifest_url: Option<String>,
+
+    /// ADR-069 D2 — time-based WAL flush interval (seconds); 0 = disabled. The RPO
+    /// floor: bounds worst-case loss on volume loss to this interval for low-traffic
+    /// collections that never reach `memory_flush_size_bytes`.
+    #[serde(default)]
+    pub flush_interval_secs: u64,
+    /// ADR-069 D6 — per-collection WAL size budget (bytes) for the capacity flush +
+    /// backpressure watermarks; 0 = disabled.
+    #[serde(default)]
+    pub wal_max_bytes: usize,
+    /// ADR-069 D3 — fraction of `wal_max_bytes` at which to force a flush.
+    #[serde(default = "default_high_watermark_pct")]
+    pub high_watermark_pct: f64,
+    /// ADR-069 D3 — fraction of `wal_max_bytes` at which to apply write backpressure.
+    #[serde(default = "default_critical_watermark_pct")]
+    pub critical_watermark_pct: f64,
+}
+
+/// Serde default for [`WriteBufferUserConfig::high_watermark_pct`] (ADR-069 D3).
+fn default_high_watermark_pct() -> f64 {
+    0.80
+}
+
+/// Serde default for [`WriteBufferUserConfig::critical_watermark_pct`] (ADR-069 D3).
+fn default_critical_watermark_pct() -> f64 {
+    0.95
 }
 
 impl Default for WriteBufferUserConfig {
@@ -1021,6 +1047,11 @@ impl Default for WriteBufferUserConfig {
             write_buffer_directory: "./data/write_buffer".to_string(),
             enable_wal: true,
             global_manifest_url: None,
+            // ADR-069 tiered-flush knobs — disabled by default (behavior-neutral).
+            flush_interval_secs: 0,
+            wal_max_bytes: 0,
+            high_watermark_pct: default_high_watermark_pct(),
+            critical_watermark_pct: default_critical_watermark_pct(),
         }
     }
 }
@@ -1039,7 +1070,17 @@ impl WriteBufferUserConfig {
             multi_disk: MultiDiskConfig::default(),
             compression: CompressionConfig::default(),
             encryption: Default::default(), // TD-016: Encryption disabled by default
-            performance: PerformanceConfig::default(),
+            // ADR-069/TD-WAL-1: honor the user's flush-policy inputs (size + the
+            // tiered time/capacity knobs) on this path too, so the optimizer is
+            // configurable identically to the shared-services conversion.
+            performance: PerformanceConfig {
+                memory_flush_size_bytes: self.memory_flush_size_bytes,
+                flush_interval_secs: self.flush_interval_secs,
+                wal_max_bytes: self.wal_max_bytes,
+                high_watermark_pct: self.high_watermark_pct,
+                critical_watermark_pct: self.critical_watermark_pct,
+                ..PerformanceConfig::default()
+            },
             enable_mvcc: true,
             enable_ttl: true,
             enable_background_compaction: true,

--- a/src/core/config_tests.rs
+++ b/src/core/config_tests.rs
@@ -184,6 +184,7 @@ mod tests {
             write_buffer_directory: "./test_wal".to_string(),
             enable_wal: true,
             global_manifest_url: None,
+            ..Default::default()
         };
 
         // Verify the values are set correctly

--- a/src/core/flush_config_tests.rs
+++ b/src/core/flush_config_tests.rs
@@ -49,6 +49,11 @@ mod tests {
             write_buffer_directory: "/custom/path".to_string(),
             enable_wal: false,
             global_manifest_url: None,
+            // ADR-069 tiered-flush knobs.
+            flush_interval_secs: 300,
+            wal_max_bytes: 25 * 1024 * 1024 * 1024,
+            high_watermark_pct: 0.75,
+            critical_watermark_pct: 0.9,
         };
 
         assert_eq!(config.write_buffer_size_mb, 16384);
@@ -57,6 +62,49 @@ mod tests {
         assert_eq!(config.memtable_type, "SkipList");
         assert_eq!(config.sync_mode, "Periodic");
         assert!(!config.enable_wal);
+        assert_eq!(config.flush_interval_secs, 300);
+        assert_eq!(config.wal_max_bytes, 25 * 1024 * 1024 * 1024);
+        assert_eq!(config.high_watermark_pct, 0.75);
+        assert_eq!(config.critical_watermark_pct, 0.9);
+    }
+
+    #[test]
+    fn test_wal_config_defaults_disable_tiered_flush() {
+        // ADR-069/TD-WAL-1: the tiered-flush knobs default OFF so existing configs
+        // are behavior-neutral (only the pre-existing size trigger stays active).
+        let config = WriteBufferUserConfig::default();
+        assert_eq!(config.flush_interval_secs, 0);
+        assert_eq!(config.wal_max_bytes, 0);
+        assert_eq!(config.high_watermark_pct, 0.80);
+        assert_eq!(config.critical_watermark_pct, 0.95);
+    }
+
+    #[test]
+    fn test_flush_knobs_propagate_through_to_engine_config() {
+        // The LIVE wiring: user TOML knobs must reach WalPerformanceConfig via
+        // to_engine_config() (the database.rs path), and reconcile into a FlushPolicy
+        // with the periodic scheduler armed.
+        use crate::storage::persistence::write_ahead_log::flush_policy::FlushPolicy;
+
+        let user = WriteBufferUserConfig {
+            memory_flush_size_bytes: 8 * 1024 * 1024,
+            flush_interval_secs: 120,
+            wal_max_bytes: 1000,
+            high_watermark_pct: 0.80,
+            critical_watermark_pct: 0.95,
+            ..Default::default()
+        };
+        let wal = user.to_engine_config();
+        assert_eq!(wal.performance.memory_flush_size_bytes, 8 * 1024 * 1024);
+        assert_eq!(wal.performance.flush_interval_secs, 120);
+        assert_eq!(wal.performance.wal_max_bytes, 1000);
+        assert_eq!(wal.performance.high_watermark_pct, 0.80);
+        assert_eq!(wal.performance.critical_watermark_pct, 0.95);
+
+        let policy = FlushPolicy::from_performance(&wal.performance);
+        assert!(policy.needs_scheduler(), "time+capacity armed ⇒ scheduler");
+        assert_eq!(policy.high_watermark_bytes, 800);
+        assert_eq!(policy.critical_watermark_bytes, 950);
     }
 
     #[test]
@@ -71,6 +119,7 @@ mod tests {
             write_buffer_directory: "./test_data/write_buffer".to_string(),
             enable_wal: true,
             global_manifest_url: None,
+            ..Default::default()
         };
 
         // Verify values are as expected

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -16,7 +16,7 @@
 pub use proximadb_metrics::{
     Alert, SystemMetrics, advisor_observations_metrics, aggregator, compression, dml_lock_metrics,
     dr_metrics, exporters, fusion, primary_pod_metrics, recall_drift_metrics, route_metrics,
-    schema, td064_metrics, td066_metrics, turboquant_metrics, wal_scan_metrics,
+    schema, td064_metrics, td066_metrics, turboquant_metrics, wal_flush_metrics, wal_scan_metrics,
 };
 
 // Deferred (storage-coupled / orchestration) modules stay root.

--- a/src/network/metrics_service.rs
+++ b/src/network/metrics_service.rs
@@ -200,6 +200,17 @@ async fn prometheus_metrics_endpoint(
         }
         text.push_str(&wal_scan_text);
     }
+    // ADR-069 / TD-WAL-1: append the WAL flush-optimizer family
+    // (proximadb_wal_flush_*, proximadb_wal_size_bytes, watermark + backpressure
+    // gauges). Empty until the first flush/size emit, so the response stays valid
+    // for binaries that never flush.
+    let wal_flush_text = crate::metrics::wal_flush_metrics::scrape_text();
+    if !wal_flush_text.is_empty() {
+        if !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str(&wal_flush_text);
+    }
     // Append the DEFAULT prometheus registry. The per-tenant CONSUMPTION families
     // (`proximadb_object_store_ops_total`, `proximadb_kou_bytes_total`,
     // `proximadb_storage_bytes_seconds`, `proximadb_object_store_write_bytes_by_tier_total`, …)

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -2771,6 +2771,12 @@ impl SharedServices {
                 "none" => SyncMode::Never,
                 _ => SyncMode::PerBatch,
             },
+            // ADR-069/TD-WAL-1: the tiered-flush knobs (time RPO floor + capacity
+            // watermarks) — the live server path where they actually reach the engine.
+            flush_interval_secs: toml_config.flush_interval_secs,
+            wal_max_bytes: toml_config.wal_max_bytes,
+            high_watermark_pct: toml_config.high_watermark_pct,
+            critical_watermark_pct: toml_config.critical_watermark_pct,
             ..Default::default()
         };
 

--- a/src/storage/persistence/write_ahead_log/config.rs
+++ b/src/storage/persistence/write_ahead_log/config.rs
@@ -122,6 +122,20 @@ pub struct WalPerformanceConfig {
 
     /// Batch size for optimized WAL writer
     pub write_buffer_batch_size: Option<usize>,
+
+    /// ADR-069 D2 — time-based memtable→SST flush interval (seconds); 0 = disabled.
+    /// The RPO floor: bounds worst-case loss on volume loss to this interval.
+    pub flush_interval_secs: u64,
+
+    /// ADR-069 D6 — per-collection WAL size budget (bytes) for the capacity flush +
+    /// backpressure watermarks; 0 = disabled.
+    pub wal_max_bytes: usize,
+
+    /// ADR-069 D3 — fraction of `wal_max_bytes` at which to force a flush + truncation.
+    pub high_watermark_pct: f64,
+
+    /// ADR-069 D3 — fraction of `wal_max_bytes` at which to apply write backpressure.
+    pub critical_watermark_pct: f64,
 }
 
 impl Default for WalPerformanceConfig {
@@ -143,6 +157,12 @@ impl Default for WalPerformanceConfig {
             enable_optimized_write_buffer_writer: Some(false), // Disabled by default for gradual rollout
             background_writer_threads: None, // Will use 2 by default in optimized writer
             write_buffer_batch_size: None,   // Will use 100 by default in optimized writer
+            // ADR-069 / TD-WAL-1 S1: config surface; triggers default DISABLED (0) — S2 (time)
+            // and S3 (capacity) activate them and set their live defaults. No behavior change here.
+            flush_interval_secs: 0,
+            wal_max_bytes: 0,
+            high_watermark_pct: 0.80,
+            critical_watermark_pct: 0.95,
         }
     }
 }
@@ -461,6 +481,20 @@ impl From<&crate::core::config::WalStorageConfig> for WALConfig {
 
         if let Some(global_shrink_factor) = core_config.global_shrink_factor {
             wal_config.performance.global_shrink_factor = global_shrink_factor;
+        }
+
+        // ADR-069 / TD-WAL-1 S1: WAL flush-control overrides (inert until S2/S3).
+        wal_config.performance.flush_interval_secs = core_config
+            .flush_interval_secs
+            .unwrap_or(wal_config.performance.flush_interval_secs);
+        wal_config.performance.wal_max_bytes = core_config
+            .wal_max_bytes
+            .unwrap_or(wal_config.performance.wal_max_bytes);
+        if let Some(pct) = core_config.high_watermark_pct {
+            wal_config.performance.high_watermark_pct = pct;
+        }
+        if let Some(pct) = core_config.critical_watermark_pct {
+            wal_config.performance.critical_watermark_pct = pct;
         }
 
         // Set global manifest URL from TOML config
@@ -878,6 +912,41 @@ mod tests {
         assert!(&config.compression.compress_disk);
     }
 
+    #[test]
+    fn wal_performance_defaults_disable_flush_triggers() {
+        // ADR-069 / TD-WAL-1 S1: new flush triggers ship DISABLED so S1 is behavior-neutral.
+        let p = WalPerformanceConfig::default();
+        assert_eq!(p.flush_interval_secs, 0, "time-based flush off by default");
+        assert_eq!(p.wal_max_bytes, 0, "capacity budget off by default");
+        assert_eq!(p.high_watermark_pct, 0.80);
+        assert_eq!(p.critical_watermark_pct, 0.95);
+    }
+
+    #[test]
+    fn wal_storage_config_overrides_flush_triggers() {
+        use crate::core::config::WalStorageConfig;
+        // Absent overrides (None) leave the runtime performance defaults intact.
+        let base = WALConfig::from(&WalStorageConfig::default());
+        assert_eq!(base.performance.flush_interval_secs, 0);
+        assert_eq!(base.performance.wal_max_bytes, 0);
+        assert_eq!(base.performance.high_watermark_pct, 0.80);
+        assert_eq!(base.performance.critical_watermark_pct, 0.95);
+
+        // Present overrides (ADR-069 D2/D3/D6) flow through to WalPerformanceConfig.
+        let core = WalStorageConfig {
+            flush_interval_secs: Some(300),
+            wal_max_bytes: Some(25 * 1024 * 1024 * 1024),
+            high_watermark_pct: Some(0.75),
+            critical_watermark_pct: Some(0.9),
+            ..WalStorageConfig::default()
+        };
+        let cfg = WALConfig::from(&core);
+        assert_eq!(cfg.performance.flush_interval_secs, 300);
+        assert_eq!(cfg.performance.wal_max_bytes, 25 * 1024 * 1024 * 1024);
+        assert_eq!(cfg.performance.high_watermark_pct, 0.75);
+        assert_eq!(cfg.performance.critical_watermark_pct, 0.9);
+    }
+
     #[tokio::test]
     async fn test_wal_config_custom() {
         let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
@@ -919,6 +988,10 @@ mod tests {
                 enable_optimized_write_buffer_writer: None,
                 background_writer_threads: None,
                 write_buffer_batch_size: None,
+                flush_interval_secs: 0,
+                wal_max_bytes: 0,
+                high_watermark_pct: 0.80,
+                critical_watermark_pct: 0.95,
             },
             enable_mvcc: true,
             enable_ttl: true,
@@ -1415,6 +1488,10 @@ mod tests {
             enable_optimized_write_buffer_writer: None, // corrected field name
             background_writer_threads: None,
             write_buffer_batch_size: None, // corrected field name
+            flush_interval_secs: 0,
+            wal_max_bytes: 0,
+            high_watermark_pct: 0.80,
+            critical_watermark_pct: 0.95,
         };
 
         let json = serde_json::to_string(&custom_config).unwrap();

--- a/src/storage/persistence/write_ahead_log/flush_policy.rs
+++ b/src/storage/persistence/write_ahead_log/flush_policy.rs
@@ -1,0 +1,315 @@
+//! ADR-069 / TD-WAL-1 — the single WAL flush **decision boundary**.
+//!
+//! Collapses the three flush pressures into ONE control decision so that every
+//! caller (the inline write path and the periodic scheduler) evaluates identical
+//! logic and can never race, double-flush, or disagree on *why* a flush fired.
+//! The pressures form a nested envelope:
+//!
+//! ```text
+//!   time (RPO floor)  ≤  size (throughput target)  ≤  high < critical (memory ceiling)
+//! ```
+//!
+//! * **SIZE** — memtable reached `memory_flush_size_bytes`: the throughput-optimal
+//!   coalescing point (flush a well-sized SST; the pre-existing trigger).
+//! * **TIME** — the unflushed window is older than `flush_interval_secs`: the RPO
+//!   floor that bounds worst-case loss for LOW-traffic collections that never hit
+//!   the size target (ADR-069 D2).
+//! * **CAPACITY** — memtable crossed `wal_max_bytes × high_watermark_pct`: the
+//!   memory safety valve; at `× critical_watermark_pct` the writer is throttled
+//!   (ADR-069 D3/D6).
+//!
+//! Precedence — most urgent wins, so the `reason` attribution is unambiguous:
+//!   `CAPACITY-critical > CAPACITY-high > SIZE > TIME`.
+//!
+//! This type is pure (no I/O, no clock) and fully unit-tested; the strategy layer
+//! feeds it the two runtime inputs (current memtable bytes, unflushed-window age)
+//! and acts on the decision. Keeping the decision pure is the whole point of the
+//! boundary: the write path and the scheduler share it verbatim.
+
+use super::config::WalPerformanceConfig;
+
+/// Trigger that caused a flush. Closed enum so the metrics `reason` label stays
+/// low-cardinality and every call site agrees on the label strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlushReason {
+    /// Memtable reached `memory_flush_size_bytes` (throughput target).
+    Size,
+    /// Unflushed window exceeded `flush_interval_secs` (RPO floor, ADR-069 D2).
+    Time,
+    /// Memtable crossed a capacity watermark (memory ceiling, ADR-069 D3/D6).
+    Capacity,
+    /// Explicit / operator-initiated flush.
+    Manual,
+}
+
+impl FlushReason {
+    /// Stable Prometheus label value (single source of truth for the label).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FlushReason::Size => "size",
+            FlushReason::Time => "time",
+            FlushReason::Capacity => "capacity",
+            FlushReason::Manual => "manual",
+        }
+    }
+}
+
+/// The outcome of a single evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlushDecision {
+    /// `Some(reason)` ⇒ flush now for this reason; `None` ⇒ no flush needed.
+    pub reason: Option<FlushReason>,
+    /// `true` ⇒ the writer should be throttled (critical watermark): the memtable
+    /// is at the memory ceiling and ingest must slow until the flush drains it.
+    pub backpressure: bool,
+}
+
+impl FlushDecision {
+    /// The no-op decision.
+    pub const NONE: FlushDecision = FlushDecision {
+        reason: None,
+        backpressure: false,
+    };
+}
+
+/// The reconciled flush policy: the four config knobs resolved *together* into
+/// one envelope with absolute byte thresholds. Built once from
+/// [`WalPerformanceConfig`]; `Copy` so callers hold it cheaply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlushPolicy {
+    /// Flush when `mem_bytes >= this` (0 = disabled). `= memory_flush_size_bytes`.
+    pub size_target_bytes: u64,
+    /// Flush when the unflushed window `age >= this` seconds (0 = disabled).
+    /// `= flush_interval_secs`.
+    pub time_floor_secs: u64,
+    /// Capacity budget (0 = capacity triggers disabled). `= wal_max_bytes`.
+    pub capacity_budget_bytes: u64,
+    /// Force-flush line in bytes: `budget × high_watermark_pct` (0 when disabled).
+    pub high_watermark_bytes: u64,
+    /// Backpressure line in bytes: `budget × critical_watermark_pct` (0 when disabled).
+    pub critical_watermark_bytes: u64,
+}
+
+impl FlushPolicy {
+    /// Derive the policy from the runtime WAL performance config, resolving the
+    /// watermark fractions into absolute bytes against the budget.
+    pub fn from_performance(cfg: &WalPerformanceConfig) -> Self {
+        let budget = cfg.wal_max_bytes as u64;
+        let (high, critical) = if budget > 0 {
+            (
+                (budget as f64 * cfg.high_watermark_pct).round() as u64,
+                (budget as f64 * cfg.critical_watermark_pct).round() as u64,
+            )
+        } else {
+            (0, 0)
+        };
+        FlushPolicy {
+            size_target_bytes: cfg.memory_flush_size_bytes as u64,
+            time_floor_secs: cfg.flush_interval_secs,
+            capacity_budget_bytes: budget,
+            high_watermark_bytes: high,
+            critical_watermark_bytes: critical,
+        }
+    }
+
+    /// True when any periodic trigger (time or capacity) is enabled — i.e. when a
+    /// background scheduler is worth spawning. When false the policy reduces to the
+    /// pre-existing inline size trigger and no ticker is needed (S1 behavior-neutral).
+    pub fn needs_scheduler(&self) -> bool {
+        self.time_floor_secs > 0 || self.capacity_budget_bytes > 0
+    }
+
+    /// Absolute gauge values `(budget, high, critical)` for observability, as i64.
+    pub fn budget_gauges(&self) -> (i64, i64, i64) {
+        (
+            self.capacity_budget_bytes as i64,
+            self.high_watermark_bytes as i64,
+            self.critical_watermark_bytes as i64,
+        )
+    }
+
+    /// The single flush decision. `mem_bytes` = current unflushed memtable size for
+    /// the collection; `age_secs` = age of the oldest unflushed data. Pure.
+    pub fn evaluate(&self, mem_bytes: u64, age_secs: u64) -> FlushDecision {
+        // 1. Capacity ceiling first — memory safety outranks throughput and RPO.
+        if self.capacity_budget_bytes > 0 {
+            if self.critical_watermark_bytes > 0 && mem_bytes >= self.critical_watermark_bytes {
+                return FlushDecision {
+                    reason: Some(FlushReason::Capacity),
+                    backpressure: true,
+                };
+            }
+            if self.high_watermark_bytes > 0 && mem_bytes >= self.high_watermark_bytes {
+                return FlushDecision {
+                    reason: Some(FlushReason::Capacity),
+                    backpressure: false,
+                };
+            }
+        }
+        // 2. Size target — the throughput-optimal coalescing point.
+        if self.size_target_bytes > 0 && mem_bytes >= self.size_target_bytes {
+            return FlushDecision {
+                reason: Some(FlushReason::Size),
+                backpressure: false,
+            };
+        }
+        // 3. Time floor (RPO) — only when there is actually unflushed data to lose.
+        if self.time_floor_secs > 0 && age_secs >= self.time_floor_secs && mem_bytes > 0 {
+            return FlushDecision {
+                reason: Some(FlushReason::Time),
+                backpressure: false,
+            };
+        }
+        FlushDecision::NONE
+    }
+
+    /// Recommended scheduler tick in seconds: fine enough to honor the time floor
+    /// without busy-looping, and a modest fixed cadence when only capacity is armed.
+    /// Clamped to `[1, 30]`.
+    pub fn scheduler_tick_secs(&self) -> u64 {
+        let base = if self.time_floor_secs > 0 {
+            // Check ~4× per interval so worst-case time-flush lag is ≤ interval/4.
+            self.time_floor_secs / 4
+        } else {
+            15
+        };
+        base.clamp(1, 30)
+    }
+
+    /// Non-fatal configuration warnings from reconciling the envelope. The strategy
+    /// logs these once at construction; a broken envelope degrades behavior (early
+    /// backpressure, size above the ceiling) but must never crash the data plane.
+    pub fn warnings(&self) -> Vec<String> {
+        let mut w = Vec::new();
+        if self.capacity_budget_bytes > 0 {
+            if self.high_watermark_bytes >= self.critical_watermark_bytes {
+                w.push(format!(
+                    "high_watermark_bytes ({}) >= critical_watermark_bytes ({}): \
+                     backpressure engages at/with force-flush — widen the gap (high_pct < critical_pct)",
+                    self.high_watermark_bytes, self.critical_watermark_bytes
+                ));
+            }
+            if self.size_target_bytes > 0 && self.size_target_bytes > self.high_watermark_bytes {
+                w.push(format!(
+                    "memory_flush_size_bytes ({}) > high_watermark_bytes ({}): the size trigger \
+                     never fires before the capacity ceiling — lower the size target or raise wal_max_bytes",
+                    self.size_target_bytes, self.high_watermark_bytes
+                ));
+            }
+        }
+        w
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(size: usize, interval: u64, max: usize, high: f64, crit: f64) -> WalPerformanceConfig {
+        WalPerformanceConfig {
+            memory_flush_size_bytes: size,
+            flush_interval_secs: interval,
+            wal_max_bytes: max,
+            high_watermark_pct: high,
+            critical_watermark_pct: crit,
+            ..WalPerformanceConfig::default()
+        }
+    }
+
+    #[test]
+    fn defaults_are_size_only_and_behavior_neutral() {
+        // Default config: size target set (2MB), time+capacity disabled.
+        let p = FlushPolicy::from_performance(&WalPerformanceConfig::default());
+        assert_eq!(p.time_floor_secs, 0);
+        assert_eq!(p.capacity_budget_bytes, 0);
+        assert!(!p.needs_scheduler(), "no periodic triggers ⇒ no scheduler");
+        // Below the size target: no flush. At/above it: size flush (old behavior).
+        assert_eq!(
+            p.evaluate(p.size_target_bytes - 1, 10_000),
+            FlushDecision::NONE
+        );
+        assert_eq!(
+            p.evaluate(p.size_target_bytes, 0).reason,
+            Some(FlushReason::Size)
+        );
+    }
+
+    #[test]
+    fn watermarks_resolve_to_absolute_bytes() {
+        let p = FlushPolicy::from_performance(&cfg(2 << 20, 0, 1000, 0.80, 0.95));
+        assert_eq!(p.capacity_budget_bytes, 1000);
+        assert_eq!(p.high_watermark_bytes, 800);
+        assert_eq!(p.critical_watermark_bytes, 950);
+        assert_eq!(p.budget_gauges(), (1000, 800, 950));
+    }
+
+    #[test]
+    fn capacity_outranks_size_and_time() {
+        // Size target tiny (1), so size would fire; capacity must still win + set backpressure.
+        let p = FlushPolicy::from_performance(&cfg(1, 1, 1000, 0.80, 0.95));
+        let d = p.evaluate(960, 10_000); // ≥ critical (950)
+        assert_eq!(d.reason, Some(FlushReason::Capacity));
+        assert!(d.backpressure, "at/over critical ⇒ throttle");
+        let d2 = p.evaluate(820, 0); // ≥ high (800), < critical
+        assert_eq!(d2.reason, Some(FlushReason::Capacity));
+        assert!(
+            !d2.backpressure,
+            "high but not critical ⇒ flush, no throttle"
+        );
+    }
+
+    #[test]
+    fn time_only_fires_with_unflushed_data() {
+        let p = FlushPolicy::from_performance(&cfg(1 << 30, 300, 0, 0.80, 0.95)); // huge size, 300s time
+        // Old enough but empty ⇒ nothing to lose ⇒ no flush.
+        assert_eq!(p.evaluate(0, 10_000), FlushDecision::NONE);
+        // Old enough with data ⇒ time flush (RPO floor).
+        assert_eq!(p.evaluate(4096, 300).reason, Some(FlushReason::Time));
+        // Young ⇒ no flush.
+        assert_eq!(p.evaluate(4096, 299), FlushDecision::NONE);
+    }
+
+    #[test]
+    fn size_outranks_time() {
+        let p = FlushPolicy::from_performance(&cfg(1000, 10, 0, 0.80, 0.95));
+        // Both size (≥1000) and time (≥10) would fire; size wins (more specific/urgent).
+        assert_eq!(p.evaluate(1000, 10_000).reason, Some(FlushReason::Size));
+    }
+
+    #[test]
+    fn scheduler_tick_is_bounded() {
+        assert_eq!(
+            FlushPolicy::from_performance(&cfg(1, 0, 0, 0.8, 0.95)).scheduler_tick_secs(),
+            15
+        );
+        assert_eq!(
+            FlushPolicy::from_performance(&cfg(1, 400, 0, 0.8, 0.95)).scheduler_tick_secs(),
+            30
+        ); // 400/4=100 → clamp 30
+        assert_eq!(
+            FlushPolicy::from_performance(&cfg(1, 8, 0, 0.8, 0.95)).scheduler_tick_secs(),
+            2
+        ); // 8/4=2
+    }
+
+    #[test]
+    fn warnings_flag_broken_envelope() {
+        // high_pct >= critical_pct
+        let p = FlushPolicy::from_performance(&cfg(1, 0, 1000, 0.96, 0.95));
+        assert!(
+            p.warnings()
+                .iter()
+                .any(|w| w.contains("critical_watermark_bytes"))
+        );
+        // size target above the ceiling
+        let p2 = FlushPolicy::from_performance(&cfg(900, 0, 1000, 0.80, 0.95));
+        assert!(
+            p2.warnings()
+                .iter()
+                .any(|w| w.contains("never fires before the capacity ceiling"))
+        );
+        // healthy envelope: no warnings
+        let p3 = FlushPolicy::from_performance(&cfg(500, 300, 1000, 0.80, 0.95));
+        assert!(p3.warnings().is_empty());
+    }
+}

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -105,6 +105,7 @@ pub mod config;
 pub mod disk_manager; // New centralized disk operations
 pub mod enhanced_flush_result;
 pub mod flush_coordinator;
+pub mod flush_policy; // ADR-069/TD-WAL-1: the single flush-decision boundary
 pub mod flush_result_optimization;
 pub mod manifest; // Global WAL manifest system (unified)
 pub mod memtable_manager; // New centralized memtable operations

--- a/src/storage/tests/storage_engine_concurrency_tests.rs
+++ b/src/storage/tests/storage_engine_concurrency_tests.rs
@@ -76,6 +76,7 @@ mod tests {
             write_buffer_directory: base_path.display().to_string(),
             enable_wal: true,
             global_manifest_url: None,
+            ..Default::default()
         };
 
         // For testing, we'll create the engine without collection service


### PR DESCRIPTION
## TD-WAL-1 — flush policy + observability surface + live config (ADR-069)

The **tested foundation** of the ADR-069 tiered-flush optimizer. Lands the pure
decision logic, the Prometheus surface, and the live server config wiring. The
auto-flush **driver is intentionally deferred** — nothing here calls a stubbed
flush. Two commits (S1 config surface + this).

### Decision logic — `write_ahead_log/flush_policy.rs` (pure, 7 tests)
`FlushPolicy::evaluate(mem_bytes, age) → {reason, backpressure}`. Envelope
`time (RPO floor) ≤ size (throughput) ≤ high < critical (memory ceiling)`,
precedence `capacity-critical > capacity-high > size > time`. Reconciles the four
knobs into absolute byte thresholds up front and warns on a broken envelope. No
I/O, no clock — the reusable primitive a future flush driver consumes.

### Observability — `proximadb-metrics::wal_flush_metrics` (private registry → `/metrics/prometheus`, 5 tests)
`proximadb_wal_flush_total{collection,reason,result}`, `_bytes_total`,
`_vectors_total`, `_duration_seconds{reason}`, and gauges `wal_size_bytes`,
`budget_bytes`, `high/critical_watermark_bytes`, `last_flush_timestamp_seconds`,
`backpressure_active/total`. Sink takes `reason: &str` so the foundation crate
never depends on the engine's `FlushReason`. Exposed on `/metrics`; reads zero
until a driver emits.

### Live config wiring (verified against a running server)
`WriteBufferUserConfig` gains `flush_interval_secs` / `wal_max_bytes` /
`high_watermark_pct` / `critical_watermark_pct` (serde back-compat defaults),
wired at **both** conversion sites (`shared_services.rs` + `database.rs`) so the
knobs reach `WalPerformanceConfig` on the live server path — not only the
test-only `WalStorageConfig::From`. A local run confirmed the server parsed the
knobs and the envelope-reconciliation warning fired. *Follow-up: dedup the two
WAL user-config structs.*

### ⚠️ Deferred — the auto-flush driver (separately scoped)
The live canonical WAL path (`WriteAheadLogManager` → shared
`GlobalPartitionedMemtable`) has **no flush trigger**; its `flush()` is a stub and
the real flush (`flush_coordinator::execute_coordinated_flush`) is never
auto-invoked and isn't reachable from the write path. A working tiered auto-flush
needs a **new coordinator-backed background flush driver** with storage-engine
access — a real engine feature, out of scope here. An earlier hook into
`BincodeSerializationStrategy` was removed: that strategy's `write_vector_batch`
has no live callers (dead for ingest).

### Tests
flush_policy 7 · wal_flush_metrics 5 · flush_config live-wiring 8 (incl.
`to_engine_config` → `FlushPolicy` propagation). 105 flush-matching lib tests
green; `fmt` + `clippy -D warnings` clean.
