### PR TITLE
TD-RDSTRAT-8 PR-A: persisted IVF probe (v3) layout — compaction-only, default-OFF

### DIFF
--- a/crates/storage/proximadb-engine-core/src/proximablocks/spatial_clustering.rs
+++ b/crates/storage/proximadb-engine-core/src/proximablocks/spatial_clustering.rs
@@ -138,6 +138,21 @@ impl IncrementalPCA {
         let projected = self.transform(sample);
         projected.first().copied().unwrap_or(0.0)
     }
+
+    /// The fitted per-dimension mean (valid after [`Self::finalize`]).
+    ///
+    /// Exposed so write paths can persist the trained model (TD-RDSTRAT-8: the
+    /// A0 coarse directory stores mean + components for query-time projection —
+    /// the query must use the exact projection the writer used).
+    pub fn mean(&self) -> &[f64] {
+        &self.mean
+    }
+
+    /// The principal components (row-major, `n_components × dim`), or `None`
+    /// before [`Self::finalize`]. Same persistence rationale as [`Self::mean`].
+    pub fn components(&self) -> Option<&[Vec<f64>]> {
+        self.components.as_deref()
+    }
 }
 
 /// Power iteration to find dominant eigenvector.

--- a/crates/storage/proximadb-storage-common/src/coarse_directory.rs
+++ b/crates/storage/proximadb-storage-common/src/coarse_directory.rs
@@ -1,0 +1,511 @@
+//! Region A0 — the persisted IVF probe directory (TD-RDSTRAT-8 rev 3).
+//!
+//! Compaction already trains an IOP-derived PCA/IVF plan (`cells ≈ N·dim/IOP`)
+//! to order rows, then discards the model, centroids, and cell runs — so the
+//! reader re-ranks every row and plans ranges blind to cell boundaries. The v3
+//! layout **persists that existing plan** as a query-visible directory: rows are
+//! ordered by IVF cell, every region (A/B/D) is cell-contiguous, and this
+//! directory maps each cell to **direct ranged-GET byte extents** into every
+//! region. The read path ranks the `k_c` centroids in RAM (trivial even at
+//! k ∝ N — ~305 at 10M, ~3050 at 100M, capped 4096) and probes `nprobe` cells,
+//! trading the whole-region O(N)-byte scan for O(nprobe) ranged GETs — the
+//! dimensional cost term this layout moves. There is NO second `sqrt(N)`
+//! quantizer (rev 3): the cells ARE the IOP-derived cells compaction computes.
+//!
+//! A0 is small (~120–300 KB: `k_c ≤ 4096` cells × 72 B + the PCA model) and sits
+//! **immediately after the header-prefix**, so a cold query fetches
+//! `[0, a0_off + a0_len)` in one ranged GET and every later wave is
+//! nprobe-scoped. It rides the per-segment invariants cache thereafter.
+//!
+//! The directory persists the **write-time PCA model** (mean + components — the
+//! TD-WLP-4b deferred persistence, required here): query-time coarse ranking
+//! must project with the exact model the writer clustered with.
+//!
+//! ## Byte layout (fixed, little-endian, deterministic)
+//!
+//! ```text
+//! [magic "PXA0" 4][version u8][flags u8][n_comp u16]
+//! [k_c u32][dim u32]
+//! [seed u64][trained_on u64][rows_covered u64]
+//! [pca_mean:       dim × f32]
+//! [pca_components: n_comp × dim × f32]   (row-major)
+//! [centroids:      k_c × n_comp × f32]   (PCA space, emission/Hilbert order)
+//! [radii:          k_c × f32]            (PCA space, max member→centroid)
+//! [cells:          k_c × 72 B]           (see CoarseCellEntry)
+//! [checksum u64]                          (FNV-1a over all preceding bytes)
+//! ```
+//!
+//! Rows NOT covered by any cell (records without a usable embedding) sort to
+//! the segment tail, after `rows_covered`; they carry no vector so the coarse
+//! probe can never miss them.
+
+#![forbid(unsafe_code)]
+
+use anyhow::{Result, bail};
+
+/// Region A0 magic — first 4 bytes of the serialized directory.
+pub const A0_MAGIC: &[u8; 4] = b"PXA0";
+
+/// A0 serde version. Single version pre-GA (in-place evolution — no versioned
+/// files on disk); versioning re-engages at GA.
+pub const A0_VERSION: u8 = 1;
+
+/// Fixed head: magic(4) + version(1) + flags(1) + n_comp(2) + k_c(4) + dim(4)
+/// + seed(8) + trained_on(8) + rows_covered(8).
+const A0_FIXED_HEAD_LEN: usize = 40;
+
+/// One per-cell entry: row range + direct byte extents into Regions A/B/C + the
+/// Region D block range.
+const A0_CELL_ENTRY_LEN: usize = 8 * 8 + 4 * 2;
+
+/// Trailing checksum length.
+const A0_CHECKSUM_LEN: usize = 8;
+
+/// The trained coarse model — everything the clustering step produces. The
+/// writer combines this with the per-cell byte extents (which only it knows,
+/// at region-assembly time) into the serialized [`CoarseDirectory`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoarseModel {
+    /// Original embedding dimensionality.
+    pub dim: u32,
+    /// PCA projection dimensionality (`n_comp ≤ dim`).
+    pub n_comp: u16,
+    /// PCA per-dimension mean (`dim` values).
+    pub pca_mean: Vec<f32>,
+    /// PCA components, row-major (`n_comp × dim` values).
+    pub pca_components: Vec<f32>,
+    /// Coarse centroids in PCA space, emission (Hilbert) order
+    /// (`k_c × n_comp` values).
+    pub centroids: Vec<f32>,
+    /// Per-cell max member→centroid distance in PCA space (`k_c` values) — the
+    /// escalation lower bound `LB(c) = d_pca(q, centroid_c) − radius_c`.
+    pub radii: Vec<f32>,
+    /// Rows per cell in emission order (`k_c` values; empty cells are 0). The
+    /// writer turns the prefix sums into cell row ranges and block boundaries.
+    pub cell_rows: Vec<u64>,
+    /// Deterministic k-means seed (diagnostics + reproducibility).
+    pub seed: u64,
+    /// Number of training samples the PCA/k-means saw (diagnostics).
+    pub trained_on: u64,
+}
+
+impl CoarseModel {
+    /// Coarse cell count.
+    pub fn k_c(&self) -> usize {
+        self.radii.len()
+    }
+
+    /// Total rows covered by cells (rows past this are the no-embedding tail).
+    pub fn rows_covered(&self) -> u64 {
+        self.cell_rows.iter().sum()
+    }
+
+    /// Structural validation — every array length must agree with
+    /// `k_c/dim/n_comp`. Fail-closed: a malformed model must never serialize.
+    pub fn validate(&self) -> Result<()> {
+        let k_c = self.k_c();
+        if k_c == 0 {
+            bail!("coarse directory requires at least one cell");
+        }
+        if self.dim == 0 || self.n_comp == 0 || self.n_comp as u32 > self.dim {
+            bail!(
+                "coarse directory: invalid dims (dim={}, n_comp={})",
+                self.dim,
+                self.n_comp
+            );
+        }
+        if self.pca_mean.len() != self.dim as usize {
+            bail!("coarse directory: pca_mean length mismatch");
+        }
+        if self.pca_components.len() != self.n_comp as usize * self.dim as usize {
+            bail!("coarse directory: pca_components length mismatch");
+        }
+        if self.centroids.len() != k_c * self.n_comp as usize {
+            bail!("coarse directory: centroids length mismatch");
+        }
+        if self.cell_rows.len() != k_c {
+            bail!("coarse directory: cell_rows length mismatch");
+        }
+        Ok(())
+    }
+}
+
+/// One coarse cell's addressing entry: the global row range plus **direct
+/// ranged-GET byte extents** into every region (absolute file offsets), so a
+/// probe never derives offsets from strides at read time — the writer, which
+/// owns the layout, records them exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CoarseCellEntry {
+    /// Global row range `[row_begin, row_end)` in segment (cluster) order.
+    pub row_begin: u64,
+    pub row_end: u64,
+    /// Region A (RaBitQ codes) byte extent for this cell's rows.
+    pub a_off: u64,
+    pub a_len: u64,
+    /// Region B (SQ8 codes) byte extent for this cell's rows.
+    pub b_off: u64,
+    pub b_len: u64,
+    /// Region C (optional exact fp32) byte extent — 0/0 until a hoisted fp32
+    /// region exists (today the exact tier lives in Region D blocks).
+    pub c_off: u64,
+    pub c_len: u64,
+    /// Region D block-ordinal range `[d_block_begin, d_block_end)` — block
+    /// boundaries never straddle a coarse cell (the writer pads/flushes at
+    /// every cell boundary).
+    pub d_block_begin: u32,
+    pub d_block_end: u32,
+}
+
+impl CoarseCellEntry {
+    fn write_to(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.row_begin.to_le_bytes());
+        out.extend_from_slice(&self.row_end.to_le_bytes());
+        out.extend_from_slice(&self.a_off.to_le_bytes());
+        out.extend_from_slice(&self.a_len.to_le_bytes());
+        out.extend_from_slice(&self.b_off.to_le_bytes());
+        out.extend_from_slice(&self.b_len.to_le_bytes());
+        out.extend_from_slice(&self.c_off.to_le_bytes());
+        out.extend_from_slice(&self.c_len.to_le_bytes());
+        out.extend_from_slice(&self.d_block_begin.to_le_bytes());
+        out.extend_from_slice(&self.d_block_end.to_le_bytes());
+    }
+
+    fn read_from(input: &[u8], p: &mut usize) -> Result<Self> {
+        Ok(Self {
+            row_begin: read_u64(input, p)?,
+            row_end: read_u64(input, p)?,
+            a_off: read_u64(input, p)?,
+            a_len: read_u64(input, p)?,
+            b_off: read_u64(input, p)?,
+            b_len: read_u64(input, p)?,
+            c_off: read_u64(input, p)?,
+            c_len: read_u64(input, p)?,
+            d_block_begin: read_u32(input, p)?,
+            d_block_end: read_u32(input, p)?,
+        })
+    }
+}
+
+/// The serialized Region A0: the trained model plus per-cell addressing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoarseDirectory {
+    pub model: CoarseModel,
+    /// Per-cell addressing, 1:1 with the model's emission-ordered cells.
+    pub cells: Vec<CoarseCellEntry>,
+}
+
+impl CoarseDirectory {
+    /// Exact serialized byte length for a `(k_c, dim, n_comp)` directory — the
+    /// writer sizes the region (and therefore every downstream offset) from
+    /// this **before** serializing, so region offsets and A0 contents can be
+    /// computed in one pass without placeholder rewrites.
+    pub fn serialized_len(k_c: usize, dim: usize, n_comp: usize) -> usize {
+        A0_FIXED_HEAD_LEN
+            + dim * 4                    // pca_mean
+            + n_comp * dim * 4           // pca_components
+            + k_c * n_comp * 4           // centroids
+            + k_c * 4                    // radii
+            + k_c * A0_CELL_ENTRY_LEN    // cells
+            + A0_CHECKSUM_LEN
+    }
+
+    /// Serialize (deterministic — identical input ⇒ identical bytes; a physical
+    /// layout must never depend on ambient state).
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        self.model.validate()?;
+        if self.cells.len() != self.model.k_c() {
+            bail!("coarse directory: cells length disagrees with model k_c");
+        }
+        let m = &self.model;
+        let k_c = m.k_c();
+        let expected = Self::serialized_len(k_c, m.dim as usize, m.n_comp as usize);
+        let mut buf = Vec::with_capacity(expected);
+        buf.extend_from_slice(A0_MAGIC);
+        buf.push(A0_VERSION);
+        buf.push(0); // flags (reserved)
+        buf.extend_from_slice(&m.n_comp.to_le_bytes());
+        let k_c_u32 =
+            u32::try_from(k_c).map_err(|_| anyhow::anyhow!("coarse cell count exceeds u32"))?;
+        buf.extend_from_slice(&k_c_u32.to_le_bytes());
+        buf.extend_from_slice(&m.dim.to_le_bytes());
+        buf.extend_from_slice(&m.seed.to_le_bytes());
+        buf.extend_from_slice(&m.trained_on.to_le_bytes());
+        buf.extend_from_slice(&m.rows_covered().to_le_bytes());
+        for &v in &m.pca_mean {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for &v in &m.pca_components {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for &v in &m.centroids {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for &v in &m.radii {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        for cell in &self.cells {
+            cell.write_to(&mut buf);
+        }
+        let checksum = fnv1a64(&buf);
+        buf.extend_from_slice(&checksum.to_le_bytes());
+        if buf.len() != expected {
+            bail!(
+                "coarse directory serialized length {} != computed {expected}",
+                buf.len()
+            );
+        }
+        Ok(buf)
+    }
+
+    /// Parse + verify. Fail-closed on magic/version/truncation/checksum — a
+    /// corrupt directory must degrade to an error (the caller falls back to the
+    /// single-level scan), never a silent mis-probe.
+    pub fn parse(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < A0_FIXED_HEAD_LEN + A0_CHECKSUM_LEN {
+            bail!("coarse directory too short: {}", bytes.len());
+        }
+        if &bytes[..4] != A0_MAGIC {
+            bail!("not a coarse directory (bad magic)");
+        }
+        let version = bytes[4];
+        if version != A0_VERSION {
+            bail!("unsupported coarse directory version {version}");
+        }
+        let mut p = 6usize; // past magic + version + flags
+        let n_comp = read_u16(bytes, &mut p)?;
+        let k_c = read_u32(bytes, &mut p)? as usize;
+        let dim = read_u32(bytes, &mut p)?;
+        let seed = read_u64(bytes, &mut p)?;
+        let trained_on = read_u64(bytes, &mut p)?;
+        let rows_covered = read_u64(bytes, &mut p)?;
+        let expected = Self::serialized_len(k_c, dim as usize, n_comp as usize);
+        if bytes.len() != expected {
+            bail!(
+                "coarse directory length {} != expected {expected} (k_c={k_c}, dim={dim}, n_comp={n_comp})",
+                bytes.len()
+            );
+        }
+        let body_len = bytes.len() - A0_CHECKSUM_LEN;
+        let stored = u64::from_le_bytes(bytes[body_len..].try_into()?);
+        let computed = fnv1a64(&bytes[..body_len]);
+        if stored != computed {
+            bail!("coarse directory checksum mismatch");
+        }
+        let pca_mean = read_f32s(bytes, &mut p, dim as usize)?;
+        let pca_components = read_f32s(bytes, &mut p, n_comp as usize * dim as usize)?;
+        let centroids = read_f32s(bytes, &mut p, k_c * n_comp as usize)?;
+        let radii = read_f32s(bytes, &mut p, k_c)?;
+        let mut cells = Vec::with_capacity(k_c);
+        for _ in 0..k_c {
+            cells.push(CoarseCellEntry::read_from(bytes, &mut p)?);
+        }
+        let model = CoarseModel {
+            dim,
+            n_comp,
+            pca_mean,
+            pca_components,
+            centroids,
+            radii,
+            cell_rows: cells.iter().map(|c| c.row_end - c.row_begin).collect(),
+            seed,
+            trained_on,
+        };
+        model.validate()?;
+        if model.rows_covered() != rows_covered {
+            bail!("coarse directory rows_covered disagrees with cell ranges");
+        }
+        Ok(Self { model, cells })
+    }
+
+    /// Project `query` into PCA space with the persisted model — the exact
+    /// projection the writer clustered with (query-time coarse ranking, PR-B).
+    pub fn project(&self, query: &[f32]) -> Vec<f32> {
+        let m = &self.model;
+        project_with_model(&m.pca_mean, &m.pca_components, m.n_comp as usize, query)
+    }
+}
+
+/// Project `v` with an f32-persisted PCA model (`mean` len `dim`, `components`
+/// row-major `n_comp × dim`). The **single shared projection kernel**: the
+/// write path assigns/radius-bounds with it and the read path ranks with it, so
+/// both sides compute bit-identical coordinates from the persisted f32 model
+/// (no write-f64 vs read-f32 drift at cell boundaries). Vectors stay f32 —
+/// only the dot-product accumulator widens to f64 (standard cancellation-safe
+/// accumulation; transient, never stored).
+pub fn project_with_model(mean: &[f32], components: &[f32], n_comp: usize, v: &[f32]) -> Vec<f32> {
+    let dim = mean.len();
+    let mut out = vec![0f32; n_comp];
+    for (c, slot) in out.iter_mut().enumerate() {
+        let row = &components[c * dim..(c + 1) * dim];
+        let mut dot = 0f64;
+        for j in 0..dim.min(v.len()) {
+            dot += (v[j] as f64 - mean[j] as f64) * row[j] as f64;
+        }
+        *slot = dot as f32;
+    }
+    out
+}
+
+/// FNV-1a 64-bit over raw bytes (checksum — deterministic, dependency-free).
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325u64;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01B3);
+    }
+    h
+}
+
+fn ensure_remaining(input: &[u8], position: usize, len: usize) -> Result<()> {
+    let end = position
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("coarse directory: length overflow"))?;
+    if end > input.len() {
+        bail!("coarse directory truncated");
+    }
+    Ok(())
+}
+
+fn read_u16(input: &[u8], p: &mut usize) -> Result<u16> {
+    ensure_remaining(input, *p, 2)?;
+    let v = u16::from_le_bytes(input[*p..*p + 2].try_into()?);
+    *p += 2;
+    Ok(v)
+}
+
+fn read_u32(input: &[u8], p: &mut usize) -> Result<u32> {
+    ensure_remaining(input, *p, 4)?;
+    let v = u32::from_le_bytes(input[*p..*p + 4].try_into()?);
+    *p += 4;
+    Ok(v)
+}
+
+fn read_u64(input: &[u8], p: &mut usize) -> Result<u64> {
+    ensure_remaining(input, *p, 8)?;
+    let v = u64::from_le_bytes(input[*p..*p + 8].try_into()?);
+    *p += 8;
+    Ok(v)
+}
+
+fn read_f32s(input: &[u8], p: &mut usize, count: usize) -> Result<Vec<f32>> {
+    ensure_remaining(input, *p, count * 4)?;
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let off = *p + i * 4;
+        out.push(f32::from_le_bytes(input[off..off + 4].try_into()?));
+    }
+    *p += count * 4;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_directory() -> CoarseDirectory {
+        let dim = 8u32;
+        let n_comp = 3u16;
+        let k_c = 4usize;
+        let model = CoarseModel {
+            dim,
+            n_comp,
+            pca_mean: (0..dim).map(|i| i as f32 * 0.5).collect(),
+            pca_components: (0..n_comp as usize * dim as usize)
+                .map(|i| (i as f32).sin())
+                .collect(),
+            centroids: (0..k_c * n_comp as usize)
+                .map(|i| i as f32 * 0.25)
+                .collect(),
+            radii: vec![1.0, 2.0, 0.0, 3.5],
+            cell_rows: vec![100, 50, 0, 25],
+            // Arbitrary round-trip fixture value (the serde container is
+            // seed-agnostic — it stores whatever u64 the plan trained with).
+            seed: 0xABCD_1234_5678_9ABC,
+            trained_on: 175,
+        };
+        let mut row = 0u64;
+        let mut cells = Vec::new();
+        for (i, &rows) in model.cell_rows.iter().enumerate() {
+            cells.push(CoarseCellEntry {
+                row_begin: row,
+                row_end: row + rows,
+                a_off: 1000 + row * 24,
+                a_len: rows * 24,
+                b_off: 9000 + row * 8,
+                b_len: rows * 8,
+                c_off: 0,
+                c_len: 0,
+                d_block_begin: i as u32,
+                d_block_end: i as u32 + u32::from(rows > 0),
+            });
+            row += rows;
+        }
+        CoarseDirectory { model, cells }
+    }
+
+    #[test]
+    fn round_trips_bytes_and_fields() {
+        let dir = sample_directory();
+        let bytes = dir.to_bytes().unwrap();
+        assert_eq!(
+            bytes.len(),
+            CoarseDirectory::serialized_len(4, 8, 3),
+            "serialized_len must predict the exact byte length"
+        );
+        let parsed = CoarseDirectory::parse(&bytes).unwrap();
+        assert_eq!(parsed, dir);
+        // Determinism: serialize again ⇒ identical bytes.
+        assert_eq!(parsed.to_bytes().unwrap(), bytes);
+    }
+
+    #[test]
+    fn checksum_detects_corruption() {
+        let bytes = sample_directory().to_bytes().unwrap();
+        // Flip one payload byte (inside centroids, past the fixed head).
+        let mut corrupt = bytes.clone();
+        corrupt[A0_FIXED_HEAD_LEN + 10] ^= 0x01;
+        let err = CoarseDirectory::parse(&corrupt).unwrap_err();
+        assert!(err.to_string().contains("checksum"), "{err}");
+    }
+
+    #[test]
+    fn parse_fail_closed_on_magic_version_truncation() {
+        let bytes = sample_directory().to_bytes().unwrap();
+        // Bad magic.
+        let mut bad = bytes.clone();
+        bad[0] = b'X';
+        assert!(CoarseDirectory::parse(&bad).is_err());
+        // Unknown version.
+        let mut v = bytes.clone();
+        v[4] = 99;
+        assert!(CoarseDirectory::parse(&v).is_err());
+        // Truncation (any prefix must error, never panic).
+        for cut in [0usize, 5, A0_FIXED_HEAD_LEN, bytes.len() - 1] {
+            assert!(CoarseDirectory::parse(&bytes[..cut]).is_err(), "cut={cut}");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_mismatched_lengths() {
+        let mut dir = sample_directory();
+        dir.model.centroids.pop();
+        assert!(dir.to_bytes().is_err());
+        let mut dir2 = sample_directory();
+        dir2.cells.pop();
+        assert!(dir2.to_bytes().is_err());
+    }
+
+    #[test]
+    fn project_uses_mean_and_components() {
+        let dir = sample_directory();
+        let query: Vec<f32> = (0..8).map(|i| i as f32).collect();
+        let proj = dir.project(&query);
+        assert_eq!(proj.len(), 3);
+        // Manual check of component 0.
+        let m = &dir.model;
+        let expect: f64 = (0..8)
+            .map(|j| (query[j] as f64 - m.pca_mean[j] as f64) * m.pca_components[j] as f64)
+            .sum();
+        assert!((proj[0] as f64 - expect).abs() < 1e-4);
+    }
+}

--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod auto_scheduler;
 pub mod bitmap;
 pub mod cache_config;
+pub mod coarse_directory;
 pub mod collection_path;
 pub mod column_projector;
 pub mod columnar_constants;

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -40,8 +40,12 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use anyhow::{Result, bail};
-use proximadb_block_format::coalesced_rabitq::{RABITQ_SEED_BASE, encode_region};
-use proximadb_block_format::coalesced_sq8::encode_region as encode_sq8_region;
+use proximadb_block_format::coalesced_rabitq::{
+    RABITQ_SEED_BASE, encode_region, region_header_len as rabitq_region_header_len,
+};
+use proximadb_block_format::coalesced_sq8::{
+    codes_offset as sq8_codes_offset, encode_region as encode_sq8_region,
+};
 use proximadb_block_format::{
     BlockCompression, BlockMode, BlockStats, BlockZoneSource, ColumnMeta, FlatRow, PaxBlockReader,
     PaxBlockWriter, RowGroupBlock, VectorQuant, col_id, header::fnv1a_hash,
@@ -49,16 +53,17 @@ use proximadb_block_format::{
 use proximadb_records::{EmbeddingValues, ProximaRecord};
 use serde::{Deserialize, Serialize};
 
+use crate::coarse_directory::{CoarseCellEntry, CoarseDirectory, CoarseModel};
 use crate::engine_constants::{
     DEFAULT_BLOCK_METADATA_OVERHEAD_BYTES, DEFAULT_TARGET_BLOCK_SIZE_BYTES,
     MAX_TARGET_BLOCK_SIZE_BYTES,
 };
 use crate::segment_layout::{
     BlockTierAssignment, EXTERNAL_CANONICAL_SOURCE_ID, FooterBlockEntry, LosslessCompressionTag,
-    LosslessTransformTag, ParameterScope, SEG_HEADER_PREFIX_LEN, SEG_LAYOUT_VERSION,
-    SegmentFooterIndex, SegmentHeaderPrefix, SourceFidelity, SourceRole, StatsKind,
-    StripeEncodingDescriptor, TierRole, VectorTransform, compression_flags, is_coalesced_segment,
-    segment_tail,
+    LosslessTransformTag, ParameterScope, SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN,
+    SEG_LAYOUT_VERSION, SEG_LAYOUT_VERSION_TWO_LEVEL, SegmentFooterIndex, SegmentHeaderPrefix,
+    SourceFidelity, SourceRole, StatsKind, StripeEncodingDescriptor, TierRole, VectorTransform,
+    compression_flags, is_coalesced_segment, segment_tail,
 };
 
 /// File extension for PAX segment files.
@@ -498,6 +503,20 @@ pub use proximadb_block_format::SegmentMeta;
 ///
 /// Records are buffered in a `PaxBlockWriter`; when the estimated block size
 /// reaches `block_size_threshold`, the block is flushed and a new one begins.
+/// TD-RDSTRAT-8 writer-side bookkeeping for the two-level (v3) layout.
+struct TwoLevelState {
+    /// The trained coarse model (validated at finish; fail-closed).
+    model: CoarseModel,
+    /// Cumulative cell-end row boundaries (prefix sums of `model.cell_rows`,
+    /// len `k_c`). Rows past the last boundary are the no-embedding tail.
+    boundaries: Vec<u64>,
+    /// Next boundary index awaiting its flush.
+    next_boundary: usize,
+    /// Block-ordinal at each crossed cell end (1:1 with `boundaries` once all
+    /// rows are fed) — the exact Region D `[d_block_begin, d_block_end)` data.
+    cell_end_blocks: Vec<u32>,
+}
+
 pub struct PaxSegmentWriter {
     path: PathBuf,
     mode: BlockMode,
@@ -562,6 +581,11 @@ pub struct PaxSegmentWriter {
     /// Embedding-0 f32 vectors in cluster (add) order, buffered for the
     /// segment-level RaBitQ region. Populated only when `coalesced_rabitq` is on.
     rabitq_vectors: Vec<Option<Vec<f32>>>,
+    /// TD-RDSTRAT-8: the two-level-IVF coarse model + boundary bookkeeping.
+    /// Present ⇒ emit the v3 layout (`[prefix][A0][A][B][D][footer]`): the
+    /// current block is force-flushed at every coarse-cell boundary (blocks
+    /// never straddle a cell) and Region A0 records per-cell byte extents.
+    two_level: Option<TwoLevelState>,
     /// Encoding-aware per-row byte estimate (computed from the first record's
     /// dim + the quant/f32_tier/embedding_count config). Replaces the flat 1024
     /// that overestimated SQ8 blocks by ~4.5×. 0 = not yet computed.
@@ -623,6 +647,7 @@ impl PaxSegmentWriter {
             block_transformed_sq8_columns: Vec::new(),
             coalesced_rabitq: false,
             rabitq_vectors: Vec::new(),
+            two_level: None,
             per_row_estimate: 0,
         }
     }
@@ -704,6 +729,40 @@ impl PaxSegmentWriter {
     pub fn with_coalesced_rabitq(mut self, enabled: bool) -> Self {
         self.coalesced_rabitq = enabled;
         self.current_writer = self.fresh_block_writer();
+        self
+    }
+
+    /// TD-RDSTRAT-8: emit the **persisted-IVF-probe (v3)** layout. The caller has
+    /// already reordered records by `(cell rank, PC1, index)` (see
+    /// `cluster_plan_ivf_probe`); `model.cell_rows` tells the writer where the
+    /// cell boundaries fall so it can pad/flush blocks there and record exact
+    /// per-cell byte extents into Region A0. Only meaningful together with
+    /// [`Self::with_coalesced_rabitq`] — without it the model is ignored
+    /// (fail-safe: a non-coalesced segment has no regions to address).
+    pub fn with_two_level(mut self, model: CoarseModel) -> Self {
+        let mut boundaries = Vec::with_capacity(model.cell_rows.len());
+        let mut acc = 0u64;
+        for &rows in &model.cell_rows {
+            acc += rows;
+            boundaries.push(acc);
+        }
+        let mut state = TwoLevelState {
+            model,
+            boundaries,
+            next_boundary: 0,
+            cell_end_blocks: Vec::new(),
+        };
+        // Leading empty cells end at row 0 — `add_record` never sees row 0, so
+        // consume them up front (their block range is empty at ordinal 0).
+        while state
+            .boundaries
+            .get(state.next_boundary)
+            .is_some_and(|&b| b == 0)
+        {
+            state.cell_end_blocks.push(0);
+            state.next_boundary += 1;
+        }
+        self.two_level = Some(state);
         self
     }
 
@@ -804,6 +863,26 @@ impl PaxSegmentWriter {
         let total = vector_bytes + metadata_bytes + block_overhead;
         if total >= self.block_size_threshold {
             self.flush_current_block()?;
+        }
+        // TD-RDSTRAT-8: pad/flush at every coarse-cell boundary so blocks never
+        // straddle a cell (per-cell Region D ranges stay exact). Empty cells
+        // share the boundary row, hence the loop. A size-triggered flush at the
+        // same row is harmless (the second flush is a no-op).
+        loop {
+            let at_boundary = self
+                .two_level
+                .as_ref()
+                .is_some_and(|tl| tl.boundaries.get(tl.next_boundary) == Some(&self.row_count));
+            if !at_boundary {
+                break;
+            }
+            self.flush_current_block()?;
+            let block_count = u32::try_from(self.index.blocks.len())
+                .map_err(|_| anyhow::anyhow!("block ordinal exceeds u32"))?;
+            if let Some(tl) = &mut self.two_level {
+                tl.cell_end_blocks.push(block_count);
+                tl.next_boundary += 1;
+            }
         }
         Ok(())
     }
@@ -1133,6 +1212,12 @@ impl PaxSegmentWriter {
     /// [blocks][FOOTER-INDEX][footer_len][SEGMENT_MAGIC]`. The RaBitQ region is
     /// one ranged GET (keep=100% scan); the footer-index block table carries
     /// absolute offsets so the read path maps survivors → blocks → coalesced GETs.
+    ///
+    /// TD-RDSTRAT-8 (v3, when [`Self::with_two_level`] armed): the same
+    /// assembly with Region A0 (the coarse directory) between the prefix and
+    /// Region A, `layout_version = 3`, and the A0 extent mirrored in the
+    /// footer. Regions A/B/D are byte-identical in format — only the row
+    /// order (coarse-cell-major) and the block padding differ.
     fn finish_coalesced(&mut self, dim: u32) -> Result<SegmentMeta> {
         // 1. Build the coalesced RaBitQ region (single segment centroid) over the
         //    cluster-ordered embedding-0 vectors. `self.file_buf` already holds the
@@ -1144,13 +1229,102 @@ impl PaxSegmentWriter {
         // rerank fetches read pure dense SQ8 (one segment-level Sq8Params fit).
         let (sq8_region_bytes, sq8_params) = encode_sq8_region(&refs, dim)?;
 
-        let header_len = SEG_HEADER_PREFIX_LEN as u64;
-        let rabitq_off = header_len;
+        // TD-RDSTRAT-8: geometry first — A0's byte length is deterministic from
+        // (k_c, dim, n_comp), so every downstream offset is known BEFORE A0's
+        // contents (which embed absolute per-cell extents) are serialized. One
+        // pass, no placeholder rewrites.
+        let two_level = self.two_level.take();
+        let (layout_version, header_len, a0_len) = match &two_level {
+            Some(tl) => {
+                tl.model.validate()?;
+                if tl.model.dim != dim {
+                    bail!(
+                        "two-level model dim {} != segment embedding dim {dim}",
+                        tl.model.dim
+                    );
+                }
+                if tl.next_boundary != tl.boundaries.len()
+                    || tl.cell_end_blocks.len() != tl.boundaries.len()
+                {
+                    bail!(
+                        "two-level cell boundaries not all reached ({}/{} — plan rows {} vs fed rows {})",
+                        tl.next_boundary,
+                        tl.boundaries.len(),
+                        tl.model.rows_covered(),
+                        self.row_count
+                    );
+                }
+                let a0_len = CoarseDirectory::serialized_len(
+                    tl.model.k_c(),
+                    dim as usize,
+                    tl.model.n_comp as usize,
+                ) as u64;
+                (
+                    SEG_LAYOUT_VERSION_TWO_LEVEL,
+                    SEG_HEADER_PREFIX_V3_LEN as u64,
+                    a0_len,
+                )
+            }
+            None => (SEG_LAYOUT_VERSION, SEG_HEADER_PREFIX_LEN as u64, 0),
+        };
+        let a0_off = if two_level.is_some() { header_len } else { 0 };
+        let rabitq_off = header_len + a0_len;
         let rabitq_len = region_bytes.len() as u64;
-        let sq8_off = header_len + rabitq_len;
+        let sq8_off = rabitq_off + rabitq_len;
         let sq8_len = sq8_region_bytes.len() as u64;
-        // Blocks (Region D) begin after header + Region A + Region B.
-        let data_offset = header_len + rabitq_len + sq8_len;
+        // Blocks (Region D) begin after header [+ A0] + Region A + Region B.
+        let data_offset = sq8_off + sq8_len;
+
+        // Serialize A0 (v3 only). Per-cell extents are ABSOLUTE file offsets
+        // into the fixed-stride code payloads of Regions A/B (the writer owns
+        // the layout, so the reader never derives offsets at query time) plus
+        // the padded Region D block ranges.
+        let a0_bytes: Option<Vec<u8>> = match two_level {
+            Some(tl) => {
+                let n_rows = self.row_count as usize;
+                let stride_a = (8 + (dim as usize).div_ceil(8)) as u64;
+                let codes_base_a =
+                    rabitq_off + rabitq_region_header_len(dim) as u64 + n_rows.div_ceil(8) as u64;
+                let codes_base_b = sq8_off + sq8_codes_offset(n_rows) as u64;
+                let mut cells = Vec::with_capacity(tl.model.k_c());
+                let mut row = 0u64;
+                for (i, &rows) in tl.model.cell_rows.iter().enumerate() {
+                    let d_block_begin = if i == 0 { 0 } else { tl.cell_end_blocks[i - 1] };
+                    cells.push(CoarseCellEntry {
+                        row_begin: row,
+                        row_end: row + rows,
+                        a_off: codes_base_a + row * stride_a,
+                        a_len: rows * stride_a,
+                        b_off: codes_base_b + row * dim as u64,
+                        b_len: rows * dim as u64,
+                        c_off: 0,
+                        c_len: 0,
+                        d_block_begin,
+                        d_block_end: tl.cell_end_blocks[i],
+                    });
+                    row += rows;
+                }
+                if row > self.row_count {
+                    bail!(
+                        "two-level cell rows {row} exceed segment rows {}",
+                        self.row_count
+                    );
+                }
+                let bytes = CoarseDirectory {
+                    model: tl.model,
+                    cells,
+                }
+                .to_bytes()?;
+                if bytes.len() as u64 != a0_len {
+                    bail!(
+                        "coarse directory serialized {} bytes != planned {a0_len}",
+                        bytes.len()
+                    );
+                }
+                Some(bytes)
+            }
+            None => None,
+        };
 
         // 2. Footer block table: absolute offsets = data_offset + block's 0-based
         //    offset; row_count from the block's zone summary (1:1 with the index).
@@ -1187,24 +1361,30 @@ impl PaxSegmentWriter {
             blocks,
             encoding_map,
             block_tier_assignments,
+            a0_off,
+            a0_len,
         };
         let footer_body = footer.to_bytes()?;
         let footer_off = data_offset + self.file_buf.len() as u64;
         let footer_len = footer_body.len() as u64;
 
         let header = SegmentHeaderPrefix {
-            layout_version: SEG_LAYOUT_VERSION,
+            layout_version,
             rabitq_off,
             rabitq_len,
             sq8_off,
             sq8_len,
             footer_off,
             footer_len,
+            a0_off,
+            a0_len,
         };
 
-        // 4. Assemble: header + Region A + Region B + blocks + [footer][footer_len][magic].
+        // 4. Assemble: header [+ A0] + Region A + Region B + blocks +
+        //    [footer][footer_len][magic].
         let mut out = Vec::with_capacity(
-            SEG_HEADER_PREFIX_LEN
+            header_len as usize
+                + a0_len as usize
                 + region_bytes.len()
                 + sq8_region_bytes.len()
                 + self.file_buf.len()
@@ -1212,6 +1392,9 @@ impl PaxSegmentWriter {
                 + 16,
         );
         out.extend_from_slice(&header.to_bytes());
+        if let Some(a0) = &a0_bytes {
+            out.extend_from_slice(a0);
+        }
         out.extend_from_slice(&region_bytes);
         out.extend_from_slice(&sq8_region_bytes);
         out.extend_from_slice(&self.file_buf);
@@ -2320,5 +2503,237 @@ mod tests {
             hits += 1;
         }
         assert!(hits < meta.block_count as usize);
+    }
+
+    /// TD-RDSTRAT-8 PR-A: the two-level (v3) writer emits
+    /// `[prefix v3][A0][A][B][D][footer]` with exact per-cell extents, pads
+    /// blocks at coarse-cell boundaries (blocks never straddle a cell), keeps
+    /// the footer-driven scanner working (mixed-read), and is deterministic
+    /// (identical input ⇒ identical segment bytes).
+    #[test]
+    fn two_level_writer_emits_v3_with_exact_cell_extents() -> Result<()> {
+        use crate::segment_layout::{SEG_HEADER_PREFIX_V3_LEN, SEG_LAYOUT_VERSION_TWO_LEVEL};
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+
+        const DIM: usize = 16;
+        // Three coarse cells (middle one empty) + 5 tail rows without embeddings.
+        let cell_rows = vec![100u64, 0, 60];
+        let n_covered = 160usize;
+        let n_rows = n_covered + 5;
+
+        let model = || CoarseModel {
+            dim: DIM as u32,
+            n_comp: 2,
+            pca_mean: vec![0.0; DIM],
+            pca_components: vec![0.1; 2 * DIM],
+            centroids: vec![0.5; 3 * 2],
+            radii: vec![1.0, 0.0, 2.0],
+            cell_rows: cell_rows.clone(),
+            seed: 42,
+            trained_on: n_covered as u64,
+        };
+        let write = |path: &Path| -> Result<SegmentMeta> {
+            let mut writer = PaxSegmentWriter::new(
+                path,
+                BlockMode::Pax,
+                BlockCompression::None,
+                "col",
+                0,
+                1,
+                Some(64 * 1024),
+            )
+            .with_quant(VectorQuant::RaBitQ)
+            .with_coalesced_rabitq(true)
+            .with_two_level(model());
+            for row in 0..n_covered {
+                let mut r = make_record(&format!("r{row:04}"), "t", 1);
+                let v: Vec<f32> = (0..DIM)
+                    .map(|d| ((row * 7 + d) % 13) as f32 - 6.0)
+                    .collect();
+                r.embeddings.push(EmbeddingCell {
+                    modality: "dense".into(),
+                    dim: DIM as u32,
+                    values: EmbeddingValues::Fp32(v),
+                    ..Default::default()
+                });
+                writer.add_record(&r)?;
+            }
+            for t in 0..(n_rows - n_covered) {
+                writer.add_record(&make_record(&format!("tail{t}"), "t", 1))?;
+            }
+            writer.finish()
+        };
+
+        let dir = tempfile::tempdir()?;
+        let p1 = dir.path().join("one.pax");
+        let p2 = dir.path().join("two.pax");
+        write(&p1)?;
+        write(&p2)?;
+        let bytes = std::fs::read(&p1)?;
+        assert_eq!(
+            bytes,
+            std::fs::read(&p2)?,
+            "v3 write must be deterministic (fixed input ⇒ identical bytes)"
+        );
+
+        // Header-prefix: version 3, A0 right after the prefix, A after A0.
+        let h = SegmentHeaderPrefix::parse(&bytes)?;
+        assert_eq!(h.layout_version, SEG_LAYOUT_VERSION_TWO_LEVEL);
+        assert_eq!(h.a0_off, SEG_HEADER_PREFIX_V3_LEN as u64);
+        assert!(h.a0_len > 0);
+        assert_eq!(h.rabitq_off, h.a0_off + h.a0_len);
+        assert_eq!(h.sq8_off, h.rabitq_off + h.rabitq_len);
+
+        // Footer mirrors the A0 extent; row count covers cells + tail.
+        let footer = SegmentFooterIndex::locate_in_segment(&bytes)?
+            .ok_or_else(|| anyhow::anyhow!("v3 segment must carry a footer-index"))?;
+        assert_eq!(footer.row_count, n_rows as u64);
+        assert_eq!(footer.a0_off, h.a0_off);
+        assert_eq!(footer.a0_len, h.a0_len);
+
+        // A0 round-trips from the segment; extents address the exact
+        // fixed-stride code runs of Regions A and B.
+        let a0 = CoarseDirectory::parse(&bytes[h.a0_off as usize..(h.a0_off + h.a0_len) as usize])?;
+        assert_eq!(a0.model.cell_rows, cell_rows);
+        assert_eq!(a0.model.rows_covered(), n_covered as u64);
+        let stride_a = 8 + DIM.div_ceil(8);
+        let codes_base_a =
+            h.rabitq_off as usize + rabitq_region_header_len(DIM as u32) + n_rows.div_ceil(8);
+        let codes_base_b = h.sq8_off as usize + sq8_codes_offset(n_rows);
+        let mut row = 0u64;
+        for (i, cell) in a0.cells.iter().enumerate() {
+            assert_eq!(cell.row_begin, row, "cell {i} row_begin");
+            assert_eq!(cell.row_end - cell.row_begin, cell_rows[i], "cell {i} rows");
+            assert_eq!(
+                cell.a_off as usize,
+                codes_base_a + row as usize * stride_a,
+                "cell {i} a_off"
+            );
+            assert_eq!(cell.a_len as usize, cell_rows[i] as usize * stride_a);
+            assert_eq!(
+                cell.b_off as usize,
+                codes_base_b + row as usize * DIM,
+                "cell {i} b_off"
+            );
+            assert_eq!(cell.b_len as usize, cell_rows[i] as usize * DIM);
+            assert_eq!((cell.c_off, cell.c_len), (0, 0), "no Region C yet");
+            row = cell.row_end;
+        }
+
+        // Blocks never straddle a cell: each cell's Region D block range holds
+        // exactly its rows, and starts exactly at its row_begin.
+        for (i, cell) in a0.cells.iter().enumerate() {
+            let (d0, d1) = (cell.d_block_begin as usize, cell.d_block_end as usize);
+            assert!(d0 <= d1 && d1 <= footer.blocks.len(), "cell {i} d-range");
+            let rows_before: u64 = footer.blocks[..d0].iter().map(|b| b.row_count as u64).sum();
+            let rows_in: u64 = footer.blocks[d0..d1]
+                .iter()
+                .map(|b| b.row_count as u64)
+                .sum();
+            assert_eq!(
+                rows_before, cell.row_begin,
+                "cell {i} starts on a block edge"
+            );
+            assert_eq!(rows_in, cell.row_end - cell.row_begin, "cell {i} padded");
+        }
+
+        // A probed cell's Region A byte slice is exactly the full-region code
+        // run for its rows (what PR-B's ranged sub-reads will fetch).
+        let cell0 = &a0.cells[0];
+        assert_eq!(
+            &bytes[cell0.a_off as usize..(cell0.a_off + cell0.a_len) as usize],
+            &bytes[codes_base_a..codes_base_a + cell_rows[0] as usize * stride_a],
+        );
+
+        // Mixed-read: the footer-driven scanner reconstructs every row of a v3
+        // segment unchanged (compaction/recovery read path).
+        let mut scanner = PaxSegmentScanner::from_bytes(bytes.clone(), ScanPredicate::default())?;
+        let recs = scanner.read_records(&[], &[], None)?;
+        assert_eq!(recs.len(), n_rows, "scanner must read all v3 rows");
+
+        // Flag-off control: the same records without `with_two_level` produce a
+        // v1 segment (no A0, version byte 1) — the two-level layout is strictly
+        // opt-in at the writer.
+        let p3 = dir.path().join("v1.pax");
+        let mut w1 = PaxSegmentWriter::new(
+            &p3,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            Some(64 * 1024),
+        )
+        .with_quant(VectorQuant::RaBitQ)
+        .with_coalesced_rabitq(true);
+        for row in 0..64usize {
+            let mut r = make_record(&format!("r{row:04}"), "t", 1);
+            let v: Vec<f32> = (0..DIM)
+                .map(|d| ((row * 7 + d) % 13) as f32 - 6.0)
+                .collect();
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: DIM as u32,
+                values: EmbeddingValues::Fp32(v),
+                ..Default::default()
+            });
+            w1.add_record(&r)?;
+        }
+        w1.finish()?;
+        let v1_bytes = std::fs::read(&p3)?;
+        let h1 = SegmentHeaderPrefix::parse(&v1_bytes)?;
+        assert_eq!(h1.layout_version, SEG_LAYOUT_VERSION);
+        assert_eq!((h1.a0_off, h1.a0_len), (0, 0));
+        Ok(())
+    }
+
+    /// A two-level plan whose row boundaries are never reached (caller fed
+    /// fewer rows than the model claims) must fail closed at finish, not write
+    /// a mis-addressed segment.
+    #[test]
+    fn two_level_writer_fails_closed_on_row_mismatch() -> Result<()> {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        const DIM: usize = 8;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("mismatch.pax");
+        let model = CoarseModel {
+            dim: DIM as u32,
+            n_comp: 1,
+            pca_mean: vec![0.0; DIM],
+            pca_components: vec![0.1; DIM],
+            centroids: vec![0.5; 2],
+            radii: vec![1.0, 1.0],
+            cell_rows: vec![50, 50], // claims 100 rows; we feed 10
+            seed: 7,
+            trained_on: 10,
+        };
+        let mut writer = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RaBitQ)
+        .with_coalesced_rabitq(true)
+        .with_two_level(model);
+        for row in 0..10usize {
+            let mut r = make_record(&format!("r{row}"), "t", 1);
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: DIM as u32,
+                values: EmbeddingValues::Fp32(vec![row as f32; DIM]),
+                ..Default::default()
+            });
+            writer.add_record(&r)?;
+        }
+        let err = writer.finish().unwrap_err();
+        assert!(
+            err.to_string().contains("boundaries not all reached"),
+            "{err}"
+        );
+        Ok(())
     }
 }

--- a/crates/storage/proximadb-storage-common/src/segment_layout.rs
+++ b/crates/storage/proximadb-storage-common/src/segment_layout.rs
@@ -36,14 +36,28 @@ use crate::pax_block::SEGMENT_MAGIC;
 /// coalesced segment starts with `PXH1`.
 pub const SEG_HEADER_MAGIC: &[u8; 4] = b"PXH1";
 
-/// Header layout version (independent of the block/segment format family — bump
-/// only when the header-prefix byte layout changes). Pre-release in-place
-/// evolution (no serialized files on disk → no versioned readers to be
-/// compatible with); versioning re-engages at GA. Constant 1 for now.
+/// Header layout version for the **single-level** coalesced layout (regions
+/// A/B/D, whole-region RaBitQ scan). The version byte is the layout selector
+/// for the per-segment read chooser (TD-RDSTRAT-8 mixed-read pattern).
 pub const SEG_LAYOUT_VERSION: u8 = 1;
 
-/// `[magic 4][version 1][pad 3][rabitq_off 8][rabitq_len 8][sq8_off 8][sq8_len 8][footer_off 8][footer_len 8]`.
+/// Header layout version for the **two-level IVF** layout (TD-RDSTRAT-8):
+/// `[prefix][Region A0 coarse directory][A][B][D][footer]`, rows ordered by
+/// coarse cell, regions cell-contiguous. The byte value 3 matches the TD/ADR
+/// "v3 layout" name (2 is intentionally skipped/reserved so code, docs, and
+/// on-disk bytes all say the same number). Written only by compaction under
+/// `PROXIMADB_IVF2=1`; version-1 readers reject it cleanly (fail-closed
+/// version check), v3-aware readers handle version-1 segments unchanged.
+pub const SEG_LAYOUT_VERSION_TWO_LEVEL: u8 = 3;
+
+/// v1: `[magic 4][version 1][pad 3][rabitq_off 8][rabitq_len 8][sq8_off 8][sq8_len 8][footer_off 8][footer_len 8]`.
 pub const SEG_HEADER_PREFIX_LEN: usize = 56;
+
+/// v3 appends `[a0_off 8][a0_len 8]` (the Region A0 coarse-directory extent) to
+/// the v1 prefix. Readers fetch `SEG_HEADER_PREFIX_V3_LEN` (clamped to file
+/// size) unconditionally — the 16 extra bytes are free within the same GET and
+/// cover both versions.
+pub const SEG_HEADER_PREFIX_V3_LEN: usize = 72;
 
 /// True iff `bytes` carries the coalesced-RaBitQ header-prefix at offset 0 — the
 /// presence-field that selects the scan-then-rerank read path (mixed-read).
@@ -51,12 +65,14 @@ pub fn is_coalesced_segment(bytes: &[u8]) -> bool {
     bytes.len() >= SEG_HEADER_MAGIC.len() && &bytes[..SEG_HEADER_MAGIC.len()] == SEG_HEADER_MAGIC
 }
 
-/// The fixed 56 B header-prefix at offset 0. The RaBitQ scan GET reads
-/// `[0, rabitq_off + rabitq_len]`, so the prefix coalesces into that one GET.
+/// The fixed header-prefix at offset 0 (56 B for v1, 72 B for v3). The RaBitQ
+/// scan GET reads `[0, rabitq_off + rabitq_len]`, so the prefix coalesces into
+/// that one GET (v3: `[0, a0_off + a0_len]` fetches prefix + coarse directory).
 #[derive(Debug, Clone)]
 pub struct SegmentHeaderPrefix {
     pub layout_version: u8,
-    /// Byte offset of the coalesced RaBitQ region (Region A == SEG_HEADER_PREFIX_LEN).
+    /// Byte offset of the coalesced RaBitQ region (Region A; v1: right after
+    /// the prefix, v3: after Region A0).
     pub rabitq_off: u64,
     /// Byte length of the coalesced RaBitQ region (Region A).
     pub rabitq_len: u64,
@@ -69,12 +85,22 @@ pub struct SegmentHeaderPrefix {
     pub footer_off: u64,
     /// Byte length of the footer-index.
     pub footer_len: u64,
+    /// Byte offset of Region A0 (the TD-RDSTRAT-8 coarse directory). `0` on
+    /// v1 segments (no coarse level).
+    pub a0_off: u64,
+    /// Byte length of Region A0. `0` on v1 segments.
+    pub a0_len: u64,
 }
 
 impl SegmentHeaderPrefix {
-    /// Serialize to a fixed 56 B buffer.
-    pub fn to_bytes(&self) -> [u8; SEG_HEADER_PREFIX_LEN] {
-        let mut buf = [0u8; SEG_HEADER_PREFIX_LEN];
+    /// Serialize (56 B for v1, 72 B for v3 — the version byte selects the form).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let len = if self.layout_version == SEG_LAYOUT_VERSION_TWO_LEVEL {
+            SEG_HEADER_PREFIX_V3_LEN
+        } else {
+            SEG_HEADER_PREFIX_LEN
+        };
+        let mut buf = vec![0u8; len];
         buf[..4].copy_from_slice(SEG_HEADER_MAGIC);
         buf[4] = self.layout_version;
         // buf[5..8] reserved (zero).
@@ -84,11 +110,17 @@ impl SegmentHeaderPrefix {
         buf[32..40].copy_from_slice(&self.sq8_len.to_le_bytes());
         buf[40..48].copy_from_slice(&self.footer_off.to_le_bytes());
         buf[48..56].copy_from_slice(&self.footer_len.to_le_bytes());
+        if len == SEG_HEADER_PREFIX_V3_LEN {
+            buf[56..64].copy_from_slice(&self.a0_off.to_le_bytes());
+            buf[64..72].copy_from_slice(&self.a0_len.to_le_bytes());
+        }
         buf
     }
 
-    /// Parse + validate (magic + version). Fail-closed on a wrong magic or
-    /// truncation — never mis-reads a legacy segment as coalesced.
+    /// Parse + validate (magic + version). Fail-closed on a wrong magic, an
+    /// unknown version, or truncation — never mis-reads a legacy segment as
+    /// coalesced, and a version-1-only binary rejects a v3 segment here (the
+    /// TD-RDSTRAT-8 mixed-read contract) rather than mis-probing it.
     pub fn parse(bytes: &[u8]) -> Result<Self> {
         if bytes.len() < SEG_HEADER_PREFIX_LEN {
             bail!("coalesced segment header too short: {}", bytes.len());
@@ -97,11 +129,27 @@ impl SegmentHeaderPrefix {
             bail!("not a coalesced-RaBitQ segment (bad header magic)");
         }
         let layout_version = bytes[4];
-        if layout_version != SEG_LAYOUT_VERSION {
+        let (required, has_a0) = match layout_version {
+            SEG_LAYOUT_VERSION => (SEG_HEADER_PREFIX_LEN, false),
+            SEG_LAYOUT_VERSION_TWO_LEVEL => (SEG_HEADER_PREFIX_V3_LEN, true),
+            v => bail!(
+                "unsupported coalesced segment layout version {v} (expected {SEG_LAYOUT_VERSION} or {SEG_LAYOUT_VERSION_TWO_LEVEL})"
+            ),
+        };
+        if bytes.len() < required {
             bail!(
-                "unsupported coalesced segment layout version {layout_version} (expected {SEG_LAYOUT_VERSION})"
+                "coalesced segment header too short for layout version {layout_version}: {}",
+                bytes.len()
             );
         }
+        let (a0_off, a0_len) = if has_a0 {
+            (
+                u64::from_le_bytes(bytes[56..64].try_into()?),
+                u64::from_le_bytes(bytes[64..72].try_into()?),
+            )
+        } else {
+            (0, 0)
+        };
         Ok(Self {
             layout_version,
             rabitq_off: u64::from_le_bytes(bytes[8..16].try_into()?),
@@ -110,6 +158,8 @@ impl SegmentHeaderPrefix {
             sq8_len: u64::from_le_bytes(bytes[32..40].try_into()?),
             footer_off: u64::from_le_bytes(bytes[40..48].try_into()?),
             footer_len: u64::from_le_bytes(bytes[48..56].try_into()?),
+            a0_off,
+            a0_len,
         })
     }
 }
@@ -272,8 +322,15 @@ pub struct BlockTierAssignment {
 const DESCRIPTOR_SIZE: usize = 28;
 const ASSIGNMENT_SIZE: usize = 11;
 const SECTION_STRIPE_ENCODING_MAP: u8 = 2;
+/// Optional footer section mirroring the Region A0 (coarse directory) extent
+/// (TD-RDSTRAT-8). Additive: parsers that predate it skip unknown section tags
+/// (pinned by `footer_v2_unknown_optional_section_is_skipped`), so the footer
+/// stays single-version — layout versioning lives in the header-prefix.
+const SECTION_COARSE_DIRECTORY: u8 = 3;
 const SECTION_VERSION_V1: u8 = 1;
 const FOOTER_V1: u8 = 1;
+/// `[a0_off u64][a0_len u64]`.
+const COARSE_DIRECTORY_SECTION_LEN: usize = 16;
 
 /// The self-describing footer-index (Parquet-style metadata hub): block table +
 /// schema snapshot + per-stripe encoding map + RaBitQ mirror + row count. Located
@@ -319,6 +376,11 @@ pub struct SegmentFooterIndex {
     pub encoding_map: Vec<StripeEncodingDescriptor>,
     /// Per-block descriptor selections for footer v2.
     pub block_tier_assignments: Vec<BlockTierAssignment>,
+    /// Region A0 (coarse directory) extent mirror (TD-RDSTRAT-8; also in the
+    /// v3 header-prefix). `0/0` = no coarse level (v1 segments). Serialized as
+    /// an optional trailing section, so v1 footers are byte-unchanged.
+    pub a0_off: u64,
+    pub a0_len: u64,
 }
 
 /// `[footer_len u64][SEGMENT_MAGIC 8B]` — the 16 B tail that locates the footer.
@@ -646,21 +708,36 @@ impl SegmentFooterIndex {
         for b in &self.blocks {
             write_block_entry(&mut buf, b);
         }
-        // Optional stripe encoding-map section: the footer carries per-stripe
-        // lossless-transform metadata only when recorded (clustered-SQ8 / scalar
-        // LZ4, TD-RDSTRAT-7). Absent ⇒ no trailing section, smallest footer.
-        // Single version-1 layout (pre-release: no versioned files on disk;
-        // versioning re-engages at GA) — ADR-065 Region B.
+        // Optional trailing sections (single version-1 footer layout —
+        // pre-release: no versioned files on disk; versioning re-engages at
+        // GA). Emitted only when at least one section has content, so a
+        // sectionless footer is byte-identical to the historical form:
+        //  - stripe encoding map: per-stripe lossless-transform metadata
+        //    (clustered-SQ8 / scalar LZ4, TD-RDSTRAT-7 / ADR-065 Region B);
+        //  - coarse directory extent: Region A0 mirror (TD-RDSTRAT-8).
+        let mut sections: Vec<(u8, Vec<u8>)> = Vec::new();
         if !self.encoding_map.is_empty() {
             self.validate_encoding_map()?;
-            let encoding_payload = self.encoding_map_payload()?;
-            buf.extend_from_slice(&1u16.to_le_bytes());
-            buf.push(SECTION_STRIPE_ENCODING_MAP);
-            buf.push(SECTION_VERSION_V1);
-            let section_len = u32::try_from(encoding_payload.len())
-                .map_err(|_| anyhow::anyhow!("footer encoding-map section exceeds u32"))?;
-            buf.extend_from_slice(&section_len.to_le_bytes());
-            buf.extend_from_slice(&encoding_payload);
+            sections.push((SECTION_STRIPE_ENCODING_MAP, self.encoding_map_payload()?));
+        }
+        if self.a0_len > 0 {
+            let mut payload = Vec::with_capacity(COARSE_DIRECTORY_SECTION_LEN);
+            payload.extend_from_slice(&self.a0_off.to_le_bytes());
+            payload.extend_from_slice(&self.a0_len.to_le_bytes());
+            sections.push((SECTION_COARSE_DIRECTORY, payload));
+        }
+        if !sections.is_empty() {
+            let section_count = u16::try_from(sections.len())
+                .map_err(|_| anyhow::anyhow!("footer section count exceeds u16"))?;
+            buf.extend_from_slice(&section_count.to_le_bytes());
+            for (tag, payload) in sections {
+                buf.push(tag);
+                buf.push(SECTION_VERSION_V1);
+                let section_len = u32::try_from(payload.len())
+                    .map_err(|_| anyhow::anyhow!("footer section exceeds u32"))?;
+                buf.extend_from_slice(&section_len.to_le_bytes());
+                buf.extend_from_slice(&payload);
+            }
         }
         Ok(buf)
     }
@@ -782,10 +859,12 @@ impl SegmentFooterIndex {
         let has_f32_tier = body[p + 1] != 0;
         p += 2;
         let blocks = read_blocks(body, &mut p)?;
-        // Optional trailing stripe encoding-map section (present only when the
-        // footer carries lossless-transform metadata). Absent ⇒ empty map.
+        // Optional trailing sections (encoding map, coarse-directory extent).
+        // Absent ⇒ defaults. Unknown tags are skipped (forward-compatible).
         let mut encoding_map = Vec::new();
         let mut block_tier_assignments = Vec::new();
+        let mut a0_off = 0u64;
+        let mut a0_len = 0u64;
         if p != body.len() {
             let section_count = read_u16(body, &mut p)? as usize;
             if section_count > body.len().saturating_sub(p) / 6 {
@@ -805,6 +884,15 @@ impl SegmentFooterIndex {
                     let (descriptors, assignments) = parse_encoding_map_payload(section)?;
                     encoding_map = descriptors;
                     block_tier_assignments = assignments;
+                } else if tag == SECTION_COARSE_DIRECTORY {
+                    if version != SECTION_VERSION_V1 {
+                        bail!("unsupported coarse-directory section version {version}");
+                    }
+                    if section.len() != COARSE_DIRECTORY_SECTION_LEN {
+                        bail!("coarse-directory section has wrong length");
+                    }
+                    a0_off = u64::from_le_bytes(section[..8].try_into()?);
+                    a0_len = u64::from_le_bytes(section[8..16].try_into()?);
                 }
             }
             if p != body.len() {
@@ -826,6 +914,8 @@ impl SegmentFooterIndex {
             blocks,
             encoding_map,
             block_tier_assignments,
+            a0_off,
+            a0_len,
         })
     }
 
@@ -879,6 +969,8 @@ mod tests {
             has_f32_tier: false,
             encoding_map: Vec::new(),
             block_tier_assignments: Vec::new(),
+            a0_off: 0,
+            a0_len: 0,
             blocks: vec![
                 FooterBlockEntry {
                     offset: 152_056,
@@ -979,6 +1071,8 @@ mod tests {
             sq8_len: 128_000,
             footer_off: 200_000,
             footer_len: 512,
+            a0_off: 0,
+            a0_len: 0,
         };
         let bytes = h.to_bytes();
         assert_eq!(bytes.len(), SEG_HEADER_PREFIX_LEN);
@@ -1002,6 +1096,8 @@ mod tests {
             sq8_len: 0,
             footer_off: 0,
             footer_len: 0,
+            a0_off: 0,
+            a0_len: 0,
         }
         .to_bytes();
         bad[0..4].copy_from_slice(b"PBLK");
@@ -1015,6 +1111,8 @@ mod tests {
             sq8_len: 0,
             footer_off: 0,
             footer_len: 0,
+            a0_off: 0,
+            a0_len: 0,
         }
         .to_bytes();
         v[4] = 99;
@@ -1031,12 +1129,123 @@ mod tests {
             sq8_len: 1,
             footer_off: 58,
             footer_len: 1,
+            a0_off: 0,
+            a0_len: 0,
         }
         .to_bytes();
         assert!(is_coalesced_segment(&h));
         // A legacy block magic prefix is NOT coalesced.
         assert!(!is_coalesced_segment(b"PBLK\x00\x00"));
         assert!(!is_coalesced_segment(&[]));
+    }
+
+    #[test]
+    fn header_prefix_v3_round_trips_with_a0() {
+        let h = SegmentHeaderPrefix {
+            layout_version: SEG_LAYOUT_VERSION_TWO_LEVEL,
+            rabitq_off: 72 + 120_000,
+            rabitq_len: 24_000,
+            sq8_off: 72 + 120_000 + 24_000,
+            sq8_len: 128_000,
+            footer_off: 400_000,
+            footer_len: 512,
+            a0_off: 72,
+            a0_len: 120_000,
+        };
+        let bytes = h.to_bytes();
+        assert_eq!(bytes.len(), SEG_HEADER_PREFIX_V3_LEN);
+        let parsed = SegmentHeaderPrefix::parse(&bytes).unwrap();
+        assert_eq!(parsed.layout_version, SEG_LAYOUT_VERSION_TWO_LEVEL);
+        assert_eq!(parsed.a0_off, 72);
+        assert_eq!(parsed.a0_len, 120_000);
+        assert_eq!(parsed.rabitq_off, 72 + 120_000);
+        assert_eq!(parsed.footer_len, 512);
+        // A v3 prefix truncated to the v1 length must fail closed, never
+        // parse with garbage a0 fields.
+        assert!(SegmentHeaderPrefix::parse(&bytes[..SEG_HEADER_PREFIX_LEN]).is_err());
+    }
+
+    /// TD-RDSTRAT-8 mixed-read contract: a **version-1-only reader** (any binary
+    /// that predates the two-level layout) must reject a v3 segment cleanly.
+    /// Old binaries are frozen, so this pins the two facts their rejection
+    /// depends on: the on-disk version byte is 3 (not 1), and a strict
+    /// `version == 1` check therefore fails.
+    #[test]
+    fn v1_only_reader_rejects_v3_prefix() {
+        let bytes = SegmentHeaderPrefix {
+            layout_version: SEG_LAYOUT_VERSION_TWO_LEVEL,
+            rabitq_off: 0,
+            rabitq_len: 0,
+            sq8_off: 0,
+            sq8_len: 0,
+            footer_off: 0,
+            footer_len: 0,
+            a0_off: 72,
+            a0_len: 1,
+        }
+        .to_bytes();
+        // The exact check the pre-TD-RDSTRAT-8 parse performed (frozen copy).
+        let legacy_v1_only_parse = |b: &[u8]| -> Result<()> {
+            if b.len() < SEG_HEADER_PREFIX_LEN {
+                bail!("too short");
+            }
+            if &b[..4] != SEG_HEADER_MAGIC {
+                bail!("bad magic");
+            }
+            if b[4] != SEG_LAYOUT_VERSION {
+                bail!("unsupported layout version {}", b[4]);
+            }
+            Ok(())
+        };
+        assert_eq!(bytes[4], SEG_LAYOUT_VERSION_TWO_LEVEL);
+        assert!(legacy_v1_only_parse(&bytes).is_err());
+        // And the current parse still accepts v1 prefixes (mixed-read).
+        let v1 = SegmentHeaderPrefix {
+            layout_version: SEG_LAYOUT_VERSION,
+            rabitq_off: 56,
+            rabitq_len: 1,
+            sq8_off: 57,
+            sq8_len: 1,
+            footer_off: 58,
+            footer_len: 1,
+            a0_off: 0,
+            a0_len: 0,
+        }
+        .to_bytes();
+        assert_eq!(v1.len(), SEG_HEADER_PREFIX_LEN);
+        assert!(SegmentHeaderPrefix::parse(&v1).is_ok());
+    }
+
+    #[test]
+    fn footer_coarse_directory_section_round_trips() {
+        let mut footer = sample_footer();
+        footer.a0_off = 72;
+        footer.a0_len = 123_456;
+        let bytes = footer.to_bytes().unwrap();
+        let parsed = SegmentFooterIndex::parse(&bytes).unwrap();
+        assert_eq!(parsed.a0_off, 72);
+        assert_eq!(parsed.a0_len, 123_456);
+        assert_eq!(parsed.blocks.len(), 2);
+        // Coexists with the encoding-map section (two sections).
+        let mut v2 = sample_v2_footer();
+        v2.a0_off = 72;
+        v2.a0_len = 99;
+        let bytes2 = v2.to_bytes().unwrap();
+        let parsed2 = SegmentFooterIndex::parse(&bytes2).unwrap();
+        assert_eq!(parsed2.encoding_map, v2.encoding_map);
+        assert_eq!(parsed2.a0_len, 99);
+        // Absent A0 (a0_len == 0) ⇒ byte-identical to the sectionless footer
+        // (v1 segments unchanged on disk by this feature).
+        let plain = sample_footer();
+        assert_eq!(plain.to_bytes().unwrap(), {
+            let mut same = sample_footer();
+            same.a0_off = 999; // off without len must NOT emit a section
+            same.a0_len = 0;
+            same.to_bytes().unwrap()
+        });
+        let reparsed = SegmentFooterIndex::parse(&plain.to_bytes().unwrap()).unwrap();
+        assert_eq!(reparsed.a0_off, 0);
+        assert_eq!(reparsed.a0_len, 0);
     }
 
     #[test]

--- a/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. Layout prototype + representative evidence are required before this architectural change is promoted to an ADR.
+| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. Layout prototype + representative evidence are required before this architectural change is promoted to an ADR. **rev 3.1 (2026-07-20): PR-A landed, write path reconciled to rev 3** — A0 serde + header-prefix `layout_version=3` + additive footer section + compaction-only write path (`cluster_plan_ivf_probe` **persists the existing IOP-derived plan**; NO second `sqrt(N)` quantizer) + production-trigger route proof; default-OFF `PROXIMADB_IVF2=0` (see §As-built delta). Reads serve v3 through the order-agnostic single-level scan until the PR-B probe reader ranks the persisted centroids.
 | Priority | P2 → **P1 once any collection approaches ~2M vectors** — downstream, AnvaiOps ADR-0044 forbids >~5M-vector pooled onboarding until this re-measures (revenue + latency gate, successor to TD-RDSTRAT-6's role).
 | Severity | n/a (new capability, no regression). Default-OFF until gates pass.
 | Component | `src/storage/engines/sst/` — `segment_format.rs` (writer/reader), `block_cluster.rs` (clustering), `compaction.rs`/`compactor_impl.rs` (the only write path that clusters), `crates/storage/proximadb-storage-common/src/pax_block.rs` + `segment_layout.rs` (regions/footer), coalesce policy + `IopsBudget`. **NOVA is explicitly NOT the host** (rev 2).
@@ -115,8 +115,8 @@ Two placement constraints inherited from ADR-065 and shipped code:
 [Region A0: IVF probe directory — NEW, cached]
 [Region A : RaBitQ codes      — existing compaction-cell order]
 [Region B : SQ8 codes         — same order (PR3 / #1069)]
-[row blocks                   — existing result/exact data; ADR-065 Region C/D remain separate gates]
-[footer-index: block table | region directory | layout_version=2]
+[Region D : row blocks        — same order; block boundaries never straddle a coarse cell; ADR-065 Region C/D remain separate gates]
+[footer-index: block table | region table | A0 offset copy (optional section) — footer stays version 1, see §As-built delta]
 ----
 
 Everything ADR-062/065 guarantees is preserved: one PUT flush, one-object compaction CAS,
@@ -207,6 +207,98 @@ the directory/A/B/D rounds, so GET-budget compaction remains part of the accepta
   change, no re-ingest.
 * Auto-threshold (later phase): compactor writes the successor only when segment rows ≥
   `PROXIMADB_IVF2_MIN_ROWS` (default 500 000) — small segments keep `PXH1`.
+
+== As-built delta (PR-A) — layout versioning + the rev-3 write-path reconciliation
+
+*Write path reuses the existing IOP-derived plan (rev 3 — not a second `sqrt(N)`
+quantizer).* An earlier PR-A cut trained a fresh coarse k-means at
+`k_c = clamp(round(√N), 64, 4096)` over the fine IVF cells. The rev-3
+first-principles reconciliation (this doc's body) replaced it:
+`cluster_plan_ivf_probe` now persists the *same* plan `cluster_plan_pca_ivf`
+already computes — IOP-derived `k = clamp(N·dim/IOP, 2, 4096)`, the
+`ivf_projection_dims` law, `PROXIMADB_IVF_TRAIN_SAMPLE`, seed
+`0x5041_585F_4956_4631`, 15 iterations — into Region A0 rather than discarding
+it. Ranking those `k` centroids in RAM (≈305 at 10M, ≈3050 at 100M, capped
+4096) already breaks GETs ∝ N; a `sqrt(N)` level bought nothing and would
+fragment Region B into sub-IOP (~128 KiB) runs. The single-level (`PXH1`) f64
+path is untouched (byte-stable); the shared row-ordering is extracted into
+`order_rows_by_cell` so both plans stay identical to their inline form.
+
+*Layout versioning lives in the header-prefix, not the footer.* Between rev 2 and
+PR-A, ADR-065 PR3 (#1069) collapsed the footer v1/v2 split into a **single
+version-1 footer** with an optional-sections framework whose unknown tags old
+parsers skip (pinned by test). PR-A therefore does NOT introduce a footer v2/v3:
+
+* `SegmentHeaderPrefix.version = 3` (`SEG_LAYOUT_VERSION_TWO_LEVEL`; byte value
+  matches this TD's "v3" name, 2 intentionally skipped/reserved) selects the
+  two-level layout; the v3 prefix is 72 B (`+[a0_off u64][a0_len u64]`).
+  Readers fetch 72 B unconditionally (free within the same GET) and branch on
+  the version byte.
+* The footer gains an **additive** `SECTION_COARSE_DIRECTORY` section
+  (`[a0_off][a0_len]` mirror). A sectionless footer stays byte-identical.
+* A0 serde: `crates/storage/proximadb-storage-common/src/coarse_directory.rs`
+  (`PXA0` magic, own version byte, FNV-1a checksum, fixed layout —
+  `serialized_len` is exact so the writer computes all offsets in one pass).
+
+*Write/read projection consistency (f32-persisted model).* The PCA model is
+truncated to the f32 precision A0 persists **before** cell assignment: rows,
+centroids, and radii are all computed with the same `project_with_model` kernel
+the query path uses — no f64-train vs f32-read drift at cell boundaries.
+Vectors stay f32 end-to-end; only dot-product accumulators widen transiently to
+f64 (cancellation-safe accumulation, never stored).
+
+*Read-compat shipped in PR-A, probe reader in PR-B.* The current binary parses
+v3 and serves it through the existing single-level whole-region scan (Regions
+A/B are byte-identical in format; a full scan over cell-ordered rows is
+order-agnostic) — correct results at v2 GET cost until PR-B lands the A0
+probe. `read_segment_records` handles v3 (incl. the Region-B vector overlay),
+so re-compaction/recovery of v3 segments never drops vectors. Version-1-only
+binaries reject v3 at the prefix version check (fail-closed; contract pinned
+by `v1_only_reader_rejects_v3_prefix`).
+
+*Enabling fix — armed compaction of coalesced `.pax` was a silent no-op.* The
+production-trigger route proof (below) caught that the compaction unified
+reader predates the coalesced layout ("Invalid SSTable magic marker"): an
+armed AppendBulk collection flushing coalesced RaBitQ L0s (default-on since
+#1024) collected 0 records, hit the empty-merge early return, reported
+`compaction_ran=true`, and left inputs unmerged — no data loss, but the entire
+re-cluster arc (and this TD's write path) was dark on the real trigger.
+`read_all_records_from_file_unified` now routes PAX segments through the
+canonical `read_segment_records` inverse (mixed-read mandate: reuse the
+existing inverse).
+
+*Eval realization (the recall/GET gates must actually reach v3).* The SIFT
+harness (`tests/sift_pax_recall_ratchet_test.rs`) drives **flush only**, and v3
+is written **only** by `write_pax_segment_compacted` — so without explicit
+wiring no eval would ever measure a v3 segment:
+
+* The recall/GET ratchet reaches v3 via the **direct compaction-writer route**
+  — the harness calls `write_pax_segment_compacted()` under `PROXIMADB_IVF2=1`,
+  byte-identical to the production compaction product (and/or the established
+  `PROXIMADB_PAX_FLUSH_CLUSTER=ivf`-style eval-knob pattern for
+  flush-reachable measurement). Production policy is unchanged:
+  compaction-only, default-OFF.
+* One **production-trigger route proof** exists as of PR-A:
+  `tests/sst_ivf2_compaction_route_proof_test.rs` (mirrors the TD-WLP-7
+  execution gate) — armed AppendBulk flush past L0 threshold ⇒ inline
+  compaction emits a v3 segment with a parsable A0 covering every merged row,
+  production search over it stays exact, and the flag-off control stays v1.
+* **CI authority (PR-B):** wire the v3 recall/GET assertion into the qa-gate
+  ANN-recall conformance ratchet tier (develop→qa MEDIUM — SIFT + release
+  build are too heavy for the per-PR LIGHT tier). If the SIFT dataset is
+  unavailable in that tier, a deterministic synthetic-corpus variant of the
+  same gate runs unconditionally and the SIFT run stays `#[ignore]`d for the
+  quiet-machine eval; record which one is the CI authority here when wired.
+
+*PR-A landed surface (all default-OFF):* `PROXIMADB_IVF2` (gate) is the only new
+env; the probe plan reuses the single-level IVF knobs — `PROXIMADB_IVF_K`
+overrides the IOP-derived cell count, `PROXIMADB_IVF_TRAIN_SAMPLE` the
+sample-train — seed `0x5041_585F_4956_4631`, 15 iterations, with **no separate
+`sqrt(N)` surface** (`PROXIMADB_IVF2_KC` / `_TRAIN_SAMPLE` removed in the rev-3
+reconciliation). Determinism, cell-extent exactness, cell-boundary block
+padding, mixed-read, and the flag gates are unit/e2e tested (`pax_block.rs`,
+`segment_layout.rs`, `coarse_directory.rs`, `block_cluster.rs`,
+`segment_format.rs`, route-proof test).
 
 == Eval gates (ADR-062 pattern; eval doc in `docs/_internal/status/`)
 

--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -245,56 +245,28 @@ pub fn cluster_order_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Ve
     cluster_plan_pca_ivf(records, idx).map(|plan| plan.order)
 }
 
-/// Compaction-grade PCA+IVF plan, including the contiguous IVF-cell runs.
-pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<ClusterPlan> {
-    /// Below this many usable rows a trained model can't beat the bootstrap.
-    const MIN_ROWS_FOR_IVF: usize = 64;
+/// Below this many usable rows a trained model can't beat the bootstrap.
+const MIN_ROWS_FOR_IVF: usize = 64;
 
-    use crate::storage::engines::core::formats::proximablocks::spatial_clustering::IncrementalPCA;
-
-    let usable: Vec<(usize, &[f32])> = records
-        .iter()
-        .enumerate()
-        .filter_map(|(i, r)| embedding_f32(r, idx).map(|v| (i, v)))
-        .collect();
-    if usable.len() < MIN_ROWS_FOR_IVF {
-        return cluster_plan(records, idx);
-    }
-    let dim = usable[0].1.len();
-    if usable.iter().any(|(_, v)| v.len() != dim) {
-        return cluster_plan(records, idx);
-    }
-
-    let trace_ivf = std::env::var_os("PROXIMADB_TRACE_IVF_FLUSH").is_some();
-    let t_start = std::time::Instant::now();
-
-    // IVF cells ≈ blockcount (ADR-065 co-design): one cell ≈ one IOP-sized
-    // block, so survivors span fewer cells → fewer GETs and each cell-fetch is
-    // one efficient IOP. k scales with N (more data ⇒ more cells, members/cell
-    // ~constant). Computed UP FRONT so n_components can couple to it.
+/// Fine IVF cell count ≈ blockcount (ADR-065 co-design): one cell ≈ one
+/// IOP-sized block, so survivors span fewer cells → fewer GETs and each
+/// cell-fetch is one efficient IOP. `PROXIMADB_IVF_K` overrides to map the
+/// GETs-vs-recall curve (eval knob, not a production setting).
+fn ivf_fine_cell_count(n_usable: usize, dim: usize) -> usize {
     let iop_target =
         proximadb_storage_common::iops_budget::IopsBudget::CLOUD.target_block_bytes() as usize;
-    // `PROXIMADB_IVF_K` overrides k to map the GETs-vs-recall curve (validate
-    // the cells=blockcount formula). Default = N·dim/IOP (one cell ≈ one IOP of
-    // SQ8 survivor data). Eval knob, not a production setting.
-    let k = std::env::var("PROXIMADB_IVF_K")
+    std::env::var("PROXIMADB_IVF_K")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
-        .unwrap_or_else(|| ((usable.len() * dim) / iop_target.max(1)).clamp(2, 4096));
+        .unwrap_or_else(|| ((n_usable * dim) / iop_target.max(1)).clamp(2, 4096))
+}
 
-    // TD-WLP-4b: PCA projection dimensionality = max of two logarithmic terms,
-    // so n_comp stays small as embeddings/corpora grow:
-    //   (a) a·log2(dim) — the embedding's intrinsic-dim term (SIFT-128 → ~10).
-    //   (b) b·log2(k)   — partition-granularity INSURANCE: finer partitioning
-    //        (high k, i.e. large merged collections) needs more discriminative
-    //        dims to separate the cells. Bites only at high k; at SIFT's k=30
-    //        the (a) term wins (matching the Phase-0 sweep: recall@10 flat 0.989
-    //        for n_comp ∈ [4,128]). The (b) term is a conservative hedge for the
-    //        high-k regime we cannot yet measure. a, b are env-tunable
-    //        (dataset-dependent floors); `PROXIMADB_IVF_NCOMP` force-sets n_comp
-    //        for the eval sweep. Clustering-only — search-time PCA keeps its
-    //        own conservative cap (for_vector_dim).
+/// TD-WLP-4b: PCA projection dimensionality = max of two logarithmic terms
+/// (`a·log2 dim` intrinsic-dim, `b·log2 k` partition-granularity insurance),
+/// env-tunable (`PROXIMADB_IVF_NCOMP[_A|_B]`). See the sweep notes at the
+/// call sites.
+fn ivf_projection_dims(dim: usize, k: usize) -> usize {
     let ivf_a = std::env::var("PROXIMADB_IVF_NCOMP_A")
         .ok()
         .and_then(|v| v.parse::<f64>().ok())
@@ -305,7 +277,7 @@ pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Clu
         .and_then(|v| v.parse::<f64>().ok())
         .filter(|x| *x > 0.0)
         .unwrap_or(1.5);
-    let n_components = std::env::var("PROXIMADB_IVF_NCOMP")
+    std::env::var("PROXIMADB_IVF_NCOMP")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
@@ -314,58 +286,19 @@ pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Clu
             let k_term = ivf_b * (k.max(2) as f64).log2();
             dim_term.max(k_term).floor() as usize
         })
-        .clamp(1, dim);
-    // TD-WLP-4b sample-train: fit PCA + train k-means on a deterministic
-    // ~SAMPLE subset (the covariance / centroids converge far before N=1M),
-    // then project + assign ALL rows. Cuts pca_fit + kmeans ~N/sample (~20x at
-    // SIFT1M) with negligible recall impact; project/assign still cover all N.
-    // Deterministic stride (a physical layout must not depend on RNG).
-    let train_sample = std::env::var("PROXIMADB_IVF_TRAIN_SAMPLE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(50_000)
-        .min(usable.len());
-    let sample_step = if usable.len() > train_sample {
-        (usable.len() / train_sample).max(1)
-    } else {
-        1
-    };
-    let mut pca = IncrementalPCA::new(dim, n_components);
-    for (_, v) in usable.iter().step_by(sample_step) {
-        pca.add_sample(v);
-    }
-    pca.finalize();
-    let t_pca = std::time::Instant::now();
-    let coords: Vec<Vec<f32>> = usable.iter().map(|(_, v)| pca.transform(v)).collect();
-    let t_proj = std::time::Instant::now();
-    // A physical layout must not depend on thread-local RNG state: identical
-    // input should produce identical IVF cells, byte counts, and eval results.
-    const PAX_IVF_KMEANS_SEED: u64 = 0x5041_585F_4956_4631;
-    // Train k-means on the sampled projections (same stride as the PCA fit);
-    // assign ALL rows to the resulting centroids.
-    let train_coords: Vec<Vec<f32>> = coords.iter().step_by(sample_step).cloned().collect();
-    let Ok(centroids) = proximadb_clustering_kernel::kmeans_clustering_seeded(
-        &train_coords,
-        k,
-        15,
-        1e-3,
-        PAX_IVF_KMEANS_SEED,
-    ) else {
-        return cluster_plan(records, idx);
-    };
-    let t_kmeans = std::time::Instant::now();
-    let assignments = proximadb_clustering_kernel::kmeans_assign(&coords, &centroids);
-    let t_assign = std::time::Instant::now();
+        .clamp(1, dim)
+}
 
-    // Order cells by the Hilbert code of their centroid. Normalization is over
-    // the CENTROID SET per dimension (per-vector min/max would destroy
-    // cross-centroid comparability).
+/// Order cells by the Hilbert code of their centroid so same-region cells are
+/// physically contiguous (coalescing-friendly). Normalization is over the
+/// CENTROID SET per dimension (per-vector min/max would destroy cross-centroid
+/// comparability). Returns `(emission order, rank per cell)`.
+fn hilbert_cell_order(centroids: &[Vec<f32>]) -> (Vec<usize>, Vec<usize>) {
     let hilbert_dims = centroids.first().map(|c| c.len().clamp(1, 6)).unwrap_or(1);
     let bits_per_dim = 10usize; // 6 dims × 10 bits ≤ u64
     let mut lo = vec![f32::INFINITY; hilbert_dims];
     let mut hi = vec![f32::NEG_INFINITY; hilbert_dims];
-    for c in &centroids {
+    for c in centroids {
         for d in 0..hilbert_dims {
             lo[d] = lo[d].min(c[d]);
             hi[d] = hi[d].max(c[d]);
@@ -394,32 +327,96 @@ pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Clu
     for (rank, &cell) in cell_order.iter().enumerate() {
         cell_rank[cell] = rank;
     }
+    (cell_order, cell_rank)
+}
+
+/// Seed for the compaction IVF k-means. A physical layout must not depend on
+/// thread-local RNG state: identical input must produce identical IVF cells,
+/// byte counts, and eval results. Shared by the single-level plan
+/// ([`cluster_plan_pca_ivf`]) and the persisted probe directory
+/// ([`cluster_plan_ivf_probe`]) — rev 3 persists the *same* plan, so the seed is
+/// the same.
+const PAX_IVF_KMEANS_SEED: u64 = 0x5041_585F_4956_4631;
+
+/// Compaction-grade PCA+IVF plan, including the contiguous IVF-cell runs.
+pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<ClusterPlan> {
+    use crate::storage::engines::core::formats::proximablocks::spatial_clustering::IncrementalPCA;
+
+    let usable: Vec<(usize, &[f32])> = records
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| embedding_f32(r, idx).map(|v| (i, v)))
+        .collect();
+    if usable.len() < MIN_ROWS_FOR_IVF {
+        return cluster_plan(records, idx);
+    }
+    let dim = usable[0].1.len();
+    if usable.iter().any(|(_, v)| v.len() != dim) {
+        return cluster_plan(records, idx);
+    }
+
+    let trace_ivf = std::env::var_os("PROXIMADB_TRACE_IVF_FLUSH").is_some();
+    let t_start = std::time::Instant::now();
+
+    // IVF cells ≈ blockcount (ADR-065 co-design); k scales with N (more data ⇒
+    // more cells, members/cell ~constant). Computed UP FRONT so n_components
+    // can couple to it. n_comp: dim-term wins at SIFT's k (Phase-0 sweep:
+    // recall@10 flat 0.989 for n_comp ∈ [4,128]); the k-term is the high-k
+    // hedge. Clustering-only — search-time PCA keeps its own cap.
+    let k = ivf_fine_cell_count(usable.len(), dim);
+    let n_components = ivf_projection_dims(dim, k);
+    // TD-WLP-4b sample-train: fit PCA + train k-means on a deterministic
+    // ~SAMPLE subset (the covariance / centroids converge far before N=1M),
+    // then project + assign ALL rows. Cuts pca_fit + kmeans ~N/sample (~20x at
+    // SIFT1M) with negligible recall impact; project/assign still cover all N.
+    // Deterministic stride (a physical layout must not depend on RNG).
+    let train_sample = std::env::var("PROXIMADB_IVF_TRAIN_SAMPLE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(50_000)
+        .min(usable.len());
+    let sample_step = if usable.len() > train_sample {
+        (usable.len() / train_sample).max(1)
+    } else {
+        1
+    };
+    let mut pca = IncrementalPCA::new(dim, n_components);
+    for (_, v) in usable.iter().step_by(sample_step) {
+        pca.add_sample(v);
+    }
+    pca.finalize();
+    let t_pca = std::time::Instant::now();
+    let coords: Vec<Vec<f32>> = usable.iter().map(|(_, v)| pca.transform(v)).collect();
+    let t_proj = std::time::Instant::now();
+    // Train k-means on the sampled projections (same stride as the PCA fit);
+    // assign ALL rows to the resulting centroids.
+    let train_coords: Vec<Vec<f32>> = coords.iter().step_by(sample_step).cloned().collect();
+    let Ok(centroids) = proximadb_clustering_kernel::kmeans_clustering_seeded(
+        &train_coords,
+        k,
+        15,
+        1e-3,
+        PAX_IVF_KMEANS_SEED,
+    ) else {
+        return cluster_plan(records, idx);
+    };
+    let t_kmeans = std::time::Instant::now();
+    let assignments = proximadb_clustering_kernel::kmeans_assign(&coords, &centroids);
+    let t_assign = std::time::Instant::now();
+
+    // Order cells by the Hilbert code of their centroid (set-normalized).
+    let (_cell_order, cell_rank) = hilbert_cell_order(&centroids);
 
     // Records: usable ordered by (cell rank, PC1, index); unusable last, stably.
-    let mut order: Vec<usize> = Vec::with_capacity(records.len());
-    let mut usable_sorted: Vec<usize> = (0..usable.len()).collect();
-    usable_sorted.sort_by(|&a, &b| {
-        cell_rank[assignments[a]]
-            .cmp(&cell_rank[assignments[b]])
-            .then_with(|| {
-                let pa = coords[a].first().copied().unwrap_or(0.0);
-                let pb = coords[b].first().copied().unwrap_or(0.0);
-                pa.partial_cmp(&pb).unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| usable[a].0.cmp(&usable[b].0))
-    });
-    order.extend(usable_sorted.iter().map(|&u| usable[u].0));
-    let in_usable: std::collections::HashSet<usize> = usable.iter().map(|(i, _)| *i).collect();
-    order.extend((0..records.len()).filter(|i| !in_usable.contains(i)));
-    let mut ordered_cells: Vec<usize> = usable_sorted
-        .iter()
-        .map(|&usable_row| assignments[usable_row])
-        .collect();
-    ordered_cells.extend(std::iter::repeat_n(
-        usize::MAX,
-        records.len() - usable.len(),
-    ));
-    let runs = contiguous_runs(&ordered_cells);
+    let usable_orig: Vec<usize> = usable.iter().map(|(i, _)| *i).collect();
+    let (order, runs) = order_rows_by_cell(
+        records.len(),
+        &usable_orig,
+        &coords,
+        &assignments,
+        &cell_rank,
+    );
     let t_end = std::time::Instant::now();
     if trace_ivf {
         eprintln!(
@@ -435,6 +432,219 @@ pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Clu
         );
     }
     Some(ClusterPlan { order, runs })
+}
+
+/// TD-RDSTRAT-8 (rev 3): opt-in gate for the persisted-IVF-probe v3 compaction
+/// layout (the IOP-derived plan written into Region A0). Default **OFF**
+/// (`PROXIMADB_IVF2=1` to enable) until the recall/GET eval gates pass;
+/// mixed-read-safe beside single-level segments either way. The env keeps its
+/// shipped `IVF2` name (the successor IVF layout), though rev 3 dropped the
+/// second `sqrt(N)` level the name originally implied.
+pub fn ivf_probe_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_IVF2")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|v| v.to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
+/// The persisted IVF probe directory compaction plan (rev 3): the physical row
+/// order + runs (one run per non-empty IOP-derived cell, in emission order) plus
+/// the trained [`CoarseModel`] the writer persists into Region A0.
+pub struct IvfProbePlan {
+    pub plan: ClusterPlan,
+    pub model: proximadb_storage_common::coarse_directory::CoarseModel,
+}
+
+/// TD-RDSTRAT-8 (rev 3): the **persisted IVF probe directory** compaction plan.
+/// Reuses the *existing* IOP-derived PCA/IVF recipe — `ivf_fine_cell_count` `k`
+/// (≈ `N·dim / IOP_target`, capped 4096), `ivf_projection_dims` `n_comp`,
+/// `PROXIMADB_IVF_TRAIN_SAMPLE` sample-train, and [`PAX_IVF_KMEANS_SEED`] — the
+/// same plan [`cluster_plan_pca_ivf`] computes for the single-level layout, and
+/// **persists it** into Region A0 rather than discarding it.
+///
+/// There is NO second `sqrt(N)` quantizer (rev 3 rejected the coarse-on-fine
+/// level): ranking the `k` IOP-derived centroids in RAM (`k` ≈ 305 at 10M,
+/// ≈ 3050 at 100M, capped 4096) is trivial and already breaks GETs ∝ N, whereas
+/// `sqrt(N)` cells would fragment Region B into sub-IOP (~128 KiB) runs — worse
+/// cloud economics. The cells here are the IOP-aligned cells the compaction
+/// already speaks; A0 just makes them query-visible so the PR-B reader ranks the
+/// directory in RAM and fetches only probed cells.
+///
+/// Write/read projection consistency: the PCA model is **truncated to the f32
+/// precision A0 persists before anything is assigned** — coordinates, centroids,
+/// and radii all come from the shared [`project_with_model`] kernel the query
+/// path uses, so a query projects into exactly the space the writer clustered
+/// (no f64-train vs f32-read drift at cell boundaries; vectors stay f32
+/// throughout, only dot-product accumulators widen transiently to f64).
+///
+/// Deterministic end to end: strided sample-train, seeded k-means, fixed-init
+/// PCA — identical input ⇒ identical plan ⇒ identical segment bytes (unit-gated
+/// in `pax_block.rs`). `PROXIMADB_IVF_K` overrides `k` (shared eval knob).
+///
+/// Returns `None` when the IOP-derived plan can't be trained (fewer than
+/// [`MIN_ROWS_FOR_IVF`] usable rows, degenerate dim, or k-means failure) — the
+/// caller falls back to [`cluster_plan_pca_ivf`] and writes the single-level
+/// layout (fail-safe, never a worse segment).
+pub fn cluster_plan_ivf_probe(records: &[ProximaRecord], idx: usize) -> Option<IvfProbePlan> {
+    use crate::storage::engines::core::formats::proximablocks::spatial_clustering::IncrementalPCA;
+    use proximadb_storage_common::coarse_directory::{CoarseModel, project_with_model};
+
+    let usable: Vec<(usize, &[f32])> = records
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| embedding_f32(r, idx).map(|v| (i, v)))
+        .collect();
+    if usable.len() < MIN_ROWS_FOR_IVF {
+        return None;
+    }
+    let dim = usable[0].1.len();
+    if dim == 0 || usable.iter().any(|(_, v)| v.len() != dim) {
+        return None;
+    }
+
+    let trace_ivf = std::env::var_os("PROXIMADB_TRACE_IVF_FLUSH").is_some();
+    let t_start = std::time::Instant::now();
+
+    // IOP-derived cell count + projection law — the SAME recipe the single-level
+    // plan uses (rev 3: reuse the existing plan, do not train a second quantizer).
+    let k = ivf_fine_cell_count(usable.len(), dim);
+    let n_comp_target = ivf_projection_dims(dim, k);
+
+    // PCA sample-train (TD-WLP-4b), deterministic stride — shared knob with the
+    // single-level plan.
+    let pca_sample = std::env::var("PROXIMADB_IVF_TRAIN_SAMPLE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(50_000)
+        .min(usable.len());
+    let pca_step = if usable.len() > pca_sample {
+        (usable.len() / pca_sample).max(1)
+    } else {
+        1
+    };
+    let mut pca = IncrementalPCA::new(dim, n_comp_target);
+    for (_, v) in usable.iter().step_by(pca_step) {
+        pca.add_sample(v);
+    }
+    pca.finalize();
+    let t_pca = std::time::Instant::now();
+
+    // Truncate the model to persisted (f32) precision FIRST; all coordinates
+    // below come from the shared projection kernel over this exact model.
+    let pca_mean: Vec<f32> = pca.mean().iter().map(|&x| x as f32).collect();
+    let components = pca.components()?;
+    let n_comp = components.len();
+    if n_comp == 0 {
+        return None;
+    }
+    let pca_components: Vec<f32> = components
+        .iter()
+        .flat_map(|row| row.iter().map(|&x| x as f32))
+        .collect();
+    let coords: Vec<Vec<f32>> = usable
+        .iter()
+        .map(|(_, v)| project_with_model(&pca_mean, &pca_components, n_comp, v))
+        .collect();
+    let t_proj = std::time::Instant::now();
+
+    // k-means over the f32-projected sample — the plan we persist IS the
+    // single-level IVF plan, so same seed + iterations. Assignment below covers
+    // ALL rows.
+    let sample_coords: Vec<Vec<f32>> = coords.iter().step_by(pca_step).cloned().collect();
+    let k = k.min(sample_coords.len());
+    let Ok(centroids) = proximadb_clustering_kernel::kmeans_clustering_seeded(
+        &sample_coords,
+        k,
+        15,
+        1e-3,
+        PAX_IVF_KMEANS_SEED,
+    ) else {
+        return None;
+    };
+    if centroids.is_empty() {
+        return None;
+    }
+    let t_kmeans = std::time::Instant::now();
+    let assignments = proximadb_clustering_kernel::kmeans_assign(&coords, &centroids);
+    // Per-cell max member→centroid distance in PCA space (diagnostic/calibration
+    // radius only; rev 3 does not use it as a correctness bound).
+    let mut radii_sq = vec![0f32; centroids.len()];
+    for (i, &cell) in assignments.iter().enumerate() {
+        let d: f32 = coords[i]
+            .iter()
+            .zip(&centroids[cell])
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum();
+        if d > radii_sq[cell] {
+            radii_sq[cell] = d;
+        }
+    }
+    let t_assign = std::time::Instant::now();
+
+    // Hilbert emission order over the centroids: near cells are near in the file,
+    // so multi-cell probes coalesce into few ranged GETs.
+    let (cell_order, cell_rank) = hilbert_cell_order(&centroids);
+
+    // Rows: usable ordered by (cell rank, PC1, index); unusable last, stably (the
+    // no-embedding tail — outside every cell, unreachable by ANN anyway).
+    let usable_orig: Vec<usize> = usable.iter().map(|(i, _)| *i).collect();
+    let (order, runs) = order_rows_by_cell(
+        records.len(),
+        &usable_orig,
+        &coords,
+        &assignments,
+        &cell_rank,
+    );
+
+    // Emission-ordered model arrays + per-cell row counts (empty cells stay — A0
+    // is dense in k so centroid ranks map 1:1 to cell entries).
+    let mut counts = vec![0u64; centroids.len()];
+    for &c in &assignments {
+        counts[c] += 1;
+    }
+    let centroids_flat: Vec<f32> = cell_order
+        .iter()
+        .flat_map(|&c| centroids[c].iter().copied())
+        .collect();
+    let radii: Vec<f32> = cell_order.iter().map(|&c| radii_sq[c].sqrt()).collect();
+    let cell_rows: Vec<u64> = cell_order.iter().map(|&c| counts[c]).collect();
+
+    let n_comp_u16 = u16::try_from(n_comp).ok()?;
+    let model = CoarseModel {
+        dim: dim as u32,
+        n_comp: n_comp_u16,
+        pca_mean,
+        pca_components,
+        centroids: centroids_flat,
+        radii,
+        cell_rows,
+        seed: PAX_IVF_KMEANS_SEED,
+        trained_on: sample_coords.len() as u64,
+    };
+    let t_end = std::time::Instant::now();
+    if trace_ivf {
+        eprintln!(
+            "[IVF probe compaction] N={n} dim={dim} k={k} n_comp={n_comp} | pca_fit {pca:.0} ms  project {proj:.0} ms  kmeans {km:.0} ms  assign+radii {asg:.0} ms  order {ord:.0} ms  | total {tot:.0} ms",
+            n = usable.len(),
+            k = centroids.len(),
+            pca = (t_pca - t_start).as_secs_f64() * 1e3,
+            proj = (t_proj - t_pca).as_secs_f64() * 1e3,
+            km = (t_kmeans - t_proj).as_secs_f64() * 1e3,
+            asg = (t_assign - t_kmeans).as_secs_f64() * 1e3,
+            ord = (t_end - t_assign).as_secs_f64() * 1e3,
+            tot = (t_end - t_start).as_secs_f64() * 1e3,
+        );
+    }
+    Some(IvfProbePlan {
+        plan: ClusterPlan { order, runs },
+        model,
+    })
 }
 
 fn contiguous_runs<T: PartialEq>(ordered_labels: &[T]) -> Vec<OrderedClusterRun> {
@@ -457,6 +667,44 @@ fn contiguous_runs<T: PartialEq>(ordered_labels: &[T]) -> Vec<OrderedClusterRun>
         row_count: ordered_labels.len() - start,
     });
     runs
+}
+
+/// Shared IVF row ordering (single-level and probe-directory plans use the same
+/// rule): usable rows sorted by `(cell rank, PC1, original index)`, then the
+/// unusable (no-embedding) rows appended last, stably. Returns the full-record
+/// permutation plus the contiguous per-cell runs (unusable tail is one trailing
+/// run keyed `usize::MAX`). Projection-agnostic — the caller decides whether
+/// `coords` came from `pca.transform` (f64 model) or `project_with_model` (f32),
+/// so extracting this keeps both plans byte-identical to their inline form.
+fn order_rows_by_cell(
+    records_len: usize,
+    usable_orig: &[usize],
+    coords: &[Vec<f32>],
+    assignments: &[usize],
+    cell_rank: &[usize],
+) -> (Vec<usize>, Vec<OrderedClusterRun>) {
+    let mut usable_sorted: Vec<usize> = (0..usable_orig.len()).collect();
+    usable_sorted.sort_by(|&a, &b| {
+        cell_rank[assignments[a]]
+            .cmp(&cell_rank[assignments[b]])
+            .then_with(|| {
+                let pa = coords[a].first().copied().unwrap_or(0.0);
+                let pb = coords[b].first().copied().unwrap_or(0.0);
+                pa.partial_cmp(&pb).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| usable_orig[a].cmp(&usable_orig[b]))
+    });
+    let mut order: Vec<usize> = Vec::with_capacity(records_len);
+    order.extend(usable_sorted.iter().map(|&u| usable_orig[u]));
+    let in_usable: std::collections::HashSet<usize> = usable_orig.iter().copied().collect();
+    order.extend((0..records_len).filter(|i| !in_usable.contains(i)));
+    let mut ordered_cells: Vec<usize> = usable_sorted.iter().map(|&u| assignments[u]).collect();
+    ordered_cells.extend(std::iter::repeat_n(
+        usize::MAX,
+        records_len - usable_orig.len(),
+    ));
+    let runs = contiguous_runs(&ordered_cells);
+    (order, runs)
 }
 
 /// Binary-reflected Gray code over the sign bits of `v - mean`, packed MSB-first
@@ -733,5 +981,81 @@ mod tests {
         let mut fs = fallback.clone();
         fs.sort_unstable();
         assert_eq!(fs, vec![0, 1, 2, 3]);
+    }
+
+    /// TD-RDSTRAT-8 (rev 3): the persisted IVF probe plan is a permutation that
+    /// groups the IOP-derived cells contiguously, produces a consistent persisted
+    /// model (cell_rows partition the usable rows, arrays sized by k), puts
+    /// no-embedding rows in the tail outside every cell, and is deterministic.
+    #[test]
+    fn cluster_plan_ivf_probe_groups_cells_and_is_deterministic() {
+        // Force k=2 so the two synthetic clusters map 1:1 to cells (the shared
+        // IOP-derived override, since the plan we persist IS the single-level
+        // plan). nextest process-per-test isolation makes the env mutation safe.
+        unsafe {
+            std::env::set_var("PROXIMADB_IVF_K", "2");
+        }
+        let mut recs = Vec::new();
+        for i in 0..100 {
+            let e = (i % 5) as f32 * 0.01;
+            recs.push(rec(&format!("a{i:03}"), vec![1.0 + e; 8]));
+            recs.push(rec(&format!("b{i:03}"), vec![-1.0 - e; 8]));
+        }
+        // Two records without embeddings — must sort last, outside all cells.
+        recs.push(ProximaRecord {
+            oid: "bare1".into(),
+            ..Default::default()
+        });
+        recs.push(ProximaRecord {
+            oid: "bare2".into(),
+            ..Default::default()
+        });
+
+        let tl = cluster_plan_ivf_probe(&recs, 0).expect("ivf probe plan");
+        // Permutation over ALL records.
+        assert_eq!(tl.plan.order.len(), recs.len());
+        let mut seen = tl.plan.order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..recs.len()).collect::<Vec<_>>());
+
+        // Model shape: 2 cells; usable rows partitioned; arrays sized by k_c
+        // (the directory's cell count = the plan's IOP-derived k).
+        assert!(tl.model.validate().is_ok());
+        assert_eq!(tl.model.k_c(), 2);
+        assert_eq!(tl.model.rows_covered(), 200);
+        assert_eq!(tl.model.cell_rows, vec![100, 100]);
+        assert_eq!(tl.model.dim, 8);
+        assert_eq!(
+            tl.model.centroids.len(),
+            2 * tl.model.n_comp as usize,
+            "centroids are k_c × n_comp in emission order"
+        );
+        assert!(tl.model.radii.iter().all(|r| r.is_finite() && *r >= 0.0));
+
+        // Cells are contiguous in the order: exactly one a↔b transition among
+        // the usable prefix, and the bare rows are the tail.
+        let labels: Vec<char> = tl.plan.order[..200]
+            .iter()
+            .map(|&i| recs[i].oid.chars().next().unwrap_or('?'))
+            .collect();
+        let transitions = labels.windows(2).filter(|w| w[0] != w[1]).count();
+        assert_eq!(transitions, 1, "cells must be contiguous: {labels:?}");
+        let tail: Vec<&str> = tl.plan.order[200..]
+            .iter()
+            .map(|&i| recs[i].oid.as_str())
+            .collect();
+        assert_eq!(tail, vec!["bare1", "bare2"], "no-embedding rows tail last");
+
+        // Deterministic: identical input ⇒ identical order AND model.
+        let again = cluster_plan_ivf_probe(&recs, 0).expect("second plan");
+        assert_eq!(again.plan.order, tl.plan.order);
+        assert_eq!(again.model, tl.model);
+
+        // Too-small batch ⇒ None (caller falls back to the single-level plan).
+        let small: Vec<ProximaRecord> = recs.iter().take(8).cloned().collect();
+        assert!(cluster_plan_ivf_probe(&small, 0).is_none());
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF_K");
+        }
     }
 }

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1923,6 +1923,49 @@ impl Compaction {
             file_path
         );
 
+        // Mixed-read: decode a PAX segment via the canonical inverse
+        // (`read_segment_records` — handles the legacy-block, coalesced v1
+        // AND two-level v3 layouts, including the Region-B vector overlay).
+        // The unified SSTable reader below predates the coalesced layout
+        // ("Invalid SSTable magic marker"), which made the ARMED compaction of
+        // coalesced `.pax` L0s a silent no-op: 0 records collected, the
+        // empty-merge early return reported success, inputs stayed unmerged —
+        // caught by the TD-RDSTRAT-8 production-trigger route proof. Non-PAX
+        // inputs fall through to the unified reader unchanged.
+        //
+        // Bytes come through the sanctioned URL→bytes boundary (#1082
+        // `read_object_bytes`), so a cloud-hosted `.pax` L0 reads through the
+        // FileSystem — never `tokio::fs::read` on a raw scheme path (the
+        // URL-string-strip class #1082 removed; would be silent data loss here
+        // since false-success compaction deletes the input segments).
+        if file_path.ends_with(proximadb_storage_common::pax_block::PAX_SEGMENT_EXT)
+            && let Ok(bytes) = crate::storage::engines::sst::staged_write::read_object_bytes(
+                &self.filesystem_factory,
+                file_path,
+            )
+            .await
+            && crate::storage::engines::sst::segment_format::SegmentFormat::detect(&bytes)
+                == crate::storage::engines::sst::segment_format::SegmentFormat::Pax
+        {
+            let records = crate::storage::engines::sst::segment_format::read_segment_records(
+                &bytes,
+                &[],
+                &[],
+                None,
+            )
+            .map_err(|e| {
+                crate::core::StorageError::SstEngine(format!(
+                    "PAX compaction read failed for {file_path}: {e}"
+                ))
+            })?;
+            info!(
+                "✅ COMPACTION UNIFIED: Read {} records from PAX segment {}",
+                records.len(),
+                file_path
+            );
+            return Ok(records.into_iter().map(VectorRecord::from).collect());
+        }
+
         // Use compaction-optimized reading strategy
         match self
             .unified_reader

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -257,6 +257,7 @@ pub fn write_pax_segment_full(
         target_block,
         cluster,
         plan,
+        None, // two-level is compaction-only (TD-RDSTRAT-8)
     )
 }
 
@@ -281,9 +282,29 @@ pub fn write_pax_segment_compacted(
     f32_tier: bool,
     target_block: Option<usize>,
 ) -> Result<SegmentMeta> {
-    let cluster = crate::storage::engines::sst::block_cluster::block_cluster_enabled();
+    use crate::storage::engines::sst::block_cluster;
+    let cluster = block_cluster::block_cluster_enabled();
+    // TD-RDSTRAT-8 rev 3 (default OFF, `PROXIMADB_IVF2=1`): compaction is the ONLY
+    // write path that emits the persisted-IVF-probe (v3) layout — production flush
+    // stays sign-bit L0 (IVF-at-flush measured ~80× flush cost, dropped), and large
+    // corpora reach v3 on their normal compaction cadence with no migration event.
+    // The probe plan persists the SAME IOP-derived PCA/IVF plan the single-level
+    // path computes (no second quantizer); it falls back to the plain single-level
+    // plan whenever the model can't be trained (fail-safe, never a worse segment).
+    let coalesced = quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled();
+    let mut probe_model = None;
     let plan = if cluster {
-        crate::storage::engines::sst::block_cluster::cluster_plan_pca_ivf(records, 0)
+        if coalesced && block_cluster::ivf_probe_enabled() {
+            match block_cluster::cluster_plan_ivf_probe(records, 0) {
+                Some(tl) => {
+                    probe_model = Some(tl.model);
+                    Some(tl.plan)
+                }
+                None => block_cluster::cluster_plan_pca_ivf(records, 0),
+            }
+        } else {
+            block_cluster::cluster_plan_pca_ivf(records, 0)
+        }
     } else {
         None
     };
@@ -298,6 +319,7 @@ pub fn write_pax_segment_compacted(
         target_block,
         cluster,
         plan,
+        probe_model,
     )
 }
 
@@ -315,6 +337,7 @@ fn write_pax_segment_ordered(
     target_block: Option<usize>,
     cluster: bool,
     plan: Option<crate::storage::engines::sst::block_cluster::ClusterPlan>,
+    two_level: Option<proximadb_storage_common::coarse_directory::CoarseModel>,
 ) -> Result<SegmentMeta> {
     let lossless_clustered = lossless_clustered_enabled() && plan.is_some();
     let lossless_scalar = lossless_scalar_enabled();
@@ -338,6 +361,12 @@ fn write_pax_segment_ordered(
     // ADR-061 pre-GA in-place amendment; `PROXIMADB_PAX_COALESCED_RABITQ=0` opts
     // out to the legacy in-block RaBitQ layout for mixed-read / measurement).
     .with_coalesced_rabitq(quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled());
+    // TD-RDSTRAT-8 rev 3: the persisted IVF probe directory (v3 layout) — the
+    // plan's runs are its IOP-derived cells, so the writer pads blocks at the
+    // same boundaries the model's cell_rows describe (a cell = whole D-blocks).
+    if let Some(model) = two_level {
+        writer = writer.with_two_level(model);
+    }
     match &plan {
         Some(plan) => {
             let mut next_run = 1usize;
@@ -909,7 +938,7 @@ pub async fn rabitq_search_segment_coalesced(
 ) -> Result<Option<Vec<CascadeHit>>> {
     use proximadb_block_format::{PaxBlockReader, RaBitQRegion, coalesced_sq8, col_id};
     use proximadb_storage_common::segment_layout::{
-        SEG_HEADER_PREFIX_LEN, SegmentFooterIndex, SegmentHeaderPrefix,
+        SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN, SegmentFooterIndex, SegmentHeaderPrefix,
     };
 
     // ADR-065 co-design diagnostic: per-GET size trace. When PROXIMADB_TRACE_GETS
@@ -934,10 +963,18 @@ pub async fn rabitq_search_segment_coalesced(
         if size < (SEG_HEADER_PREFIX_LEN as u64 + SEGMENT_MAGIC.len() as u64) {
             return Ok(None);
         }
-        fs.read_range(path, 0, SEG_HEADER_PREFIX_LEN as u64)
+        // TD-RDSTRAT-8: fetch the v3 prefix length unconditionally (clamped to
+        // file size) — the 16 extra bytes ride the same GET and cover both the
+        // v1 (56 B) and v3 (72 B) forms; `parse` branches on the version byte.
+        fs.read_range(path, 0, (SEG_HEADER_PREFIX_V3_LEN as u64).min(size))
             .await
             .map_err(|e| anyhow::anyhow!("coalesced scan header {path}: {e}"))?
     };
+    // A v3 (two-level) segment parses here too and falls through to the same
+    // single-level whole-region scan: Regions A/B are byte-identical in format
+    // (`rabitq_off/sq8_off` skip past A0), and a full scan over coarse-ordered
+    // rows is order-agnostic — correct results, v2 GET budget. The A0
+    // coarse-probe branch (nprobe-scoped sub-reads) is PR-B of TD-RDSTRAT-8.
     let header = match SegmentHeaderPrefix::parse(&header_bytes) {
         Ok(h) => h,
         Err(_) => return Ok(None), // not coalesced → don't cache
@@ -1956,5 +1993,141 @@ mod tests {
             ids(&hits2),
             "the survivor cache must not change search results"
         );
+    }
+
+    /// TD-RDSTRAT-8 PR-A (rev 3): `write_pax_segment_compacted` emits the
+    /// persisted-IVF-probe (v3) layout ONLY under `PROXIMADB_IVF2=1` (default-OFF,
+    /// compaction-only), and the current binary reads a v3 segment through the
+    /// SAME single-level scan path with full parity (correctness before the PR-B
+    /// probe reader lands): search recall holds, and `read_segment_records`
+    /// reconstructs every row WITH its Region-B vectors (the compaction/recovery
+    /// inverse — a v3 segment must never silently drop vectors when re-compacted).
+    #[tokio::test]
+    async fn ivf_probe_compaction_gate_and_v3_read_compat() {
+        enable_coalesced_rabitq();
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+        use proximadb_storage_common::coarse_directory::CoarseDirectory;
+        use proximadb_storage_common::segment_layout::{
+            SEG_LAYOUT_VERSION, SEG_LAYOUT_VERSION_TWO_LEVEL, SegmentHeaderPrefix,
+        };
+
+        const DIM: usize = 64;
+        const N: usize = 400;
+        const K: usize = 10;
+        // Small k (the shared IOP-derived override) so the tiny fixture still
+        // forms multiple cells — the natural N·dim/IOP count would be ~2 here.
+        unsafe {
+            std::env::set_var("PROXIMADB_IVF2", "1");
+            std::env::set_var("PROXIMADB_IVF_K", "4");
+        }
+
+        let corpus: Vec<Vec<f32>> = (0..N)
+            .map(|i| {
+                (0..DIM)
+                    .map(|d| (((i * 131 + d * 17) % 251) as f32) * 0.01)
+                    .collect()
+            })
+            .collect();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| rec(&format!("r{i}"), 1000 + i as i64, v.clone()))
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+
+        // Flag ON ⇒ compaction writes v3 (header + A0 + footer mirror agree).
+        let v3_path = dir.path().join("v3.pax");
+        write_pax_segment_compacted(
+            &v3_path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        let v3_bytes = std::fs::read(&v3_path).unwrap();
+        let h = SegmentHeaderPrefix::parse(&v3_bytes).unwrap();
+        assert_eq!(
+            h.layout_version, SEG_LAYOUT_VERSION_TWO_LEVEL,
+            "PROXIMADB_IVF2=1 compaction must emit the v3 layout"
+        );
+        let a0 =
+            CoarseDirectory::parse(&v3_bytes[h.a0_off as usize..(h.a0_off + h.a0_len) as usize])
+                .expect("Region A0 parses from the compacted segment");
+        assert_eq!(a0.model.rows_covered(), N as u64);
+        assert_eq!(a0.model.dim as usize, DIM);
+
+        // Flag OFF ⇒ same records compact to the v1 (single-level) layout.
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF2");
+        }
+        let v1_path = dir.path().join("v1.pax");
+        write_pax_segment_compacted(
+            &v1_path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        let h1 = SegmentHeaderPrefix::parse(&std::fs::read(&v1_path).unwrap()).unwrap();
+        assert_eq!(
+            h1.layout_version, SEG_LAYOUT_VERSION,
+            "without PROXIMADB_IVF2 the compaction layout is unchanged (v1)"
+        );
+
+        // v3 read-compat: the coalesced cascade searches the v3 segment with
+        // brute-force-level recall (single-level full scan until PR-B).
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let query = corpus[137].clone();
+        let hits = rabitq_search_segment_coalesced(
+            &fs,
+            v3_path.to_str().unwrap(),
+            &query,
+            K,
+            RankMetric::L2,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("v3 segment must be searchable by the current binary");
+        assert_eq!(hits[0].oid, "r137", "nearest neighbour on the v3 layout");
+        let l2 =
+            |a: &[f32], b: &[f32]| a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum::<f32>();
+        let mut idx: Vec<usize> = (0..N).collect();
+        idx.sort_by(|&a, &b| {
+            l2(&corpus[a], &query)
+                .partial_cmp(&l2(&corpus[b], &query))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let truth: std::collections::HashSet<String> =
+            idx.iter().take(K).map(|i| format!("r{i}")).collect();
+        let got: std::collections::HashSet<String> = hits.iter().map(|h| h.oid.clone()).collect();
+        let recall = truth.iter().filter(|o| got.contains(*o)).count() as f32 / K as f32;
+        assert!(recall >= 0.90, "v3 read-compat recall@{K} = {recall:.2}");
+
+        // Compaction/recovery inverse: every row reads back WITH its vector
+        // (Region-B overlay must work through the v3 prefix).
+        let recs = read_segment_records(&v3_bytes, &[], &[], None).unwrap();
+        assert_eq!(recs.len(), N);
+        assert!(
+            recs.iter().all(|r| r
+                .embeddings
+                .first()
+                .is_some_and(|e| !e.as_fp32_slice().is_empty())),
+            "v3 read_segment_records must reconstruct vectors (never drop Region B)"
+        );
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF_K");
+        }
     }
 }

--- a/tests/sst_ivf2_compaction_route_proof_test.rs
+++ b/tests/sst_ivf2_compaction_route_proof_test.rs
@@ -1,0 +1,287 @@
+//! TD-RDSTRAT-8 PR-A route proof: the PRODUCTION compaction trigger emits the
+//! persisted-IVF-probe (v3) layout under `PROXIMADB_IVF2=1` — and only then.
+//!
+//! The SIFT recall harness drives flush only, and v3 is written exclusively by
+//! `write_pax_segment_compacted`, so without this gate the v3 emission path
+//! would be reachable in production yet never exercised by any test that goes
+//! through the real trigger. This test mirrors the TD-WLP-7 execution gate
+//! (`sst_compaction_execution_test.rs`): flush an armed AppendBulk collection
+//! past its L0 threshold so compaction runs INLINE on the flush path (no
+//! manual compaction call), then proves the compacted product on disk carries
+//! `layout_version=3` + a parsable Region A0, and that the production search
+//! path still returns exact top-k over it (v3 reads as a single-level full
+//! scan until the PR-B probe reader lands).
+//!
+//! Env-scoped (nextest process-per-test isolation): the flag-off control runs
+//! as its own test/process and must produce NO v3 segment.
+
+use anyhow::Result;
+use proximadb::compute::distance_computation::DistanceMetric;
+use proximadb::core::search::{BlockPruneConfig, BlockPruneMode, SearchParams};
+use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::traits::{
+    FlushParameters, FlushResult, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
+};
+use proximadb_proto::v1::{Collection, CollectionConfig, StorageAssignment, StorageEngine};
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
+use proximadb_storage_common::coarse_directory::CoarseDirectory;
+use proximadb_storage_common::segment_layout::{
+    SEG_LAYOUT_VERSION_TWO_LEVEL, SegmentHeaderPrefix, is_coalesced_segment,
+};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const DIM: usize = 8;
+/// Per-flush batch size — two batches merge to 128 rows at compaction, above
+/// the 64-usable-row training floor so the IVF probe model actually trains.
+const BATCH: usize = 64;
+const TOP_K: usize = 5;
+
+fn vector_for(row: usize) -> Vec<f32> {
+    // Deterministic xorshift per row — distinct, well-spread vectors so the
+    // top-1 self-match assertion is tie-free.
+    let mut s = (row as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    (0..DIM)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            (s >> 11) as f32 / (1u64 << 53) as f32
+        })
+        .collect()
+}
+
+fn record(row: usize) -> ProximaRecord {
+    ProximaRecord {
+        oid: format!("v{row:04}"),
+        created_at_ns: 1_000 + row as i64,
+        updated_at_ns: 1_000 + row as i64,
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "test".into(),
+            modality: "dense_vector".into(),
+            dim: DIM as u32,
+            values: EmbeddingValues::Fp32(vector_for(row)),
+            ..Default::default()
+        }],
+        ..ProximaRecord::default()
+    }
+}
+
+fn collection(id: &str, base_location: &str) -> Collection {
+    Collection {
+        id: id.to_string(),
+        config: Some(CollectionConfig {
+            name: id.to_string(),
+            dimension: DIM as u32,
+            distance_metric: Some(DistanceMetric::Euclidean as i32),
+            storage_engine: Some(StorageEngine::Sst as i32),
+            // Armed AppendBulk with a tiny threshold: the second flush crosses
+            // L0 >= 2 and executes compaction inline (the production trigger).
+            tags: vec!["workload_profile:append".into(), "l0_threshold:2".into()],
+            ..Default::default()
+        }),
+        storage_assignment: Some(StorageAssignment {
+            base_location: base_location.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+async fn flush_batch(
+    engine: &SstEngine,
+    coll: &Collection,
+    rows: std::ops::Range<usize>,
+) -> Result<FlushResult> {
+    let params = FlushParameters {
+        collection_id: Some(coll.id.clone()),
+        vector_records: rows.map(record).collect(),
+        force: true,
+        synchronous: true,
+        collection_config: Some(coll.clone()),
+        ..Default::default()
+    };
+    engine.do_flush(&params).await
+}
+
+fn compaction_ran(result: &FlushResult) -> bool {
+    result
+        .engine_metrics
+        .get("compaction_ran")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Every `.pax` segment under `dir`, recursively.
+fn pax_segments(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|e| e == "pax") {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// Layout versions of every coalesced `.pax` segment under `dir`.
+fn coalesced_versions(dir: &Path) -> Vec<(PathBuf, u8)> {
+    pax_segments(dir)
+        .into_iter()
+        .filter_map(|p| {
+            let bytes = std::fs::read(&p).ok()?;
+            if !is_coalesced_segment(&bytes) {
+                return None;
+            }
+            let h = SegmentHeaderPrefix::parse(&bytes).ok()?;
+            Some((p, h.layout_version))
+        })
+        .collect()
+}
+
+async fn search_ids(engine: &SstEngine, coll: &Collection, query: Vec<f32>) -> Vec<String> {
+    let ctx = StorageQueryContext {
+        search_params: Arc::new(SearchParams {
+            query_vectors: Some(vec![query]),
+            top_k: Some(TOP_K),
+            distance_metric: Some(DistanceMetric::Euclidean),
+            block_prune: BlockPruneConfig {
+                radius_k: 0.0,
+                force_exact: false,
+                mode: BlockPruneMode::Ratio,
+                ratio: 1.0,
+                min_keep: 1,
+                max_keep: 0,
+                min_blocks_override: Some(0),
+            },
+            ..Default::default()
+        }),
+        collection: Arc::new(coll.clone()),
+        metadata: StorageQueryMetadata {
+            collection_id: coll.id.clone(),
+            ..Default::default()
+        },
+        user_context: None,
+        tenant_context: None,
+    };
+    engine
+        .search_vectors_unified(&ctx)
+        .await
+        .expect("search succeeds")
+        .into_iter()
+        .map(|r| r.id)
+        .collect()
+}
+
+/// Shared flow: flush twice (crossing L0 >= 2 arms + runs compaction inline),
+/// return the collection dir + engine + collection for assertions.
+async fn flush_to_compaction(id: &str) -> Result<(tempfile::TempDir, SstEngine, Collection)> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    unsafe {
+        std::env::remove_var("PROXIMADB_L0_COMPACTION_ENABLED");
+        std::env::remove_var("PROXIMADB_STORAGE_PROFILE");
+        // Flush writes `.pax` + RaBitQ so compaction re-emits the coalesced
+        // layout (the substrate v3 extends).
+        std::env::set_var("PROXIMADB_PAX_VECTOR_SEGMENTS", "1");
+        std::env::set_var("PROXIMADB_PAX_VECTOR_QUANT", "rabitq");
+        // Small cell count for the 128-row fixture (the shared IOP-derived
+        // override; the natural N·dim/IOP count is ~2 here — legal but coarse).
+        std::env::set_var("PROXIMADB_IVF_K", "4");
+    }
+    let engine = SstEngine::new().await?;
+    let dir = tempfile::tempdir()?;
+    let coll = collection(id, dir.path().to_str().expect("utf8 tempdir"));
+
+    let first = flush_batch(&engine, &coll, 0..BATCH).await?;
+    assert!(
+        first.success && !compaction_ran(&first),
+        "no compaction at L0=1"
+    );
+    let second = flush_batch(&engine, &coll, BATCH..2 * BATCH).await?;
+    assert!(second.success, "second flush must succeed");
+    assert!(
+        compaction_ran(&second),
+        "the armed compaction must execute inline (compaction_error: {:?})",
+        second.compaction_error
+    );
+    Ok((dir, engine, coll))
+}
+
+/// `PROXIMADB_IVF2=1`: the production compaction product is a v3 segment with
+/// a parsable Region A0, and production search over it stays exact.
+#[tokio::test]
+async fn test_ivf2_compaction_route_emits_v3_and_searches() -> Result<()> {
+    unsafe {
+        std::env::set_var("PROXIMADB_IVF2", "1");
+    }
+    let (dir, engine, coll) = flush_to_compaction("ivf2_route_on").await?;
+
+    let versions = coalesced_versions(dir.path());
+    assert!(
+        !versions.is_empty(),
+        "compaction must leave coalesced .pax segments under {:?}",
+        dir.path()
+    );
+    let v3: Vec<_> = versions
+        .iter()
+        .filter(|(_, v)| *v == SEG_LAYOUT_VERSION_TWO_LEVEL)
+        .collect();
+    assert!(
+        !v3.is_empty(),
+        "PROXIMADB_IVF2=1: the compacted product must carry layout_version=3 \
+         (found versions: {versions:?})"
+    );
+    // The v3 segment's Region A0 parses and covers the merged corpus.
+    let (v3_path, _) = v3[0];
+    let bytes = std::fs::read(v3_path)?;
+    let h = SegmentHeaderPrefix::parse(&bytes)?;
+    let a0 = CoarseDirectory::parse(&bytes[h.a0_off as usize..(h.a0_off + h.a0_len) as usize])?;
+    assert_eq!(
+        a0.model.rows_covered(),
+        (2 * BATCH) as u64,
+        "A0 cells must cover every merged row"
+    );
+
+    // Production search over the v3 product: the query vector's own id is the
+    // top hit (exact self-match; v3 reads as a single-level scan until PR-B).
+    let ids = search_ids(&engine, &coll, vector_for(17)).await;
+    assert_eq!(
+        ids.first().map(String::as_str),
+        Some("v0017"),
+        "top-1 self-match over the compacted v3 segment (got {ids:?})"
+    );
+    Ok(())
+}
+
+/// Flag-off control (own process under nextest): the same production trigger
+/// leaves every segment at layout v1 — v3 is strictly opt-in.
+#[tokio::test]
+async fn test_ivf2_off_compaction_route_stays_v1() -> Result<()> {
+    unsafe {
+        std::env::remove_var("PROXIMADB_IVF2");
+    }
+    let (dir, engine, coll) = flush_to_compaction("ivf2_route_off").await?;
+
+    let versions = coalesced_versions(dir.path());
+    assert!(!versions.is_empty(), "compaction must leave coalesced .pax");
+    assert!(
+        versions
+            .iter()
+            .all(|(_, v)| *v != SEG_LAYOUT_VERSION_TWO_LEVEL),
+        "without PROXIMADB_IVF2 no v3 segment may exist (found: {versions:?})"
+    );
+    let ids = search_ids(&engine, &coll, vector_for(17)).await;
+    assert_eq!(ids.first().map(String::as_str), Some("v0017"));
+    Ok(())
+}


### PR DESCRIPTION
## TD-RDSTRAT-8 PR-A — persisted IVF probe (v3) segment layout

Breaks the `GETs ∝ N` / whole-region-scan-bytes wall the single-level IVF layout hits at scale (~5–10M vectors) by persisting the compaction IVF plan as a **query-visible probe directory (Region A0)** — a new segment `layout_version=3`. **Default-OFF (`PROXIMADB_IVF2=0`), compaction-only, mixed-read-safe.**

### Design — reconciled to the merged rev-3 (#1089)
An earlier cut of this work trained a fresh **√N coarse k-means** on top of the fine cells. The merged rev-3 first-principles reconciliation rejected that (`sqrt(N)` fragments Region B into sub-IOP runs and buys nothing — ranking the `k` IOP-derived centroids in RAM already breaks `GETs ∝ N`). This PR implements rev-3:

- **`cluster_plan_ivf_probe`** persists the *same* IOP-derived PCA/IVF plan `cluster_plan_pca_ivf` already computes (`k ≈ N·dim/IOP`, `ivf_projection_dims` law, `PROXIMADB_IVF_TRAIN_SAMPLE`, shared seed, 15 iters) into Region A0 — **no second quantizer**.
- Shared row ordering extracted into `order_rows_by_cell`, so the single-level (`PXH1`) path stays **byte-identical** (proven by `sst_compaction_reclustering_test`).
- No new `√N` env surface — the probe reuses the single-level `PROXIMADB_IVF_K` knob. `PROXIMADB_IVF2` (gate) is the only new env.

### Layout (post-#1069 single-v1 footer)
- `layout_version=3` lives in the **header-prefix** (`SegmentHeaderPrefix`, 72 B), **not** a footer v2/v3 — the footer stays single-v1 with an **additive** `SECTION_COARSE_DIRECTORY` section (sectionless footer byte-identical). `PXA0`-magic A0 serde with FNV-1a checksum; exact `serialized_len` so the writer computes all offsets in one pass.
- **Write/read projection consistency:** the PCA model is truncated to persisted f32 precision *before* assignment; write and query share `project_with_model`. Vectors stay f32 end-to-end — only dot-product accumulators widen transiently to f64.

### Scope: write + read-compat here, probe reader in PR-B
The current binary parses v3 and serves it through the existing **order-agnostic single-level scan** (correct results at pre-v3 GET cost) until PR-B lands the A0 coarse probe. `read_segment_records` reconstructs v3 (incl. the Region-B overlay), so re-compaction/recovery never drops vectors; v1-only readers reject v3 at the prefix version check (fail-closed).

### Also: silent-no-op compaction fix
Armed compaction of coalesced `.pax` collected **0 records** (the unified reader predated the coalesced layout) and reported success with inputs unmerged — a real correctness bug the route-proof caught. Now routed through the canonical `read_segment_records` inverse via the sanctioned `read_object_bytes` boundary (#1082 URL→bytes contract; never a raw-scheme `fs::read`).

### Eval realization (per the co-design mandate)
The SIFT recall harness drives flush-only and v3 is compaction-only, so a **production-trigger route proof** (`tests/sst_ivf2_compaction_route_proof_test.rs`, mirrors the TD-WLP-7 execution gate) proves an armed AppendBulk flush past L0 emits a v3 segment with a parsable A0 covering every merged row, exact search over it, and a flag-off control that stays v1. The **≤ N-GET recall ratchet is deferred to PR-B** (the probe reader doesn't exist yet) and wires into the qa-gate MEDIUM tier.

### Verification (on the rebased develop base)
- `cargo fmt --check`, `clippy --lib --bins -D warnings`, `check-fast` (all targets) — clean
- Lib: `cluster_plan_ivf_probe_...`, `ivf_probe_compaction_gate_and_v3_read_compat`
- Integration: route-proof ×2, `sst_compaction_reclustering_test` ×2 (v2 byte-stability), `sst_compaction_execution_test` ×2 (silent-no-op fix)

Refs TD-RDSTRAT-8 (rev 3.1), ADR-061 (mixed-read), ADR-065 (regions), #1069 (single-v1 footer), #1082 (URL→bytes boundary).
