### PR TITLE
feat(admin-ui): auto-refresh, tabbed dashboard, Prometheus metric charts

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -18,6 +18,12 @@ default_tenant = "default"
 # See docs/04-operations/admin-dashboard.adoc.
 [server.admin_ui]
 enabled = false
+# Client-side auto-refresh of the dashboard. When false (default) the
+# auto-refresh toggle in the UI is rendered disabled (greyed out) and the page
+# only refreshes on an explicit click. Set true to allow live polling.
+auto_refresh = false
+# Auto-refresh poll interval in seconds (only effective when auto_refresh = true).
+refresh_interval_seconds = 30
 
 [storage]
 # Metadata storage (collection definitions, schemas)

--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -274,6 +274,26 @@ pub struct AdminUiConfig {
     /// (`bool::default()`).
     #[serde(default)]
     pub enabled: bool,
+
+    /// Enable client-side auto-refresh of the dashboard. Default: `false`
+    /// (`bool::default()`). When `false`, the auto-refresh toggle in the UI is
+    /// rendered **disabled** (greyed out) and the page only refreshes on an
+    /// explicit click — an operator must opt in here to allow live polling.
+    /// The setting is server-injected into the page; it does not persist per
+    /// user session beyond the configured default.
+    #[serde(default)]
+    pub auto_refresh: bool,
+
+    /// Auto-refresh poll interval in seconds. Default: `30`. Only takes effect
+    /// when `auto_refresh = true`. Clamped to a minimum of `5` at serve time so
+    /// a misconfigured tiny interval cannot DoS the diagnostic endpoints.
+    #[serde(default = "default_admin_refresh_interval")]
+    pub refresh_interval_seconds: u32,
+}
+
+/// Default admin-dashboard auto-refresh interval (seconds).
+fn default_admin_refresh_interval() -> u32 {
+    30
 }
 
 /// Request-tenant resolution mode encoded in TOML.

--- a/crates/platform/proximadb-admin-ui/README.adoc
+++ b/crates/platform/proximadb-admin-ui/README.adoc
@@ -27,6 +27,8 @@ diagnostic endpoints:
 * `GET /health`, `GET /health/ready` — liveness / readiness
 * `GET /api/v2/_meta/capabilities` — build + capability summary
 * `GET /api/v2/collections` and `GET /api/v2/collections/{id}` — collections + detail
+* `GET /metrics/prometheus` — Prometheus text exposition, parsed client-side to
+  drive the Cache / Storage / Query / I/O-Trace charts (no data leaves the browser)
 * `GET /metrics/json` — numeric metrics (when the metrics collector is enabled)
 
 It renders no create/update/delete controls, so it cannot mutate state. A crate
@@ -37,8 +39,8 @@ URLs, and no write verbs in the page.
 
 [source,rust]
 ----
-// in the REST router assembly:
-base_router = base_router.merge(proximadb_admin_ui::admin_router());
+// in the REST router assembly (opts: AdminUiOptions from [server.admin_ui]):
+base_router = base_router.merge(proximadb_admin_ui::admin_router_if(opts));
 ----
 
 == Enabling (off by default)
@@ -50,12 +52,20 @@ for Kubernetes pods and embedded/UDS mode):
 ----
 [server.admin_ui]
 enabled = true
+# Client-side auto-refresh (default false). When false the UI toggle is greyed
+# out and the page only refreshes on an explicit click.
+auto_refresh = false
+# Auto-refresh poll interval in seconds (only effective when auto_refresh = true).
+refresh_interval_seconds = 30
 ----
 
-The router-build path always merges `admin_router_if(enabled)`; the toggle decides
-whether `/admin` actually exists. The flag flows
-`[server.admin_ui] enabled` → `ServerConfig` → `MultiServerBuilder::with_admin_ui_enabled`
-→ `MultiServerConfig::admin_ui_enabled` → `build_router_for_unified(.., admin_ui_enabled)`.
+The router-build path always merges `admin_router_if(AdminUiOptions { .. })`; the
+`enabled` toggle decides whether `/admin` actually exists. The config flows
+`[server.admin_ui]` → `ServerConfig::admin_ui` (`AdminUiConfig`) →
+`MultiServerBuilder::with_admin_ui_enabled` + `with_admin_ui_refresh` →
+`MultiServerConfig` → `build_router_for_unified(..)` → `AdminUiOptions` →
+`render_admin_html`, which injects the `auto_refresh` / `refresh_interval_seconds`
+defaults into the page (the toggle is greyed out when `auto_refresh = false`).
 
 == Accessing
 

--- a/crates/platform/proximadb-admin-ui/assets/admin.html
+++ b/crates/platform/proximadb-admin-ui/assets/admin.html
@@ -9,6 +9,13 @@
     --bg: #0f1320; --panel: #171c2e; --panel2: #1d2438; --border: #2a3350;
     --text: #e6eaf5; --muted: #8893b0; --accent: #5b8def; --ok: #22c55e;
     --warn: #f59e0b; --err: #ef4444; --chip: #243049;
+    /* Categorical series identity (validated CVD-safe on --panel #171c2e).
+       RESERVED for multi-series identity — never reused for status. */
+    --c1: #3987e5; --c2: #d95926; --c3: #199e70; --c4: #c98500;
+    --c5: #d55181; --c6: #008300; --c7: #9085e9; --c8: #e66767;
+    /* Ordinal blue ramp (light=hot → dark=cold); single-hue, monotone L. */
+    --ord1: #6da7ec; --ord2: #3987e5; --ord3: #256abf; --ord4: #184f95;
+    --grid: #26304a;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { background: var(--bg); color: var(--text); font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
@@ -21,8 +28,21 @@
   header .meta { color: var(--muted); font-size: 12px; }
   button, label.toggle { background: var(--panel2); color: var(--text); border: 1px solid var(--border); border-radius: 8px; padding: 6px 12px; font-size: 13px; cursor: pointer; }
   button:hover { border-color: var(--accent); }
+  label.toggle { display: inline-flex; align-items: center; gap: 6px; user-select: none; }
+  label.toggle input { accent-color: var(--accent); }
+  label.toggle input:disabled { cursor: not-allowed; }
+  label.toggle.disabled { opacity: .5; }
+
+  .tabs { display: flex; gap: 2px; padding: 0 12px; border-bottom: 1px solid var(--border); background: var(--panel); position: sticky; top: 51px; z-index: 4; overflow-x: auto; }
+  .tab { background: transparent; border: none; border-bottom: 2px solid transparent; border-radius: 0; padding: 10px 14px; color: var(--muted); font-size: 13px; white-space: nowrap; }
+  .tab:hover { color: var(--text); }
+  .tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
   .notice { margin: 14px 20px 0; padding: 8px 12px; border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 8px; background: var(--panel); color: var(--muted); font-size: 12.5px; }
-  main { display: grid; grid-template-columns: repeat(auto-fit, minmax(330px, 1fr)); gap: 14px; padding: 16px 20px 40px; }
+  main { padding: 4px 20px 40px; }
+  .tab-panel { display: none; padding-top: 14px; }
+  .tab-panel.active { display: block; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(330px, 1fr)); gap: 14px; }
   .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; }
   .card.wide { grid-column: 1 / -1; }
   .card h2 { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); padding: 12px 14px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 8px; }
@@ -30,10 +50,29 @@
   .kv { display: grid; grid-template-columns: minmax(120px, 38%) 1fr; gap: 4px 10px; }
   .kv .k { color: var(--muted); }
   .kv .v { color: var(--text); word-break: break-word; font-variant-numeric: tabular-nums; }
