### PR TITLE
chore(deps): sandhi-core from crates.io (0.1) — registry release replaces the git-rev pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9475,8 +9475,9 @@ dependencies = [
 
 [[package]]
 name = "sandhi-core"
-version = "0.1.0"
-source = "git+https://github.com/anvai-labs/sandhi?rev=deee223221d18df6449ccebf169f64e81aab39e7#deee223221d18df6449ccebf169f64e81aab39e7"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c7f348589b603bac430076f5a0c70ee7a58658a0c2c512d0d990c2acf1177a"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,8 +314,8 @@ serde_json = "1.0"
 # Sandhi neutral usage parsers (TD-SANDHI-2 / ADR-0047 D10a): single-sourced, fixture-proven
 # (Sandhi TD-0001 W1) usage/cache-split extraction adopted by the generation LLM path — not a
 # hand-rolled 4th extractor. `sandhi-core` is serde-only (no reqwest/tokio); dependency direction
-# one-way (ProximaDB → Sandhi, ADR-060). Pinned by rev until Sandhi publishes to crates.io.
-sandhi-core = { git = "https://github.com/anvai-labs/sandhi", rev = "deee223221d18df6449ccebf169f64e81aab39e7" }
+# one-way (ProximaDB → Sandhi, ADR-060). Registry release since sandhi v0.1.1.
+sandhi-core = "0.1"
 
 # OpenAPI spec-from-code (TD-126 Phase 1). The `ToSchema`/`IntoParams`/`path`
 # derives annotate the v2 REST DTOs + handlers so `docs/openapi/proximadb-openapi.yaml`


### PR DESCRIPTION
Sandhi **v0.1.1** is now published (crates.io: `sandhi-core`/`-providers`/`-store`/`-proxy`; PyPI: `sandhi-gateway` 0.1.1), so the dependency comment's own condition — *"Pinned by rev until Sandhi publishes to crates.io"* — is met.

- `sandhi-core = "0.1"` replaces the git-rev pin; resolves to v0.1.1 (which contains the pinned rev's parser code unchanged — the 0.1.1 delta is in `sandhi-providers`/proxy/bindings, not core).
- Verified: `cargo tree -i sandhi-core` resolves cleanly for both `proximadb` and the Rust SDK; `cargo test --lib metrics::usage_event` 5/5 green against the registry crate.
- This is the dependency-hygiene half only; the chat `LLMClient` transport consolidation onto `sandhi-providers` (TD-SANDHI-2 part b) remains its own future piece of work.

Prepared for maintainer review per the sandhi consolidation program (AnvaiOps ADR-0047 D10a / ADR-067).