### PR TITLE
docs(trace): ADR-066 hot-path evidence — sink adds ~16µs p95, CPU-only

### DIFF
--- a/docs/12-design/runtime-evidence/IO_TRACE_SINK_HOT_PATH_P50_P95_2026_07_22.md
+++ b/docs/12-design/runtime-evidence/IO_TRACE_SINK_HOT_PATH_P50_P95_2026_07_22.md
@@ -1,0 +1,61 @@
+# io_trace sink hot-path overhead — sink OFF vs ON (2026-07-22)
+
+**Purpose.** ADR-066 §6 acceptance condition #3: prove the structured-io-trace
+sink adds **bounded, CPU-only overhead** to the query path and performs **no
+filesystem / network / compression work there**. This is the gate that blocks
+flipping ADR-066 from Proposed → Accepted.
+
+**Method.** The sink's *only* synchronous query-path work is the observer
+closure installed at `src/observability/io_trace_sink.rs:167`:
+
+1. `TraceEnvelope::from_snapshot` — clone the header fields + classify the
+   modality payload (no I/O).
+2. `serde_json::to_vec` — serialize the envelope (the dominant cost).
+3. a bounded `Spool::push` (Mutex lock + `saturating_add` + Vec push).
+
+The expensive work — `zstd::encode_all` compression, local seal, and the
+object-store conditional-create upload — all run in the **background `Worker`**
+(`spawn_blocking` at `io_trace_sink.rs:371`+), never on the query path. The
+`IoTrace` snapshot itself is taken at `instrument()` exit **unconditionally**
+(sink ON or OFF), so the sink's *incremental* per-query cost is exactly the
+closure above.
+
+The micro-bench `observer_closure_hot_path_is_bounded`
+(`src/observability/io_trace_sink.rs::tests`) drives those exact components over
+**N = 20,000** representative vector-ANN envelopes (12 GETs, ~1.2 MB read, 8
+range-gets, a 64-block centroid prune, two compute engines — 585 B serialized),
+timing each closure with `Instant::now()`. The snapshot is built via the public
+`IoTrace` record API (no struct-literal drift); the spool has a 64 MiB cap (no
+drops during the run).
+
+Reproduce:
+```
+cargo nextest run --lib observer_closure_hot_path_is_bounded --run-ignored only --nocapture
+```
+
+**Result (N = 20,000, macOS arm64 dev machine, serialized run):**
+
+| metric | value |
+|---|---|
+| p50 | **13,959 ns (~14 µs)** |
+| p95 | **15,959 ns (~16 µs)** |
+| p99 | 58,666 ns (~59 µs) |
+| envelope size | 585 bytes |
+
+The p99 tail (~59 µs) is scheduler/GC jitter across 20k samples; p50/p95 are
+tight (~14–16 µs). The closure's sanity guard (`p95 < 100 µs`) holds with ~6×
+headroom.
+
+**Conclusion.** ADR-066 §6 #3 is satisfied: the sink adds a bounded ~16 µs p95
+of **CPU-only** work per query (serialize + enqueue) and performs **no fsync,
+network, or compression** on the query path — that work is the background
+worker's. For context, a single object-store range-GET is ~1–10 ms (orders of
+magnitude larger), so the sink's overhead is in the noise of any real query.
+
+**Caveats / follow-ups.** Indicative dev-machine run, **not an SLA** — absolute
+numbers vary by hardware/load; the re-runnable micro-bench + the `p95 < 100 µs`
+guard are the durable artifact. A future end-to-end measurement (full query
+latency distribution with the sink installed against a live object store, OFF vs
+ON) would strengthen this to a full-query-path claim; this micro-bench isolates
+the sink's *incremental* cost, which is the part the ADR's acceptance condition
+names. Governed by `BENCHMARK_EVIDENCE.toml` claim `io_trace_sink_hotpath_p95`.

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -30,6 +30,23 @@ header_status = "ran the benches 2026-06-16 (docs/_internal/status/BENCH_RUN_202
 # ---------------------------------------------------------------------------
 
 [[claims]]