-  .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; }
+
+  .metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
   .stat { background: var(--panel2); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
   .stat .num { font-size: 20px; font-weight: 700; font-variant-numeric: tabular-nums; }
-  .stat .lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
+  .stat .lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; margin-top: 2px; }
+  .stat .sub { font-size: 11px; color: var(--muted); margin-top: 3px; }
+  .lvl { height: 4px; background: var(--bg); border-radius: 3px; margin-top: 7px; overflow: hidden; }
+  .lvl > span { display: block; height: 100%; background: var(--c1); border-radius: 3px; }
+
+  .legend { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 10px; font-size: 12px; color: var(--muted); }
+  .legend .sw { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+  .chart-wrap { padding: 4px 0 2px; }
+  svg.spark { width: 100%; height: 36px; display: block; }
+  svg.spark polyline { fill: none; stroke-width: 2; vector-effect: non-scaling-stroke; stroke-linejoin: round; stroke-linecap: round; }
+  svg.spark polygon { opacity: .16; }
+  svg.spark circle { vector-effect: non-scaling-stroke; }
+
+  .bar-row { display: grid; grid-template-columns: 92px 1fr 74px; align-items: center; gap: 8px; margin-bottom: 8px; }
+  .bar-lbl { color: var(--muted); font-size: 12px; }
+  .bar-track { background: var(--bg); border-radius: 4px; height: 12px; overflow: hidden; }
+  .bar-fill { display: block; height: 100%; border-radius: 4px; min-width: 2px; }
+  .bar-val { color: var(--text); font-size: 12px; text-align: right; font-variant-numeric: tabular-nums; }
+
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
   th, td { text-align: left; padding: 7px 10px; border-bottom: 1px solid var(--border); }
   th { color: var(--muted); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .4px; }
@@ -47,6 +86,7 @@
   pre { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 10px; overflow: auto; max-height: 260px; font-size: 12px; color: var(--muted); }
   .empty { color: var(--muted); font-style: italic; }
   .err-line { color: var(--err); font-size: 12.5px; }
+  .hint { font-size: 11.5px; color: var(--muted); margin-top: 8px; }
   footer { color: var(--muted); font-size: 12px; padding: 0 20px 28px; }
   code { background: var(--chip); padding: 1px 5px; border-radius: 5px; font-size: 12px; }
 </style>
@@ -58,58 +98,200 @@
   <span class="pill">Admin &middot; read-only</span>
   <span class="spacer"></span>
   <span class="meta" id="last-updated">never refreshed</span>
-  <label class="toggle"><input type="checkbox" id="auto" checked> auto-refresh</label>
+  <label class="toggle" id="auto-label" title="Auto-refresh (configured via [server.admin_ui])"><input type="checkbox" id="auto"> auto-refresh</label>
   <button id="refresh">Refresh</button>
 </header>
+
+<nav class="tabs" id="tabs">
+  <button class="tab active" data-tab="health">Health</button>
+  <button class="tab" data-tab="cache">Cache</button>
+  <button class="tab" data-tab="storage">Storage</button>
+  <button class="tab" data-tab="query">Query</button>
+  <button class="tab" data-tab="iotrace">I/O Trace</button>
+</nav>
 
 <div class="notice">
   This is a <strong>read-only</strong> dashboard for local standalone / embedded operation. It only
   issues <code>GET</code> requests against the server's diagnostic endpoints &mdash; it cannot create,
   modify, or delete data. For mutations use the SDKs, REST <code>/api/v2</code>, gRPC, or pgwire.
+  Metric charts parse the <code>/metrics/prometheus</code> exposition client-side; no data leaves the browser.
 </div>
 
 <main>
-  <section class="card">
-    <h2><span class="dot" id="health-dot"></span> Server Health</h2>
-    <div class="body"><div class="kv" id="health">Loading&hellip;</div></div>
+  <!-- ───────────────────────── Health ───────────────────────── -->
+  <section class="tab-panel active" data-panel="health">
+    <div class="grid">
+      <section class="card">
+        <h2><span class="dot" id="health-dot"></span> Server Health</h2>
+        <div class="body"><div class="kv" id="health">Loading&hellip;</div></div>
+      </section>
+      <section class="card">
+        <h2>Build &amp; Capabilities</h2>
+        <div class="body"><div class="kv" id="caps">Loading&hellip;</div></div>
+      </section>
+      <section class="card wide">
+        <h2>Collections</h2>
+        <div class="body" id="collections">Loading&hellip;</div>
+      </section>
+      <section class="card wide" id="detail-card" style="display:none">
+        <h2>Collection Detail &mdash; <span id="detail-name"></span></h2>
+        <div class="body"><pre id="detail">Select a collection above.</pre></div>
+      </section>
+    </div>
   </section>
 
-  <section class="card">
-    <h2>Build &amp; Capabilities</h2>
-    <div class="body"><div class="kv" id="caps">Loading&hellip;</div></div>
+  <!-- ───────────────────────── Cache ───────────────────────── -->
+  <section class="tab-panel" data-panel="cache">
+    <div class="grid">
+      <section class="card wide">
+        <h2>Cache Effectiveness</h2>
+        <div class="body">
+          <div class="metric-grid" id="cache-tiles"></div>
+          <div class="chart-wrap">
+            <div class="legend" id="cache-trend-legend"></div>
+            <svg class="spark" viewBox="0 0 100 36" preserveAspectRatio="none" id="cache-trend"></svg>
+            <div class="hint">Rate per refresh interval (delta of cumulative counters). Accumulates while the page polls.</div>
+          </div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>Hits by tier (l1 hot → l3 cold)</h2>
+        <div class="body" id="cache-tier-bars"><span class="empty">no cache metrics</span></div>
+      </section>
+    </div>
   </section>
 
-  <section class="card">
-    <h2>Metrics</h2>
-    <div class="body"><div class="stat-grid" id="metrics">Loading&hellip;</div></div>
+  <!-- ───────────────────────── Storage ───────────────────────── -->
+  <section class="tab-panel" data-panel="storage">
+    <div class="grid">
+      <section class="card wide">
+        <h2>Object-store read pressure (TD-IOTRACE-2 physical KRU)</h2>
+        <div class="body">
+          <div class="metric-grid" id="storage-tiles"></div>
+          <div class="chart-wrap">
+            <div class="legend" id="storage-trend-legend"></div>
+            <svg class="spark" viewBox="0 0 100 36" preserveAspectRatio="none" id="storage-trend"></svg>
+            <div class="hint">Ranged-GETs and bytes read per refresh interval.</div>
+          </div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>Ops by operation</h2>
+        <div class="body" id="storage-ops-bars"><span class="empty">no object-store metrics</span></div>
+      </section>
+      <section class="card">
+        <h2>Write bytes by access tier (hot → archive)</h2>
+        <div class="body" id="storage-tier-bars"><span class="empty">no write-by-tier metrics</span></div>
+      </section>
+      <section class="card">
+        <h2>Network / embedding outgress</h2>
+        <div class="body">
+          <div class="metric-grid" id="kou-tiles"><span class="empty">no outgress metrics</span></div>
+          <div class="hint">KOU = bytes moved out of the deployment (Dimension 2). KEU = embedding units (Dimension 5). Neutral telemetry; pricing lives in the control plane.</div>
+        </div>
+      </section>
+    </div>
   </section>
 
-  <section class="card wide">
-    <h2>Collections</h2>
-    <div class="body" id="collections">Loading&hellip;</div>
+  <!-- ───────────────────────── Query ───────────────────────── -->
+  <section class="tab-panel" data-panel="query">
+    <div class="grid">
+      <section class="card wide">
+        <h2>Request latency (HTTP)</h2>
+        <div class="body">
+          <div class="metric-grid" id="latency-tiles"><span class="empty">no latency histogram</span></div>
+          <div class="chart-wrap">
+            <div class="legend"><span><span class="sw" style="background:var(--c1)"></span>p95 over time</span></div>
+            <svg class="spark" viewBox="0 0 100 36" preserveAspectRatio="none" id="p95-trend"></svg>
+            <div class="hint">Quantiles computed from the <code>http_request_duration_seconds</code> histogram buckets (aggregated across routes). Status color vs 100&nbsp;ms / 500&nbsp;ms thresholds is indicative.</div>
+          </div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>Compute time by engine</h2>
+        <div class="body" id="engine-bars"><span class="empty">no task-execution metrics</span></div>
+      </section>
+      <section class="card wide">
+        <h2>SQL conformance</h2>
+        <div class="body">
+          TPC-H (22) and TPC-DS (16) suites are the <strong>conformance driver</strong> and run as ratcheted
+          qa-gate integration suites &mdash; their pass counts are not emitted as live Prometheus series.
+          Track progress via the qa-gate runs; each newly-passing query is the ratchet of progress toward
+          full ANSI SQL over pgwire.
+          <div class="hint">Live query-shape counters (e.g. <code>proximadb_task_execution_time_ms</code>) appear left when present.</div>
+        </div>
+      </section>
+    </div>
   </section>
 
-  <section class="card wide" id="detail-card" style="display:none">
-    <h2>Collection Detail &mdash; <span id="detail-name"></span></h2>
-    <div class="body"><pre id="detail">Select a collection above.</pre></div>
+  <!-- ───────────────────────── I/O Trace ───────────────────────── -->
+  <section class="tab-panel" data-panel="iotrace">
+    <div class="grid">
+      <section class="card wide">
+        <h2>io_trace sink (TD-TRACE-2)</h2>
+        <div class="body">
+          <div class="metric-grid" id="iotrace-tiles"><span class="empty">no io_trace metrics — feature off or warehouse unconfigured</span></div>
+          <div class="hint">The Iceberg-managed Parquet warehouse sink ships query-scoped I/O traces. Records dropped / upload failures are colored when non-zero. Requires the <code>io-trace</code> feature and a configured warehouse.</div>
+        </div>
+      </section>
+      <section class="card wide">
+        <h2>Physical ranged reads (per refresh)</h2>
+        <div class="body">
+          <div class="chart-wrap">
+            <div class="legend" id="iotrace-trend-legend"></div>
+            <svg class="spark" viewBox="0 0 100 36" preserveAspectRatio="none" id="iotrace-trend"></svg>
+            <div class="hint">Same physical GET / bytes-read counters surfaced in the Storage tab, plotted over time.</div>
+          </div>
+        </div>
+      </section>
+    </div>
   </section>
 </main>
 
 <footer>
   Polls (GET only): <code>/health</code>, <code>/health/ready</code>,
   <code>/api/v2/_meta/capabilities</code>, <code>/api/v2/collections</code>,
-  <code>/api/v2/collections/{id}</code>, <code>/metrics/json</code>.
-  Panels that show <span class="empty">n/a</span> mean that endpoint is disabled,
-  unauthorized, or unavailable in this deployment.
+  <code>/api/v2/collections/{id}</code>, <code>/metrics/prometheus</code>,
+  <code>/metrics/json</code>. Panels that show <span class="empty">n/a</span> mean that
+  endpoint/family is disabled, feature-gated, or unavailable in this deployment.
 </footer>
 
+<!--__ADMIN_CONFIG__-->
 <script>
 "use strict";
+/* ───────────────────────── helpers ───────────────────────── */
 const $ = (id) => document.getElementById(id);
-const esc = (s) => String(s).replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+function fmtNum(n) {
+  if (n == null || n === '' || Number.isNaN(Number(n))) return String(n);
+  n = Number(n);
+  const a = Math.abs(n);
+  if (a >= 1e12) return (n/1e12).toFixed(2) + 'T';
+  if (a >= 1e9) return (n/1e9).toFixed(2) + 'B';
+  if (a >= 1e6) return (n/1e6).toFixed(2) + 'M';
+  if (a >= 1e3) return (n/1e3).toFixed(1) + 'K';
+  return Number.isInteger(n) ? String(n) : n.toFixed(2);
+}
+function fmtBytes(n) {
+  n = Number(n) || 0;
+  const u = ['B','KB','MB','GB','TB','PB'];
+  let i = 0; while (Math.abs(n) >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+  return n.toFixed(i ? 2 : 0) + ' ' + u[i];
+}
+function fmtSec(ms_or_s) { // seconds-ish → human
+  const s = Number(ms_or_s) || 0;
+  if (s <= 0) return '—';
+  const now = Date.now()/1000;
+  const ago = now - s;
+  if (ago < 0 || ago > 1e9) return esc(new Date(s*1000).toISOString().slice(11,19)) + 'Z';
+  if (ago < 60) return Math.max(0,Math.floor(ago)) + 's ago';
+  if (ago < 3600) return Math.floor(ago/60) + 'm ago';
+  if (ago < 86400) return Math.floor(ago/3600) + 'h ago';
+  return Math.floor(ago/86400) + 'd ago';
+}
 
-// READ-ONLY data access: every request is a GET (fetch default verb), no-store,
-// with an 8s timeout. No write verbs are ever issued from this page.
+/* READ-ONLY data access: every request is a GET (fetch default verb), no-store,
+ * with an 8s timeout. No write verbs are ever issued from this page. */
 async function getJSON(url) {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), 8000);
@@ -123,6 +305,16 @@ async function getJSON(url) {
     return { ok: false, status: 0, error: String(e && e.message || e) };
   } finally { clearTimeout(t); }
 }
