### PR TITLE
fix(sdk): land TD-SDK-1 S2b — search() transport delegation + status correction

### DIFF
--- a/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
+++ b/clients/python/src/proximadb_sdk/adapters/rest_adapter.py
@@ -447,11 +447,16 @@ class RestProtocolAdapter(BaseProtocolAdapter):
         if hasattr(query_vector, "tolist"):
             query_vector = query_vector.tolist()
 
+        # Delegate to the REST transport (protocols.rest_sync.ProximaDBClient).
+        # Kwarg names must match the transport's `search` signature EXACTLY
+        # (`vector` / `metadata_filter`, not `query_vector` / `metadata_filters`);
+        # a mismatch raises TypeError, which unified_client.search_single catches
+        # and silently converts into a local-only fallback (TD-SDK-1 S2b / ADR-068).
         results = self._client.search(
             collection_id=collection_id,
-            query_vector=query_vector,
+            vector=query_vector,
             top_k=top_k,
-            metadata_filters=filter,
+            metadata_filter=filter,
             include_vectors=include_vectors,
             include_metadata=include_metadata,
             **kwargs,

--- a/clients/python/tests/test_search_delegates_to_transport.py
+++ b/clients/python/tests/test_search_delegates_to_transport.py
@@ -34,7 +34,9 @@ def _fresh_client():
 
 def test_search_delegates_to_transport_and_returns_results(monkeypatch) -> None:
     client = _fresh_client()
-    adapter = client._adapter  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
+    adapter = (
+        client._adapter
+    )  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
     assert adapter is not None, "REST adapter must be wired for connect_rest"
 
     expected = [
@@ -77,7 +79,9 @@ def test_search_delegates_to_transport_and_returns_results(monkeypatch) -> None:
 
 def test_search_metadata_filter_flows_to_transport(monkeypatch) -> None:
     client = _fresh_client()
-    adapter = client._adapter  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
+    adapter = (
+        client._adapter
+    )  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
     captured: dict[str, object] = {}
 
     def fake_transport_search(

--- a/clients/python/tests/test_search_delegates_to_transport.py
+++ b/clients/python/tests/test_search_delegates_to_transport.py
@@ -1,0 +1,95 @@
+"""Regression: SDK search() must hit the server, not silently fall back to a
+client-side local store (TD-SDK-1 S2b / ADR-068 D5).
+
+Symptom (2026-07-20 local Azurite round-trip): ``client.search(...)`` returned
+``[]`` though the server returned correct results (curl + server logs confirm).
+Root cause: ``adapters/rest_adapter.RestAdapter.search`` called the REST transport
+(``protocols.rest_sync.ProximaDBClient.search``) with the WRONG kwarg names —
+``query_vector`` / ``metadata_filters`` instead of ``vector`` / ``metadata_filter``
+— raising ``TypeError``, which ``unified_client.search_single`` catches and
+converts into a sticky *local fallback* (``_activate_local_fallback``), so the
+read never reaches the server.
+
+This is exactly the facade bug the codegen-drift gate cannot see; per ADR-068 D5
+it is owned by a behavioral/differential check. Here we drive the full
+facade -> adapter -> transport chain with the transport mocked to a recorded
+response shape (fixture-replay) and assert (a) the call reaches the transport,
+(b) the kwargs flow correctly, and (c) the results pass through — i.e. NO local
+fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proximadb_sdk import connect_rest
+from proximadb_sdk.models import SearchResult
+
+
+def _fresh_client():
+    # Fresh client => _prefer_local_fallback is False, so search_single tries
+    # the adapter (transport) path rather than the local store.
+    return connect_rest("http://127.0.0.1:5678")
+
+
+def test_search_delegates_to_transport_and_returns_results(monkeypatch) -> None:
+    client = _fresh_client()
+    adapter = client._adapter  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
+    assert adapter is not None, "REST adapter must be wired for connect_rest"
+
+    expected = [
+        SearchResult(id="r1", score=0.987),
+        SearchResult(id="r2", score=0.523),
+    ]
+
+    captured: dict[str, object] = {}
+
+    def fake_transport_search(
+        collection_id: str,
+        vector: list[float],
+        top_k: int = 10,
+        metadata_filter: dict | None = None,
+        **kwargs: object,
+    ) -> list[SearchResult]:
+        # Signature matches protocols.rest_sync.ProximaDBClient.search. If the
+        # adapter passes the OLD wrong kwargs (query_vector / metadata_filters),
+        # this is never reached — the TypeError trips local fallback first.
+        captured.update(
+            collection_id=collection_id,
+            vector=vector,
+            top_k=top_k,
+            metadata_filter=metadata_filter,
+        )
+        return expected
+
+    # Replace the leaf REST transport's search (NOT the adapter, NOT the facade).
+    adapter._client.search = fake_transport_search  # type: ignore[assignment]
+
+    results = client.search("testcol", [0.1, 0.2, 0.3, 0.4], top_k=5)
+
+    # (c) results pass through — no silent [] / local fallback.
+    assert [r.id for r in results] == ["r1", "r2"]
+    # (a)+(b) the transport was reached with the correctly-named kwargs.
+    assert captured.get("collection_id") == "testcol"
+    assert captured.get("vector") == [0.1, 0.2, 0.3, 0.4]
+    assert captured.get("top_k") == 5
+
+
+def test_search_metadata_filter_flows_to_transport(monkeypatch) -> None:
+    client = _fresh_client()
+    adapter = client._adapter  # the instance search_single uses (NOT _get_rest_adapter(), a different one)
+    captured: dict[str, object] = {}
+
+    def fake_transport_search(
+        collection_id: str,
+        vector: list[float],
+        top_k: int = 10,
+        metadata_filter: dict | None = None,
+        **kwargs: object,
+    ) -> list[SearchResult]:
+        captured["metadata_filter"] = metadata_filter
+        return []
+
+    adapter._client.search = fake_transport_search  # type: ignore[assignment]
+    client.search("c", [0.1, 0.2, 0.3, 0.4], top_k=3, metadata_filter={"t": "x"})
+    assert captured.get("metadata_filter") == {"t": "x"}

--- a/docs/10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc
+++ b/docs/10-quality/td/TD-SDK-1-sdk-codegen-doctrine-migration.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open; S0 shipped #1112 and S2a/S2b shipped #1113.** The known short-name rejection and remote-search silent local fallback are fixed with regression tests. S1's live behavioral round-trip harness and S3–S5's oracle/gate migration remain open; the legacy `<lang>-sdk-codegen-drift` gates keep enforcing the old contract until S4 lands.
+| Status | **Open; S0 shipped #1112, S2a shipped #1113, and S2b ships here.** The short-name rejection (#1113) and the remote-search silent local fallback (this PR) are fixed with regression tests. *Correction:* the prior revision recorded S2b as shipped in #1113 — only S2a landed there; the S2b fix was orphaned on `feat/sdk-facade-fixes` (`a56296f5c`) and lands here. S1's live behavioral round-trip harness and S3–S5's oracle/gate migration remain open; the legacy `<lang>-sdk-codegen-drift` gates keep enforcing the old contract until S4 lands.
 | Priority | P1 — the SDK is the customer-facing seam; two facade bugs (8-char name, broken `search()`) already escape the current gate to the VM. Unblocks spec-evolution PRs (the progenitor-panic class) and moves SDK correctness to a gate that actually catches customer-visible failures.
 | Component | `clients/{python,go,rust,nodejs-embedded}` (facades + generated dirs), `src/network/rest/openapi.rs` (spec gen), `.github/workflows/*sdk-codegen-drift*` (the gates), a new in-process/Azurite round-trip test harness.
 | Evidence | 2026-07-20 local Azurite round-trip: server endpoints clean (create/insert/search + 7 blobs persisted); Python SDK facade buggy — `CollectionConfig` rejects <8-char names (`models.py:893 min_length=8` + `:958` validator) while the server accepts `aztest` (6); `unified_client.search()` (`:3015 search_single`) routes to `_search_local_vectors` (`:665`) whenever the REST adapter raises, returning `[]` though the server logs "2 results". Also: #1103 progenitor 0.14 panic (`response_types.len() <= 1`) on inline-structured responses blocked the Rust SDK. ADR-068 §1.
@@ -47,13 +47,13 @@ Write the S1 round-trip test that **reproduces** each bug (red), then fix:
   collision" validator (`clients/python/.../models.py`) and the `unified_client_async.py:77`
   guard; the server relaxed this for relational DDL (TPC-H `part`/`orders`/`region`). The round-trip
   test creates a 4-char collection and asserts success.
-* **S2b — REST `search()` local-fallback (shipped #1113).** `search_single` (`unified_client.py:3015`) falls to
+* **S2b — REST `search()` local-fallback (lands here).** `search_single` (`unified_client.py:3015`) falls to
   `_search_local_vectors` (`:665`) when the REST adapter raises, silently returning `[]`. Root-cause
   why `self._adapter.search()` raises/mis-parses (the server returns correct results), fix the
   adapter, and stop letting a remote failure degrade to a local-only read without a loud error. The
   round-trip test asserts `search()` hits the server and returns the inserted records.
 
-_Status: both known facade defects fixed with targeted regression tests; the S1 live round-trip gate remains open._
+_Status: S2a fixed (#1113); S2b fixed in this PR (the prior "shipped #1113" note was erroneous — only S2a landed there, the S2b fix was orphaned on `feat/sdk-facade-fixes`); the S1 live round-trip gate remains open._
 
 === S3 — Demote the generated client to a CI oracle
 Move the full generated client in each language to a dev/CI-only path (not linked into the shipped

--- a/docs/12-design/adr/ADR-068-sdk-codegen-doctrine-hand-facade-generated-oracle.adoc
+++ b/docs/12-design/adr/ADR-068-sdk-codegen-doctrine-hand-facade-generated-oracle.adoc
@@ -5,7 +5,7 @@
 [cols="1,3",options="header"]
 |===
 | Field | Value
-| Status | **Proposed; migration started** (reconciled 2026-07-21). S0 landed in #1112 and the two known Python facade defects landed in #1113. The decision is not yet accepted or operationally complete: S1's live behavioral round-trip and S3–S5's oracle/gate migration remain open, so the existing `<lang>-sdk-codegen-drift` gates still enforce the legacy contract.
+| Status | **Proposed; migration started** (reconciled 2026-07-22). S0 landed in #1112 and the S2a facade defect (collection-name length) landed in #1113. *Correction:* the prior revision recorded S2b (`search()` silent local fallback) as shipped in #1113 — that was erroneous; only S2a landed in #1113, and the S2b fix was orphaned on `feat/sdk-facade-fixes` (`a56296f5c`); it lands here. The decision is not yet accepted or operationally complete: S1's live behavioral round-trip and S3–S5's oracle/gate migration remain open, so the existing `<lang>-sdk-codegen-drift` gates still enforce the legacy contract.
 | Decider | Vijaykumar Singh (2026-07-20)
 | Date | 2026-07-20
 | Relates to | link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design — the SDK is the customer-facing seam; correctness is measured, not asserted), link:ADR-060-oss-commercial-boundary.adoc[ADR-060] (the SDK is an OSS surface; neutral, stable), CLAUDE.md mandates #15/#16 (the spec-driven-SDK rule this ADR *refines*, not repeals). Inspired by Sandhi ADR-0003 (provider-adapter authoring — hand-written transport, generated types as a narrow reference + test oracle).


### PR DESCRIPTION
## Summary

Lands the **orphaned S2b fix** from `feat/sdk-facade-fixes` (`a56296f5c`) and corrects the doc drift that recorded it as shipped.

**The bug (live, shipping):** `RestProtocolAdapter.search` called the REST transport (`protocols.rest_sync.ProximaDBClient.search`) with the wrong kwarg names — `query_vector` / `metadata_filters` instead of `vector` / `metadata_filter`. That raised `TypeError`, which `unified_client.search_single` catches and converts into a **sticky local-only fallback**, so `client.search(...)` silently returned `[]` even though the server returned correct results (confirmed 2026-07-20 local Azurite round-trip). This is exactly the facade bug the `codegen-drift` gate cannot see (ADR-068 D5).

**Why it was orphaned:** ADR-068 / TD-SDK-1 both stated "S2a/S2b shipped #1113", but `#1113` contained only the S2a commit (`5ddfc4ead`, collection-name `min_length`). The S2b commit never made it onto `develop`; it sat on `feat/sdk-facade-fixes`.

## Changes
- `clients/python/src/proximadb_sdk/adapters/rest_adapter.py` — pass the transport's actual kwargs (`vector` / `metadata_filter`).
- `clients/python/tests/test_search_delegates_to_transport.py` — fixture-replay regression test (mocks the leaf transport): asserts the call reaches the transport with correctly-named kwargs and results pass through (no local fallback). RED before the rename, GREEN after.
- `docs/12-design/adr/ADR-068-*.adoc` + `docs/10-quality/td/TD-SDK-1-*.adoc` — status correction (S2a #1113; S2b lands here; notes the prior "shipped #1113" claim was erroneous).

## Verification
- `pytest clients/python/tests/test_search_delegates_to_transport.py` → **2 passed** (against the worktree source).
- `scripts/check_td_adr_unique.py` → 0 errors; `scripts/check_no_agent_attribution.py` → clean.

## Scope note
The full ADR-068 doctrine migration (S1 live behavioral round-trip gate, S3–S5 generated-client oracle relocation + gate conversion) remains open and is tracked separately. This PR only closes the S2b facade defect.