### PR TITLE
feat(sst): TD-RDSTRAT-8 durable IVF coarse-probe telemetry (io_trace + Prometheus)

### DIFF
--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -149,6 +149,19 @@ pub struct IoTrace {
     /// (`centroid_pruned_blocks > 0`) rather than silently falling back to a full scan.
     centroid_total_blocks: AtomicU64,
     centroid_pruned_blocks: AtomicU64,
+    /// TD-RDSTRAT-8 two-level IVF coarse-probe outcome (durable — lands in the
+    /// warehouse `VectorAnnPayload` satellite via `TracePayload::classify`). The
+    /// coarse probe ranks `k_c` centroids in RAM and ranged-reads only `nprobe`
+    /// cells, cutting the dominant per-query cost term (GET round-trips). These
+    /// counters make that cut observable per-query so nprobe/spill tuning is
+    /// evidence-led ("trace before you tune"), not asserted.
+    /// `ivf_whole_region_fallback` counts segments where the probe was armed but
+    /// missed and the read fell back to the whole Region-A scan.
+    ivf_cells_total: AtomicU64,
+    ivf_cells_probed: AtomicU64,
+    ivf_probed_rows: AtomicU64,
+    ivf_fetch_rounds: AtomicU64,
+    ivf_whole_region_fallback: AtomicU64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): how often the probe scan's
     /// `wait_complete()` rendezvous resolved with the filter arrived (pruning
     /// enabled) vs timed out (filterless, conservative), plus the wall ms spent
@@ -385,6 +398,35 @@ impl IoTrace {
             .fetch_add(pruned, Ordering::Relaxed);
     }
 
