### PR TITLE
feat(wal): ADR-069 S4 residuals — batch 429 + S6 metrics + S1 guardrail

### DIFF
--- a/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
+++ b/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
@@ -19,6 +19,8 @@
 //!   * `proximadb_wal_last_flush_timestamp_seconds{collection}`   — gauge, unixtime of last OK flush (age = `time()-metric`)
 //!   * `proximadb_wal_backpressure_active{collection}`            — gauge, 1 while a write is being throttled
 //!   * `proximadb_wal_backpressure_total{collection}`             — counter, backpressure engagements
+//!   * `proximadb_wal_truncation_segments_reclaimed_total`        — counter, WAL segments reclaimed below the canonical marker (TD-WAL-1 S6)
+//!   * `proximadb_wal_replay_duration_seconds`                    — gauge, last boot's WAL replay wall-clock (TD-WAL-1 S6)
 //!
 //! Wiring mirrors [`crate::wal_scan_metrics`]: a *private* Prometheus registry
 //! (no boot init required) whose [`scrape_text`] is appended to the
@@ -94,6 +96,19 @@ lazy_static! {
         "proximadb_wal_backpressure_total",
         "Count of write-backpressure engagements at the critical watermark, per collection (ADR-069 D3)",
         &["collection"],
+    );
+    // TD-WAL-1 S6 residuals. Both are boot/compaction-wide aggregates (no
+    // collection label) — the per-collection + per-tenant durable attribution
+    // lives in the io_trace warehouse surface (ADR-066), not Prometheus.
+    static ref TRUNCATION_SEGMENTS_RECLAIMED: IntCounterVec = build_counter(
+        "proximadb_wal_truncation_segments_reclaimed_total",
+        "WAL segments reclaimed by `truncate_through_canonical_marker` (below the canonical-emission marker), boot/compaction-wide (TD-WAL-1 S6)",
+        &[],
+    );
+    static ref REPLAY_DURATION: IntGaugeVec = build_gauge(
+        "proximadb_wal_replay_duration_seconds",
+        "Wall-clock seconds spent replaying the WAL on the last boot (TD-WAL-1 S6)",
+        &[],
     );
 }
 
@@ -215,6 +230,23 @@ pub fn inc_backpressure(collection: &str) {
     BACKPRESSURE_TOTAL.with_label_values(&[collection]).inc();
 }
 
+/// Count WAL segments reclaimed by canonical-marker truncation (TD-WAL-1 S6).
+/// Boot/compaction-wide aggregate — no collection label.
+pub fn inc_truncation_segments_reclaimed(n: u64) {
+    if n > 0 {
+        TRUNCATION_SEGMENTS_RECLAIMED
+            .with_label_values::<&str>(&[])
+            .inc_by(n);
+    }
+}
+
+/// Record the wall-clock duration of the last WAL replay on boot (TD-WAL-1 S6).
+pub fn set_replay_duration(seconds: f64) {
+    REPLAY_DURATION
+        .with_label_values::<&str>(&[])
+        .set(seconds.max(0.0) as i64);
+}
+
 /// Prometheus text exposition for this family. Empty until the first emit,
 /// appended to `/metrics/prometheus`.
 pub fn scrape_text() -> String {
@@ -299,5 +331,28 @@ mod tests {
         assert!(text.contains("proximadb_wal_size_bytes"), "{text}");
         assert!(text.contains("col_scrape"), "{text}");
         assert!(text.contains("reason=\"size\""), "{text}");
+    }
+
+    #[test]
+    fn s6_truncation_and_replay_metrics_round_trip() {
+        inc_truncation_segments_reclaimed(3);
+        inc_truncation_segments_reclaimed(0); // no-op guard
+        set_replay_duration(1.5); // truncated to whole seconds
+        assert_eq!(
+            TRUNCATION_SEGMENTS_RECLAIMED
+                .with_label_values::<&str>(&[])
+                .get(),
+            3
+        );
+        assert_eq!(REPLAY_DURATION.with_label_values::<&str>(&[]).get(), 1);
+        let text = scrape_text();
+        assert!(
+            text.contains("proximadb_wal_truncation_segments_reclaimed_total"),
+            "{text}"
+        );
+        assert!(
+            text.contains("proximadb_wal_replay_duration_seconds"),
+            "{text}"
+        );
     }
 }

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -609,9 +609,13 @@ impl RecordOpsService {
             }
             Err(error) => {
                 tracing::error!("Failed to process rich record batch: {:?}", error);
+                // ADR-069 S4: preserve the `WalBackpressure` discriminant so the
+                // boundary surfaces 429 / RESOURCE_EXHAUSTED (retryable) instead
+                // of a generic RECORD_INSERT_FAILED (non-retryable).
+                let error_code = crate::storage::persistence::write_ahead_log::flush_policy::write_batch_error_code(&error, "RECORD_INSERT_FAILED");
                 Ok(BatchOperationResult::failure(
                     format!("Record insert failed: {}", error),
-                    "RECORD_INSERT_FAILED".to_string(),
+                    error_code,
                 ))
             }
         }
