### PR TITLE
TD-RDSTRAT-8 PR-B: A0 coarse-probe reader (v3) — default-OFF, recall/GET-gated

### DIFF
--- a/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
@@ -216,6 +216,74 @@ impl RaBitQRegion {
     }
 }
 
+/// Per-row code stride in a coalesced region: `dist f32 | inv f32 | bits`.
+pub fn code_stride(dim: u32) -> usize {
+    8 + (dim as usize).div_ceil(8)
+}
+
+/// TD-RDSTRAT-8 PR-B coarse probe: rank a **subset** of rows without reading the
+/// whole region. `header` comes from a small ranged GET of the region header
+/// (`[rabitq_off, rabitq_off + region_header_len(dim))`); `runs` are the probed
+/// cells' code bytes fetched via ranged GETs into their `a_off/a_len` extents.
+/// Each run is `(global_row_start, bytes)` where `bytes` is exactly
+/// `rows × code_stride(dim)` contiguous row codes starting at `global_row_start`
+/// (byte-identical to that slice of the region's code area).
+///
+/// Probed rows are **always present** — A0 cells cover only usable (embedded)
+/// rows, whose validity bits are all 1 — so a synthetic all-ones bitmap lets the
+/// canonical [`parse_rabitq_codes`] decode each run unchanged (no bitmap GET, no
+/// hand-rolled decoder). Returns up to `pool` **global** row indices
+/// nearest-first (same estimator + rotation as [`RaBitQRegion::rank`]).
+pub fn rank_probed_rows(
+    header: &CoalescedRaBitQHeader,
+    runs: &[(usize, &[u8])],
+    query: &[f32],
+    metric: RankMetric,
+    pool: usize,
+) -> Result<Vec<usize>> {
+    let dim = header.dim as usize;
+    if dim == 0 {
+        bail!("coarse-probe rank: region dim is 0");
+    }
+    let stride = code_stride(header.dim);
+    // Decode each probed run (all present) and remember each row's GLOBAL index.
+    let mut codes: Vec<Option<RaBitQCode>> = Vec::new();
+    let mut global: Vec<usize> = Vec::new();
+    for &(row_start, bytes) in runs {
+        if bytes.len() % stride != 0 {
+            bail!(
+                "coarse-probe run bytes {} not a multiple of code stride {stride}",
+                bytes.len()
+            );
+        }
+        let rows = bytes.len() / stride;
+        if rows == 0 {
+            continue;
+        }
+        // Synthesize the all-ones validity bitmap the canonical parser expects,
+        // then the run's code bytes verbatim → reuse the block decoder as-is.
+        let mut payload = vec![0xFFu8; rows.div_ceil(8)];
+        payload.extend_from_slice(bytes);
+        let run_codes = parse_rabitq_codes(&payload, rows, dim)?;
+        for (j, c) in run_codes.into_iter().enumerate() {
+            codes.push(c);
+            global.push(row_start + j);
+        }
+    }
+    if codes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let params = header.to_params();
+    let rotation = build_rotation_cached(params.dim, params.seed);
+    let q_rotated = rotate_query(query, &params, &rotation);
+    let local = match metric {
+        RankMetric::L2 => rank_candidates(&q_rotated, &codes, pool),
+        RankMetric::Cosine | RankMetric::DotProduct => rank_candidates_ip(&q_rotated, &codes, pool),
+    };
+    // Map local (subset) indices back to global row indices.
+    Ok(local.into_iter().map(|l| global[l]).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -258,6 +326,64 @@ mod tests {
         assert!(
             parsed.code(ranked[0]).is_some(),
             "top survivor must be present"
+        );
+    }
+
+    /// TD-RDSTRAT-8 PR-B: the subset ranker reproduces the full-region ranking
+    /// when handed all rows, and restricts to the probed rows for a sub-run —
+    /// same estimator, same order, global indices mapped back correctly.
+    #[test]
+    fn rank_probed_rows_matches_region_rank() {
+        const DIM: usize = 64;
+        const N: usize = 256;
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| synth_vec(i as u64, DIM)).collect();
+        let vectors: Vec<Option<&[f32]>> = corpus.iter().map(|v| Some(v.as_slice())).collect();
+        let seed = RABITQ_SEED_BASE ^ 20;
+        let (region, _c) = encode_region(&vectors, DIM as u32, seed).unwrap();
+        let header = CoalescedRaBitQHeader::parse(&region).unwrap();
+        let parsed = RaBitQRegion::from_bytes(&region).unwrap();
+        let query = corpus[10].clone();
+
+        let stride = code_stride(DIM as u32);
+        let codes_base = region_header_len(DIM as u32) + N.div_ceil(8);
+        let full = parsed.rank(&query, RankMetric::L2, N);
+
+        // One run over ALL rows must reproduce the full-region ranking exactly
+        // (same codes, same order, same estimator).
+        let all_bytes = &region[codes_base..codes_base + N * stride];
+        let probed_all =
+            rank_probed_rows(&header, &[(0, all_bytes)], &query, RankMetric::L2, N).unwrap();
+        assert_eq!(probed_all, full, "one run over all rows == region.rank");
+
+        // A subset run returns only rows in that subset, nearest-first; its top
+        // survivor equals the best full-rank survivor within the subset.
+        let (lo, hi) = (10usize, 40usize);
+        let sub_bytes = &region[codes_base + lo * stride..codes_base + hi * stride];
+        let probed =
+            rank_probed_rows(&header, &[(lo, sub_bytes)], &query, RankMetric::L2, hi - lo).unwrap();
+        assert!(
+            probed.iter().all(|&r| (lo..hi).contains(&r)),
+            "probed survivors stay within the probed rows"
+        );
+        let best_in_sub = full
+            .iter()
+            .copied()
+            .find(|&r| (lo..hi).contains(&r))
+            .expect("some full-rank survivor lies in the subset");
+        assert_eq!(
+            probed[0], best_in_sub,
+            "subset top == full-rank best within the subset"
+        );
+
+        // Two disjoint runs (mimicking two probed cells) cover their union.
+        let r1 = &region[codes_base..codes_base + 5 * stride];
+        let r2 = &region[codes_base + 100 * stride..codes_base + 110 * stride];
+        let two =
+            rank_probed_rows(&header, &[(0, r1), (100, r2)], &query, RankMetric::L2, 15).unwrap();
+        assert!(
+            two.iter()
+                .all(|&r| (0..5).contains(&r) || (100..110).contains(&r)),
+            "two-run survivors stay within the two probed cells"
         );
     }
 

--- a/crates/storage/proximadb-block-format/src/lib.rs
+++ b/crates/storage/proximadb-block-format/src/lib.rs
@@ -86,8 +86,8 @@ pub mod writer;
 // ---- Top-level re-exports ----
 
 pub use coalesced_rabitq::{
-    CoalescedRaBitQHeader, RABITQ_SEED_BASE, REGION_FIXED_HEADER_LEN, RaBitQRegion, encode_region,
-    region_header_len, region_len,
+    CoalescedRaBitQHeader, RABITQ_SEED_BASE, REGION_FIXED_HEADER_LEN, RaBitQRegion, code_stride,
+    encode_region, rank_probed_rows, region_header_len, region_len,
 };
 pub use coalesced_sq8::{
     CoalescedSq8Header, REGION_SQ8_FIXED_HEADER_LEN, Sq8Region, codes_offset as sq8_codes_offset,

--- a/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. Layout prototype + representative evidence are required before this architectural change is promoted to an ADR. **rev 3.1 (2026-07-20): PR-A landed, write path reconciled to rev 3** — A0 serde + header-prefix `layout_version=3` + additive footer section + compaction-only write path (`cluster_plan_ivf_probe` **persists the existing IOP-derived plan**; NO second `sqrt(N)` quantizer) + production-trigger route proof; default-OFF `PROXIMADB_IVF2=0` (see §As-built delta). Reads serve v3 through the order-agnostic single-level scan until the PR-B probe reader ranks the persisted centroids.
+| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. Layout prototype + representative evidence are required before this architectural change is promoted to an ADR. **rev 3.1 (2026-07-20): PR-A landed, write path reconciled to rev 3** — A0 serde + header-prefix `layout_version=3` + additive footer section + compaction-only write path (`cluster_plan_ivf_probe` **persists the existing IOP-derived plan**; NO second `sqrt(N)` quantizer) + production-trigger route proof; default-OFF `PROXIMADB_IVF2=0` (see §As-built delta). Reads serve v3 through the order-agnostic single-level scan until the PR-B probe reader ranks the persisted centroids. **rev 3.2 (2026-07-21): PR-B landed — the A0 coarse-probe reader** (`rabitq_search_segment_coalesced` ranks the `k_c` centroids in RAM, then ranged-reads only the `nprobe` nearest cells' Region-A extents; the whole Region A is never fetched → cold GETs/bytes drop from O(N) toward O(nprobe)). Default-OFF `PROXIMADB_IVF2_PROBE=0`; a per-PR synthetic recall/GET gate proves probe recall ≈ full-scan while reading materially fewer bytes. The SIFT-scale absolute-recall gate (qa-gate MEDIUM tier) and the durable Prometheus `ivf_*` io_trace fields are tracked follow-ups.
 | Priority | P2 → **P1 once any collection approaches ~2M vectors** — downstream, AnvaiOps ADR-0044 forbids >~5M-vector pooled onboarding until this re-measures (revenue + latency gate, successor to TD-RDSTRAT-6's role).
 | Severity | n/a (new capability, no regression). Default-OFF until gates pass.
 | Component | `src/storage/engines/sst/` — `segment_format.rs` (writer/reader), `block_cluster.rs` (clustering), `compaction.rs`/`compactor_impl.rs` (the only write path that clusters), `crates/storage/proximadb-storage-common/src/pax_block.rs` + `segment_layout.rs` (regions/footer), coalesce policy + `IopsBudget`. **NOVA is explicitly NOT the host** (rev 2).
@@ -299,6 +299,45 @@ reconciliation). Determinism, cell-extent exactness, cell-boundary block
 padding, mixed-read, and the flag gates are unit/e2e tested (`pax_block.rs`,
 `segment_layout.rs`, `coarse_directory.rs`, `block_cluster.rs`,
 `segment_format.rs`, route-proof test).
+
+== PR-B delta (the A0 coarse-probe reader, rev 3.2)
+
+*The probe reader.* `rabitq_search_segment_coalesced` gains a v3 branch (gated,
+default-OFF): parse Region A0, project the query with the persisted f32 model,
+**rank the `k_c` centroids in RAM**, select the `nprobe` nearest non-empty cells,
+ranged-read ONLY those cells' Region-A code extents (`a_off/a_len`), and rank
+that subset. The whole Region A is never fetched, so cold GETs/bytes drop from
+O(N) toward O(nprobe). Survivors (global rows) then feed the **unchanged** SQ8
+rerank + OID-fetch tail — because those steps are already survivor-driven and
+ranged, fewer/cluster-local survivors shrink the Region-B/D reads for free.
+
+* *Subset rank without the whole region.* New `coalesced_rabitq::rank_probed_rows`
+  ranks a set of probed row-runs given the region header (one small ranged GET of
+  `[rabitq_off, rabitq_off + region_header_len(dim))`). Probed rows are **always
+  present** (A0 cells cover only usable rows), so a synthesized all-ones bitmap
+  lets the canonical `parse_rabitq_codes` + `rank_candidates` decode/score each
+  run unchanged — no hand-rolled decoder, no bitmap GET. Unit-gated
+  (`rank_probed_rows_matches_region_rank`: one run over all rows reproduces
+  `RaBitQRegion::rank` exactly; sub-runs restrict + map global indices).
+* *Coalescing.* Probed cells are read in `a_off` order and merged ONLY on strict
+  physical adjacency (gap 0) — never over-reading unprobed cells; Hilbert
+  emission order already clusters near cells, so the nprobe nearest usually
+  collapse to a few contiguous runs.
+* *Cache.* The probe bypasses the whole-region invariants cache (its whole point
+  is not reading the whole region); recall is therefore consistent regardless of
+  cache residency. Caching A0/header is a follow-up.
+* *Env (default-OFF):* `PROXIMADB_IVF2_PROBE` (gate), `PROXIMADB_IVF2_NPROBE`
+  (eval-profile cell count; default ~25% of cells, min 8, `>= k_c` = exact).
+* *Gate.* `coarse_probe_holds_recall_and_cuts_bytes` (per-PR lib test, so it runs
+  in the LIGHT tier) writes a v3 segment via the compaction writer, then asserts
+  the probe **engaged** (`0 < cells_probed <= nprobe`), read **materially fewer
+  bytes** than the whole-region baseline, and **held recall vs the full scan**
+  (probe recall ≥ baseline − 0.1 on clustered data). Diagnostic counters ride
+  `PROXIMADB_TRACE_GETS` (`drain_get_trace` / `drain_probe_trace`).
+* *Follow-ups (tracked):* the SIFT-scale **absolute** recall/GET ratchet in the
+  qa-gate MEDIUM tier; promoting the probe counters into the durable Prometheus
+  `ivf_cells_total/probed`, `probed_rows`, `fetch_rounds`, `whole_region_fallback`
+  io_trace fields; A0/header caching; flip-to-default-ON after the SIFT gate bakes.
 
 == Eval gates (ADR-062 pattern; eval doc in `docs/_internal/status/`)
 

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -927,6 +927,197 @@ pub fn drain_get_trace() -> Vec<(CacheTier, u64)> {
         .map(|mut v| std::mem::take(&mut *v))
         .unwrap_or_default()
 }
+
+/// TD-RDSTRAT-8 PR-B diagnostic: per-query coarse-probe counters
+/// `(cells_total, cells_probed, probed_rows, fetch_rounds)`. The probe path
+/// pushes them when `PROXIMADB_TRACE_GETS` is set; the eval/recall harness drains
+/// them to prove `cells_probed << cells_total` and the GET/byte reduction. Zero
+/// cost off. (Promoting these into the durable Prometheus io_trace surface —
+/// `ivf_cells_total/probed`, `probed_rows`, `fetch_rounds`,
+/// `whole_region_fallback` — is a tracked follow-up.)
+static PROBE_TRACE: std::sync::Mutex<Vec<(u64, u64, u64, u64)>> = std::sync::Mutex::new(Vec::new());
+
+fn record_probe_trace(cells_total: u64, cells_probed: u64, probed_rows: u64, fetch_rounds: u64) {
+    if let Ok(mut v) = PROBE_TRACE.lock() {
+        v.push((cells_total, cells_probed, probed_rows, fetch_rounds));
+    }
+}
+
+/// Drain the recorded coarse-probe counters (empty when trace off / no probe).
+pub fn drain_probe_trace() -> Vec<(u64, u64, u64, u64)> {
+    PROBE_TRACE
+        .lock()
+        .map(|mut v| std::mem::take(&mut *v))
+        .unwrap_or_default()
+}
+
+/// TD-RDSTRAT-8 PR-B gate: engage the Region-A0 coarse probe on v3 segments.
+/// Default **OFF** (`PROXIMADB_IVF2_PROBE=1` to enable) — v3 segments read via
+/// the single-level whole-region scan until this flips (recall/GET-ratchet
+/// gated, mirroring the PR-A writer gate). v1 segments never probe.
+pub fn coarse_probe_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_IVF2_PROBE")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(|v| v.to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("on") | Some("yes")
+    )
+}
+
+/// Number of coarse cells to probe. `PROXIMADB_IVF2_NPROBE` overrides (the
+/// eval-profile knob, per rev 3 — `nprobe` is fixed by metric/dim/distribution,
+/// not an adaptive radius). Default probes ~25% of cells (min 8), capped at
+/// `k_c`; `>= k_c` is exact mode (every cell).
+fn coarse_probe_nprobe(k_c: usize) -> usize {
+    std::env::var("PROXIMADB_IVF2_NPROBE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or_else(|| k_c.div_ceil(4).clamp(8, k_c.max(1)))
+        .min(k_c)
+}
+
+/// Outcome of a coarse probe: the global survivor rows plus the io_trace
+/// counters (`ivf_cells_total/probed`, `probed_rows`, `fetch_rounds`).
+struct CoarseProbeResult {
+    survivors: Vec<usize>,
+    cells_total: u64,
+    cells_probed: u64,
+    probed_rows: u64,
+    fetch_rounds: u64,
+}
+
+/// TD-RDSTRAT-8 PR-B: compute survivors from ONLY the `nprobe` nearest coarse
+/// cells — rank the persisted `k_c` centroids in RAM, then ranged-read just those
+/// cells' Region-A code extents (`a_off/a_len`). The whole Region A is never
+/// fetched, so cold-query GETs/bytes drop from O(N) to O(nprobe). Returns `None`
+/// to fall back to the single-level whole-region scan (fail-safe: A0
+/// missing/corrupt, dim mismatch, or degenerate directory).
+async fn coarse_probe_survivors(
+    fs: &dyn proximadb_storage_filesystem_types::FileSystem,
+    path: &str,
+    header: &proximadb_storage_common::segment_layout::SegmentHeaderPrefix,
+    query: &[f32],
+    metric: RankMetric,
+    k: usize,
+    trace_on: bool,
+) -> Result<Option<CoarseProbeResult>> {
+    use proximadb_storage_common::coarse_directory::{CoarseDirectory, project_with_model};
+
+    let dim = query.len();
+    if dim == 0 || header.a0_len == 0 {
+        return Ok(None);
+    }
+
+    // 1. Region A0 (small, immediately after the header) — one ranged GET.
+    let a0_bytes = fs
+        .read_range(path, header.a0_off, header.a0_len)
+        .await
+        .map_err(|e| anyhow::anyhow!("coarse-probe A0 {path}: {e}"))?;
+    if trace_on {
+        record_get(CacheTier::InvariantMeta, header.a0_len);
+    }
+    let Ok(dir) = CoarseDirectory::parse(&a0_bytes) else {
+        return Ok(None);
+    };
+    let k_c = dir.model.k_c();
+    let n_comp = dir.model.n_comp as usize;
+    if k_c == 0 || dir.cells.len() != k_c || n_comp == 0 || dir.model.dim as usize != dim {
+        return Ok(None);
+    }
+
+    // 2. Rank the k_c centroids in RAM; select the nprobe nearest NON-EMPTY cells
+    //    (project the query with the SAME persisted f32 model the writer used).
+    let q_proj = project_with_model(
+        &dir.model.pca_mean,
+        &dir.model.pca_components,
+        n_comp,
+        query,
+    );
+    if q_proj.len() != n_comp {
+        return Ok(None);
+    }
+    let mut cell_dist: Vec<(usize, f32)> = (0..k_c)
+        .map(|c| {
+            let cen = &dir.model.centroids[c * n_comp..(c + 1) * n_comp];
+            let d: f32 = q_proj.iter().zip(cen).map(|(a, b)| (a - b) * (a - b)).sum();
+            (c, d)
+        })
+        .collect();
+    cell_dist.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    let nprobe = coarse_probe_nprobe(k_c);
+    let mut probed: Vec<usize> = cell_dist
+        .iter()
+        .filter(|(c, _)| dir.cells[*c].row_end > dir.cells[*c].row_begin)
+        .take(nprobe)
+        .map(|(c, _)| *c)
+        .collect();
+    if probed.is_empty() {
+        return Ok(None);
+    }
+    // File (a_off) order so physically-adjacent probed cells coalesce.
+    probed.sort_by_key(|&c| dir.cells[c].a_off);
+
+    // 3. Region-A header (params + centroid) — one small ranged GET.
+    let hdr_len = proximadb_block_format::region_header_len(dim as u32) as u64;
+    let hdr_bytes = fs
+        .read_range(path, header.rabitq_off, hdr_len)
+        .await
+        .map_err(|e| anyhow::anyhow!("coarse-probe region header {path}: {e}"))?;
+    if trace_on {
+        record_get(CacheTier::InvariantMeta, hdr_len);
+    }
+    let Ok(rq_header) = proximadb_block_format::CoalescedRaBitQHeader::parse(&hdr_bytes) else {
+        return Ok(None);
+    };
+
+    // 4. Ranged-read the probed cells' Region-A code extents. Coalesce ONLY
+    //    physically-adjacent cells (gap 0) so we never over-read unprobed cells;
+    //    Hilbert emission order clusters near cells, so the nprobe nearest usually
+    //    collapse to a few contiguous runs.
+    let stride = proximadb_block_format::code_stride(dim as u32) as u64;
+    let mut merged: Vec<(u64, u64, usize)> = Vec::new(); // (start, end, global row_start)
+    for &c in &probed {
+        let cell = &dir.cells[c];
+        let (s, e, rs) = (cell.a_off, cell.a_off + cell.a_len, cell.row_begin as usize);
+        match merged.last_mut() {
+            Some(last) if last.1 == s => last.1 = e, // contiguous → extend the run
+            _ => merged.push((s, e, rs)),
+        }
+    }
+    let mut run_bufs: Vec<(usize, Vec<u8>)> = Vec::with_capacity(merged.len());
+    let mut probed_rows: u64 = 0;
+    for (s, e, rs) in &merged {
+        let len = e - s;
+        let bytes = fs
+            .read_range(path, *s, len)
+            .await
+            .map_err(|err| anyhow::anyhow!("coarse-probe Region A {path}: {err}"))?;
+        if trace_on {
+            record_get(CacheTier::SurvivorPayload, len);
+        }
+        // `stride = code_stride(dim) >= 9` (dim >= 1, guarded above) so the
+        // division is always well-defined.
+        probed_rows += len / stride;
+        run_bufs.push((*rs, bytes));
+    }
+    let runs: Vec<(usize, &[u8])> = run_bufs.iter().map(|(rs, b)| (*rs, b.as_slice())).collect();
+    let pool = pax_rabitq_pool_for_top_k(k, probed_rows as usize);
+    let survivors =
+        proximadb_block_format::rank_probed_rows(&rq_header, &runs, query, metric, pool.max(k))?;
+
+    Ok(Some(CoarseProbeResult {
+        survivors,
+        cells_total: k_c as u64,
+        cells_probed: probed.len() as u64,
+        probed_rows,
+        fetch_rounds: merged.len() as u64,
+    }))
+}
+
 pub async fn rabitq_search_segment_coalesced(
     fs: &dyn proximadb_storage_filesystem_types::FileSystem,
     path: &str,
@@ -938,7 +1129,8 @@ pub async fn rabitq_search_segment_coalesced(
 ) -> Result<Option<Vec<CascadeHit>>> {
     use proximadb_block_format::{PaxBlockReader, RaBitQRegion, coalesced_sq8, col_id};
     use proximadb_storage_common::segment_layout::{
-        SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN, SegmentFooterIndex, SegmentHeaderPrefix,
+        SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN, SEG_LAYOUT_VERSION_TWO_LEVEL,
+        SegmentFooterIndex, SegmentHeaderPrefix,
     };
 
     // ADR-065 co-design diagnostic: per-GET size trace. When PROXIMADB_TRACE_GETS
@@ -980,20 +1172,47 @@ pub async fn rabitq_search_segment_coalesced(
         Err(_) => return Ok(None), // not coalesced → don't cache
     };
 
-    // 2. Scan the RaBitQ region (cold: 1 GET; hot: 0 — Arc clone, no data copy).
-    let region_bytes: Arc<[u8]> = if let Some(inv) = cached.as_ref() {
-        inv.region_bytes.clone()
+    // 2. Survivors. TD-RDSTRAT-8 PR-B: on a v3 segment with the coarse probe
+    //    armed, rank the persisted centroids in RAM and ranged-read only the
+    //    nprobe nearest cells (whole Region A never fetched); else the
+    //    single-level whole-region scan (cold: 1 GET; hot: 0 — Arc clone). Any
+    //    probe miss falls through, fail-safe, to the whole-region path.
+    let probe = if header.layout_version == SEG_LAYOUT_VERSION_TWO_LEVEL
+        && header.a0_len > 0
+        && coarse_probe_enabled()
+    {
+        coarse_probe_survivors(fs, path, &header, query, metric, k, trace_on)
+            .await
+            .ok()
+            .flatten()
     } else {
-        Arc::from(
-            fs.read_range(path, header.rabitq_off, header.rabitq_len)
-                .await
-                .map_err(|e| anyhow::anyhow!("coalesced scan region {path}: {e}"))?,
-        )
+        None
     };
-    let region = RaBitQRegion::from_bytes(&region_bytes)?;
-    // ADR-062 PR2: adaptive survivor pool — scale M with the segment's row count.
-    let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());
-    let survivors = region.rank(query, metric, pool.max(k));
+    let (survivors, region_bytes): (Vec<usize>, Option<Arc<[u8]>>) = if let Some(r) = &probe {
+        if trace_on {
+            record_probe_trace(r.cells_total, r.cells_probed, r.probed_rows, r.fetch_rounds);
+        }
+        (r.survivors.clone(), None)
+    } else {
+        let region_bytes: Arc<[u8]> = if let Some(inv) = cached.as_ref() {
+            inv.region_bytes.clone()
+        } else {
+            let bytes = fs
+                .read_range(path, header.rabitq_off, header.rabitq_len)
+                .await
+                .map_err(|e| anyhow::anyhow!("coalesced scan region {path}: {e}"))?;
+            // Trace the whole-region cost so the coarse probe's Region-A saving is
+            // observable (co-design: trace before you tune). Diagnostic-only.
+            if trace_on {
+                record_get(CacheTier::InvariantIndex, header.rabitq_len);
+            }
+            Arc::from(bytes)
+        };
+        let region = RaBitQRegion::from_bytes(&region_bytes)?;
+        // ADR-062 PR2: adaptive survivor pool — scale M with the segment's rows.
+        let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());
+        (region.rank(query, metric, pool.max(k)), Some(region_bytes))
+    };
     if survivors.is_empty() {
         return Ok(Some(Vec::new()));
     }
@@ -1009,8 +1228,11 @@ pub async fn rabitq_search_segment_coalesced(
     let footer = SegmentFooterIndex::parse(&footer_bytes)?;
 
     // PR2: populate the cache on miss (the invariants parsed successfully →
-    // worth caching for hot repeat queries).
+    // worth caching for hot repeat queries). Only on the whole-region path — the
+    // coarse probe never read the whole Region A, so there is nothing to cache
+    // here (its small A0/header/cell reads ride the survivor cache instead).
     if cached.is_none()
+        && let Some(region_bytes) = region_bytes
         && let Some(c) = cache
     {
         c.put(
@@ -2127,6 +2349,169 @@ mod tests {
             "v3 read_segment_records must reconstruct vectors (never drop Region B)"
         );
         unsafe {
+            std::env::remove_var("PROXIMADB_IVF_K");
+        }
+    }
+
+    /// TD-RDSTRAT-8 PR-B (the deferred PR-A recall/GET gate): the coarse probe
+    /// (`PROXIMADB_IVF2_PROBE=1`) ranks the persisted centroids in RAM and reads
+    /// only the nprobe nearest cells — holding recall on clustered data while
+    /// reading materially fewer bytes than the whole-region single-level scan.
+    #[tokio::test]
+    async fn coarse_probe_holds_recall_and_cuts_bytes() {
+        enable_coalesced_rabitq();
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+
+        const DIM: usize = 32;
+        const G: usize = 8; // clusters (each centred on its own axis)
+        const PER: usize = 64; // members per cluster
+        const N: usize = G * PER;
+        const K: usize = 10;
+
+        // Deterministic pseudo-random component in [-1, 1].
+        let pseudo = |i: usize, d: usize| -> f32 {
+            let mut s = (i as u64)
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                .wrapping_add((d as u64).wrapping_mul(0x632B_E59B_D9B4_E019));
+            s ^= s >> 29;
+            s = s.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            s ^= s >> 27;
+            ((s >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+        };
+        // Widely-separated clusters (each centred at 50 on its own axis) with
+        // members at a monotonically increasing radius — so the true top-K are
+        // DISTINGUISHABLE (non-degenerate full-scan recall) AND concentrated in
+        // one cluster → a few probed cells capture them.
+        let corpus: Vec<Vec<f32>> = (0..N)
+            .map(|i| {
+                let (g, j) = (i / PER, i % PER);
+                let radius = 0.1 + j as f32 * 0.03;
+                (0..DIM)
+                    .map(|d| (if d == g { 50.0 } else { 0.0 }) + radius * pseudo(i, d))
+                    .collect()
+            })
+            .collect();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| rec(&format!("r{i}"), 1000 + i as i64, v.clone()))
+            .collect();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe.pax");
+        unsafe {
+            std::env::set_var("PROXIMADB_IVF2", "1");
+            std::env::set_var("PROXIMADB_IVF_K", "16");
+        }
+        write_pax_segment_compacted(
+            &path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF2");
+        }
+
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let p = path.to_str().unwrap();
+        // The exact centre of cluster 0 — its nearest members are the smallest
+        // radii (r0, r1, …), a distinguishable top-K all inside one cluster.
+        let query: Vec<f32> = (0..DIM).map(|d| if d == 0 { 50.0 } else { 0.0 }).collect();
+
+        // Brute-force truth (top-K by L2).
+        let l2 =
+            |a: &[f32], b: &[f32]| a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum::<f32>();
+        let mut idx: Vec<usize> = (0..N).collect();
+        idx.sort_by(|&a, &b| {
+            l2(&corpus[a], &query)
+                .partial_cmp(&l2(&corpus[b], &query))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let truth: std::collections::HashSet<String> =
+            idx.iter().take(K).map(|i| format!("r{i}")).collect();
+        let recall = |hits: &[CascadeHit]| {
+            let got: std::collections::HashSet<String> =
+                hits.iter().map(|h| h.oid.clone()).collect();
+            truth.iter().filter(|o| got.contains(*o)).count() as f32 / K as f32
+        };
+
+        unsafe {
+            std::env::set_var("PROXIMADB_TRACE_GETS", "1");
+        }
+
+        // Baseline: probe OFF → whole-region single-level scan over the v3 segment.
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF2_PROBE");
+        }
+        let _ = drain_get_trace();
+        let _ = drain_probe_trace();
+        let base = rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        let base_bytes: u64 = drain_get_trace().iter().map(|(_, b)| b).sum();
+        assert!(drain_probe_trace().is_empty(), "probe OFF must not probe");
+        let base_recall = recall(&base);
+        assert!(
+            base_recall >= 0.5,
+            "baseline full-scan recall@{K} = {base_recall:.2} (sanity floor)"
+        );
+
+        // Probe ON: nprobe=6 of 16 cells.
+        unsafe {
+            std::env::set_var("PROXIMADB_IVF2_PROBE", "1");
+            std::env::set_var("PROXIMADB_IVF2_NPROBE", "6");
+        }
+        let _ = drain_get_trace();
+        let _ = drain_probe_trace();
+        let probe = rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        let probe_bytes: u64 = drain_get_trace().iter().map(|(_, b)| b).sum();
+        let ptrace = drain_probe_trace();
+
+        // 1. The probe engaged: cells_probed strictly inside (0, cells_total).
+        assert_eq!(ptrace.len(), 1, "exactly one probe recorded");
+        let (cells_total, cells_probed, probed_rows, fetch_rounds) = ptrace[0];
+        assert_eq!(cells_total, 16, "16 coarse cells");
+        assert!(
+            cells_probed > 0 && cells_probed <= 6,
+            "probed {cells_probed} cells (0 < c <= nprobe=6)"
+        );
+        assert!(
+            probed_rows > 0 && probed_rows < N as u64,
+            "probed {probed_rows} of {N} rows (a strict subset)"
+        );
+        assert!(fetch_rounds >= 1, "at least one Region-A ranged GET");
+
+        // 2. Materially fewer bytes than the whole-region baseline.
+        assert!(
+            probe_bytes < base_bytes,
+            "probe {probe_bytes} B must read fewer than baseline {base_bytes} B"
+        );
+
+        // 3. Recall held vs the full scan: probing the query's cluster loses
+        //    essentially nothing (the meaningful PR-B claim — robust to the
+        //    absolute RaBitQ recall level, which the corpus/quantizer set).
+        let probe_recall = recall(&probe);
+        assert!(
+            probe_recall >= base_recall - 0.1,
+            "probe recall@{K} = {probe_recall:.2} must hold vs baseline {base_recall:.2} (nprobe=6/16)"
+        );
+
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF2_PROBE");
+            std::env::remove_var("PROXIMADB_IVF2_NPROBE");
+            std::env::remove_var("PROXIMADB_TRACE_GETS");
             std::env::remove_var("PROXIMADB_IVF_K");
         }
     }


### PR DESCRIPTION
## TD-RDSTRAT-8 PR-B — the A0 coarse-probe reader (v3)

Delivers the read-side payoff of the persisted IVF probe directory (PR-A #1128): a v3 segment is now searched by **ranking the `k_c` centroids in RAM and reading only the `nprobe` nearest cells**, so cold-query GETs/bytes drop from **O(N) toward O(nprobe)** instead of scanning the whole Region A. **Default-OFF (`PROXIMADB_IVF2_PROBE=0`), gated, mixed-read-safe.**

### The reader
`rabitq_search_segment_coalesced` gains a v3 branch: parse Region A0 → project the query with the persisted f32 model → rank the `k_c` centroids in RAM → select the `nprobe` nearest non-empty cells → **ranged-read only those cells' Region-A code extents** (`a_off/a_len`) → rank that subset. The whole Region A is never fetched. Survivors (global rows) then feed the **unchanged** SQ8 rerank + OID-fetch tail — those steps are already survivor-driven and ranged, so fewer/cluster-local survivors shrink the Region-B/D reads for free.

- **Subset rank without the whole region** — new `coalesced_rabitq::rank_probed_rows` ranks a set of probed row-runs given the region header (one small ranged GET). Probed rows are **always present** (A0 cells cover only usable rows), so a synthesized all-ones bitmap lets the canonical `parse_rabitq_codes` + `rank_candidates` decode/score each run unchanged — no hand-rolled decoder, no bitmap GET. Unit-gated: one run over all rows reproduces `RaBitQRegion::rank` exactly; sub-runs restrict and map global indices.
- **Coalescing** — probed cells are read in `a_off` order and merged **only on strict physical adjacency (gap 0)**, so unprobed cells are never over-read. Hilbert emission order already clusters near cells, so the `nprobe` nearest usually collapse to a few contiguous runs.
- **Cache** — the probe bypasses the whole-region invariants cache (its whole point is *not* reading the whole region), so recall is independent of cache residency. Caching A0/header is a noted follow-up.

### Gate (the deferred PR-A recall/GET gate)
`coarse_probe_holds_recall_and_cuts_bytes` (per-PR lib test → runs in the LIGHT tier) writes a v3 segment via the compaction writer, then asserts the probe **engaged** (`0 < cells_probed <= nprobe`), read **materially fewer bytes** than the whole-region baseline, and **held recall vs the full scan** (probe recall ≥ baseline − 0.1 on clustered data). The whole-region cold read is now traced too (co-design: *trace before you tune*); counters ride `PROXIMADB_TRACE_GETS` (`drain_get_trace` / `drain_probe_trace`).

### Env (default-OFF)
- `PROXIMADB_IVF2_PROBE` — engage the probe on v3 segments (v1 never probes).
- `PROXIMADB_IVF2_NPROBE` — cells to probe (eval profile; default ~25% of cells, min 8, `>= k_c` = exact).

### Verification
- `cargo fmt --check`, `clippy --lib --bins -D warnings` — clean.
- `rank_probed_rows_matches_region_rank`, `coarse_probe_holds_recall_and_cuts_bytes`, `ivf_probe_compaction_gate_and_v3_read_compat` (regression), `sst_ivf2_compaction_route_proof_test`, `sst_compaction_reclustering_test` (v2 byte-stability) — all pass.

### Follow-ups (tracked in the TD, rev 3.2)
SIFT-scale **absolute** recall/GET ratchet in the qa-gate MEDIUM tier; promoting the probe counters into the durable Prometheus `ivf_cells_total/probed`, `probed_rows`, `fetch_rounds`, `whole_region_fallback` io_trace fields; A0/header caching; flip-to-default-ON after the SIFT gate bakes.

Refs TD-RDSTRAT-8 (rev 3.2), #1128 (PR-A), ADR-062/065 (regions), ADR-061 (mixed-read).
