### PR TITLE
docs(td): TD-RDSTRAT-9 collection read-cost envelope

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-9-collection-read-cost-envelope.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-9-collection-read-cost-envelope.adoc
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-9: Collection read-cost envelope — close the loop between file geometry, region cache, and compaction
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — architecture/control-plane prerequisite.** The current `l0_threshold:N` mechanism is a fixed segment-count trigger, not ADR-062's query-GET-budget controller. Implement observe/recommend mode before permitting automatic compaction decisions.
+| Priority | P1 for scale promotion. TD-RDSTRAT-8 may prototype its per-segment layout in parallel, but neither automatic successor-layout promotion nor adaptive compaction becomes default until this collection-level envelope is measured.
+| Severity | High — the wrong file geometry either multiplies cold GETs or creates Region-A entries too large to admit usefully into cache; over-compaction merely converts read cost into write amplification.
+| Component | Collection/catalog policy, SST compaction scheduling, `SegmentInvariantsCache` / `SurvivorRangeCache`, `IopsBudget`, query-scoped I/O trace, and EXPLAIN/decision trace. No new storage encoding or query metric.
+| Governs | The collection-level decision to leave segments alone, compact a subset, change successor-layout eligibility, or report that the configured GET/cache envelope is infeasible.
+| Relates to | link:../../12-design/adr/ADR-061-per-collection-workload-profiles.adoc[ADR-061], link:../../12-design/adr/ADR-062-coalesced-rabitq-header-self-describing-footer-pax-layout.adoc[ADR-062], link:../../12-design/adr/ADR-065-clustered-tier-regions-single-segment.adoc[ADR-065], link:TD-RDSTRAT-6-coalesced-binary-tier-rerank-driven-io.adoc[TD-RDSTRAT-6], link:TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc[TD-RDSTRAT-8], link:TD-IOTRACE-3-actual-scan-gb-logical-contract.adoc[TD-IOTRACE-3], link:TD-WLP-2-per-collection-compaction-override.adoc[TD-WLP-2]
+| Pillar | COST / PERF / OE / SUS
+|===
+
+== Why this is a system problem, not another codec or threshold
+
+ADR-062 correctly made file count a vector-query GET knob, and ADR-065 made
+Regions A/B independently addressable. The implementation now has the pieces,
+but no collection-level controller joins them:
+
+* `resolve_l0_threshold` triggers at a configured number of L0 files. It does not
+  consume measured GETs/query, bytes/query, cache admission, query rate, or write
+  amplification.
+* `IopsBudget` sizes the **survivor-fetch unit** and range coalescing for Region B.
+  It does not determine how many rows belong in a segment or whether the whole
+  Region-A entry is cacheable.
+* `SegmentInvariantsCache` is byte-bounded, but its budget and misses do not feed
+  back into compaction. `SurvivorRangeCache` similarly optimizes repeated ranges;
+  neither cache is a file-layout policy authority.
+* TD-RDSTRAT-8 bounds work *within one large segment*. A collection with `F` live
+  segments still pays the per-segment directory/rank/rerank chain roughly `F`
+  times. A per-segment format cannot choose the collection's LSM shape.
+
+Changing `l0_threshold:5` to another constant would tune one corpus and move the
+failure elsewhere. The controller must minimize the integrated read + write cost
+under recall, exactness, tenant fairness, and recovery constraints.
+
+== First-principles model
+
+For a collection with `N` rows, dimension `d`, and `F` live segments, define:
+
+----
+b_A(d)       = declared Region-A bytes/row (approximately ceil(d/8)+8 today)
+A_i          = Region-A bytes of live segment i
+A_entry_max  = largest single invariant entry the cache policy will admit
+C_A          = collection/tenant Region-A working-set budget
+G_budget     = collection cold-GET budget per query
+g_i          = measured cold GET contribution of segment i for the query mix
+----
+
+The segment-size/cache constraint is:
+
+----
+max(A_i) <= A_entry_max
+rows_per_file <= floor(A_entry_max / b_A(d))
+F_min_admission = ceil(N / rows_per_file)
+----
+
+The GET constraint is an **upper** bound on file count, derived from measured
+per-file contributions rather than assuming exactly one GET/file:
+
+----
+sum(g_i) <= G_budget
+F <= F_max_get  (only after calibration for layout, cache state, and backend)
+----
+
+Therefore the feasible **file-count band** is:
+
+----
+F_min_admission <= F <= F_max_get
+----
+
+Equivalently, file *size* is bounded below by the GET budget and above by the
+single-entry cache-admission budget. This wording matters: reversing file count
+and file size produces the wrong compaction action.
+
+Two corrections follow from the algebra:
+
+1. Splitting a collection changes entry granularity but does **not** shrink the
+   total Region-A working set: `sum(A_i) ~= N * b_A(d)` independently of `F`.
+   Keeping every Region A hot additionally requires `sum(A_i) <= C_A`; otherwise
+   the policy must accept misses, allocate more cache, or use TD-RDSTRAT-8's
+   selective Region-A probing. Compaction alone cannot make an oversized total
+   index resident.
+2. If `F_min_admission > F_max_get`, no file-count setting satisfies both sides.
+   The controller must report an infeasible envelope and choose an architectural
+   lever (selective probing, a different cache/service tier, or a revised SLA),
+   not thrash between split and merge operations.
+
+The decision objective is collection-level and amortized over time:
+
+----
+read_cost/time = query_rate * (p_get*GETs + p_byte*bytes + p_round*fetch_rounds
+                               + p_cpu*compute + cache_miss_penalty)
+write_cost/time = write_rate * (compaction_read + compaction_write
+                                + clustering_compute + recovery/staging cost)
+storage_cost/time = persisted_bytes * access_tier_rate
+----
+
+Rates are policy inputs, not engine constants. Pricing remains outside the OSS
+engine; the engine emits physical quantities and a deterministic decision trace.
+Provider-specific `IopsBudget` remains an I/O geometry input, not a workload
+profile or billing table.
+
+== Decision boundary and policy inputs
+
+The controller operates at the collection/manifest boundary because that is the
+lowest layer that sees all live files and the highest layer allowed to schedule
+their rewrite. It consumes:
+
+* catalog facts: `N`, `d`, metric, exact-vector authority/projection policy,
+  workload profile, object access tier, and live segment manifests;
+* physical layout facts from each header/footer: region presence and lengths,
+  row count, encoding, successor-layout eligibility, and block/range geometry;
+* observed trace distributions: cold/warm GETs, bytes by region, fetch rounds,
+  p50/p95, cache admissions/hits/evictions, queries/time, and writes/time;
+* compaction facts: bytes read/written, peak memory, clustering CPU, wall time,
+  write amplification, failures, and recovery parity;
+* operator envelopes: GET, byte, latency, cache, write-amplification, and minimum
+  payback-horizon limits. These become catalog-resolved policy, not a growing set
+  of process-wide environment variables.
+
+It may recommend one of four actions: `NoOp`, `Compact(files)`,
+`RewriteSuccessorLayout(files)`, or `EnvelopeInfeasible(reason)`. Cache resizing
+and service-tier changes are recommendations, never silent engine mutations.
+
+`AppendBulk` and `Churn` use the same durable authority but different amortization:
+read-heavy append collections can repay expensive clustering; a write-heavy churn
+collection may rationally retain more small durable files while the bounded Strong
+memtable merge serves freshness. Workload profile supplies priors, never substitutes
+for the measured trace.
+
+== Explicit lever separation
+
+[cols="2,2,3", options="header"]
+|===
+| Lever | Owner | What it can move
+| Region-B block/range size | `IopsBudget` | Transfer efficiency and GET splitting for survivor fetches; not Region-A cacheability
+| Survivor pool `M` | ADR-062 reader/eval | Recall and Region-B survivor bytes; not file count or Region-A bytes
+| Bounded parallel `read_ranges` | TD-RDSTRAT-8/#1094 experiment | Wall/tail latency by overlapping GETs; not GET billing or bytes
+| Successor Region A0 | TD-RDSTRAT-8 | Per-segment Region-A/B bytes at large `N`; not collection live-file count
+| Lossless encoding | TD-RDSTRAT-7/shared codec | Stored/transferred bytes when end-to-end wins; not recall, GET count, or fetch rounds
+| Compaction selection | **this TD** | Live-file geometry and locality, paid for with write amplification
+| Logical/physical accounting | TD-IOTRACE-2/3 | Decision and billing truth; it does not optimize the path itself
+|===
+
+== TDD and rollout sequence
+
+1. **Pure model tests.** Implement an engine-neutral `ReadCostEnvelope` value
+   object and pure evaluator. Table-test feasible/infeasible bands, zero/overflow
+   values, 128/768/1536 dimensions, mixed layouts, and provider budgets. It must
+   never mutate storage.
+2. **Observe-only integration.** At query/compaction boundaries, emit the inputs,
+   derived band, proposed action, payback estimate, and rejection reason. Reconcile
+   every value with backend I/O counters. TD-IOTRACE-3's logical/physical contract
+   lands before any observed field is used for control.
+3. **Recommend-only collection evaluation.** Replay real AppendBulk and Churn
+   traces over identical manifests. Verify recommendations are deterministic and
+   stable under small input changes; add hysteresis, cooldown, and a maximum
+   rewrite budget so the evaluator cannot oscillate.
+4. **Default-OFF actuation.** Permit compaction only through the existing
+   fresh-name + manifest-advance seam. The global hard-disable and per-collection
+   opt-out remain authoritative. Any format upgrade remains independently gated.
+5. **Promotion.** Move from fixed threshold to the envelope only after a dated,
+   ledgered end-to-end evaluation proves lower collection cost/latency at equal
+   recall and exactness without unacceptable write amplification.
+
+== Acceptance gates
+
+* **Correctness:** byte-identical logical results and unchanged recall/exact-mode
+  guarantees across legacy, `PXH1`, and successor segments; mixed layouts normal.
+* **Collection economics:** report cold/warm GETs, bytes by region, fetch rounds,
+  cache working set, p50/p95, and compaction read/write/CPU for the *same live-file
+  geometry*. Per-segment wins cannot headline the gate.
+* **Scale/metric matrix:** at minimum 100K/1M/10M-shaped corpora, 128/768/1536d,
+  L2/cosine/dot, single-file and realistic multi-file states.
+* **Workload matrix:** bulk ingest/read-heavy, steady trickle, and churn bursts;
+  include query/write ratios and the compaction payback horizon.
+* **Stability:** no repeated split/merge oscillation; bounded work per decision,
+  cooldown after rewrite, and fail-closed no-op on missing/stale telemetry.
+* **Tenant/cache governance:** real `TenantContext` attribution and fair cache
+  budgets; no shared synthetic tenant key as the promoted control signal.
+* **Evidence:** release-profile end-to-end traces recorded in
+  `BENCHMARK_EVIDENCE.toml`; codec/kernel or local-filesystem-only results remain
+  diagnostics, not promotion evidence.
+
+== Non-goals
+
+* No new vector quantizer, metric restriction, storage region, or magic/version.
+* No pricing or SKU selection inside the OSS engine.
+* No automatic cache resizing, cross-tenant borrowing policy, or background
+  compaction thread introduced by this TD.
+* No claim that one fixed file count, `M/N` ratio, or `nprobe` serves every
+  dimension, metric, provider, and workload.


### PR DESCRIPTION
Extracts the unique TD-RDSTRAT-9 (collection read-cost envelope — close the loop between file geometry, region cache, and compaction) from the stale `docs/rdstrat-codesign-envelope` worktree. The other 4 docs there already landed on develop; this is the one unique piece. All 7 links resolve (ADR-061/062/065, TD-RDSTRAT-6/8, TD-IOTRACE-3, TD-WLP-2). `check_td_adr_unique` clean (0 errors). Docs-only.