+id = "io_trace_sink_hotpath_p95"
+claim = "ADR-066 trace-sink observer closure (the only synchronous query-path work: TraceEnvelope::from_snapshot + serde_json::to_vec + bounded Spool::push) adds a bounded ~16 us p95 / ~14 us p50 per query and is CPU-only — no fsync, network upload, or zstd compression on the query path (those run in the background Worker). Satisfies ADR-066 §6 acceptance #3 (the Proposed → Accepted blocker)."
+metric = "per-query observer-closure latency p50/p95/p99 + envelope bytes"
+status = "measured"
+asserted_in = [
+  "docs/12-design/adr/ADR-066-structured-io-trace-etl-sink.adoc",
+  "docs/10-quality/td/TD-TRACE-2-structured-io-trace-etl-sink.adoc",
+]
+bench_source = "src/observability/io_trace_sink.rs"
+bench_command = "cargo nextest run --lib observer_closure_hot_path_is_bounded --run-ignored only --nocapture"
+artifact = "docs/12-design/runtime-evidence/IO_TRACE_SINK_HOT_PATH_P50_P95_2026_07_22.md"
+hardware = "Local macOS arm64 (Apple Silicon), serialized run, no competing workload"
+date = "2026-07-22"
+version = "feat/adr066-hotpath-evidence off develop @ f5246f5d2"
+notes = "N=20000 representative vector-ANN envelopes (585 bytes each): p50=13959ns p95=15959ns p99=58666ns. Closure sanity guard p95<100us holds with ~6x headroom. Micro-bench isolates the sink's INCREMENTAL cost (the snapshot is taken unconditionally at instrument() exit, sink ON or OFF); a full-query-path latency distribution OFF-vs-ON is the follow-up strengthening. Indicative dev-machine run, not an SLA."
+
+[[claims]]
 id = "object_economy_cpu_cost"
 claim = "Object-economy vector route building-block CPU costs (100/1K/10K/100K records) non-regression baseline"
 metric = "cpu_cost_ms"

--- a/src/observability/io_trace_sink.rs
+++ b/src/observability/io_trace_sink.rs
@@ -882,4 +882,76 @@ mod tests {
         assert_eq!(trace_files_recursive(first.path()).len(), 1);
         assert!(trace_files_recursive(second.path()).is_empty());
     }