+/* GET the prometheus text exposition (no headers needed; default verb = GET). */
+async function getText(url) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 8000);
+  try {
+    const r = await fetch(url, { cache: 'no-store', signal: ctrl.signal });
+    return r.ok ? { ok: true, text: await r.text() } : { ok: false, status: r.status };
+  } catch (e) { return { ok: false, error: String(e && e.message || e) }; }
+  finally { clearTimeout(t); }
+}
 
 function kvRows(obj) {
   const entries = Object.entries(obj || {});
@@ -132,29 +324,170 @@ function kvRows(obj) {
     return `<span class="k">${esc(k)}</span><span class="v">${esc(val)}</span>`;
   }).join('');
 }
-
-function flattenNumbers(obj, prefix, out) {
-  out = out || {}; prefix = prefix || '';
-  if (obj && typeof obj === 'object') {
-    for (const [k, v] of Object.entries(obj)) {
-      const key = prefix ? prefix + '.' + k : k;
-      if (typeof v === 'number') out[key] = v;
-      else if (v && typeof v === 'object') flattenNumbers(v, key, out);
-    }
-  }
-  return out;
-}
-
-function fmtNum(n) {
-  if (typeof n !== 'number') return String(n);
-  if (Math.abs(n) >= 1e9) return (n/1e9).toFixed(2) + 'B';
-  if (Math.abs(n) >= 1e6) return (n/1e6).toFixed(2) + 'M';
-  if (Math.abs(n) >= 1e3) return (n/1e3).toFixed(1) + 'K';
-  return Number.isInteger(n) ? String(n) : n.toFixed(3);
-}
-
 function setDot(el, cls) { el.className = 'dot ' + (cls || ''); }
 
