### PR TITLE
test(objstore): write_if_absent conformance gate — backends + decorators (TD-OBJSTORE-4)

### DIFF
--- a/src/storage/encryption_filesystem_tests.rs
+++ b/src/storage/encryption_filesystem_tests.rs
@@ -50,6 +50,43 @@ async fn test_encrypted_filesystem_round_trip() {
     assert_eq!(fs.read_range(&logical_path, 1, 6).await.unwrap(), b"ecret-");
 }
 
+/// TD-OBJSTORE-4 S2/S3: the encryption decorator MUST delegate `write_if_absent`
+/// to the backend's atomic conditional-create — not emulate it with an overwriting
+/// `write`. The recovery commit primitive rests on this: a wrapper that clobbered
+/// would let a crash-window re-replay silently overwrite a committed segment.
+#[tokio::test]
+async fn write_if_absent_delegates_through_encryption_wrapper() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = LocalConfig {
+        root_dir: Some(temp_dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let underlying: Arc<dyn FileSystem> = Arc::new(LocalFileSystem::new(config).await.unwrap());
+    let fs = EncryptedFilesystem::new(underlying, test_key_manager(13), true);
+
+    let logical_path = temp_dir.path().join("commit.pax");
+    let logical_path = logical_path.to_string_lossy().to_string();
+
+    fs.write_if_absent(&logical_path, b"first", None)
+        .await
+        .expect("first conditional create succeeds");
+
+    let err = fs
+        .write_if_absent(&logical_path, b"second", None)
+        .await
+        .expect_err("second conditional create on the same key must fail");
+    assert!(
+        matches!(err, FilesystemError::AlreadyExists(_)),
+        "encryption wrapper must surface the backend's AlreadyExists; got {err:?}"
+    );
+
+    assert_eq!(
+        fs.read(&logical_path).await.expect("read back decrypts"),
+        b"first",
+        "first value must survive the rejected second create through encryption"
+    );
+}
+
 #[tokio::test]
 async fn test_encrypted_filesystem_reads_plaintext_files() {
     let temp_dir = TempDir::new().unwrap();

--- a/src/storage/persistence/filesystem/caching_filesystem.rs
+++ b/src/storage/persistence/filesystem/caching_filesystem.rs
@@ -708,6 +708,36 @@ mod tests {
         )
     }
 
+    /// TD-OBJSTORE-4 S2/S3: the caching decorator MUST delegate `write_if_absent`
+    /// to the underlying backend's atomic conditional-create, not emulate it with an
+    /// overwriting `write` — the crash-window recovery commit primitive rests on it.
+    #[tokio::test]
+    async fn write_if_absent_delegates_through_caching_wrapper() {
+        let (fs, _temp_dir) = test_caching_fs().await;
+
+        fs.write_if_absent("commit.pax", b"first", None)
+            .await
+            .expect("first conditional create succeeds");
+
+        let err = fs
+            .write_if_absent("commit.pax", b"second", None)
+            .await
+            .expect_err("second conditional create on the same key must fail");
+        assert!(
+            matches!(
+                err,
+                crate::storage::persistence::filesystem::FilesystemError::AlreadyExists(_)
+            ),
+            "caching wrapper must surface the backend's AlreadyExists; got {err:?}"
+        );
+
+        assert_eq!(
+            fs.read("commit.pax").await.expect("read back"),
+            b"first",
+            "first value must be preserved (no clobber) through the caching wrapper"
+        );
+    }
+
     #[tokio::test]
     async fn read_range_records_access_for_pattern_learning() {
         let (fs, _temp_dir) = test_caching_fs().await;

--- a/tests/objstore_backend_contract_test.rs
+++ b/tests/objstore_backend_contract_test.rs
@@ -154,7 +154,15 @@ async fn gcs_multi_page_list_returns_all_objects_best_effort() {
 /// after a crash would greenwash a duplicate commit over the real one. This pins the
 /// exact put-if-absent semantics per cloud backend (S3 `PutMode::Create`, Azure
 /// `PutMode::Create`, GCS `if_generation_match=0`).
-async fn contract_write_if_absent_semantics(base: &str) {
+///
+/// `strict` gates the collision assertion. Azurite and MinIO enforce put-if-absent,
+/// so Azure/S3 assert it as a hard gate. fake-gcs, however, does NOT enforce
+/// `ifGenerationMatch=0` (a documented emulator gap — our backend sets the
+/// precondition and maps 409/412 to `AlreadyExists`, see `gcs_store.rs`), so the GCS
+/// tier runs best-effort: it warns rather than fails when the emulator lets the
+/// colliding create through. Real-GCS put-if-absent conformance is validated in the
+/// nightly tier (TD-OBJSTORE-5), never against fake-gcs.
+async fn contract_write_if_absent_semantics(base: &str, strict: bool) {
     let run = uuid::Uuid::new_v4().simple().to_string();
     let key = format!("{base}/contract-cas/{run}/L0_recovery.pax");
 
@@ -167,21 +175,29 @@ async fn contract_write_if_absent_semantics(base: &str) {
         .expect("first conditional create must succeed");
 
     // Second conditional create on the same key must be rejected, not overwrite.
-    let err = fs
-        .write_if_absent(&key, b"second-commit", None)
-        .await
-        .expect_err("second conditional create on the same key must fail");
-    assert!(
-        matches!(err, FilesystemError::AlreadyExists(_)),
-        "backend must reject the colliding create with AlreadyExists; got {err:?}"
-    );
-
-    // The first-committed bytes must survive the rejected create (no clobber).
-    assert_eq!(
-        fs.read(&key).await.expect("read back the committed object"),
-        b"first-commit",
-        "first-committed bytes must survive the rejected second create"
-    );
+    match fs.write_if_absent(&key, b"second-commit", None).await {
+        // Conformant: the first-committed bytes must survive the rejected create.
+        Err(FilesystemError::AlreadyExists(_)) => {
+            assert_eq!(
+                fs.read(&key).await.expect("read back the committed object"),
+                b"first-commit",
+                "first-committed bytes must survive the rejected second create"
+            );
+        }
+        // Best-effort tier (GCS/fake-gcs): the emulator did not enforce the
+        // precondition. Our backend sets `ifGenerationMatch=0`; warn, do not gate.
+        Ok(()) if !strict => {
+            eprintln!(
+                "::warning:: {base}: emulator did not enforce put-if-absent on \
+                 write_if_absent (fake-gcs lacks ifGenerationMatch=0 enforcement); \
+                 backend sets the precondition — real-backend conformance runs in the \
+                 nightly tier"
+            );
+        }
+        other => {
+            panic!("backend must reject the colliding create with AlreadyExists; got {other:?}")
+        }
+    }
 
     let _ = fs.delete(&key).await;
 }
@@ -193,7 +209,7 @@ async fn azure_write_if_absent_contract() {
         eprintln!("skip: set AZURE_STORAGE_USE_EMULATOR=true with Azurite running");
         return;
     }
-    contract_write_if_absent_semantics("az://proximadb-test").await;
+    contract_write_if_absent_semantics("az://proximadb-test", true).await;
 }
 
 #[tokio::test]
@@ -203,7 +219,7 @@ async fn s3_write_if_absent_contract() {
         eprintln!("skip: set AWS_ENDPOINT (MinIO) to run");
         return;
     }
-    contract_write_if_absent_semantics("s3://proximadb-test").await;
+    contract_write_if_absent_semantics("s3://proximadb-test", true).await;
 }
 
 // GCS is best-effort (documented fake-gcs/object_store incompatibilities; never a
@@ -221,5 +237,5 @@ async fn gcs_write_if_absent_contract_best_effort() {
         eprintln!("::warning:: GCS backend did not register (best-effort tier) — skipping");
         return;
     }
-    contract_write_if_absent_semantics("gs://proximadb-test").await;
+    contract_write_if_absent_semantics("gs://proximadb-test", false).await;
 }

--- a/tests/objstore_backend_contract_test.rs
+++ b/tests/objstore_backend_contract_test.rs
@@ -16,7 +16,9 @@
 
 use std::sync::Arc;
 
-use proximadb::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+use proximadb::storage::persistence::filesystem::{
+    FilesystemConfig, FilesystemError, FilesystemFactory,
+};
 
 async fn factory() -> Arc<FilesystemFactory> {
     Arc::new(
@@ -143,4 +145,81 @@ async fn gcs_multi_page_list_returns_all_objects_best_effort() {
     for i in 0..5 {
         let _ = fs.delete(&format!("{prefix}/obj-{i}.bin")).await;
     }
+}
+
+/// `write_if_absent` is the recovery COMMIT primitive (ADR-063 D4/D5, TD-OBJSTORE-4
+/// S2/S3): the first create wins, and a second create on the SAME key must fail
+/// `AlreadyExists` WITHOUT clobbering the committed bytes. A backend that silently
+/// overwrote would make crash-window materialization non-idempotent — a re-replay
+/// after a crash would greenwash a duplicate commit over the real one. This pins the
+/// exact put-if-absent semantics per cloud backend (S3 `PutMode::Create`, Azure
+/// `PutMode::Create`, GCS `if_generation_match=0`).
+async fn contract_write_if_absent_semantics(base: &str) {
+    let run = uuid::Uuid::new_v4().simple().to_string();
+    let key = format!("{base}/contract-cas/{run}/L0_recovery.pax");
+
+    let factory = factory().await;
+    let fs = factory.get_filesystem(&key).expect("backend for key");
+
+    // First conditional create commits the object.
+    fs.write_if_absent(&key, b"first-commit", None)
+        .await
+        .expect("first conditional create must succeed");
+
+    // Second conditional create on the same key must be rejected, not overwrite.
+    let err = fs
+        .write_if_absent(&key, b"second-commit", None)
+        .await
+        .expect_err("second conditional create on the same key must fail");
+    assert!(
+        matches!(err, FilesystemError::AlreadyExists(_)),
+        "backend must reject the colliding create with AlreadyExists; got {err:?}"
+    );
+
+    // The first-committed bytes must survive the rejected create (no clobber).
+    assert_eq!(
+        fs.read(&key).await.expect("read back the committed object"),
+        b"first-commit",
+        "first-committed bytes must survive the rejected second create"
+    );
+
+    let _ = fs.delete(&key).await;
+}
+
+#[tokio::test]
+#[ignore = "needs Azurite — set AZURE_STORAGE_USE_EMULATOR=true with Azurite running"]
+async fn azure_write_if_absent_contract() {
+    if std::env::var("AZURE_STORAGE_USE_EMULATOR").is_err() {
+        eprintln!("skip: set AZURE_STORAGE_USE_EMULATOR=true with Azurite running");
+        return;
+    }
+    contract_write_if_absent_semantics("az://proximadb-test").await;
+}
+
+#[tokio::test]
+#[ignore = "needs MinIO — set AWS_ENDPOINT to the emulator"]
+async fn s3_write_if_absent_contract() {
+    if std::env::var("AWS_ENDPOINT").is_err() {
+        eprintln!("skip: set AWS_ENDPOINT (MinIO) to run");
+        return;
+    }
+    contract_write_if_absent_semantics("s3://proximadb-test").await;
+}
+
+// GCS is best-effort (documented fake-gcs/object_store incompatibilities; never a
+// gate — TD-OBJSTORE-5 nightly tier). If the backend does not register against
+// fake-gcs, warn and pass rather than block.
+#[tokio::test]
+#[ignore = "needs fake-gcs — set PROXIMADB_GCS_ENDPOINT + PROXIMADB_GCS_ANONYMOUS=1"]
+async fn gcs_write_if_absent_contract_best_effort() {
+    if std::env::var("PROXIMADB_GCS_ENDPOINT").is_err() {
+        eprintln!("skip: set PROXIMADB_GCS_ENDPOINT (fake-gcs) to run");
+        return;
+    }
+    let factory = factory().await;
+    if factory.get_filesystem("gs://proximadb-test/probe").is_err() {
+        eprintln!("::warning:: GCS backend did not register (best-effort tier) — skipping");
+        return;
+    }
+    contract_write_if_absent_semantics("gs://proximadb-test").await;
 }


### PR DESCRIPTION
## What

Adds the **`write_if_absent` conformance gate** for TD-OBJSTORE-4 — the missing test coverage for the recovery **commit primitive** (ADR-063 D4/D5, TD-OBJSTORE-4 S2/S3).

`write_if_absent` guarantees first-create-wins: a colliding create on the same key must fail `AlreadyExists` **without clobbering** the committed bytes. It was already implemented across every backend + the caching/encryption decorators, but only unit-tested on the **local** backend — untested on the cloud backends and, critically, **through the decorators**, where a silent fall-back to overwriting `write()` would break crash-window materialization idempotency (S2 put-if-absent create + S3 `AlreadyExists` digest-verify both rest on it).

## Changes (test-only — no production code)

- **Local decorator guards** (run every PR, no emulator) — assert the **caching** and **encryption** wrappers delegate `write_if_absent` to the backend's atomic create and preserve the first value on collision:
  - `caching_filesystem::tests::write_if_absent_delegates_through_caching_wrapper`
  - `encryption_filesystem_tests::write_if_absent_delegates_through_encryption_wrapper`
- **Cloud raw-backend conformance** extending `tests/objstore_backend_contract_test.rs` (Azure/S3 strict, GCS best-effort) — auto-run by `run_cloud_emulator_tests.sh --restart/--qa`; the **Azurite PR-tier gate** exercises `azure_write_if_absent_contract` on this PR.

## Honest result

Both local decorator guards are **GREEN** — the wrappers already delegate correctly, so they land as **regression guards** (no bug found). The value is locking the behavior so a future refactor that swaps a decorator's `write_if_absent` for an overwriting `write` fails CI immediately.

## Scope

Closes the `write_if_absent` slice of the TD-OBJSTORE-4 gate spec (conformance + backend contract tests, gate lines 143–144 / 149–150). Follow-ups (separate PRs): double-replay crash-window idempotency e2e (S3), recovery-compaction-suppression test (S3). S6 semantic-orphan detector stays deferred (spec-acceptable pre-GA).

Verified locally: `fmt --check` clean; targeted clippy on the integration test clean; the 3 local `write_if_absent` tests pass (`3 passed`); cloud tests compile + skip cleanly without emulators.