+
+    /// ADR-066 §6 #3 — the trace sink's *query-path* cost is bounded and CPU-only.
+    ///
+    /// The sink's observer closure (the only thing that runs synchronously on the
+    /// query path) does: `TraceEnvelope::from_snapshot` + `serde_json::to_vec` + a
+    /// bounded spool `push`. fsync / object-store upload / zstd compression all
+    /// happen in the *background* `Worker` (off the query path). This micro-bench
+    /// measures the closure's components over N representative envelopes and prints
+    /// p50/p95/p99 + bytes/query for the evidence ledger — the sink's incremental
+    /// per-query cost. Run:
+    ///   `cargo nextest run --lib observer_closure_hot_path_is_bounded -- --ignored --nocapture`
+    #[test]
+    #[ignore = "ADR-066 hot-path measurement — run with --ignored --nocapture"]
+    fn observer_closure_hot_path_is_bounded() {
+        // Representative vector-ANN snapshot, built via the public API to avoid
+        // struct-literal drift: 12 GETs, ~1.2 MB read, 8 range-gets, a centroid
+        // prune, two compute engines — the shape that lands in the warehouse.
+        let trace = io_trace::IoTrace::new();
+        for _ in 0..12 {
+            trace.record_op(io_trace::IoOp::Get);
+        }
+        trace.record_bytes_read(1_200_000);
+        trace.record_range_gets(8);
+        trace.record_centroid_prune(64, 40);
+        trace.record_compute_ms("volcano", 3);
+        trace.record_compute_ms("datafusion", 17);
+        let snap = trace.snapshot();
+
+        // The sink's spool (large cap ⇒ no drops during the bench).
+        let spool: Arc<Mutex<Spool>> = Arc::new(Mutex::new(Spool::new(64 * 1024 * 1024)));
+
+        const N: usize = 20_000;
+        let mut samples_ns: Vec<u64> = Vec::with_capacity(N);
+        let mut last_envelope_bytes = 0usize;
+        for i in 0..N as u64 {
+            let t0 = std::time::Instant::now();
+            let envelope = TraceEnvelope::from_snapshot(
+                &snap,
+                Some("tenant-acme"),
+                "writer-bench",
+                i,
+                1_700_000_000_000,
+            );
+            let mut bytes = serde_json::to_vec(&envelope).expect("serialize envelope");
+            bytes.push(b'\n');
+            last_envelope_bytes = bytes.len();
+            spool
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(SpoolLine { bytes, sequence: i });
+            samples_ns.push(t0.elapsed().as_nanos() as u64);
+        }
+        samples_ns.sort_unstable();
+        let p50 = samples_ns[N / 2];
+        let p95 = samples_ns[(N * 95) / 100];
+        let p99 = samples_ns[(N * 99) / 100];
+        eprintln!(
+            "ADR-066 hot-path: N={N} observer-closure p50={p50}ns p95={p95}ns p99={p99}ns \
+             envelope_bytes={last_envelope_bytes} (CPU-only: from_snapshot + serde_json + \
+             spool_push; no fsync/network/compress on the query path — those are the \
+             background worker)"
+        );
+        // Sanity guard (NOT a perf SLA): the sink must not add pathological per-query
+        // overhead. 100µs is well above any representative envelope's serialize+push
+        // and leaves headroom for a loaded CI runner; the evidence doc records the
+        // actual p50/p95 measured on a quiet machine.
+        assert!(
+            p95 < 100_000,
+            "sink observer p95 {p95}ns unexpectedly high — investigate"
+        );
+        assert!(last_envelope_bytes > 0);
+    }
 }


### PR DESCRIPTION
## Summary

Records the measured evidence for **ADR-066 §6 acceptance condition #3** — the Proposed → Accepted blocker: prove the trace sink adds **bounded, CPU-only overhead** to the query path and performs **no filesystem / network / compression work there**.

## What the sink actually does on the query path
The observer closure (`io_trace_sink.rs:167`) is the **only** synchronous query-path work: `TraceEnvelope::from_snapshot` + `serde_json::to_vec` + a bounded `Spool::push`. The expensive work (zstd, local seal, object-store upload) runs in the **background Worker** (`spawn_blocking`). The `IoTrace` snapshot is taken unconditionally at `instrument()` exit (sink ON or OFF), so the sink's *incremental* cost is exactly that closure.

## Evidence
- **Micro-bench** `observer_closure_hot_path_is_bounded` (re-runnable, `#[ignore]`d) drives the closure components over N=20k representative vector-ANN envelopes (585 B), prints p50/p95/p99, guards p95 < 100µs.
- **Evidence doc** `docs/12-design/runtime-evidence/IO_TRACE_SINK_HOT_PATH_P50_P95_2026_07_22.md`.
- **Ledger** `BENCHMARK_EVIDENCE.toml` claim `io_trace_sink_hotpath_p95` (`status=measured`).

## Result (macOS arm64, N=20,000)
| metric | value |
|---|---|
| p50 | **13,959 ns (~14µs)** |
| p95 | **15,959 ns (~16µs)** |
| p99 | 58,666 ns (~59µs) |
| envelope | 585 bytes |

For context, a single object-store range-GET is ~1–10 ms — the sink overhead is in the noise. Indicative dev-machine run, not an SLA; the re-runnable bench + `p95 < 100µs` guard are the durable artifact.

## Verification
- `cargo nextest run --lib observer_closure_hot_path_is_bounded --run-ignored only --nocapture` → **1 passed** (numbers above).
- `python3 scripts/validate_benchmark_evidence.py` → passed (32 claims, 20 measured).
- `make work-commit-check` → passed; `cargo fmt --check` clean; no-agent-attribution clean.

Refs ADR-066, TD-TRACE-2.