@@ -695,9 +699,11 @@ impl RecordOpsService {
                     "Failed to process insert-only rich record batch: {:?}",
                     error
                 );
+                // ADR-069 S4: preserve the `WalBackpressure` discriminant (→ 429).
+                let error_code = crate::storage::persistence::write_ahead_log::flush_policy::write_batch_error_code(&error, "RECORD_INSERT_FAILED");
                 Ok(BatchOperationResult::failure(
                     format!("Record insert failed: {}", error),
-                    "RECORD_INSERT_FAILED".to_string(),
+                    error_code,
                 ))
             }
         }

--- a/src/network/rest/v2/documents.rs
+++ b/src/network/rest/v2/documents.rs
@@ -640,9 +640,15 @@ fn batch_failure_to_api_error(
     };
     match resp.error_code.as_deref() {
         Some("NOT_FOUND") => ApiError::NotFound(format!("Collection '{collection}' not found")),
-        Some("SCHEMA_VALIDATION_FAILED") | Some("INSERT_CONFLICT") | Some("WAL_LANE_REJECTED") => {
+        Some("SCHEMA_VALIDATION_FAILED") | Some("INSERT_CONFLICT") => {
             ApiError::InvalidArgument(detail)
         }
+        // ADR-069 S4: write-admission backpressure — the batch was shed at the
+        // critical watermark (`WAL_BACKPRESSURE`, raised inside the write path) or
+        // the write lane rejected it pre-write (`WAL_LANE_REJECTED`, #951). Both
+        // are *retryable*: surface 429 / RESOURCE_EXHAUSTED so the client backs off
+        // instead of treating a shed write as a hard 400/500.
+        Some("WAL_BACKPRESSURE") | Some("WAL_LANE_REJECTED") => ApiError::ResourceExhausted(detail),
         // Dimension violations surface as RECORD_INSERT_FAILED with the
         // validator's message — a client error, not a server fault.
         _ if detail.contains("dimension") => ApiError::InvalidArgument(detail),

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1299,13 +1299,32 @@ pub async fn insert_records(
             // HTTP 404 here so SDK consumers and curl users see the same
             // signal. Other failure codes still flow through the body, which
             // matches the batched per-record contract.
-            if !resp.success && resp.error_code.as_deref() == Some("NOT_FOUND") {
-                return Err(ApiError::NotFound(
-                    resp.errors
-                        .into_iter()
-                        .next()
-                        .unwrap_or_else(|| format!("Collection '{}' not found", collection)),
-                ));
+            if !resp.success {
+                if resp.error_code.as_deref() == Some("NOT_FOUND") {
+                    return Err(ApiError::NotFound(
+                        resp.errors
+                            .into_iter()
+                            .next()
+                            .unwrap_or_else(|| format!("Collection '{}' not found", collection)),
+                    ));
+                }
+                // ADR-069 S4: the whole batch was shed by write-admission
+                // backpressure — surface 429 / RESOURCE_EXHAUSTED so the client
+                // retries with backoff. (`WAL_BACKPRESSURE` is raised inside the
+                // write path; `WAL_LANE_REJECTED` is the #951 pre-write lane
+                // rejection. No partial results to represent — unlike a partial
+                // success, the batch was wholly rejected.)
+                if matches!(
+                    resp.error_code.as_deref(),
+                    Some("WAL_BACKPRESSURE") | Some("WAL_LANE_REJECTED")
+                ) {
+                    return Err(ApiError::ResourceExhausted(
+                        resp.errors.into_iter().next().unwrap_or_else(|| {
+                            "WAL write-admission backpressure; retry after a flush drains"
+                                .to_string()
+                        }),
+                    ));
+                }
             }
             // Check for success - if successful, all records were inserted
             let validation_error_count = errors.len();

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -2780,6 +2780,38 @@ impl SharedServices {
             ..Default::default()
         };
 
+        // ADR-069 S1 guardrail: the WAL belongs on a local reattachable disk
+        // (object-store WAL was the pre-pivot architecture and pays an I/O
+        // round-trip per append). Warn — at `error` level when a durability-
+        // sensitive `sync_mode` is also set, because an object store does not
+        // honour `fsync` the way a local block device does, so a remote WAL +
+        // PerBatch/Always makes a durability claim that does not hold. A bare
+        // path (no `scheme://`) is local (resolved to `file://`).
+        {
+            let dir = toml_config.write_buffer_directory.trim();
+            let is_remote = dir.contains("://") && !dir.starts_with("file:");
+            if is_remote {
+                let sync = toml_config.sync_mode.to_lowercase();
+                if matches!(sync.as_str(), "perbatch" | "always") {
+                    tracing::error!(
+                        wal_dir = %dir,
+                        sync_mode = %toml_config.sync_mode,
+                        "ADR-069 S1: WAL write_buffer_directory is on a remote (object-store) \
+                         scheme with a durability-sensitive sync_mode — object stores do not \
+                         honour fsync like a local disk, so the durability claim is not trustworthy. \
+                         Move the WAL to a local file:// path."
+                    );
+                } else {
+                    tracing::warn!(
+                        wal_dir = %dir,
+                        "ADR-069 S1: WAL write_buffer_directory is on a remote (object-store) \
+                         scheme; ADR-069 places the WAL on local disk. Remote WAL pays an I/O \
+                         round-trip per append."
+                    );
+                }
+            }
+        }
+
         // Create memtable config
         let memtable = MemTableConfig {
             global_memory_limit: toml_config.write_buffer_size_mb as usize * 1024 * 1024,

--- a/src/services/operations/vectors/write.rs
+++ b/src/services/operations/vectors/write.rs
@@ -357,9 +357,14 @@ impl VectorWriteCoordinator {
                     ));
                 }
                 warn!("WAL batch insert failed: {}", e);
+                // ADR-069 S4: preserve the `WalBackpressure` discriminant
+                // (→ "WAL_BACKPRESSURE") so the REST/gRPC boundary surfaces a
+                // retryable 429 / RESOURCE_EXHAUSTED instead of a non-retryable
+                // 400/500. Other errors keep the generic `WAL_WRITE_ERROR` code.
+                let error_code = crate::storage::persistence::write_ahead_log::flush_policy::write_batch_error_code(&e, "WAL_WRITE_ERROR");
                 Ok(BatchOperationResult::failure(
                     format!("Batch insert failed: {}", e),
-                    "WAL_WRITE_ERROR".to_string(),
+                    error_code,
                 ))
             }
         }

--- a/src/storage/persistence/write_ahead_log/flush_policy.rs
+++ b/src/storage/persistence/write_ahead_log/flush_policy.rs
@@ -252,6 +252,30 @@ impl std::fmt::Display for WalBackpressure {
 
 impl std::error::Error for WalBackpressure {}
 
+/// Classify a write-path `anyhow::Error` into a `BatchOperationResult::error_code`,
+/// promoting an ADR-069 S4 `WalBackpressure` found *anywhere* in the error chain
+/// to `"WAL_BACKPRESSURE"` so the REST/gRPC boundary can map it to a retryable
+/// 429 / `RESOURCE_EXHAUSTED` instead of a non-retryable 400/500.
+///
+/// The batch write path (`#951`) folds inner write errors into
+/// `Ok(BatchOperationResult { success: false, .. })`, and the fold sites
+/// historically stamped a generic `"RECORD_INSERT_FAILED"` / `"WAL_WRITE_ERROR"`
+/// code — losing the backpressure discriminant so the shed write looked like a
+/// hard failure. Walking the chain (rather than string-matching the message)
+/// keeps the classification robust to `.context(..)` wrapping by intermediate
+/// layers, mirroring `ApiError::from_write_error`. Any non-backpressure error
+/// keeps the caller's `default_code` (behavior unchanged).
+pub fn write_batch_error_code(err: &anyhow::Error, default_code: &str) -> String {
+    if err
+        .chain()
+        .any(|cause| cause.downcast_ref::<WalBackpressure>().is_some())
+    {
+        "WAL_BACKPRESSURE".to_string()
+    } else {
+        default_code.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -394,5 +418,29 @@ mod tests {
         // healthy envelope: no warnings
         let p3 = FlushPolicy::from_performance(&cfg(500, 300, 1000, 0.80, 0.95));
         assert!(p3.warnings().is_empty());
+    }
+
+    #[test]
+    fn write_batch_error_code_promotes_backpressure_through_context_layers() {
+        // A WalBackpressure wrapped in two .context() layers (how the write path
+        // actually propagates it) must still classify as WAL_BACKPRESSURE so the
+        // boundary can map it to a retryable 429, not a generic failure.
+        let bp = anyhow::Error::new(WalBackpressure {
+            collection_id: "c1".into(),
+            fill_pct: 97.0,
+        })
+        .context("insert batch")
+        .context("tenant write lane");
+        assert_eq!(
+            write_batch_error_code(&bp, "RECORD_INSERT_FAILED"),
+            "WAL_BACKPRESSURE"
+        );
+
+        // A plain (non-backpressure) write error keeps the caller's default code.
+        let other = anyhow::anyhow!("schema mismatch");
+        assert_eq!(
+            write_batch_error_code(&other, "WAL_WRITE_ERROR"),
+            "WAL_WRITE_ERROR"
+        );
     }
 }

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -154,6 +154,9 @@ impl RecoveryManager {
             "🔄 Starting WAL recovery using global manifest (mode: {:?})",
             self.recovery_mode
         );
+        // TD-WAL-1 S6: measure this boot's replay wall-clock for the
+        // `proximadb_wal_replay_duration_seconds` gauge.
+        let replay_started_at = std::time::Instant::now();
 
         // Get the recovery thread pool
         let thread_pool = get_recovery_thread_pool();
@@ -207,6 +210,9 @@ impl RecoveryManager {
         if collections.is_empty() {
             // Recovery phase complete
             recovery_guard.complete(0, 0).await;
+            crate::metrics::wal_flush_metrics::set_replay_duration(
+                replay_started_at.elapsed().as_secs_f64(),
+            );
             return Ok(WalRecoveryStats::default());
         }
 
@@ -327,6 +333,9 @@ impl RecoveryManager {
             info!("🧹 Removed {} flushed manifest entries", removed);
         }
 
+        crate::metrics::wal_flush_metrics::set_replay_duration(
+            replay_started_at.elapsed().as_secs_f64(),
+        );
         Ok(stats)
     }
 

--- a/src/storage/persistence/write_ahead_log/wal_operations.rs
+++ b/src/storage/persistence/write_ahead_log/wal_operations.rs
@@ -751,6 +751,9 @@ impl UnifiedWALWriter {
             tracing::debug!(segment = seg, lsn, "TD-066 (d): reclaimed WAL segment");
         }
 
+        // TD-WAL-1 S6: observe segments reclaimed (operator aggregate; per-tenant
+        // durable attribution lives in the io_trace warehouse, ADR-066).
+        crate::metrics::wal_flush_metrics::inc_truncation_segments_reclaimed(reclaimed);
         Ok(reclaimed)
     }
 


### PR DESCRIPTION
## Summary

Closes the three **TD-WAL-1 residuals** blocking end-to-end backpressure on the batch write path. Co-design framing: backpressure is the write-shedding cost-control that protects the WAL I/O budget; until now a shed batch looked like a hard 400/500 (non-retryable), defeating client backoff.

## S4 — REST/gRPC batch 429 propagation
The `WalBackpressure` discriminant was **lost at the batch fold sites** (`record_ops_service`, `vectors/write`), which stamped generic `RECORD_INSERT_FAILED`/`WAL_WRITE_ERROR` codes. Fix:
- **`flush_policy::write_batch_error_code`** — classifies a `WalBackpressure` found anywhere in the anyhow chain as `WAL_BACKPRESSURE` (chain walk, robust to `.context` wrapping — mirrors `ApiError::from_write_error`).
- **`documents.rs` `batch_failure_to_api_error`** + **`records.rs` `Ok(!success)` arm** — map `WAL_BACKPRESSURE` + `WAL_LANE_REJECTED` → `ResourceExhausted` (HTTP 429 / gRPC `RESOURCE_EXHAUSTED`). `records.rs` previously returned HTTP 200 on a total batch failure other than `NOT_FOUND`.

## S6 — residual metrics
- `proximadb_wal_truncation_segments_reclaimed_total` counter (emitted at `truncate_through_canonical_marker`).
- `proximadb_wal_replay_duration_seconds` gauge (timed in `recover_all`).
- Operator-aggregate Prometheus; the per-tenant **durable** attribution stays in the io_trace warehouse (ADR-066).

## S1 — `write_buffer_directory` scheme guardrail
`shared_services`: warn when the WAL dir is a remote object-store scheme (ADR-069 places the WAL on local disk; object-store WAL pays an I/O round-trip per append); **error-level** when a durability-sensitive `sync_mode` (PerBatch/Always) is also set, since an object store does not honour `fsync` like a local block device.

## Verification
- `cargo check --lib` clean; **new unit tests green**: `write_batch_error_code_promotes_backpressure_through_context_layers` (chain-walk through `.context` layers), `s6_truncation_and_replay_metrics_round_trip`.
- `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean; `scripts/check_no_agent_attribution.py` clean.

Refs ADR-069, TD-WAL-1.