+    /// Record a TD-RDSTRAT-8 two-level IVF coarse-probe outcome for the active
+    /// query: of `cells_total` persisted coarse centroids, `cells_probed` were
+    /// ranked in RAM and `probed_rows` rows read across `fetch_rounds` coalesced
+    /// Region-A ranged-reads. `whole_region_fallback = true` marks a segment where
+    /// the probe was armed but missed and the read fell back to the whole Region-A
+    /// scan (the GET budget the probe exists to avoid). Lands in the warehouse
+    /// `VectorAnnPayload` via `TracePayload::classify`.
+    pub fn record_ivf_coarse_probe(
+        &self,
+        cells_total: u64,
+        cells_probed: u64,
+        probed_rows: u64,
+        fetch_rounds: u64,
+        whole_region_fallback: bool,
+    ) {
+        self.ivf_cells_total
+            .fetch_add(cells_total, Ordering::Relaxed);
+        self.ivf_cells_probed
+            .fetch_add(cells_probed, Ordering::Relaxed);
+        self.ivf_probed_rows
+            .fetch_add(probed_rows, Ordering::Relaxed);
+        self.ivf_fetch_rounds
+            .fetch_add(fetch_rounds, Ordering::Relaxed);
+        if whole_region_fallback {
+            self.ivf_whole_region_fallback
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
     /// Record a runtime-filter wait outcome (ADR-056 AQE-S11): `arrived` = the
     /// filter completed within the wait budget (pruning enabled); otherwise it
     /// timed out (splits read filterless, conservative). `waited_ms` = the wall
@@ -566,6 +608,11 @@ impl IoTrace {
             splits_pruned: self.splits_pruned.load(Ordering::Relaxed),
             centroid_total_blocks: self.centroid_total_blocks.load(Ordering::Relaxed),
             centroid_pruned_blocks: self.centroid_pruned_blocks.load(Ordering::Relaxed),
+            ivf_cells_total: self.ivf_cells_total.load(Ordering::Relaxed),
+            ivf_cells_probed: self.ivf_cells_probed.load(Ordering::Relaxed),
+            ivf_probed_rows: self.ivf_probed_rows.load(Ordering::Relaxed),
+            ivf_fetch_rounds: self.ivf_fetch_rounds.load(Ordering::Relaxed),
+            ivf_whole_region_fallback: self.ivf_whole_region_fallback.load(Ordering::Relaxed),
             runtime_filter_arrived: self.runtime_filter_arrived.load(Ordering::Relaxed),
             runtime_filter_timed_out: self.runtime_filter_timed_out.load(Ordering::Relaxed),
             runtime_filter_wait_ms: self.runtime_filter_wait_ms.load(Ordering::Relaxed),
@@ -645,6 +692,18 @@ pub struct IoTraceSnapshot {
     pub centroid_total_blocks: u64,
     #[serde(default)]
     pub centroid_pruned_blocks: u64,
+    /// TD-RDSTRAT-8 two-level IVF coarse-probe outcome (durable warehouse
+    /// satellite — see `VectorAnnPayload`).
+    #[serde(default)]
+    pub ivf_cells_total: u64,
+    #[serde(default)]
+    pub ivf_cells_probed: u64,
+    #[serde(default)]
+    pub ivf_probed_rows: u64,
+    #[serde(default)]
+    pub ivf_fetch_rounds: u64,
+    #[serde(default)]
+    pub ivf_whole_region_fallback: u64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): arrived vs timed-out +
     /// the wall ms spent waiting. `arrived / (arrived + timed_out)` is the
     /// per-workload signal the route cost model learns to tune the wait budget.
@@ -885,6 +944,27 @@ pub fn record_splits(total: u64, pruned: u64) {
 /// probe. Silently no-ops outside an active scope.
 pub fn record_centroid_prune(total: u64, pruned: u64) {
     let _ = IO_TRACE.try_with(|t| t.record_centroid_prune(total, pruned));
+}
+
+/// Record a TD-RDSTRAT-8 two-level IVF coarse-probe outcome for the active
+/// query (durable — lands in the warehouse `VectorAnnPayload`). See
+/// [`IoTrace::record_ivf_coarse_probe`]. Silently no-ops outside an active scope.
+pub fn record_ivf_coarse_probe(
+    cells_total: u64,
+    cells_probed: u64,
+    probed_rows: u64,
+    fetch_rounds: u64,
+    whole_region_fallback: bool,
+) {
+    let _ = IO_TRACE.try_with(|t| {
+        t.record_ivf_coarse_probe(
+            cells_total,
+            cells_probed,
+            probed_rows,
+            fetch_rounds,
+            whole_region_fallback,
+        )
+    });
 }
 
 /// Record a runtime-filter wait outcome for the active query (ADR-056 AQE-S11).
@@ -1333,6 +1413,21 @@ mod tests {
         assert_eq!(s.total_compute_ms(), 17);
         assert_eq!(s.compute_ms.get("volcano"), Some(&7));
         assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn ivf_coarse_probe_record_populates_snapshot() {
+        // TD-RDSTRAT-8: record_ivf_coarse_probe must populate all five durable
+        // counters so the warehouse VectorAnnPayload captures the probe outcome.
+        let t = IoTrace::new();
+        t.record_ivf_coarse_probe(64, 8, 4096, 3, false);
+        t.record_ivf_coarse_probe(0, 0, 0, 0, true); // armed-but-missed fallback
+        let s = t.snapshot();
+        assert_eq!(s.ivf_cells_total, 64);
+        assert_eq!(s.ivf_cells_probed, 8);
+        assert_eq!(s.ivf_probed_rows, 4096);
+        assert_eq!(s.ivf_fetch_rounds, 3);
+        assert_eq!(s.ivf_whole_region_fallback, 1);
     }
 
     #[test]

--- a/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
+++ b/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
@@ -173,8 +173,10 @@ pub struct RelationalPayload {
     pub runtime_filter_wait_ms: u64,
 }
 
-/// Vector-ANN modality payload — PAX centroid block-prune (TD-RDSTRAT-5) and the
-/// logical striped-read projection (ADR-057 / TD-RDSTRAT-3).
+/// Vector-ANN modality payload — PAX centroid block-prune (TD-RDSTRAT-5), the
+/// logical striped-read projection (ADR-057 / TD-RDSTRAT-3), and the two-level
+/// IVF coarse-probe outcome (TD-RDSTRAT-8). Each field defaults to 0 so an older
+/// reader deserializes a newer writer's envelope losslessly.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VectorAnnPayload {
     #[serde(default)]
@@ -185,6 +187,23 @@ pub struct VectorAnnPayload {
     pub logical_striped_bytes: u64,
     #[serde(default)]
     pub logical_striped_gets: u64,
+    /// TD-RDSTRAT-8 two-level IVF coarse probe: of `ivf_cells_total` persisted
+    /// coarse centroids, `ivf_cells_probed` were ranked in RAM and
+    /// `ivf_probed_rows` rows read across `ivf_fetch_rounds` coalesced Region-A
+    /// ranged-reads. `ivf_whole_region_fallback` counts segments where the armed
+    /// probe missed and the read fell back to the whole Region-A scan (the GET
+    /// budget the probe exists to avoid). The dominant cloud cost term is GET
+    /// round-trips — these make the probe's cut observable per-query.
+    #[serde(default)]
+    pub ivf_cells_total: u64,
+    #[serde(default)]
+    pub ivf_cells_probed: u64,
+    #[serde(default)]
+    pub ivf_probed_rows: u64,
+    #[serde(default)]
+    pub ivf_fetch_rounds: u64,
+    #[serde(default)]
+    pub ivf_whole_region_fallback: u64,
 }
 
 /// Embedding modality payload — KEU token counts.
@@ -247,12 +266,19 @@ impl TracePayload {
         if snap.centroid_total_blocks > 0
             || snap.logical_striped_gets > 0
             || snap.logical_striped_bytes > 0
+            || snap.ivf_cells_total > 0
+            || snap.ivf_whole_region_fallback > 0
         {
             TracePayload::VectorAnn(VectorAnnPayload {
                 centroid_total_blocks: snap.centroid_total_blocks,
                 centroid_pruned_blocks: snap.centroid_pruned_blocks,
                 logical_striped_bytes: snap.logical_striped_bytes,
                 logical_striped_gets: snap.logical_striped_gets,
+                ivf_cells_total: snap.ivf_cells_total,
+                ivf_cells_probed: snap.ivf_cells_probed,
+                ivf_probed_rows: snap.ivf_probed_rows,
+                ivf_fetch_rounds: snap.ivf_fetch_rounds,
+                ivf_whole_region_fallback: snap.ivf_whole_region_fallback,
             })
         } else if snap.plan_nodes > 0
             || snap.plan_depth > 0
@@ -411,6 +437,31 @@ mod tests {
             TracePayload::classify(&snap),
             TracePayload::Embedding(_)
         ));
+    }
+
+    #[test]
+    fn classify_packs_ivf_coarse_probe_into_vector_ann() {
+        // TD-RDSTRAT-8: an IVF coarse-probe outcome (no centroid/striped signal)
+        // must classify as VectorAnn and carry all five durable fields, so the
+        // warehouse satellite captures the probe's GET cut per query.
+        let snap = IoTraceSnapshot {
+            ivf_cells_total: 64,
+            ivf_cells_probed: 8,
+            ivf_probed_rows: 4096,
+            ivf_fetch_rounds: 3,
+            ivf_whole_region_fallback: 1,
+            ..Default::default()
+        };
+        match TracePayload::classify(&snap) {
+            TracePayload::VectorAnn(v) => {
+                assert_eq!(v.ivf_cells_total, 64);
+                assert_eq!(v.ivf_cells_probed, 8);
+                assert_eq!(v.ivf_probed_rows, 4096);
+                assert_eq!(v.ivf_fetch_rounds, 3);
+                assert_eq!(v.ivf_whole_region_fallback, 1);
+            }
+            other => panic!("expected VectorAnn, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/storage/engines/sst/metrics.rs
+++ b/src/storage/engines/sst/metrics.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! TD-RDSTRAT-8 two-level IVF coarse-probe operator metrics (SST engine).
+//!
+//! Aggregate operator view of the coarse probe — whether it is engaging, how
+//! much of Region-A it avoids reading, and how often it falls back to the whole
+//! region scan. These are the signals the default-on promotion gate watches
+//! (`proximadb_ivf_whole_region_fallback_total` climbing ⇒ nprobe too small).
+//!
+//! Global counters (no collection label): the per-query, per-tenant *durable*
+//! record lives in the io_trace warehouse `VectorAnnPayload` (ADR-066); this
+//! Prometheus surface is the real-time aggregate operator dashboard. A
+//! collection label can be layered on once the warehouse data shows
+//! per-collection demand — keeping cardinality intentional, not eager.
+
+use lazy_static::lazy_static;
+use prometheus::{IntCounter, register_int_counter};
+
+fn counter(name: &str, help: &str) -> IntCounter {
+    register_int_counter!(name, help).unwrap_or_else(|_| {
+        IntCounter::new(format!("{name}_fallback"), help)
+            .unwrap_or_else(|_| unreachable!("valid counter metric descriptor"))
+    })
+}
+
+lazy_static! {
+    pub static ref IVF_CELLS_TOTAL: IntCounter = counter(
+        "proximadb_ivf_cells_total",
+        "Persisted coarse centroids seen by the TD-RDSTRAT-8 two-level IVF coarse probe",
+    );
+    pub static ref IVF_CELLS_PROBED: IntCounter = counter(
+        "proximadb_ivf_cells_probed_total",
+        "Coarse centroids ranked in RAM by the nprobe-scoped TD-RDSTRAT-8 probe",
+    );
+    pub static ref IVF_PROBED_ROWS: IntCounter = counter(
+        "proximadb_ivf_probed_rows_total",
+        "Rows ranged-read from the probed cells' Region-A extents (TD-RDSTRAT-8)",
+    );
+    pub static ref IVF_FETCH_ROUNDS: IntCounter = counter(
+        "proximadb_ivf_fetch_rounds_total",
+        "Coalesced Region-A ranged-read runs issued by the TD-RDSTRAT-8 probe (the GET round-trip budget it pays)",
+    );
+    pub static ref IVF_WHOLE_REGION_FALLBACK: IntCounter = counter(
+        "proximadb_ivf_whole_region_fallback_total",
+        "Segments where the armed TD-RDSTRAT-8 coarse probe missed and the read fell back to the whole Region-A scan",
+    );
+}
+
+/// Record a coarse-probe outcome to the aggregate operator surface. Mirrors the
+/// durable per-query record in `io_trace::record_ivf_coarse_probe` (which lands
+/// in the warehouse `VectorAnnPayload`); this is the real-time operator aggregate.
+pub fn record_ivf_coarse_probe(
+    cells_total: u64,
+    cells_probed: u64,
+    probed_rows: u64,
+    fetch_rounds: u64,
+    whole_region_fallback: bool,
+) {
+    IVF_CELLS_TOTAL.inc_by(cells_total);
+    IVF_CELLS_PROBED.inc_by(cells_probed);
+    IVF_PROBED_ROWS.inc_by(probed_rows);
+    IVF_FETCH_ROUNDS.inc_by(fetch_rounds);
+    if whole_region_fallback {
+        IVF_WHOLE_REGION_FALLBACK.inc();
+    }
+}

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -228,6 +228,7 @@ pub mod error;
 pub mod extraction;
 pub mod filter_methods;
 pub mod flush_eventlog_integration;
+pub mod metrics; // TD-RDSTRAT-8: IVF coarse-probe operator metrics
 pub(crate) mod staged_write;
 // Quantization now handled by unified compute module
 pub mod compactor_impl;

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -943,6 +943,33 @@ fn record_probe_trace(cells_total: u64, cells_probed: u64, probed_rows: u64, fet
     }
 }
 
+/// Record a coarse-probe outcome to BOTH durable surfaces (TD-RDSTRAT-8):
+/// the per-query io_trace → warehouse `VectorAnnPayload` (per-tenant, durable)
+/// and the aggregate Prometheus operator view. Call whenever the probe engages
+/// or armed-but-missed falls back to the whole region scan.
+fn record_ivf_probe_durable(
+    cells_total: u64,
+    cells_probed: u64,
+    probed_rows: u64,
+    fetch_rounds: u64,
+    whole_region_fallback: bool,
+) {
+    crate::observability::io_trace::record_ivf_coarse_probe(
+        cells_total,
+        cells_probed,
+        probed_rows,
+        fetch_rounds,
+        whole_region_fallback,
+    );
+    crate::storage::engines::sst::metrics::record_ivf_coarse_probe(
+        cells_total,
+        cells_probed,
+        probed_rows,
+        fetch_rounds,
+        whole_region_fallback,
+    );
+}
+
 /// Drain the recorded coarse-probe counters (empty when trace off / no probe).
 pub fn drain_probe_trace() -> Vec<(u64, u64, u64, u64)> {
     PROBE_TRACE
@@ -1177,10 +1204,10 @@ pub async fn rabitq_search_segment_coalesced(
     //    nprobe nearest cells (whole Region A never fetched); else the
     //    single-level whole-region scan (cold: 1 GET; hot: 0 — Arc clone). Any
     //    probe miss falls through, fail-safe, to the whole-region path.
-    let probe = if header.layout_version == SEG_LAYOUT_VERSION_TWO_LEVEL
+    let probe_armed = header.layout_version == SEG_LAYOUT_VERSION_TWO_LEVEL
         && header.a0_len > 0
-        && coarse_probe_enabled()
-    {
+        && coarse_probe_enabled();
+    let probe = if probe_armed {
         coarse_probe_survivors(fs, path, &header, query, metric, k, trace_on)
             .await
             .ok()
@@ -1192,8 +1219,25 @@ pub async fn rabitq_search_segment_coalesced(
         if trace_on {
             record_probe_trace(r.cells_total, r.cells_probed, r.probed_rows, r.fetch_rounds);
         }
+        // TD-RDSTRAT-8: durable per-query probe outcome → warehouse `VectorAnnPayload`
+        // (always-on when an io_trace scope is active; no-ops otherwise). The dominant
+        // cloud cost term is GET round-trips — recording the probe's cut per query is
+        // what makes nprobe/spill tuning evidence-led ("trace before you tune").
+        record_ivf_probe_durable(
+            r.cells_total,
+            r.cells_probed,
+            r.probed_rows,
+            r.fetch_rounds,
+            false,
+        );
         (r.survivors.clone(), None)
     } else {
+        // Armed probe that missed → whole-Region-A fallback (the GET budget the probe
+        // exists to avoid). Record the miss so it is observable; a non-v3 / probe-off
+        // read records nothing (no IVF occurred).
+        if probe_armed {
+            record_ivf_probe_durable(0, 0, 0, 0, true);
+        }
         let region_bytes: Arc<[u8]> = if let Some(inv) = cached.as_ref() {
             inv.region_bytes.clone()
         } else {


### PR DESCRIPTION
## Summary

Closes the **durable IVF telemetry** half of TD-RDSTRAT-8 (the other half — the SIFT-scale recall gate — stacks on this PR). Co-design framing: for a cloud DB the dominant cost term is **GET round-trips**; the two-level IVF coarse probe cuts those by ranking `k_c` centroids in RAM and ranged-reading only `nprobe` cells — but until now that cut was invisible per-query, so nprobe/spill tuning could only be asserted, not measured. "Trace before you tune."

## Two durable surfaces

**1. io_trace → warehouse (per-tenant source of truth):** 5 counters (`ivf_cells_total/probed`, `ivf_probed_rows`, `ivf_fetch_rounds`, `ivf_whole_region_fallback`) through the full `IoTrace` lifecycle (atomic → record → snapshot → free helper), packed into **`VectorAnnPayload`** — the payload satellite, deliberately *not* a flat `IoTraceSnapshot` field (avoids ADR-066 §2.2 flat-superset anti-pattern). `TracePayload::classify` now tags an IVF probe as `VectorAnn` even without centroid/striped signal. Tenant attribution rides the existing `TraceHeader`.

**2. Prometheus operator surface:** new `sst/metrics.rs` (mirrors `io_trace_sink_metrics` `IntCounter` pattern) — global `proximadb_ivf_*` counters; the default-on promotion gate watches `ivf_whole_region_fallback_total` (climbing ⇒ nprobe too small). Per-tenant detail stays in the warehouse; a collection label can be layered on once warehouse data shows demand.

## Record sites
`segment_format.rs::rabitq_search_segment_coalesced`: the durable record fires whenever the probe engages, plus a `whole_region_fallback` record when an **armed** probe misses (a non-v3 / probe-off read records nothing — no IVF occurred). Always-on when an io_trace scope is active; no-ops otherwise. The probe itself remains **default-OFF** (`PROXIMADB_IVF2_PROBE`).

## Verification
- observability-engine crate: lib+tests compile; **325 tests pass** incl. 2 new (`classify_packs_ivf_coarse_probe_into_vector_ann`, `ivf_coarse_probe_record_populates_snapshot`).
- `cargo check --lib` clean; `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean; no-agent-attribution clean.

Refs TD-RDSTRAT-8 (rev 3.2); stacks under the forthcoming SIFT recall-gate PR.