+/* ───────────────────────── prometheus parser ─────────────────────────
+ * Minimal, dependency-free Prometheus text-format parser. Produces a map of
+ * metric-name -> { type, help, samples: [{labels, value}] }. Handles the
+ * counter/gauge/histogram/summary exposition; _bucket/_sum/_count lines land as
+ * their own keys (caller looks up "<base>_bucket" directly). */
+function parseProm(text) {
+  const fams = Object.create(null);
+  const fam = (name) => (fams[name] || (fams[name] = { name, type: 'untyped', help: '', samples: [] }));
+  const sampleRe = /^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([-+]?(?:\d[\d.eE+-]*)|nan|inf|\+inf|-inf)/i;
+  const labelRe = /(\w+)="((?:\\.|[^"\\])*)"/g;
+  for (const raw of (text || '').split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line[0] === '#') {
+      if (line.startsWith('# HELP ')) {
+        const rest = line.slice(7); const sp = rest.indexOf(' ');
+        const f = fam(sp < 0 ? rest : rest.slice(0, sp)); f.help = sp < 0 ? '' : rest.slice(sp + 1);
+      } else if (line.startsWith('# TYPE ')) {
+        const rest = line.slice(6); const sp = rest.indexOf(' ');
+        const f = fam(sp < 0 ? rest : rest.slice(0, sp)); f.type = (sp < 0 ? 'untyped' : rest.slice(sp + 1)).trim();
+      }
+      continue;
+    }
+    const m = line.match(sampleRe);
+    if (!m) continue;
+    const name = m[1];
+    const labels = {};
+    if (m[2]) { let lm; labelRe.lastIndex = 0; while ((lm = labelRe.exec(m[2]))) labels[lm[1]] = lm[2].replace(/\\(.)/g, '$1'); }
+    let val = parseFloat(m[3]);
+    if (!Number.isFinite(val)) { const tok = m[3].toLowerCase(); val = tok === 'nan' ? NaN : (tok === '-inf' ? -Infinity : Infinity); }
+    fam(name).samples.push({ labels, value: val });
+  }
+  return fams;
+}
+const famSum = (f) => (!f || !f.samples.length) ? 0 : f.samples.reduce((a, s) => a + (Number.isFinite(s.value) ? s.value : 0), 0);
+const famFirst = (f) => (f && f.samples.length ? f.samples[0].value : null);
+/* group a family's samples by one label's value (e.g. tier, op) → { labelVal: sum } */
+function byLabel(f, key) {
+  const out = {}; if (!f) return out;
+  for (const s of f.samples) { const k = s.labels[key] != null ? s.labels[key] : '(none)'; out[k] = (out[k] || 0) + (Number.isFinite(s.value) ? s.value : 0); }
+  return out;
+}
+/* histogram quantile from <base>_bucket (cumulative le= buckets), aggregated across labelsets */
+function histQuantile(fams, base, q) {
+  const b = fams[base + '_bucket'];
+  if (!b || !b.samples.length) return null;
+  const byLe = {};
+  for (const s of b.samples) { const le = s.labels.le; if (le == null) continue; byLe[le] = (byLe[le] || 0) + (Number.isFinite(s.value) ? s.value : 0); }
+  const total = byLe['+Inf'];
+  if (!total) return null;
+  const target = total * q;
+  const les = Object.keys(byLe).filter((l) => l !== '+Inf').map(Number).filter((n) => Number.isFinite(n)).sort((a, b) => a - b);
+  let prev = 0, prevCnt = 0;
+  for (const le of les) {
+    const cnt = byLe[String(le)];
+    if (cnt >= target) {
+      if (cnt <= prevCnt) return le;
+      return prev + ((target - prevCnt) / (cnt - prevCnt)) * (le - prev);
+    }
+    prev = le; prevCnt = cnt;
+  }
+  return les.length ? les[les.length - 1] : null;
+}
+
+/* ───────────────────────── time-series history ─────────────────────────
+ * Rolling window (60 pts) of {t, v}. Counters are stored cumulatively and the
+ * sparkline renderer derives per-interval deltas when rate:true. */
+const HIST_MAX = 60;
+const hist = Object.create(null);
+function pushHist(key, v) {
+  if (v == null || Number.isNaN(v)) return;
+  const arr = hist[key] || (hist[key] = []);
+  arr.push({ t: Date.now(), v });
+  if (arr.length > HIST_MAX) arr.shift();
+}
+function rateSeries(key) {
+  const arr = hist[key] || [];
+  if (arr.length < 2) return [];
+  const out = [];
+  for (let i = 1; i < arr.length; i++) { let d = arr[i].v - arr[i-1].v; if (d < 0) d = arr[i].v; out.push(d); }
+  return out;
+}
+function rawSeries(key) { return (hist[key] || []).map((p) => p.v); }
+function lastVal(key) { const a = hist[key]; return a && a.length ? a[a.length - 1].v : null; }
+function peakVal(key) { const a = hist[key]; if (!a || !a.length) return null; let p = a[0].v; for (const x of a) if (x.v > p) p = x.v; return p; }
+
+/* ───────────────────────── chart renderers (inline SVG / CSS) ───────────────────────── */
+function spark(svgEl, series, opts) {
+  // series: [{ pts:[num], color }] (shared y-scale across all). opts.rate for labeling only.
+  if (!svgEl) return;
+  const valid = series.filter((s) => s.pts && s.pts.length);
+  if (!valid.length) { svgEl.innerHTML = ''; return; }
+  const W = 100, H = 36, PAD = 3;
+  let mn = Infinity, mx = -Infinity;
+  for (const s of valid) for (const v of s.pts) { if (v < mn) mn = v; if (v > mx) mx = v; }
+  if (mn === mx) { mn -= 1; mx += 1; }
+  const rng = mx - mn;
+  const map = (pts) => {
+    const step = pts.length > 1 ? (W - PAD*2) / (pts.length - 1) : 0;
+    return pts.map((v, i) => [PAD + i*step, PAD + (H - PAD*2) * (1 - (v - mn)/rng)]);
+  };
+  let out = '';
+  for (const s of valid) {
+    const xy = map(s.pts);
+    const poly = xy.map((p) => p[0].toFixed(2) + ',' + p[1].toFixed(2)).join(' ');
+    const area = `${PAD},${H-PAD} ${poly} ${W-PAD},${H-PAD}`;
+    out += `<polygon points="${area}" fill="${s.color}" stroke="none"/>`;
+    out += `<polyline points="${poly}" stroke="${s.color}"/>`;
+  }
+  svgEl.innerHTML = out;
+}
+function legend(el, items) {
+  if (!el) return;
+  el.innerHTML = items.map((it) => `<span><span class="sw" style="background:${it.color}"></span>${esc(it.label)}</span>`).join('');
+}
+function statTile(num, lbl, opts) {
+  opts = opts || {};
+  const style = opts.color ? ` style="color:${opts.color}"` : '';
+  let sub = opts.sub ? `<div class="sub">${opts.sub}</div>` : '';
+  if (opts.lvl != null) { const pct = Math.max(0, Math.min(100, opts.lvl)).toFixed(1); sub += `<div class="lvl"><span style="width:${pct}%;background:${opts.color || 'var(--c1)'}"></span></div>`; }
+  return `<div class="stat"><div class="num"${style}>${esc(num)}</div><div class="lbl">${esc(lbl)}</div>${sub}</div>`;
+}
+/* horizontal bars; entries:[{label,value,color}]; singleColor (CSS var) forces one hue. */
+function bars(entries, singleColor) {
+  if (!entries || !entries.length) return '<span class="empty">n/a</span>';
+  const max = Math.max(...entries.map((e) => Math.abs(e.value)), 1);
+  return entries.map((e) => {
+    const pct = (Math.abs(e.value) / max) * 100;
+    const col = e.color || singleColor || 'var(--c1)';
+    const val = e.fmt ? e.fmt(e.value) : fmtNum(e.value);
+    return `<div class="bar-row"><span class="bar-lbl">${esc(e.label)}</span><span class="bar-track"><span class="bar-fill" style="width:${pct.toFixed(1)}%;background:${col}"></span></span><span class="bar-val">${esc(val)}</span></div>`;
+  }).join('');
+}
+function emptyInto(el, msg) { if (el) el.innerHTML = `<span class="empty">${esc(msg)}</span>`; }
+
+/* ───────────────────────── config + tabs ───────────────────────── */
+const CFG = (window.__ADMIN_CONFIG__ && typeof window.__ADMIN_CONFIG__ === 'object')
+  ? window.__ADMIN_CONFIG__ : { autoRefresh: false, intervalSec: 30 };
+
+function initTabs() {
+  const tabs = $('tabs');
+  tabs.addEventListener('click', (e) => {
+    const btn = e.target.closest('.tab'); if (!btn) return;
+    const name = btn.getAttribute('data-tab');
+    tabs.querySelectorAll('.tab').forEach((t) => t.classList.toggle('active', t === btn));
+    document.querySelectorAll('.tab-panel').forEach((p) => p.classList.toggle('active', p.getAttribute('data-panel') === name));
+    renderActive();
+  });
+}
+let activeTab = 'health';
+function renderActive() {
+  const pan = document.querySelector('.tab-panel.active');
+  activeTab = pan ? pan.getAttribute('data-panel') : 'health';
+  try {
+    if (activeTab === 'cache') renderCache();
+    else if (activeTab === 'storage') renderStorage();
+    else if (activeTab === 'query') renderQuery();
+    else if (activeTab === 'iotrace') renderIoTrace();
+  } catch (e) { /* one tab's renderer must never abort the refresh loop */ }
+}
+
+/* ───────────────────────── Health loaders (existing) ───────────────────────── */
 async function loadHealth() {
   const [h, ready] = await Promise.all([getJSON('/health'), getJSON('/health/ready')]);
   const out = {};
@@ -166,31 +499,14 @@ async function loadHealth() {
   setDot($('health-dot'), cls);
   return cls;
 }
-
 async function loadCaps() {
   const r = await getJSON('/api/v2/_meta/capabilities');
   if (!r.ok) { $('caps').innerHTML = `<span class="err-line">n/a (${esc(r.status || r.error)})</span>`; return; }
   const d = r.data || {};
-  // Prefer a few well-known summary keys, fall back to the whole object.
   const summary = {};
   for (const k of ['version', 'build', 'commit', 'edition', 'tier', 'mode', 'name']) if (k in d) summary[k] = d[k];
   $('caps').innerHTML = kvRows(Object.keys(summary).length ? summary : d);
 }
-
-async function loadMetrics() {
-  const r = await getJSON('/metrics/json');
-  if (!r.ok) { $('metrics').innerHTML = `<span class="err-line">n/a (${esc(r.status || r.error)})</span>`; return; }
-  const nums = flattenNumbers(r.data);
-  const keys = Object.keys(nums);
-  if (!keys.length) { $('metrics').innerHTML = '<span class="empty">no numeric metrics</span>'; return; }
-  // Surface a readable subset (first 12), sorted by name, as stat cards.
-  keys.sort();
-  $('metrics').innerHTML = keys.slice(0, 12).map((k) => {
-    const short = k.split('.').slice(-2).join('.');
-    return `<div class="stat"><div class="num">${esc(fmtNum(nums[k]))}</div><div class="lbl" title="${esc(k)}">${esc(short)}</div></div>`;
-  }).join('');
-}
-
 function collectionRows(list) {
   return list.map((c, i) => {
     const id = c.id || c.collection_id || c.name || ('#' + i);
@@ -206,7 +522,6 @@ function collectionRows(list) {
     </tr>`;
   }).join('');
 }
-
 async function loadCollections() {
   const r = await getJSON('/api/v2/collections');
   if (!r.ok) { $('collections').innerHTML = `<span class="err-line">n/a (${esc(r.status || r.error)})</span>`; return; }
@@ -224,7 +539,6 @@ async function loadCollections() {
     });
   });
 }
-
 async function loadDetail(id, name) {
   $('detail-card').style.display = '';
   $('detail-name').textContent = name || id;
@@ -233,21 +547,212 @@ async function loadDetail(id, name) {
   $('detail').textContent = r.ok ? JSON.stringify(r.data, null, 2) : ('n/a (' + (r.status || r.error) + ')');
 }
 
+/* ───────────────────────── Cache tab ───────────────────────── */
+function renderCache() {
+  const fams = state.prom;
+  const has = fams && (fams['proximadb_cache_hits_total'] || fams['proximadb_cache_misses_total'] || fams['proximadb_cache_entries']);
+  if (!has) { emptyInto($('cache-tiles'), 'no cache metrics'); $('cache-tier-bars').innerHTML = '<span class="empty">no cache metrics</span>'; $('cache-trend').innerHTML = ''; $('cache-trend-legend').innerHTML = ''; return; }
+  const hitsByTier = byLabel(fams['proximadb_cache_hits_total'], 'tier');
+  const hits = Object.values(hitsByTier).reduce((a, b) => a + b, 0);
+  const misses = famFirst(fams['proximadb_cache_misses_total']) || 0;
+  const evictions = famFirst(fams['proximadb_cache_evictions_total']) || 0;
+  const entries = famFirst(fams['proximadb_cache_entries']);
+  const bytes = famFirst(fams['proximadb_cache_bytes']);
+  const ratio = (hits + misses) > 0 ? hits / (hits + misses) : null;
+
+  pushHist('cache_hits', hits);
+  pushHist('cache_misses', misses);
+  pushHist('cache_entries', entries);
+  pushHist('cache_bytes', bytes);
+
+  // status-colored hit ratio: good ≥ .8, warn ≥ .5, err < .5
+  const ratioColor = ratio == null ? '' : (ratio >= 0.8 ? 'var(--ok)' : (ratio >= 0.5 ? 'var(--warn)' : 'var(--err)'));
+  const peakBytes = peakVal('cache_bytes');
+  // level bar for cache bytes relative to the peak seen this session (honest
+  // magnitude cue; the absolute number stays in the stat value).
+  const bytesLvl = (bytes != null && peakBytes > 0) ? (bytes / peakBytes) * 100 : null;
+  const tiles = [];
+  tiles.push(statTile(ratio == null ? '—' : (ratio*100).toFixed(1) + '%', 'Hit ratio', { color: ratioColor, sub: (ratio==null? '' : (fmtNum(hits)+' hit / ' + fmtNum(misses) + ' miss')) }));
+  tiles.push(statTile(entries == null ? '—' : fmtNum(entries), 'Entries'));
+  tiles.push(statTile(bytes == null ? '—' : fmtBytes(bytes), 'Cache bytes', { lvl: bytesLvl, color: 'var(--c1)', sub: peakBytes != null ? 'peak ' + fmtBytes(peakBytes) + ' seen' : '' }));
+  tiles.push(statTile(fmtNum(evictions), 'Evictions', { color: evictions > 0 ? 'var(--warn)' : '' }));
+  $('cache-tiles').innerHTML = tiles.join('');
+
+  // hits vs misses rate trend (2 categorical series)
+  legend($('cache-trend-legend'), [{ color: 'var(--c1)', label: 'hits/interval' }, { color: 'var(--c2)', label: 'misses/interval' }]);
+  spark($('cache-trend'), [
+    { pts: rateSeries('cache_hits'), color: 'var(--c1)' },
+    { pts: rateSeries('cache_misses'), color: 'var(--c2)' },
+  ]);
+
+  // hits by tier — ordinal blue ramp (l1 hot → l3 cold)
+  const tierOrder = ['l1', 'l2', 'l3'];
+  const ramp = ['var(--ord1)', 'var(--ord2)', 'var(--ord3)', 'var(--ord4)'];
+  const tierEntries = tierOrder.filter((t) => hitsByTier[t] != null).map((t, i) => ({ label: t, value: hitsByTier[t] || 0, color: ramp[i] }));
+  // any tier not in the canonical order appends with the next ramp step
+  let step = tierEntries.length;
+  for (const t of Object.keys(hitsByTier)) { if (!tierOrder.includes(t)) { tierEntries.push({ label: t, value: hitsByTier[t], color: ramp[Math.min(step++, ramp.length-1)] }); } }
+  $('cache-tier-bars').innerHTML = tierEntries.length
+    ? bars(tierEntries.sort((a, b) => b.value - a.value))
+    : '<span class="empty">no per-tier samples</span>';
+}
+
+/* ───────────────────────── Storage tab ───────────────────────── */
+function renderStorage() {
+  const fams = state.prom;
+  const gets = famSum(fams && fams['proximadb_object_store_gets_total']);
+  const bytesRead = famSum(fams && fams['proximadb_object_store_bytes_read_total']);
+  const ops = fams && fams['proximadb_object_store_ops_total'];
+  const writeTier = fams && fams['proximadb_object_store_write_bytes_by_tier_total'];
+  const kou = fams && fams['proximadb_kou_bytes_total'];
+  const keu = fams && fams['proximadb_keu_units_total'];
+
+  pushHist('obj_gets', gets);
+  pushHist('obj_bytes', bytesRead);
+
+  const hasAny = gets || bytesRead || (ops && ops.samples.length) || (kou && kou.samples.length);
+  if (!hasAny) { emptyInto($('storage-tiles'), 'no object-store metrics'); $('storage-ops-bars').innerHTML = '<span class="empty">no object-store metrics</span>'; $('storage-tier-bars').innerHTML = '<span class="empty">no write-by-tier metrics</span>'; emptyInto($('kou-tiles'), 'no outgress metrics'); $('storage-trend').innerHTML = ''; $('storage-trend-legend').innerHTML = ''; return; }
+
+  const tiles = [];
+  tiles.push(statTile(fmtNum(gets), 'Range GETs', { sub: 'cumulative' }));
+  tiles.push(statTile(fmtBytes(bytesRead), 'Bytes read', { sub: 'cumulative' }));
+  tiles.push(statTile(fmtNum(famSum(ops)), 'Ops total', { sub: 'put/get/list/delete' }));
+  $('storage-tiles').innerHTML = tiles.join('');
+
+  // One axis, one series: range-GETs per interval. Bytes-read lives in the stat
+  // tile above (different scale — plotting both would force a dual axis, which
+  // invents a false correlation, so it stays a separate single number).
+  legend($('storage-trend-legend'), [{ color: 'var(--c1)', label: 'range GETs / interval' }]);
+  spark($('storage-trend'), [{ pts: rateSeries('obj_gets'), color: 'var(--c1)' }]);
+
+  // ops by operation — nominal breakdown → single hue (slot 1)
+  const opsBy = byLabel(ops, 'operation');
+  const opsEntries = Object.keys(opsBy).map((k) => ({ label: k, value: opsBy[k] })).sort((a, b) => b.value - a.value);
+  $('storage-ops-bars').innerHTML = opsEntries.length ? bars(opsEntries, 'var(--c1)') : '<span class="empty">no op samples</span>';
+
+  // write bytes by tier — ordinal ramp (hot → archive)
+  const tierRank = { hot: 0, cool: 1, cold: 2, archive: 3 };
+  const wtBy = byLabel(writeTier, 'tier');
+  let wtEntries = Object.keys(wtBy).map((k) => ({ label: k, value: wtBy[k], color: rampFor(tierRank, k) }));
+  wtEntries.sort((a, b) => (tierRank[a.label] != null ? tierRank[a.label] : 99) - (tierRank[b.label] != null ? tierRank[b.label] : 99));
+  $('storage-tier-bars').innerHTML = wtEntries.length ? bars(wtEntries.map((e) => ({ label: e.label, value: e.value, color: e.color, fmt: fmtBytes }))) : '<span class="empty">no write-tier samples</span>';
+
+  // KOU / KEU outgress tiles
+  const kouTotal = famSum(kou);
+  const keuTotal = famSum(keu);
+  const ktiles = [];
+  if (kouTotal) ktiles.push(statTile(fmtBytes(kouTotal), 'KOU outgress', { color: 'var(--c2)', sub: 'bytes shipped out' }));
+  if (keuTotal) ktiles.push(statTile(fmtNum(keuTotal), 'KEU embed units', { color: 'var(--c3)', sub: 'embedding dimension' }));
+  $('kou-tiles').innerHTML = ktiles.length ? ktiles.join('') : '<span class="empty">no outgress metrics</span>';
+}
+function rampFor(rank, key) { const i = rank[key]; const r = ['var(--ord1)','var(--ord2)','var(--ord3)','var(--ord4)']; return i != null && i < r.length ? r[i] : 'var(--c4)'; }
+
+/* ───────────────────────── Query tab ───────────────────────── */
+function renderQuery() {
+  const fams = state.prom;
+  const p50 = fams ? histQuantile(fams, 'http_request_duration_seconds', 0.5) : null;
+  const p95 = fams ? histQuantile(fams, 'http_request_duration_seconds', 0.95) : null;
+  const p99 = fams ? histQuantile(fams, 'http_request_duration_seconds', 0.99) : null;
+  pushHist('http_p50', p50); pushHist('http_p95', p95); pushHist('http_p99', p99);
+
+  const latColor = (ms) => ms == null ? '' : (ms < 100 ? 'var(--ok)' : (ms < 500 ? 'var(--warn)' : 'var(--err)'));
+  if (p50 == null && p95 == null && p99 == null) {
+    emptyInto($('latency-tiles'), 'no latency histogram');
+  } else {
+    const ms = (v) => v == null ? '—' : (v*1000).toFixed(v*1000 < 10 ? 1 : 0) + ' ms';
+    $('latency-tiles').innerHTML = [
+      statTile(ms(p50), 'p50', { color: latColor(p50 == null ? null : p50*1000) }),
+      statTile(ms(p95), 'p95', { color: latColor(p95 == null ? null : p95*1000) }),
+      statTile(ms(p99), 'p99', { color: latColor(p99 == null ? null : p99*1000) }),
+    ].join('');
+  }
+  spark($('p95-trend'), [{ pts: rawSeries('http_p95'), color: 'var(--c1)' }]);
+
+  // task execution time by engine — nominal → single hue
+  const task = fams && fams['proximadb_task_execution_time_ms'];
+  const byEng = byLabel(task, 'engine');
+  const engEntries = Object.keys(byEng).map((k) => ({ label: k, value: byEng[k] })).sort((a, b) => b.value - a.value);
+  $('engine-bars').innerHTML = engEntries.length ? bars(engEntries.map((e) => ({ label: e.label, value: e.value, fmt: (v) => fmtNum(v) + ' ms' })), 'var(--c1)') : '<span class="empty">no task-execution samples</span>';
+}
+
+/* ───────────────────────── I/O Trace tab ───────────────────────── */
+function renderIoTrace() {
+  const fams = state.prom;
+  const sink = (n) => famFirst(fams && fams[n]);
+  const pendingBytes = sink('proximadb_io_trace_sink_pending_bytes');
+  const pendingFiles = sink('proximadb_io_trace_sink_pending_files');
+  const recDropped = sink('proximadb_io_trace_sink_records_dropped_total');
+  const bytesDropped = sink('proximadb_io_trace_sink_bytes_dropped_total');
+  const upFail = sink('proximadb_io_trace_sink_upload_failures_total');
+  const upRetry = sink('proximadb_io_trace_sink_upload_retries_total');
+  const sealFail = sink('proximadb_io_trace_sink_seal_failures_total');
+  const lastSuccess = sink('proximadb_io_trace_sink_last_success_unix_seconds');
+
+  const any = [pendingBytes, pendingFiles, recDropped, bytesDropped, upFail, upRetry, sealFail, lastSuccess].some((v) => v != null);
+  if (!any) {
+    emptyInto($('iotrace-tiles'), 'no io_trace metrics — feature off or warehouse unconfigured');
+    $('iotrace-trend').innerHTML = ''; $('iotrace-trend-legend').innerHTML = ''; return;
+  }
+  const tiles = [];
+  const addStat = (val, lbl, opts) => { if (val != null) tiles.push(statTile(opts && opts.fmt ? opts.fmt(val) : fmtNum(val), lbl, opts || {})); };
+  addStat(pendingBytes, 'Pending bytes', { fmt: fmtBytes, color: pendingBytes > 0 ? 'var(--warn)' : 'var(--ok)' });
+  addStat(pendingFiles, 'Pending files', { color: pendingFiles > 0 ? 'var(--warn)' : 'var(--ok)' });
+  addStat(recDropped, 'Records dropped', { color: recDropped > 0 ? 'var(--err)' : 'var(--ok)' });
+  addStat(bytesDropped, 'Bytes dropped', { fmt: fmtBytes, color: bytesDropped > 0 ? 'var(--err)' : 'var(--ok)' });
+  addStat(upFail, 'Upload failures', { color: upFail > 0 ? 'var(--err)' : 'var(--ok)' });
+  addStat(upRetry, 'Upload retries', { color: upRetry > 0 ? 'var(--warn)' : '' });
+  addStat(sealFail, 'Seal failures', { color: sealFail > 0 ? 'var(--err)' : 'var(--ok)' });
+  if (lastSuccess != null) tiles.push(statTile(fmtSec(lastSuccess), 'Last success', { sub: 'warehouse flush' }));
+  $('iotrace-tiles').innerHTML = tiles.length ? tiles.join('') : '<span class="empty">no io_trace samples</span>';
+
+  // physical reads over time (same counters as Storage)
+  legend($('iotrace-trend-legend'), [{ color: 'var(--c1)', label: 'range GETs / interval' }]);
+  spark($('iotrace-trend'), [{ pts: rateSeries('obj_gets'), color: 'var(--c1)' }]);
+}
+
+/* ───────────────────────── refresh loop ───────────────────────── */
+const state = { prom: null, healthCls: '' };
 let refreshing = false;
 async function refreshAll() {
   if (refreshing) return; refreshing = true;
   try {
-    const [healthCls] = await Promise.all([loadHealth(), loadCaps(), loadMetrics(), loadCollections()]);
+    // Fetch the prometheus exposition ONCE and feed every metric tab from it.
+    const prom = await getText('/metrics/prometheus');
+    state.prom = prom.ok ? parseProm(prom.text) : null;
+    const [healthCls] = await Promise.all([loadHealth(), loadCaps(), loadCollections()]);
+    state.healthCls = healthCls;
     setDot($('status-dot'), healthCls);
+    renderActive(); // re-render whichever tab is visible (history recorded for all)
     $('last-updated').textContent = 'updated ' + new Date().toLocaleTimeString();
   } finally { refreshing = false; }
 }
 
 $('refresh').addEventListener('click', refreshAll);
 let timer = null;
-function arm() { if (timer) clearInterval(timer); if ($('auto').checked) timer = setInterval(refreshAll, 10000); }
+function arm() {
+  if (timer) { clearInterval(timer); timer = null; }
+  const cb = $('auto');
+  if (!cb.disabled && cb.checked) { const ms = Math.max(5, (CFG.intervalSec || 30)) * 1000; timer = setInterval(refreshAll, ms); }
+}
 $('auto').addEventListener('change', arm);
-refreshAll(); arm();
+
+/* Apply server-injected config to the auto-refresh control. When the operator's
+ * [server.admin_ui] auto_refresh = false, the toggle is disabled (greyed) and the
+ * page only refreshes on an explicit click — per the config default. */
+(function initAuto() {
+  const cb = $('auto'); const label = $('auto-label');
+  cb.checked = !!CFG.autoRefresh;
+  if (CFG.autoRefresh) {
+    label.title = 'Auto-refresh every ' + (CFG.intervalSec || 30) + 's (configured via [server.admin_ui])';
+  } else {
+    cb.disabled = true; label.classList.add('disabled');
+    label.title = 'Auto-refresh disabled by config ([server.admin_ui] auto_refresh = false)';
+  }
+})();
+
+initTabs();
+refreshAll();
+arm();
 </script>
 </body>
 </html>

--- a/crates/platform/proximadb-admin-ui/src/lib.rs
+++ b/crates/platform/proximadb-admin-ui/src/lib.rs
@@ -7,56 +7,127 @@
 //! into the binary via [`include_str!`] and served at `GET /admin` (with
 //! `/dashboard` kept as a back-compat alias). The page calls existing read-only
 //! REST endpoints — `/health`, `/api/v2/_meta/capabilities`,
-//! `/api/v2/collections`, `/metrics/json` — with `fetch`, and renders **no
-//! mutation controls**, so it is read-only by construction.
+//! `/api/v2/collections`, `/metrics/prometheus`, `/metrics/json` — with `fetch`,
+//! and renders **no mutation controls**, so it is read-only by construction.
+//!
+//! ## Auto-refresh
+//! The dashboard's client-side auto-refresh is driven by the operator's
+//! `[server.admin_ui]` config (`auto_refresh`, `refresh_interval_seconds`).
+//! [`render_admin_html`] injects that config into the page at serve time by
+//! replacing the [`ADMIN_CONFIG_SENTINEL`] token with a JSON literal — no
+//! external URLs or write verbs are introduced, so the read-only / air-gapped
+//! contract is preserved. When `auto_refresh = false` the page renders the
+//! toggle **disabled** (greyed out); polling then only happens on an explicit
+//! Refresh click.
 //!
 //! It lives in its own crate (apps = bins, root = lib, functionality in
-//! `crates/`) so the root server only mounts the router; the ~1k-line inline
-//! dashboard HTML no longer bloats `src/network/rest/server.rs`.
+//! `crates/`) so the root server only mounts the router; the inline dashboard
+//! HTML no longer bloats `src/network/rest/server.rs`.
+
+use std::sync::Arc;
 
 use axum::{Router, response::Html, routing::get};
 
-/// The embedded dashboard page. Self-contained: no external scripts, styles, or
-/// links, so it is safe for offline / air-gapped / embedded deployments.
+/// The embedded dashboard page (static template). Self-contained: no external
+/// scripts, styles, or links, so it is safe for offline / air-gapped / embedded
+/// deployments. The [`ADMIN_CONFIG_SENTINEL`] token is replaced at serve time
+/// with the runtime config JSON (see [`render_admin_html`]).
 pub const ADMIN_HTML: &str = include_str!("../assets/admin.html");
 
-/// Axum handler returning the read-only admin dashboard HTML.
+/// Sentinel HTML comment in [`ADMIN_HTML`] replaced at serve time with a
+/// `<script>window.__ADMIN_CONFIG__ = {...};</script>` block carrying the
+/// operator's `[server.admin_ui]` auto-refresh defaults. Kept as a plain HTML
+/// comment so the static asset stays well-formed and the read-only contract (the
+/// `http://` / write-verb scan in the `html_is_embedded_and_self_contained`
+/// test) holds even when served without substitution.
+const ADMIN_CONFIG_SENTINEL: &str = "<!--__ADMIN_CONFIG__-->";
+
+/// Minimum auto-refresh poll interval enforced at render time (seconds). Guards
+/// against a misconfigured tiny interval DoS-ing the diagnostic endpoints.
+const MIN_REFRESH_INTERVAL_SECS: u32 = 5;
+
+/// Dashboard runtime options, derived from `[server.admin_ui]` (`AdminUiConfig`
+/// in the `proximadb-config` crate). Kept as plain primitives so this crate
+/// stays decoupled from the config crate (it depends only on `axum`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AdminUiOptions {
+    /// Mount the `/admin` (+ `/dashboard`) route. When `false` the router is
+    /// empty.
+    pub enabled: bool,
+    /// Enable client-side auto-refresh. When `false` the UI toggle is disabled.
+    pub auto_refresh: bool,
+    /// Auto-refresh poll interval in seconds; clamped to
+    /// [`MIN_REFRESH_INTERVAL_SECS`] at render time.
+    pub refresh_interval_seconds: u32,
+}
+
+/// Render the dashboard HTML with the operator config injected.
+///
+/// The injected payload is a JSON literal of two scalars (`bool`/`u32`, so it
+/// can never carry untrusted string content) consumed by the page's inline
+/// script. The [`ADMIN_CONFIG_SENTINEL`] token is replaced exactly once.
+pub fn render_admin_html(opts: AdminUiOptions) -> String {
+    // Treat an unset/zero interval as the documented default (30s), then clamp
+    // to a sane floor so a tiny value cannot hammer the diagnostic endpoints.
+    let interval = if opts.refresh_interval_seconds == 0 {
+        30
+    } else {
+        opts.refresh_interval_seconds.max(MIN_REFRESH_INTERVAL_SECS)
+    };
+    let inject = format!(
+        r#"<script>window.__ADMIN_CONFIG__={{"autoRefresh":{},"intervalSec":{}}};</script>"#,
+        opts.auto_refresh, interval
+    );
+    ADMIN_HTML.replacen(ADMIN_CONFIG_SENTINEL, &inject, 1)
+}
+
+/// Axum handler returning the read-only admin dashboard HTML **without** config
+/// injection (auto-refresh falls back to the page's own disabled default). Used
+/// by callers that embed the page without the `[server.admin_ui]` extras; the
+/// configured path goes through [`admin_router`] + [`render_admin_html`].
 pub async fn admin_page() -> Html<&'static str> {
     Html(ADMIN_HTML)
 }
 
 /// Router exposing the read-only admin dashboard at `/admin` and the back-compat
-/// `/dashboard` alias.
+/// `/dashboard` alias, with the operator's auto-refresh config injected.
 ///
 /// Generic over the caller's router state `S` so it merges cleanly into the main
 /// `Router<AppState>` — the handler takes no [`axum::extract::State`], so it is
 /// state-agnostic.
-pub fn admin_router<S>() -> Router<S>
+pub fn admin_router<S>(opts: AdminUiOptions) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
+    if !opts.enabled {
+        return Router::new();
+    }
+    // The HTML depends only on boot-time config, so render it once and share the
+    // allocation across requests via `Arc`. Each request clones the string
+    // (cheap relative to an admin page view) — config never changes at runtime.
+    let html: Arc<String> = Arc::new(render_admin_html(opts));
+    let a = html.clone();
+    let b = html.clone();
     Router::new()
-        .route("/admin", get(admin_page))
-        .route("/dashboard", get(admin_page))
+        .route(
+            "/admin",
+            get(move || std::future::ready(Html::<String>((*a).clone()))),
+        )
+        .route(
+            "/dashboard",
+            get(move || std::future::ready(Html::<String>((*b).clone()))),
+        )
 }
 
-/// Like [`admin_router`], but returns an empty router when `enabled` is `false`.
-///
-/// The dashboard is **disabled by default** and opt-in via TOML
-/// (`[server.admin_ui] enabled = true`). Keep it off for Kubernetes pods and for
-/// embedded / UDS deployments (which serve over a local Unix-domain socket, not a
-/// browser-reachable TCP port) unless an operator explicitly enables it for a
-/// standalone instance. The router-build path always merges this; the toggle
-/// decides whether the `/admin` route actually exists.
-pub fn admin_router_if<S>(enabled: bool) -> Router<S>
+/// Like [`admin_router`], but reads as "mount only when enabled" at the call
+/// site. The dashboard is **disabled by default** and opt-in via TOML
+/// (`[server.admin_ui] enabled = true`); the enable check happens inside
+/// [`admin_router`] regardless.
+pub fn admin_router_if<S>(opts: AdminUiOptions) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
-    if enabled {
-        admin_router()
-    } else {
-        Router::new()
-    }
+    admin_router(opts)
 }
 
 #[cfg(test)]
@@ -68,6 +139,12 @@ mod tests {
         // The asset is baked into the binary.
         assert!(ADMIN_HTML.contains("<!DOCTYPE html>"));
         assert!(ADMIN_HTML.contains("ProximaDB"));
+        // The serve-time injection anchor is present exactly once.
+        assert_eq!(
+            ADMIN_HTML.matches(ADMIN_CONFIG_SENTINEL).count(),
+            1,
+            "admin HTML must carry exactly one config-injection sentinel"
+        );
         // Offline / read-only contract: no external script/style/link CDNs.
         assert!(
             !ADMIN_HTML.contains("http://") && !ADMIN_HTML.contains("https://"),
@@ -85,5 +162,89 @@ mod tests {
                 "admin dashboard must be read-only ({verb})"
             );
         }
+    }
+
+    #[test]
+    fn render_injects_config_and_preserves_readonly_contract() {
+        let rendered = render_admin_html(AdminUiOptions {
+            enabled: true,
+            auto_refresh: true,
+            refresh_interval_seconds: 30,
+        });
+        // Sentinel consumed exactly once.
+        assert!(!rendered.contains(ADMIN_CONFIG_SENTINEL));
+        assert!(
+            rendered.contains(r#"window.__ADMIN_CONFIG__={"autoRefresh":true,"intervalSec":30}"#),
+            "rendered HTML must carry the injected config JSON"
+        );
+        // Read-only / air-gapped contract still holds post-injection.
+        assert!(
+            !rendered.contains("http://") && !rendered.contains("https://"),
+            "injected config must not introduce external URLs"
+        );
+        for verb in [
+            "method: 'POST'",
+            "method: 'PUT'",
+            "method: 'DELETE'",
+            "method: 'PATCH'",
+        ] {
+            assert!(
+                !rendered.contains(verb),
+                "injection must stay read-only ({verb})"
+            );
+        }
+    }
+
+    #[test]
+    fn render_clamps_interval_and_defaults_zero() {
+        // Zero resolves to the documented default (30s).
+        let r = render_admin_html(AdminUiOptions {
+            enabled: true,
+            auto_refresh: false,
+            refresh_interval_seconds: 0,
+        });
+        assert!(
+            r.contains(r#""intervalSec":30"#),
+            "zero interval defaults to 30s"
+        );
+
+        // A tiny interval is clamped to the minimum floor.
+        let r = render_admin_html(AdminUiOptions {
+            enabled: true,
+            auto_refresh: true,
+            refresh_interval_seconds: 1,
+        });
+        assert!(
+            r.contains(&format!(r#""intervalSec":{}"#, MIN_REFRESH_INTERVAL_SECS)),
+            "sub-minimum interval clamped to floor"
+        );
+
+        // A sane interval passes through unchanged.
+        let r = render_admin_html(AdminUiOptions {
+            enabled: true,
+            auto_refresh: true,
+            refresh_interval_seconds: 45,
+        });
+        assert!(
+            r.contains(r#""intervalSec":45"#),
+            "valid interval preserved"
+        );
+    }
+
+    #[test]
+    fn injected_config_payload_is_only_json_scalars() {
+        // The injected payload is built only from a bool + u32, so it can never
+        // contain quotes/braces that would break the JSON literal or enable an
+        // injection. Isolate the literal and assert its exact shape.
+        let rendered = render_admin_html(AdminUiOptions {
+            enabled: true,
+            auto_refresh: false,
+            refresh_interval_seconds: 30,
+        });
+        let prefix = "window.__ADMIN_CONFIG__=";
+        let start = rendered.find(prefix).expect("config global present");
+        let slice = &rendered[start + prefix.len()..];
+        let semi = slice.find(';').expect("statement terminated");
+        assert_eq!(&slice[..semi], r#"{"autoRefresh":false,"intervalSec":30}"#);
     }
 }

--- a/crates/platform/proximadb-runtime/src/bootstrap_config.rs
+++ b/crates/platform/proximadb-runtime/src/bootstrap_config.rs
@@ -116,6 +116,13 @@ pub struct MultiServerConfig {
     /// operator explicitly opts in for a standalone instance.
     pub admin_ui_enabled: bool,
 
+    /// Sourced from `[server.admin_ui] auto_refresh` (default `false`). When
+    /// `false`, the dashboard's auto-refresh toggle is rendered disabled.
+    pub admin_ui_auto_refresh: bool,
+
+    /// Sourced from `[server.admin_ui] refresh_interval_seconds` (default 30).
+    pub admin_ui_refresh_interval_seconds: u32,
+
     /// Cluster mode configuration (consensus, replication, health services)
     /// Only used when `cluster` feature is enabled
     #[cfg(feature = "cluster")]
@@ -580,6 +587,8 @@ impl Default for MultiServerConfig {
             unified_bind_address: "0.0.0.0".to_string(),
             uds_socket_dir: None,    // TCP mode by default; portless opt-in only
             admin_ui_enabled: false, // read-only /admin dashboard off by default; opt-in via TOML
+            admin_ui_auto_refresh: false, // dashboard auto-refresh off by default; opt-in via TOML
+            admin_ui_refresh_interval_seconds: 30, // default poll cadence (seconds)
             // Cluster mode defaults
             #[cfg(feature = "cluster")]
             cluster_config: None, // Cluster mode disabled by default

--- a/src/database.rs
+++ b/src/database.rs
@@ -457,7 +457,11 @@ impl ProximaDB {
             .grpc(|g| g.bind_address(grpc_addr))
             .with_api_config(config.api.clone())
             .with_data_dir(config.server.data_dir.clone())
-            .with_admin_ui_enabled(config.server.admin_ui.enabled);
+            .with_admin_ui_enabled(config.server.admin_ui.enabled)
+            .with_admin_ui_refresh(
+                config.server.admin_ui.auto_refresh,
+                config.server.admin_ui.refresh_interval_seconds,
+            );
 
         // Add TLS configuration if enabled
         if config.api.enable_tls.unwrap_or(false) {

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -1057,6 +1057,8 @@ impl MultiServer {
                     self.tenant_deployment_mode.clone(),
                 ),
                 self.config.admin_ui_enabled,
+                self.config.admin_ui_auto_refresh,
+                self.config.admin_ui_refresh_interval_seconds,
             );
 
             info!(

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -730,6 +730,11 @@ impl RestServer {
         tenant_config: TenantExtractorConfig,
         // Mount the read-only `/admin` dashboard (from `[server.admin_ui] enabled`).
         admin_ui_enabled: bool,
+        // Dashboard auto-refresh (from `[server.admin_ui] auto_refresh`).
+        admin_ui_auto_refresh: bool,
+        // Dashboard auto-refresh interval seconds (from
+        // `[server.admin_ui] refresh_interval_seconds`).
+        admin_ui_refresh_interval_seconds: u32,
     ) -> Router {
         let mut base_state = AppState::new(
             core,
@@ -838,7 +843,15 @@ impl RestServer {
         // Read-only admin dashboard at /admin (+ back-compat /dashboard alias),
         // gated by `[server.admin_ui] enabled` (off by default — empty router when
         // disabled). Mounted from the self-contained `proximadb-admin-ui` crate.
-        base_router = base_router.merge(proximadb_admin_ui::admin_router_if(admin_ui_enabled));
+        // The auto-refresh fields are server-injected into the page so the toggle
+        // reflects the operator's `[server.admin_ui]` default.
+        base_router = base_router.merge(proximadb_admin_ui::admin_router_if(
+            proximadb_admin_ui::AdminUiOptions {
+                enabled: admin_ui_enabled,
+                auto_refresh: admin_ui_auto_refresh,
+                refresh_interval_seconds: admin_ui_refresh_interval_seconds,
+            },
+        ));
         if admin_ui_enabled {
             tracing::info!("🖥️  Read-only admin dashboard enabled at /admin (+ /dashboard)");
         }

--- a/src/network/server_builder.rs
+++ b/src/network/server_builder.rs
@@ -600,6 +600,11 @@ pub struct MultiServerBuilder {
     /// Mount the read-only `/admin` dashboard (from `[server.admin_ui] enabled`).
     /// Off by default; opt-in for standalone instances.
     admin_ui_enabled: bool,
+    /// Dashboard client-side auto-refresh (from `[server.admin_ui] auto_refresh`).
+    admin_ui_auto_refresh: bool,
+    /// Auto-refresh poll interval seconds (from `[server.admin_ui]
+    /// refresh_interval_seconds`).
+    admin_ui_refresh_interval_seconds: u32,
 }
 
 impl Default for MultiServerBuilder {
@@ -611,6 +616,8 @@ impl Default for MultiServerBuilder {
             api_config: None,
             data_dir: PathBuf::from("/tmp/proximadb/data"),
             admin_ui_enabled: false,
+            admin_ui_auto_refresh: false,
+            admin_ui_refresh_interval_seconds: 30,
         }
     }
 }
@@ -693,6 +700,14 @@ impl MultiServerBuilder {
         self
     }
 
+    /// Configure the dashboard's client-side auto-refresh (off by default). Wire
+    /// from `config.server.admin_ui.{auto_refresh, refresh_interval_seconds}`.
+    pub fn with_admin_ui_refresh(mut self, auto_refresh: bool, interval_seconds: u32) -> Self {
+        self.admin_ui_auto_refresh = auto_refresh;
+        self.admin_ui_refresh_interval_seconds = interval_seconds;
+        self
+    }
+
     /// Build the complete multi-server configuration
     pub fn build(mut self) -> Result<MultiServerConfig> {
         // Apply API config compression settings to builders if available
@@ -738,6 +753,8 @@ impl MultiServerBuilder {
             // `[api].transport`/`socket_dir`; the builder always starts in TCP mode.
             uds_socket_dir: None,
             admin_ui_enabled: self.admin_ui_enabled,
+            admin_ui_auto_refresh: self.admin_ui_auto_refresh,
+            admin_ui_refresh_interval_seconds: self.admin_ui_refresh_interval_seconds,
             // Cluster mode defaults
             #[cfg(feature = "cluster")]
             cluster_config: None, // Cluster mode disabled by default


### PR DESCRIPTION
## Summary

Enriches the read-only `/admin` dashboard with **configurable auto-refresh**, **five tabs**, and **Prometheus-driven metric charts**. Frontend-only behavior change; the Rust side just adds two config fields and threads them to the page template.

### Auto-refresh (default-OFF, configurable)
- `[server.admin_ui]` gains `auto_refresh` (default `false`) and `refresh_interval_seconds` (default `30`).
- When `auto_refresh = false`, the UI toggle is rendered **disabled (greyed out)**; the page refreshes only on an explicit click.
- When `true`, the dashboard polls every `refresh_interval_seconds`.

### Tabs
- **Health** — status, version/build/caps, collections (+detail).
- **Cache** — `proximadb_cache_hits_total{tier}`, misses, evictions, entries, bytes (#1115); hits-vs-misses trend + per-tier bars.
- **Storage** — `object_store_gets_total` / `bytes_read_total` (TD-IOTRACE-2), ops by operation, write-bytes by access tier, KOU/KEU outgress.
- **Query** — p50/p95/p99 from `http_request_duration_seconds` histogram; compute-by-engine; SQL-conformance note (TPC-H/TPC-DS run as qa-gate suites, not live series).
- **I/O Trace** — `proximadb_io_trace_sink_*` (TD-TRACE-2) + physical ranged-read trend.

### Charts
- Single self-contained HTML (inline CSS + JS), **air-gapped, no CDN**.
- Fetches `/metrics/prometheus` once per refresh and parses the text exposition client-side.
- Inline SVG sparklines + CSS bars + stat tiles. Categorical and ordinal palettes validated CVD-safe on the dashboard surface; status colors reserved.

### Wiring
- Config is injected at serve time via a sentinel token (`AdminUiOptions` → `render_admin_html`), preserving the read-only / no-external-URL contract.
- Threaded `database.rs → MultiServerBuilder → MultiServerConfig → rest build → admin_router_if`. The admin-ui crate keeps depending only on `axum` (`AdminUiOptions` decouples it from the config crate).

## Verification
- admin-ui unit tests (4) + config crate tests (45) pass.
- `cargo fmt --check`, `clippy -D warnings`, and `cargo check` clean on the admin-ui, runtime, and root-lib crates.

## Notes
- Single interpretation call: req #4's "greyed-out/disabled" vs "user can enable per-session" conflict — resolved to **disabled when config default is off** per the explicit verification clause. Easy to flip to interactive-per-session if preferred.
- Toggles/polling are GET-only; no mutation controls introduced (crate test enforces).