### PR TITLE
feat(wal): TD-WAL-1 auto-flush driver (ADR-069)

### DIFF
--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -1,0 +1,235 @@
+//! ADR-069 / TD-WAL-1 — the live auto-flush DRIVER.
+//!
+//! The foundation PR (#1117) landed the flush *decision* (`flush_policy`) and the
+//! *observability* (`wal_flush_metrics`) but deliberately shipped no trigger,
+//! because the live canonical WAL path has no flush driver. This is that driver.
+//!
+//! It is a policy-gated, timer-driven clone of
+//! [`crate::storage::engine::StorageEngine::flush_memtable_to_storage`]: each tick
+//! it enumerates collections with unflushed data in the GLOBAL write buffer (the
+//! same singleton REST/gRPC ingest writes to), evaluates the [`FlushPolicy`] per
+//! collection (size / time / capacity envelope), and for those that are due calls
+//! the proven [`materialize_collection`] recipe with `free_wal=true` — writing an
+//! L0 SST and freeing the covered WAL. Every decision + flush is metered through
+//! [`wal_flush_metrics`], so `/metrics/prometheus` shows exactly what fired.
+//!
+//! Durability is unaffected: the WAL fsync on write (SyncMode=PerBatch) is the
+//! durability primitive; this driver only controls WHEN the memtable is
+//! materialized to SST (RTO / WAL reclamation / object-store coalescing, plus the
+//! volume-loss RPO bound). `free_wal=true` is the same setting the shutdown path
+//! uses (de-risked by TD-165 cold-read recall); the live insert→flush→search
+//! round-trip is the acceptance check.
+//!
+//! Spawned once from `StorageEngine::start()` and ONLY when a periodic trigger is
+//! armed (`policy.needs_scheduler()` — time or capacity budget set). With default
+//! config (size-only, both disabled) this is a no-op: no task, no wakeups.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::RwLock;
+
+use crate::index::AxisManager;
+use crate::metrics::wal_flush_metrics;
+use crate::storage::flush_materializer::{CollectionFlushPlan, materialize_collection};
+use crate::storage::persistence::write_ahead_log::flush_policy::FlushPolicy;
+use crate::storage::persistence::write_ahead_log::{
+    get_global_write_buffer_behavior, list_collections_from_catalog,
+};
+use crate::storage::write_fence::StorageWriteFence;
+
+/// Background driver that materializes unflushed memtable data to SST on the
+/// ADR-069 flush policy.
+pub struct AutoFlushDriver {
+    policy: FlushPolicy,
+    axis_index_manager: Arc<AxisManager>,
+    /// A6 storage-write fence (default-OFF). Captured at spawn time; on the live
+    /// server it is injected into the storage engine post-construction, so this
+    /// may be `None` here — acceptable at MVP (single-pod, fence default-OFF).
+    /// Hardening (spawn after fence injection) is a follow-up.
+    storage_write_fence: Option<Arc<dyn StorageWriteFence>>,
+    /// Per-collection start of the current unflushed window (last flush, or first
+    /// observation). Feeds the time trigger's RPO decision; one clock, read by the
+    /// decision and reset on a successful flush.
+    flush_clock: Arc<RwLock<HashMap<String, Instant>>>,
+}
+
+impl AutoFlushDriver {
+    /// Spawn the driver's background loop iff a periodic trigger is armed. No-op
+    /// (behavior-neutral) when only the size trigger is configured.
+    pub fn spawn(
+        policy: FlushPolicy,
+        axis_index_manager: Arc<AxisManager>,
+        storage_write_fence: Option<Arc<dyn StorageWriteFence>>,
+    ) {
+        if !policy.needs_scheduler() {
+            return;
+        }
+        let tick = policy.scheduler_tick_secs();
+        let driver = Self {
+            policy,
+            axis_index_manager,
+            storage_write_fence,
+            flush_clock: Arc::new(RwLock::new(HashMap::new())),
+        };
+        tracing::info!(
+            "🕒 ADR-069 auto-flush driver armed: tick={}s time_floor={}s capacity_budget={}B",
+            tick,
+            driver.policy.time_floor_secs,
+            driver.policy.capacity_budget_bytes
+        );
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(tick));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                driver.tick().await;
+            }
+        });
+    }
+
+    fn now_unixtime() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+
+    /// Age (seconds) of the current unflushed window; lazily initialized to *now*
+    /// on first sight so a brand-new collection never time-flushes immediately.
+    async fn window_age_secs(&self, collection_id: &str) -> u64 {
+        let mut clock = self.flush_clock.write().await;
+        let base = clock
+            .entry(collection_id.to_string())
+            .or_insert_with(Instant::now);
+        base.elapsed().as_secs()
+    }
+
+    /// Reset the unflushed-window clock after a flush (the RPO window restarts).
+    async fn note_flushed(&self, collection_id: &str) {
+        let mut clock = self.flush_clock.write().await;
+        clock.insert(collection_id.to_string(), Instant::now());
+    }
+
+    /// One evaluation+flush pass over all collections with unflushed data.
+    async fn tick(&self) {
+        let Some(write_buffer) = get_global_write_buffer_behavior() else {
+            return;
+        };
+        let collections = write_buffer.list_collections_with_unflushed_data().await;
+        if collections.is_empty() {
+            return;
+        }
+        let (budget, high, critical) = self.policy.budget_gauges();
+        // Catalog is the metadata authority (engine / dimension / path / tenant) —
+        // the same source flush_memtable_to_storage resolves each plan from.
+        let catalog = list_collections_from_catalog().await;
+
+        for collection_id in &collections {
+            let mem_bytes: u64 = match write_buffer.get_unflushed_batches(collection_id).await {
+                Ok(batches) => batches.iter().map(|b| b.total_size_bytes as u64).sum(),
+                Err(_) => 0,
+            };
+            // Observation is emitted at the decision boundary: what /metrics shows
+            // is exactly what the policy acted on.
+            wal_flush_metrics::set_wal_size(collection_id, mem_bytes as i64);
+            wal_flush_metrics::set_budget(collection_id, budget, high, critical);
+
+            let age = self.window_age_secs(collection_id).await;
+            let decision = self.policy.evaluate(mem_bytes, age);
+            let Some(reason) = decision.reason else {
+                continue;
+            };
+            if decision.backpressure {
+                wal_flush_metrics::inc_backpressure(collection_id);
+            }
+
+            let Some(meta) = catalog.iter().find(|c| &c.id == collection_id) else {
+                tracing::warn!(
+                    "⚠️ ADR-069 auto-flush: no catalog metadata for '{}', skipping",
+                    collection_id
+                );
+                continue;
+            };
+            let config = meta.config.as_ref();
+            let assignment = meta.storage_assignment.as_ref();
+            let engine_type = assignment
+                .map(|a| a.engine)
+                .or_else(|| config.and_then(|c| c.storage_engine))
+                .unwrap_or(crate::proto::proximadb_v1::StorageEngine::Sst as i32);
+            let dimension = config.map(|c| c.dimension).unwrap_or(0);
+            let base_location = assignment
+                .map(|a| a.base_location.clone())
+                .unwrap_or_default();
+            let tenant_id = proximadb_tenant::tenant_id_of(meta);
+
+            let plan = CollectionFlushPlan {
+                wal_key: collection_id.clone(),
+                canonical_id: collection_id.clone(),
+                base_location,
+                engine_type,
+                dimension,
+                tenant_id,
+            };
+
+            // free_wal=true: once the SST segment is written, free the covered WAL
+            // so the materialized segment (not a WAL replay) is the durable restart
+            // source — the same posture as the shutdown flush (engine.rs), gated by
+            // the insert→flush→search recall round-trip.
+            let start = Instant::now();
+            let res = materialize_collection(
+                &write_buffer,
+                &plan,
+                self.storage_write_fence.as_ref(),
+                None,
+                true,
+                Some(&self.axis_index_manager),
+            )
+            .await;
+            let dur = start.elapsed().as_secs_f64();
+
+            match res {
+                Ok(Some(outcome)) => {
+                    wal_flush_metrics::record_flush(
+                        collection_id,
+                        reason.as_str(),
+                        true,
+                        outcome.bytes as i64,
+                        outcome.entries_flushed as i64,
+                        dur,
+                        Self::now_unixtime(),
+                    );
+                    self.note_flushed(collection_id).await;
+                    wal_flush_metrics::set_wal_size(collection_id, 0);
+                    tracing::info!(
+                        "✅ ADR-069 auto-flush [{}] '{}': {} vectors, {} bytes in {:.3}s",
+                        reason.as_str(),
+                        collection_id,
+                        outcome.entries_flushed,
+                        outcome.bytes,
+                        dur
+                    );
+                }
+                Ok(None) => {
+                    // Raced to empty; reset the window so we don't re-decide every tick.
+                    self.note_flushed(collection_id).await;
+                }
+                Err(e) => {
+                    wal_flush_metrics::record_flush(
+                        collection_id,
+                        reason.as_str(),
+                        false,
+                        0,
+                        0,
+                        dur,
+                        0,
+                    );
+                    tracing::warn!(
+                        "❌ ADR-069 auto-flush [{}] '{}' failed: {}",
+                        reason.as_str(),
+                        collection_id,
+                        e
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -208,6 +208,21 @@ impl StorageEngine {
         temp_manager.start_workers(2).await?; // Start 2 worker threads
         self.compaction_manager = Arc::new(temp_manager);
 
+        // ADR-069/TD-WAL-1: spawn the live auto-flush driver. No-op unless a time or
+        // capacity trigger is armed in wal_config, so default (size-only) config is
+        // behavior-neutral. The driver mirrors flush_memtable_to_storage's recipe,
+        // policy-gated + metered. (Fence is injected post-construction, so it may be
+        // None here — acceptable at MVP: the A6 fence is default-OFF.)
+        let flush_policy =
+            crate::storage::persistence::write_ahead_log::flush_policy::FlushPolicy::from_performance(
+                &self.config.wal_config.to_engine_config().performance,
+            );
+        crate::storage::auto_flush_driver::AutoFlushDriver::spawn(
+            flush_policy,
+            self.axis_index_manager.clone(),
+            self.storage_write_fence.clone(),
+        );
+
         tracing::info!("✅ STORAGE_ENGINE: Storage engine started successfully");
         Ok(())
     }

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -248,6 +248,32 @@ pub async fn materialize_collection(
             .iter()
             .map(|batch| batch.batch_id.to_base62())
             .collect();
+        // ADR-069: ALSO retire the batches in the BATCH COORDINATOR — the store
+        // `get_unflushed_batches` / `list_collections_with_unflushed_data` read
+        // from. `clear_flushed` above only clears the inner memtable, so without
+        // this the just-flushed batches are re-served as "unflushed" forever —
+        // harmless on the terminal shutdown flush, but an infinite re-flush loop
+        // for any periodic caller (the auto-flush driver exposed this).
+        for batch_id in &batch_id_strings {
+            if let Err(e) = write_buffer
+                .mark_batch_flushed(&plan.wal_key, batch_id)
+                .await
+            {
+                tracing::warn!(
+                    "flush: failed to mark batch {} flushed for '{}': {}",
+                    batch_id,
+                    plan.wal_key,
+                    e
+                );
+            }
+        }
+        if let Err(e) = write_buffer.clear_flushed_batches(&plan.wal_key).await {
+            tracing::warn!(
+                "flush: failed to clear coordinator batches for '{}': {}",
+                plan.wal_key,
+                e
+            );
+        }
         if !batch_id_strings.is_empty()
             && let Err(e) = crate::storage::persistence::write_ahead_log::manifest::mark_flushed_and_delete_files(
                 &batch_id_strings,

--- a/src/storage/memtable/specialized/wal_behavior.rs
+++ b/src/storage/memtable/specialized/wal_behavior.rs
@@ -52,6 +52,42 @@ pub struct WALVectorBatch {
 }
 
 impl WALVectorBatch {
+    /// Estimate the resident size of a record slice — the CANONICAL
+    /// `total_size_bytes` source for WAL batches (ADR-069/TD-WAL-1).
+    ///
+    /// Embedding payload bytes are exact and precision-aware
+    /// (`EmbeddingCell::values_byte_size`: 4B/elem fp32, 2B fp16/bf16, …);
+    /// props/identity use the same overhead model as
+    /// `BulkWriteRouter::estimate_record_batch_size` (96B/prop + 256B/record +
+    /// oid + 64B). An estimate is sufficient: the consumers are watermark
+    /// fractions, backpressure sums, and gauges — not exact accounting.
+    ///
+    /// Two consumers depend on a non-zero value: the wal_behavior
+    /// per-collection backpressure check and the auto-flush driver's
+    /// size/capacity triggers — a batch constructed with `total_size_bytes: 0`
+    /// silently disables BOTH. (Dedup follow-up: point the BulkWriteRouter
+    /// copy of this math here.)
+    pub fn estimate_records_size(records: &[ProximaRecord]) -> usize {
+        const PROPERTY_OVERHEAD_PER_RECORD: usize = 256;
+        const ID_OVERHEAD_PER_RECORD: usize = 64;
+        const PROP_BYTES: usize = 96;
+        records
+            .iter()
+            .map(|record| {
+                let embedding_bytes: usize =
+                    record.embeddings.iter().map(|e| e.values_byte_size()).sum();
+                let props_bytes = record.props.len() * PROP_BYTES + PROPERTY_OVERHEAD_PER_RECORD;
+                let id_bytes = record.oid.len() + ID_OVERHEAD_PER_RECORD;
+                embedding_bytes + props_bytes + id_bytes
+            })
+            .sum()
+    }
+
+    /// [`Self::estimate_records_size`] over this batch's records.
+    pub fn estimated_size_bytes(&self) -> usize {
+        Self::estimate_records_size(&self.vector_records)
+    }
+
     /// Create bloom filter for batch metadata
     pub fn create_bloom_filter(&mut self) -> Result<()> {
         // Create bloom filter with optimal false positive rate

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -198,6 +198,9 @@ pub mod write_fence;
 // Shared per-collection flush materialization (server shutdown + embedded)
 pub mod flush_materializer;
 
+// ADR-069/TD-WAL-1: live auto-flush driver (policy-gated materialization).
+pub mod auto_flush_driver;
+
 // Engine capabilities and supportability checks
 pub mod engine_capabilities;
 

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1972,11 +1972,21 @@ impl WriteAheadLogManager {
         // Create native WALVectorBatch with Arc (zero-copy)
         let batch_id = crate::storage::persistence::write_ahead_log::BatchId::new();
 
+        // ADR-069: estimate the batch's resident size UP FRONT via the canonical
+        // estimator on WALVectorBatch. The old `0 // calculated by strategy` was
+        // never calculated on this live path — which silently zeroed both the
+        // memtable backpressure sum (wal_behavior.rs) and the auto-flush driver's
+        // capacity/size evaluation.
+        let total_size_bytes =
+            crate::storage::memtable::specialized::wal_behavior::WALVectorBatch::estimate_records_size(
+                &native_vectors,
+            );
+
         let native_batch = crate::storage::memtable::specialized::wal_behavior::WALVectorBatch {
             batch_id,
             vector_records: native_vectors,
             timestamp: std::time::SystemTime::now(),
-            total_size_bytes: 0, // Will be calculated by strategy
+            total_size_bytes,
             is_flushed: false,
             metadata_bloom_filter: None,
         };


### PR DESCRIPTION
## TD-WAL-1 auto-flush driver (ADR-069)

Completes the ADR-069 tiered-flush optimizer. Stacked on #1117 (flush policy + metrics + config foundation): this PR adds the **driver** that makes them operate on the **live** canonical WAL path, plus two latent bugs the live verification exposed.

### Driver — `src/storage/auto_flush_driver.rs`
Policy-gated, timer-driven clone of the proven flush recipe (`StorageEngine::flush_memtable_to_storage` → `materialize_collection(free_wal=true)`). Each tick: enumerate collections with unflushed data in the **global** write buffer, evaluate `FlushPolicy(mem_bytes, window_age)` per collection, materialize the due ones, meter through `wal_flush_metrics`. Spawned from `StorageEngine::start()` **only** when a time/capacity trigger is armed — default config spawns nothing (behavior-neutral).

### Bug 1 — batch size never computed on the live path
`WALVectorBatch { total_size_bytes: 0 /* calculated by strategy */ }` — the strategy is dead code, so the field stayed 0: the memtable **backpressure sum** and any size/capacity evaluation were silently zeroed. Fixed with canonical `WALVectorBatch::estimate_records_size` (same math as `BulkWriteRouter::estimate_record_batch_size`) at the live construction site.

### Bug 2 — `materialize_collection(free_wal=true)` never retired coordinator batches
It cleared only the inner memtable; `get_unflushed_batches` / `list_collections_with_unflushed_data` read the **batch coordinator**, so flushed batches were re-served forever. Harmless on the terminal shutdown flush — an **infinite re-flush loop** for any periodic caller: the pre-fix run re-materialized the same 810 vectors once per tick (**94 duplicate SST flushes and climbing**). Fixed via `mark_batch_flushed` + `clear_flushed_batches` in the `free_wal` block.

### Live verification (dim-2 sst collection; `flush_interval_secs=3`, `wal_max_bytes=100000`, high 0.5 / critical 0.8)
```
proximadb_wal_flush_total{collection="1",reason="time",result="success"} 1      # 10-vector burst after idle
proximadb_wal_flush_total{collection="1",reason="capacity",result="success"} 1  # 800-vector burst
proximadb_wal_flush_vectors_total{...reason="time"} 10 / {...reason="capacity"} 800
proximadb_wal_backpressure_total{collection="1"} 1
proximadb_wal_size_bytes{collection="1"} 0
```
- **Loop terminates**: counters frozen after 30 s idle (pre-fix: 94×810 and growing); `🧹 Cleared 1 flushed batches` ×2 in the log.
- **Recall with WAL freed**: post-flush search returns both bursts' ids (`a3`, `b*`).
- **Restart recovery from SST**: same config → `No collections found in WAL to restore`, and search + record GET (`a3`, `b40`) still return both bursts — served from the materialized SSTs, not WAL replay.

### Gates
`cargo test --lib flush` **105 passed** · `fmt` + `clippy -D warnings` clean.

Depends on #1117 (branched from it — merge that first).
