### PR TITLE
fix(storage): #1126 — manifest drain barrier + coverage-aware AXIS rebuild

### DIFF
--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -489,12 +489,34 @@ impl SstEngine {
         let Some(axis) = self.axis_manager() else {
             return;
         };
-        // Already present in the AXIS store (warm / cold-loaded / rebuilt)?
+        // Already COVERED by the AXIS store (warm / cold-loaded / rebuilt)?
         // Nothing to do. (We key on the store rather than HNSW/IVF presence,
         // since those structures are built lazily and aren't a reliable signal
         // for small collections.)
-        if axis.registered_vector_count(collection_id).await > 0 {
-            return;
+        //
+        // Issue #1126 (L3): a bare `> 0` check here conflated "warm" with
+        // "has ANY vectors". WAL replay after a restart seeds the AXIS store
+        // with just the replayed records, which skipped this rebuild and made
+        // the orchestrated cold search return ONLY that subset — flushed-SST
+        // records were invisible to search while GET-by-id still found them.
+        // Rebuild whenever the durable segments hold more records than the
+        // store; when the durable total is uncountable (unknown format),
+        // rebuild anyway — an extra rebuild is cheap, invisible data is not.
+        let registered = axis.registered_vector_count(collection_id).await;
+        if registered > 0 {
+            let covered = match self.discover_sstable_files(storage_url).await {
+                Ok(files) if !files.is_empty() => {
+                    match self.durable_vector_count_for_rebuild(&files).await {
+                        Some(durable) => registered as u64 >= durable,
+                        None => false, // unknown → rebuild
+                    }
+                }
+                // No durable segments (or unlistable): nothing to rebuild from.
+                _ => true,
+            };
+            if covered {
+                return;
+            }
         }
         // Attempt at most one rebuild per collection concurrently. Attempts are
         // not sticky; the permit drop removes them so a later query can retry
@@ -578,6 +600,44 @@ impl SstEngine {
     /// segment (RawF32/SQ8/RaBitQ-with-tier) returns `false` (→ rebuild).
     /// Short-circuits on the first non-coarse segment. `files` is non-empty when
     /// called from the rebuild path.
+    /// Issue #1126 (L3): total record count across a collection's durable
+    /// segments, for the AXIS rebuild coverage check ONLY. `Some(total)` when
+    /// every file is countable (`SST1` header or `.pax` block scan);
+    /// `None` when any file is an unknown/uncountable format — the caller then
+    /// errs toward rebuilding. Kept separate from the TD-165
+    /// `segment_vector_count` gate, whose 0-on-unknown semantics ("fall through
+    /// to the approximate path") must not change.
+    async fn durable_vector_count_for_rebuild(&self, files: &[String]) -> Option<u64> {
+        use crate::storage::engines::sst::SstableHeader;
+        let mut total: u64 = 0;
+        for file_path in files {
+            let fs = self.filesystem().get_filesystem(file_path).ok()?;
+            if file_path.ends_with(".pax") {
+                // Segments are the flush unit and small relative to query cost;
+                // a full read + index parse is the same cost class as the
+                // coarse-RaBitQ probe below.
+                let bytes = fs.read(file_path).await.ok()?;
+                use proximadb_storage_common::pax_block::{PaxSegmentScanner, ScanPredicate};
+                let mut scanner =
+                    PaxSegmentScanner::from_bytes(bytes, ScanPredicate::default()).ok()?;
+                while let Some(block) = scanner.next_block() {
+                    total += block.row_count() as u64;
+                }
+            } else {
+                let prefix = fs.read_range(file_path, 0, 8).await.ok()?;
+                if prefix.len() < 8 || &prefix[0..4] != b"SST1" {
+                    return None; // unknown format (e.g. .arrow) → rebuild
+                }
+                let header_len =
+                    u32::from_le_bytes([prefix[4], prefix[5], prefix[6], prefix[7]]) as u64;
+                let header_data = fs.read_range(file_path, 8, header_len).await.ok()?;
+                let header = bincode::deserialize::<SstableHeader>(&header_data).ok()?;
+                total += header.entry_count;
+            }
+        }
+        Some(total)
+    }
+
     async fn all_segments_coarse_rabitq_pax_without_f32_tier(&self, files: &[String]) -> bool {
         use crate::storage::engines::sst::segment_format::pax_segment_is_coarse_rabitq_without_f32_tier;
         for file in files {
@@ -1031,7 +1091,14 @@ impl SstEngine {
                     )
                     .await
                 {
-                    Ok(Some(records)) => Some(records),
+                    Ok(Some(records)) => {
+                        debug!(
+                            file = %sstable_path,
+                            n = records.len(),
+                            "SST per-file result source=pax_cascade"
+                        );
+                        Some(records)
+                    }
                     Ok(None) => None,
                     Err(e) => {
                         warn!(
@@ -1144,10 +1211,10 @@ impl SstEngine {
 
             match search_result {
                 Ok(results) => {
-                    trace!(
-                        "SST: Found {} candidates in file {}",
-                        results.len(),
-                        file_idx + 1
+                    debug!(
+                        file = %sstable_path,
+                        n = results.len(),
+                        "SST per-file result (post-dispatch)"
                     );
                     all_candidates.extend(results);
                 }

--- a/src/storage/persistence/write_ahead_log/manifest/service.rs
+++ b/src/storage/persistence/write_ahead_log/manifest/service.rs
@@ -50,12 +50,23 @@ impl Default for GlobalManifestServiceConfig {
     }
 }
 
-/// Request to append a manifest entry
+/// Request sent to the background manifest worker.
+///
+/// Issue #1126 (L1): the worker batches appends (write-behind), so readers of
+/// `entries` could race in-flight appends — a shutdown flush inside the
+/// batching window under-marked the freshest batch, leaving live WAL files
+/// that the next boot re-materialized as duplicate `L0_recovery_*` segments.
+/// `Barrier` lets a caller force the worker to drain its pending batch and
+/// ack, making "append happened-before lookup" enforceable.
 #[derive(Debug)]
-struct AppendRequest {
-    entry: GlobalManifestEntry,
-    /// Optional response channel for synchronous append
-    response: Option<tokio::sync::oneshot::Sender<Result<()>>>,
+enum AppendRequest {
+    Append {
+        entry: GlobalManifestEntry,
+        /// Optional response channel for synchronous append
+        response: Option<tokio::sync::oneshot::Sender<Result<()>>>,
+    },
+    /// Flush the worker's pending batch, then ack. Never enters the batch.
+    Barrier(tokio::sync::oneshot::Sender<()>),
 }
 
 /// Global manifest service - centralized singleton for all collections
@@ -140,13 +151,26 @@ impl GlobalManifestService {
                 tokio::select! {
                     // Receive append requests
                     Some(request) = append_rx.recv() => {
-                        pending_batch.push(request);
-
-                        // Force write if batch is full
-                        if pending_batch.len() >= config.max_batch_size
-                            && let Err(e) = service.flush_pending_batch(&mut pending_batch).await {
-                                error!("❌ Failed to flush manifest batch: {}", e);
+                        match request {
+                            AppendRequest::Barrier(ack) => {
+                                // Issue #1126 L1: drain everything queued ahead of
+                                // the barrier so post-barrier readers see it all.
+                                if !pending_batch.is_empty()
+                                    && let Err(e) = service.flush_pending_batch(&mut pending_batch).await {
+                                        error!("❌ Failed to flush manifest batch at barrier: {}", e);
+                                    }
+                                let _ = ack.send(());
                             }
+                            append @ AppendRequest::Append { .. } => {
+                                pending_batch.push(append);
+
+                                // Force write if batch is full
+                                if pending_batch.len() >= config.max_batch_size
+                                    && let Err(e) = service.flush_pending_batch(&mut pending_batch).await {
+                                        error!("❌ Failed to flush manifest batch: {}", e);
+                                    }
+                            }
+                        }
                     }
 
                     // Periodic batch write
@@ -183,9 +207,15 @@ impl GlobalManifestService {
 
         debug!("💾 Flushing {} manifest entries to disk", batch.len());
 
-        // Extract entries and sort by LSN
-        let mut entries_to_write: Vec<GlobalManifestEntry> =
-            batch.iter().map(|req| req.entry.clone()).collect();
+        // Extract entries and sort by LSN (the batch only ever holds Append
+        // requests — Barriers are handled inline by the worker loop).
+        let mut entries_to_write: Vec<GlobalManifestEntry> = batch
+            .iter()
+            .filter_map(|req| match req {
+                AppendRequest::Append { entry, .. } => Some(entry.clone()),
+                AppendRequest::Barrier(_) => None,
+            })
+            .collect();
         entries_to_write.sort_by_key(|e| e.global_lsn);
 
         // Write to staging file first (crash safety)
@@ -203,13 +233,21 @@ impl GlobalManifestService {
 
         // Send responses to synchronous callers
         for request in batch.drain(..) {
-            if let Some(tx) = request.response {
-                // Convert Result to cloneable form
-                let response = match &write_result {
-                    Ok(()) => Ok(()),
-                    Err(e) => Err(anyhow::anyhow!("{}", e)),
-                };
-                let _ = tx.send(response);
+            match request {
+                AppendRequest::Append {
+                    response: Some(tx), ..
+                } => {
+                    // Convert Result to cloneable form
+                    let response = match &write_result {
+                        Ok(()) => Ok(()),
+                        Err(e) => Err(anyhow::anyhow!("{}", e)),
+                    };
+                    let _ = tx.send(response);
+                }
+                AppendRequest::Append { response: None, .. } => {}
+                AppendRequest::Barrier(ack) => {
+                    let _ = ack.send(());
+                }
             }
         }
 
@@ -445,7 +483,7 @@ impl GlobalManifestService {
 
         // Send to background worker (non-blocking)
         self.append_tx
-            .send(AppendRequest {
+            .send(AppendRequest::Append {
                 entry,
                 response: None,
             })
@@ -465,7 +503,7 @@ impl GlobalManifestService {
 
         // Send to background worker
         self.append_tx
-            .send(AppendRequest {
+            .send(AppendRequest::Append {
                 entry,
                 response: Some(tx),
             })
@@ -511,11 +549,32 @@ impl GlobalManifestService {
         self.latest_checkpoint.read().await.clone()
     }
 
+    /// Issue #1126 L1: drain the worker's write-behind queue so every append
+    /// enqueued before this call is visible in `entries`. Errors are swallowed:
+    /// a gone worker means the channel is closed and nothing is pending.
+    pub async fn drain_pending(&self) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self
+            .append_tx
+            .send(AppendRequest::Barrier(tx))
+            .await
+            .is_ok()
+        {
+            let _ = rx.await;
+        }
+    }
+
     /// Mark entries as flushed
     ///
     /// Cloud-optimized: Writes status update as new manifest segment
     /// instead of editing existing files (append-only for S3/Azure/GCS)
     pub async fn mark_flushed(&self, batch_ids: &[String]) -> Result<()> {
+        // Issue #1126 L1: the append path is write-behind; without this
+        // barrier a flush racing the batching window under-marks the
+        // freshest batch → leftover WAL → duplicate L0_recovery segments
+        // on the next boot.
+        self.drain_pending().await;
+
         // Update in-memory state
         let mut entries = self.entries.write().await;
         let mut status_updates = Vec::new();
@@ -556,6 +615,12 @@ impl GlobalManifestService {
         if batch_ids.is_empty() {
             return Ok(0);
         }
+
+        // Issue #1126 L1: drain the write-behind queue BEFORE the lookup —
+        // otherwise a batch appended moments ago is invisible here, its WAL
+        // file survives, and the next boot re-materializes it as a duplicate
+        // L0_recovery segment.
+        self.drain_pending().await;
 
         // Collect file URLs before marking as flushed (need Active status entries)
         let file_urls: Vec<String> = {
@@ -1074,6 +1139,68 @@ impl crate::storage::engines::sst::object_economy_directory::FreshnessLsnSource
 {
     async fn current_lsn(&self, _collection_id: &str) -> u64 {
         self.manifest.current_lsn().await
+    }
+}
+
+#[cfg(test)]
+mod barrier_tests {
+    use super::*;
+    use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use crate::storage::persistence::write_ahead_log::manifest::types::WalEntryStatus;
+    use crate::storage::persistence::write_ahead_log::serialization::SerializationFormat;
+
+    /// Issue #1126 L1 regression: an entry appended via the WRITE-BEHIND path
+    /// must be visible to `mark_flushed_and_delete_files` immediately — the
+    /// drain barrier makes append happen-before the flush-time lookup. Without
+    /// the barrier this test flakes/fails whenever the worker's batch window
+    /// (batch_interval_ms) hasn't elapsed — which was the restart data-loss
+    /// trigger (leftover WAL → duplicate L0_recovery segments on next boot).
+    #[tokio::test]
+    async fn write_behind_append_visible_to_flush_lookup_without_sleep() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let wal_url = format!("file://{}", temp_dir.path().display());
+        let fs_factory = Arc::new(
+            FilesystemFactory::create(FilesystemConfig::default())
+                .await
+                .expect("fs factory"),
+        );
+        let service = GlobalManifestService::new(
+            GlobalManifestServiceConfig::default(),
+            fs_factory,
+            wal_url.clone(),
+        )
+        .await
+        .expect("service");
+
+        let entry = GlobalManifestEntry {
+            global_lsn: 0, // allocated by append_async
+            collection_id: "c1".to_string(),
+            batch_id: "b1126".to_string(),
+            file_path: "c1/wal/b1126.bcwal".to_string(),
+            storage_url: wal_url.clone(),
+            size_bytes: 42,
+            checksum_crc32: 0,
+            timestamp_ms: 1,
+            format: SerializationFormat::Bincode,
+            vector_count: 1,
+            status: WalEntryStatus::Active,
+            checkpoint_id: None,
+        };
+
+        // Async (write-behind) append, then IMMEDIATELY mark — no sleep.
+        service.append_async(entry).await.expect("append");
+        service
+            .mark_flushed_and_delete_files(&["b1126".to_string()])
+            .await
+            .expect("mark+delete");
+
+        let entries = service.get_collection_entries("c1").await;
+        assert_eq!(entries.len(), 1, "entry must be visible post-barrier");
+        assert_eq!(
+            entries[0].status,
+            WalEntryStatus::Flushed,
+            "freshly appended batch must be marked Flushed, not missed"
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #1126 — post-restart vector search silently under-returned flushed-SST records (GET-by-id still found them). Found by the anvaiOps commercial-image smoke; three-link root cause, two fixes.

### L1 — manifest write-behind raced the flush-time lookup
`GlobalManifestService` appends via an async mpsc queue drained by a batched background worker. `mark_flushed*` read `entries` without draining, so a shutdown flush inside the batching window **under-marked the freshest batch** (`Marked 3 of 4`) → leftover live WAL → duplicate `L0_recovery_*` segments next boot. **Fix:** `AppendRequest` → enum with a `Barrier(oneshot)` variant; worker flushes pending then acks; `drain_pending()` at the top of both `mark_flushed*` paths (no sleeps). Regression test asserts an async-appended entry is visible to an immediate `mark_flushed_and_delete_files`.

### L3 — AXIS rebuild coverage check conflated "warm" with "has any vectors"
`ensure_axis_index_from_sst` skipped the SST rebuild whenever AXIS held **any** records. Post-restart, WAL replay seeds AXIS with only the replayed records → the orchestrated cold search returned just that subset; flushed-SST records stayed invisible to search. **Fix:** rebuild unless `registered >= durable_count(segments)`; uncountable ⇒ rebuild anyway. New `durable_vector_count_for_rebuild` (SST1 header + PAX block scan), kept separate from the TD-165 `segment_vector_count` gate.

### Acceptance (5-trial repro: 4 batches, **no** pre-restart search, SIGTERM→restart, then r5 + kill-9 → restart)
| | before | after |
|---|---|---|
| post-SIGTERM search | `[r4]` (5/5 fail) | **`[r1,r2,r3,r4]`** (5/5) |
| post-kill-9 search | `[r5]` (5/5 fail) | **`[r1,r2,r3,r4,r5]`** (5/5) |

Log confirms `Marked 4 entries` + `Deleted 4/4 WAL files`, no leftover `L0_recovery` duplicates, `merge_input_directory_records=4`.

### Tests
barrier race-regression (no-sleep) + manifest/recovery module tests green; `wal_list_authority_s1_test` (TD-OBJSTORE-4) 5/5; `clippy -D warnings` + fmt clean.

Follow-up (defense-in-depth, noted): recovery could also dedupe WAL batches already covered by a `Flushed` manifest entry.