### PR TITLE
fix(wal): flush memtable→segments on the live write path (root cause of 0 segments / ~4% recall)

### DIFF
--- a/docs/10-quality/td/TD-WAL-3-flush-mechanism-consolidation.adoc
+++ b/docs/10-quality/td/TD-WAL-3-flush-mechanism-consolidation.adoc
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-WAL-3: Memtable-flush / WAL-management consolidation — dead-code removal, config-plumbing dedup, placement hardening
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** The urgent root-cause fix shipped separately (default `flush_interval_secs` 0→300 + inline size-trigger on the live write path). This TD tracks the three deferred consolidation slices (S1–S3) that reduce the flush-mechanism proliferation surfaced during that investigation. See link:TD-WAL-1-wal-local-disk-tiered-flush.adoc[TD-WAL-1] (the ADR-069 design) and ADR-069 for the time/capacity trigger contract this builds on.
+| Priority | **P2** — correctness-neutral hygiene + co-design placement hardening. The root cause is already fixed; these remove confusing dead code, dedup misleading config plumbing, and harden object-store placement. No live-data risk; pure deletion/rename + one read-side scheme binding.
+| Component | `src/storage/persistence/write_ahead_log/` (`mod.rs`, `bincode`/`avro`/`proto` `_serialization_strategy.rs`, `optimized_write_buffer_writer.rs`, `batch_strategy.rs`, `memtable_manager.rs`); `src/storage/memtable/specialized/wal_behavior.rs`, `src/storage/memtable/implementations/global_partitioned.rs`; `src/storage/engines/sst/core.rs`.
+| Evidence | Audit (2026-07-22): **three distinct "flush" meanings** conflated across ~20 functions — (A) WAL-buffer→WAL-file durable write batching, (B) memtable→SST/PAX segment materialization (`materialize_collection`), (C) flush-decision bool evaluation. Only `materialize_collection` (B) actually writes segments; it has exactly 3 live callers (AutoFlushDriver, shutdown, embedded). The size-trigger *decision* functions (C) — `needs_global_flush` (`wal_behavior.rs:676`, **zero callers**), the unused-result `should_flush_collection` (`memtable_manager.rs:178`), logging-only `needs_flush` (`global_partitioned.rs:409`/`:1166`) — return bools nobody acts on. The serialization-strategy `flush_collection`/`trigger_background_flush` path is dead on the live native write path (bails on `storage_engine = None`, `bincode_serialization_strategy.rs:403`). ~22 `MemtableConfig::default()` args in `mod.rs` are `ResettableOnceLock` (`mod.rs:956`) no-ops (the singleton is init'd once with the real config). SST reader-side cache FS is hardcoded `file://` (`sst/core.rs:378`) — the *write* path already routes segments to `base_location` (`core.rs:770`/`:812`), so this is a read-cache-locality issue, not a write-path bug.
+|===
+
+== The finding
+
+The flush-mechanism investigation (root cause of the 0-segments / ~2-4% recall regression) surfaced a
+proliferation: multiple uncoordinated "flush" paths, only one of which materializes segments; dead
+decision-functions whose results are ignored; a bypassed serialization-strategy flush that bails silently;
+and ~22 misleading `MemtableConfig::default()` args that are silently ignored by the OnceLock singleton.
+The root cause (no flush trigger fires on the live write path) is fixed by the separate PR. This TD removes
+the confusing residue so the mechanism has ONE materialization path and an honest config surface.
+
+NOTE: The flush-vs-concurrent-write "orphan race" flagged during the audit was **investigated and disproven**:
+both the `BatchCoordinator` (the search source — `get_unflushed_batches` reads here, `wal_behavior.rs:692`) and
+the inner `GlobalPartitionedMemtable::clear_flushed` clear **only `is_flushed` batches** (coordinator
+`retain(!is_flushed)` `wal_behavior.rs:245`; inner `filter(is_flushed)` `global_partitioned.rs:377`). A batch
+appended mid-flush is never marked flushed, so it survives in both layers and stays searchable. No id-keyed
+cleanup is needed; the per-collection guard added in the root-cause PR is sufficient.
+
+== Direction
+
+ONE materialization path (`materialize_collection`), called by every trigger; delete the parallel dead paths.
+Disambiguate the "flush" vocabulary so (A) WAL-buffering, (B) segment materialization, and (C) decision
+evaluation are named distinctly. Bind the SST reader-side cache FS to the `data_directory` scheme (not a
+hardcoded `file://`). These are hygiene/hardening — no behavior change beyond dead-code removal.
+
+== Slices
+
+S1 — **Dead-code removal.** Delete the orphaned flush paths that never reach `materialize_collection`:
+`flush_collection` + `trigger_background_flush` + the `should_flush_collection` call site in
+`bincode`/`avro`/`proto` `_serialization_strategy.rs`; `needs_global_flush` (`wal_behavior.rs:676`, zero
+callers); the logging-only `needs_flush`/`collections_needing_flush` (`global_partitioned.rs:409`/`:1166`);
+and the `WALBatchStrategy::flush_collection` trait method + its test mock (`batch_strategy.rs`,
+`batch_strategy_tests.rs`). Pure deletion; the inline trigger (root-cause PR) is the live size-trigger now.
+
+S2 — **Config-plumbing dedup + flush-naming disambiguation.** Replace the ~22 misleading
+`MemtableConfig::default()` `get_or_init` no-op sites in `mod.rs` with one `shared_wal()` helper (keep the
+`ResettableOnceLock` — do not swap for std `OnceLock`; tests rely on `reset()`). Rename to disambiguate:
+`flush` (strategy layer) → `materialize_to_segments`; `should_flush_batch`
+(`optimized_write_buffer_writer.rs:681`) → `should_flush_wal_buffer`. Rename-only; no behavior change.
+
+S3 — **Placement hardening (ADR-069 D1 residual).** Bind the SST *reader-side* cache filesystem
+(`sst/core.rs:378`) from the configured `data_directory` scheme rather than a hardcoded `file://`, so the
+read cache is local to where segments live. Add the startup guardrail (ADR-069 S1): warn when
+`write_buffer_directory` resolves to an object-store scheme (`adls://`/`s3://`/`gs://`) — the WAL belongs on
+local reattachable disk. (The *write* path already routes segments to `base_location` correctly; this slice
+is read-cache locality + the D1 nudge, non-fatal warnings.)
+
+== Verification
+- `cargo check-fast` + `cargo clippy -- -D warnings` clean (deletions must not leave dangling refs).
+- The existing post-flush recall suites (`tests/td112_postflush_recall_e2e.rs`,
+  `tests/v2_post_flush_search_e2e.rs`) still pass (S1/S2 are behavior-neutral).
+- S3: a config with `data_directory = adls://…` resolves the reader FS to the object-store backend (unit
+  test on the scheme→FS mapping).

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1026,9 +1026,13 @@ pub struct WriteBufferUserConfig {
     pub global_manifest_url: Option<String>,
 
     /// ADR-069 D2 — time-based WAL flush interval (seconds); 0 = disabled. The RPO
-    /// floor: bounds worst-case loss on volume loss to this interval for low-traffic
-    /// collections that never reach `memory_flush_size_bytes`.
-    #[serde(default)]
+    /// floor: bounds worst-case loss on permanent local-volume loss to this interval for
+    /// low-traffic collections that never reach the inline size trigger
+    /// (`memory_flush_size_bytes`). With `sync_mode = "PerBatch"` (default) acknowledged
+    /// writes are fsync'd, so process-kill RPO is 0 and this only bounds volume-loss RPO.
+    /// Defaults to 300s so the inline size trigger (throughput) dominates and this stays
+    /// a coarse safety net (fewer/larger segments → fewer object-store PUTs).
+    #[serde(default = "default_flush_interval_secs")]
     pub flush_interval_secs: u64,
     /// ADR-069 D6 — per-collection WAL size budget (bytes) for the capacity flush +
     /// backpressure watermarks; 0 = disabled.
@@ -1052,6 +1056,13 @@ fn default_critical_watermark_pct() -> f64 {
     0.95
 }
 
+/// Serde default for [`WriteBufferUserConfig::flush_interval_secs`] (ADR-069 D2). The
+/// RPO floor — coarse on purpose so the inline size trigger dominates throughput and this
+/// only bounds volume-loss RPO for trickle workloads. See the field doc for rationale.
+fn default_flush_interval_secs() -> u64 {
+    300
+}
+
 impl Default for WriteBufferUserConfig {
     fn default() -> Self {
         Self {
@@ -1063,8 +1074,9 @@ impl Default for WriteBufferUserConfig {
             write_buffer_directory: "./data/write_buffer".to_string(),
             enable_wal: true,
             global_manifest_url: None,
-            // ADR-069 tiered-flush knobs — disabled by default (behavior-neutral).
-            flush_interval_secs: 0,
+            // ADR-069 D2: time floor defaults to 300s (RPO safety net; the inline
+            // size trigger handles throughput). wal_max_bytes stays 0 → S4 backpressure OFF.
+            flush_interval_secs: default_flush_interval_secs(),
             wal_max_bytes: 0,
             high_watermark_pct: default_high_watermark_pct(),
             critical_watermark_pct: default_critical_watermark_pct(),

--- a/src/core/flush_config_tests.rs
+++ b/src/core/flush_config_tests.rs
@@ -69,11 +69,13 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_config_defaults_disable_tiered_flush() {
-        // ADR-069/TD-WAL-1: the tiered-flush knobs default OFF so existing configs
-        // are behavior-neutral (only the pre-existing size trigger stays active).
+    fn test_wal_config_defaults_arm_time_floor() {
+        // ADR-069 D2: the time floor defaults to 300s (RPO safety net) so the
+        // auto-flush driver spawns by default and segments materialize while the
+        // server runs. The inline size trigger handles throughput; wal_max_bytes
+        // stays 0 so S4 write-shedding stays OFF.
         let config = WriteBufferUserConfig::default();
-        assert_eq!(config.flush_interval_secs, 0);
+        assert_eq!(config.flush_interval_secs, 300);
         assert_eq!(config.wal_max_bytes, 0);
         assert_eq!(config.high_watermark_pct, 0.80);
         assert_eq!(config.critical_watermark_pct, 0.95);

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -105,10 +105,30 @@ pub use geo::{
 
 // Placeholder index structures for compilation
 use anyhow::Result;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::core::VectorId;
 use proximadb_records::ProximaRecord;
+
+/// Global concrete `AxisManager` handle, set once at storage-engine init
+/// (`StorageEngine::start`, alongside `set_sst_axis_manager`). The WAL-layer inline
+/// flush trigger resolves it here (mirroring `AutoFlushDriver`'s field) so an inline
+/// size-triggered flush can clear the in-memory AXIS projection exactly like the
+/// periodic/shutdown paths — preventing duplicate results for collections that use AXIS.
+static GLOBAL_AXIS_MANAGER: OnceLock<Arc<AxisManager>> = OnceLock::new();
+
+/// Set the global concrete `AxisManager` (once, at engine start). Idempotent: a second
+/// call is a no-op (the first wins), matching `OnceLock` semantics.
+pub fn set_global_axis_manager(manager: Arc<AxisManager>) {
+    let _ = GLOBAL_AXIS_MANAGER.set(manager);
+}
+
+/// Get the global concrete `AxisManager` if the engine has started. `None` before init
+/// — acceptable for the inline flush trigger, which then flushes without clearing the
+/// AXIS projection (same as if the manager were absent; the periodic driver clears it).
+pub fn get_global_axis_manager() -> Option<Arc<AxisManager>> {
+    GLOBAL_AXIS_MANAGER.get().cloned()
+}
 
 /// Global ID Index for cross-collection vector tracking
 ///

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -20,9 +20,10 @@
 //! uses (de-risked by TD-165 cold-read recall); the live insert→flush→search
 //! round-trip is the acceptance check.
 //!
-//! Spawned once from `StorageEngine::start()` and ONLY when a periodic trigger is
-//! armed (`policy.needs_scheduler()` — time or capacity budget set). With default
-//! config (size-only, both disabled) this is a no-op: no task, no wakeups.
+//! Spawned once from `StorageEngine::start()` when a periodic trigger is armed
+//! (`policy.needs_scheduler()` — time or capacity budget set). The default config arms
+//! the 300s time floor (ADR-069 D2 RPO safety net), so the driver spawns by default;
+//! a config setting both `flush_interval_secs = 0` and `wal_max_bytes = 0` opts out.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -56,8 +57,9 @@ pub struct AutoFlushDriver {
 }
 
 impl AutoFlushDriver {
-    /// Spawn the driver's background loop iff a periodic trigger is armed. No-op
-    /// (behavior-neutral) when only the size trigger is configured.
+    /// Spawn the driver's background loop iff a periodic trigger is armed. The default
+    /// config arms the 300s time floor so this spawns by default; setting both
+    /// `flush_interval_secs = 0` and `wal_max_bytes = 0` makes this a no-op.
     pub fn spawn(
         policy: FlushPolicy,
         axis_index_manager: Arc<AxisManager>,

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -137,6 +137,10 @@ impl StorageEngine {
 
         // Make AXIS manager available to SST engine for HNSW/IVF search
         crate::storage::engines::sst::core::set_sst_axis_manager(axis_index_manager.clone());
+        // Also expose the concrete AxisManager for the WAL-layer inline flush trigger
+        // (resolved via `crate::index::get_global_axis_manager`), so an inline flush
+        // clears the AXIS projection exactly like the periodic/shutdown paths.
+        crate::index::set_global_axis_manager(axis_index_manager.clone());
         info!("✅ AXIS manager registered with SST engine for HNSW/IVF search");
 
         // Initialize compaction manager with default config if not provided
@@ -208,11 +212,12 @@ impl StorageEngine {
         temp_manager.start_workers(2).await?; // Start 2 worker threads
         self.compaction_manager = Arc::new(temp_manager);
 
-        // ADR-069/TD-WAL-1: spawn the live auto-flush driver. No-op unless a time or
-        // capacity trigger is armed in wal_config, so default (size-only) config is
-        // behavior-neutral. The driver mirrors flush_memtable_to_storage's recipe,
-        // policy-gated + metered. (Fence is injected post-construction, so it may be
-        // None here — acceptable at MVP: the A6 fence is default-OFF.)
+        // ADR-069/TD-WAL-1: spawn the live auto-flush driver. The default config arms the
+        // 300s time floor so the driver spawns and segments materialize while the server
+        // runs (no shutdown needed); setting both flush_interval_secs=0 and wal_max_bytes=0
+        // opts out. The driver mirrors flush_memtable_to_storage's recipe, policy-gated +
+        // metered. (Fence is injected post-construction, so it may be None here —
+        // acceptable at MVP: the A6 fence is default-OFF.)
         let flush_policy =
             crate::storage::persistence::write_ahead_log::flush_policy::FlushPolicy::from_performance(
                 &self.config.wal_config.to_engine_config().performance,

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -51,6 +51,34 @@ pub struct CollectionFlushPlan {
     pub tenant_id: Option<String>,
 }
 
+/// Build a [`CollectionFlushPlan`] from a collection's catalog metadata. The single
+/// recipe shared by the inline size-trigger (`spawn_inline_flush`), the periodic
+/// `AutoFlushDriver`, and the shutdown flush — only *when* to fire differs across the
+/// three triggers, not *what* they materialize.
+pub fn flush_plan_from_collection_meta(
+    meta: &crate::proto::proximadb_v1::Collection,
+) -> CollectionFlushPlan {
+    let config = meta.config.as_ref();
+    let assignment = meta.storage_assignment.as_ref();
+    let engine_type = assignment
+        .map(|a| a.engine)
+        .or_else(|| config.and_then(|c| c.storage_engine))
+        .unwrap_or(crate::proto::proximadb_v1::StorageEngine::Sst as i32);
+    let dimension = config.map(|c| c.dimension).unwrap_or(0);
+    let base_location = assignment
+        .map(|a| a.base_location.clone())
+        .unwrap_or_default();
+    let tenant_id = proximadb_tenant::tenant_id_of(meta);
+    CollectionFlushPlan {
+        wal_key: meta.id.clone(),
+        canonical_id: meta.id.clone(),
+        base_location,
+        engine_type,
+        dimension,
+        tenant_id,
+    }
+}
+
 /// What a single collection's materialization produced.
 pub struct CollectionFlushOutcome {
     /// Records submitted to the engine (post tombstone-filter) — the count used

--- a/src/storage/memtable/specialized/wal_behavior.rs
+++ b/src/storage/memtable/specialized/wal_behavior.rs
@@ -202,6 +202,22 @@ impl BatchCoordinator {
         }
     }
 
+    /// Sum the unflushed bytes for a collection WITHOUT cloning the batches. The
+    /// inline flush trigger checks this on the hot write path (per write), where
+    /// `get_unflushed_batches`'s per-batch clone was a throughput regression.
+    fn unflushed_bytes(&self, collection_id: &str) -> u64 {
+        self.batches
+            .get(collection_id)
+            .map(|collection_batches| {
+                collection_batches
+                    .values()
+                    .filter(|batch| !batch.is_flushed)
+                    .map(|batch| batch.total_size_bytes as u64)
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+
     /// Mark batch as flushed
     fn mark_batch_flushed(&mut self, collection_id: &str, batch_id: &str) -> Result<()> {
         if let Some(collection_batches) = self.batches.get_mut(collection_id)
@@ -721,6 +737,14 @@ impl WALBehaviorWrapper {
             .collect();
 
         Ok(unflushed_batches)
+    }
+
+    /// Sum unflushed bytes for a collection without cloning batches (hot-path
+    /// accessor for the inline flush trigger — `get_unflushed_batches` clones every
+    /// batch and regressed write throughput when called per write).
+    pub async fn unflushed_bytes(&self, collection_id: &str) -> u64 {
+        let coordinator = self.batch_coordinator.read().await;
+        coordinator.unflushed_bytes(collection_id)
     }
 
     /// Clear flushed batches for collection (MODERN - after successful storage engine flush)

--- a/src/storage/persistence/write_ahead_log/config.rs
+++ b/src/storage/persistence/write_ahead_log/config.rs
@@ -157,9 +157,11 @@ impl Default for WalPerformanceConfig {
             enable_optimized_write_buffer_writer: Some(false), // Disabled by default for gradual rollout
             background_writer_threads: None, // Will use 2 by default in optimized writer
             write_buffer_batch_size: None,   // Will use 100 by default in optimized writer
-            // ADR-069 / TD-WAL-1 S1: config surface; triggers default DISABLED (0) — S2 (time)
-            // and S3 (capacity) activate them and set their live defaults. No behavior change here.
-            flush_interval_secs: 0,
+            // ADR-069 D2: time floor defaults to 300s (RPO safety net). The live server
+            // also derives this from WriteBufferUserConfig (toml) via to_engine_config();
+            // kept in sync here so programmatic WALConfig::default()/tests agree.
+            // wal_max_bytes stays 0 → S4 write-shedding admission control stays OFF.
+            flush_interval_secs: 300,
             wal_max_bytes: 0,
             high_watermark_pct: 0.80,
             critical_watermark_pct: 0.95,
@@ -913,10 +915,12 @@ mod tests {
     }
 
     #[test]
-    fn wal_performance_defaults_disable_flush_triggers() {
-        // ADR-069 / TD-WAL-1 S1: new flush triggers ship DISABLED so S1 is behavior-neutral.
+    fn wal_performance_defaults_arm_time_trigger() {
+        // ADR-069 D2: the 300s time floor is armed by default (RPO safety net) so the
+        // auto-flush driver spawns and segments materialize while the server runs.
+        // wal_max_bytes stays 0 → S4 capacity/backpressure trigger stays OFF.
         let p = WalPerformanceConfig::default();
-        assert_eq!(p.flush_interval_secs, 0, "time-based flush off by default");
+        assert_eq!(p.flush_interval_secs, 300, "time floor armed by default");
         assert_eq!(p.wal_max_bytes, 0, "capacity budget off by default");
         assert_eq!(p.high_watermark_pct, 0.80);
         assert_eq!(p.critical_watermark_pct, 0.95);
@@ -925,9 +929,10 @@ mod tests {
     #[test]
     fn wal_storage_config_overrides_flush_triggers() {
         use crate::core::config::WalStorageConfig;
-        // Absent overrides (None) leave the runtime performance defaults intact.
+        // Absent overrides (None) leave the runtime performance defaults intact
+        // (the 300s time floor — ADR-069 D2).
         let base = WALConfig::from(&WalStorageConfig::default());
-        assert_eq!(base.performance.flush_interval_secs, 0);
+        assert_eq!(base.performance.flush_interval_secs, 300);
         assert_eq!(base.performance.wal_max_bytes, 0);
         assert_eq!(base.performance.high_watermark_pct, 0.80);
         assert_eq!(base.performance.critical_watermark_pct, 0.95);

--- a/src/storage/persistence/write_ahead_log/flush_policy.rs
+++ b/src/storage/persistence/write_ahead_log/flush_policy.rs
@@ -113,8 +113,11 @@ impl FlushPolicy {
     }
 
     /// True when any periodic trigger (time or capacity) is enabled — i.e. when a
-    /// background scheduler is worth spawning. When false the policy reduces to the
-    /// pre-existing inline size trigger and no ticker is needed (S1 behavior-neutral).
+    /// background scheduler is worth spawning. The default config arms the 300s time
+    /// floor (ADR-069 D2 RPO safety net), so the auto-flush driver spawns by default and
+    /// segments materialize while the server runs. A config that sets both
+    /// `flush_interval_secs = 0` and `wal_max_bytes = 0` disables both periodic triggers
+    /// and falls back to the inline size trigger alone.
     pub fn needs_scheduler(&self) -> bool {
         self.time_floor_secs > 0 || self.capacity_budget_bytes > 0
     }
@@ -292,20 +295,27 @@ mod tests {
     }
 
     #[test]
-    fn defaults_are_size_only_and_behavior_neutral() {
-        // Default config: size target set (2MB), time+capacity disabled.
+    fn defaults_arm_time_trigger() {
+        // Default config (ADR-069 D2): the 300s time floor is armed so the auto-flush
+        // driver spawns by default and segments materialize while the server runs
+        // (no shutdown required). The inline size trigger still fires at the size target.
         let p = FlushPolicy::from_performance(&WalPerformanceConfig::default());
-        assert_eq!(p.time_floor_secs, 0);
+        assert_eq!(p.time_floor_secs, 300);
         assert_eq!(p.capacity_budget_bytes, 0);
-        assert!(!p.needs_scheduler(), "no periodic triggers ⇒ no scheduler");
-        // Below the size target: no flush. At/above it: size flush (old behavior).
-        assert_eq!(
-            p.evaluate(p.size_target_bytes - 1, 10_000),
-            FlushDecision::NONE
-        );
+        assert!(p.needs_scheduler(), "default time floor ⇒ driver spawns");
+        // Capacity stays off (S4 write-shedding admission control default-OFF).
+        assert!(p.write_admission_reject_pct(0).is_none());
+        // Below the size target, under the time floor: no flush.
+        assert_eq!(p.evaluate(p.size_target_bytes - 1, 10), FlushDecision::NONE);
+        // At/above the size target: size flush (the inline throughput trigger).
         assert_eq!(
             p.evaluate(p.size_target_bytes, 0).reason,
             Some(FlushReason::Size)
+        );
+        // Past the time floor with unflushed data: time flush (the RPO safety net).
+        assert_eq!(
+            p.evaluate(1, p.time_floor_secs).reason,
+            Some(FlushReason::Time)
         );
     }
 

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -2127,11 +2127,9 @@ impl WriteAheadLogManager {
             use crate::storage::persistence::write_ahead_log::flush_policy::{
                 FlushPolicy, FlushReason,
             };
-            let mem_bytes = write_buffer
-                .get_unflushed_batches(collection_id)
-                .await
-                .map(|b| b.iter().map(|x| x.total_size_bytes as u64).sum())
-                .unwrap_or(0);
+            // Lean per-write size check (sums sizes under the lock, no batch clone —
+            // get_unflushed_batches clones every batch and regressed write throughput).
+            let mem_bytes = write_buffer.unflushed_bytes(collection_id).await;
             let policy = FlushPolicy::from_performance(&self.config.performance);
             if matches!(
                 policy.evaluate(mem_bytes, 0).reason,

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1145,6 +1145,77 @@ pub fn get_global_write_buffer_behavior()
         .cloned()
 }
 
+/// Per-collection in-flight flush guard for the inline size-trigger. A `Semaphore(1)`
+/// per collection: [`spawn_inline_flush`] try-acquires and skips if a flush is already
+/// running for that collection, so a burst of size-threshold-crossing writes collapses
+/// into a single in-flight materialization (avoiding duplicate segments). The periodic
+/// `AutoFlushDriver` is independently rate-limited by its tick; a concurrent driver
+/// flush of the same collection is harmless — `materialize_collection` no-ops via its
+/// `Ok(None)` empty-batches early-return once the inline flush has cleared them.
+static INLINE_FLUSH_GUARDS: std::sync::LazyLock<
+    dashmap::DashMap<String, std::sync::Arc<tokio::sync::Semaphore>>,
+> = std::sync::LazyLock::new(dashmap::DashMap::new);
+
+/// ADR-069 D2 inline size-trigger: fire-and-forget a `materialize_collection` for the
+/// collection. Per-collection guarded (see [`INLINE_FLUSH_GUARDS`]). Reuses the exact
+/// `AutoFlushDriver` recipe (same globals, same plan shape via
+/// `flush_plan_from_collection_meta`) — ONE materialization path; the inline trigger
+/// only adds *when* to fire (a size crossing on the live write path, vs. the driver's
+/// periodic tick).
+fn spawn_inline_flush(collection_id: String) {
+    use crate::storage::flush_materializer::{
+        flush_plan_from_collection_meta, materialize_collection,
+    };
+
+    tokio::spawn(async move {
+        // per-collection guard: skip if a flush is already in flight for this collection
+        let guard = INLINE_FLUSH_GUARDS
+            .entry(collection_id.clone())
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Semaphore::new(1)))
+            .clone();
+        let _permit = match guard.try_acquire() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::trace!(
+                    "inline size-flush: already in flight for '{}', skipping",
+                    collection_id
+                );
+                return;
+            }
+        };
+
+        let Some(write_buffer) = get_global_write_buffer_behavior() else {
+            return;
+        };
+        let axis = crate::index::get_global_axis_manager();
+        let catalog = list_collections_from_catalog().await;
+        let Some(meta) = catalog.iter().find(|c| c.id == collection_id) else {
+            tracing::warn!(
+                "inline size-flush: no catalog metadata for '{}', skipping",
+                collection_id
+            );
+            return;
+        };
+        let plan = flush_plan_from_collection_meta(meta);
+
+        let start = std::time::Instant::now();
+        match materialize_collection(&write_buffer, &plan, None, None, true, axis.as_deref()).await
+        {
+            Ok(Some(outcome)) => tracing::info!(
+                "✅ inline size-flush '{}': {} entries, {} bytes in {:.3}s",
+                collection_id,
+                outcome.entries_flushed,
+                outcome.bytes,
+                start.elapsed().as_secs_f64()
+            ),
+            Ok(None) => {
+                // nothing unflushed — a concurrent driver tick already flushed it
+            }
+            Err(e) => tracing::warn!("⚠️ inline size-flush '{}' failed: {}", collection_id, e),
+        }
+    });
+}
+
 /// Get the global WriteAheadLogManager registry
 pub fn get_write_ahead_log_manager_registry() -> &'static WriteAheadLogManagerRegistry {
     WAL_MANAGER_REGISTRY.get().get_or_init(|| {
@@ -2045,6 +2116,30 @@ impl WriteAheadLogManager {
                     .await
             }
         }?;
+
+        // ADR-069 D2 inline size-trigger — the responsive throughput path (the 300s
+        // periodic AutoFlushDriver is the RPO floor). After a successful append, if the
+        // collection's unflushed data crosses the size target, fire-and-forget a flush.
+        // Skipped for insert-only (tombstone/delete) writes so deletes never trigger a
+        // segment flush. ONE materialization path (spawn_inline_flush reuses the driver
+        // recipe); per-collection guarded so a burst of writes collapses to one flush.
+        if !insert_only && let Some(write_buffer) = get_global_write_buffer_behavior() {
+            use crate::storage::persistence::write_ahead_log::flush_policy::{
+                FlushPolicy, FlushReason,
+            };
+            let mem_bytes = write_buffer
+                .get_unflushed_batches(collection_id)
+                .await
+                .map(|b| b.iter().map(|x| x.total_size_bytes as u64).sum())
+                .unwrap_or(0);
+            let policy = FlushPolicy::from_performance(&self.config.performance);
+            if matches!(
+                policy.evaluate(mem_bytes, 0).reason,
+                Some(FlushReason::Size)
+            ) {
+                spawn_inline_flush(collection_id.to_string());
+            }
+        }
 
         // Then, persist to disk if sync mode requires it
         if self.should_sync_to_disk(collection_id).await? {


### PR DESCRIPTION
## Root cause

The memtable→SST/PAX segment flush almost never fired on the live write path. Bulk-ingested vectors never materialized to segments, so search could see only a sliver of them — **0 `.pax` files in `data_directory`, ~2–4% recall@10** (reproduced on both `adls://` and local `file://`).

Three converging defects (triple-confirmed by code trace + empirical evidence):
1. The live native write path (`write_vector_batch_native_arc_with_mode`) added to the memtable + synced the WAL and returned — **no size-check, no materialize call**.
2. Only `materialize_collection` actually writes segments, reachable from just three callers (AutoFlushDriver, shutdown, embedded). The inline size-check that existed lived on the **bypassed** serialization-strategy path and bailed on `storage_engine = None`.
3. `AutoFlushDriver::spawn` **early-exits for default config** (`flush_interval_secs=0`, `wal_max_bytes=0` → `needs_scheduler()=false`) → no flush until graceful shutdown.

## Fix (PR 1 of the consolidation — TD-WAL-3 tracks the rest)

- **Default `flush_interval_secs` 0→300** (ADR-069 D2 RPO floor) → the auto-flush driver spawns by default and segments materialize while the server runs. With `sync_mode=PerBatch`, process-kill RPO is 0; 300s only bounds permanent-volume loss. The inline size-trigger (next) handles throughput, so the floor is a coarse safety net (fewer/larger segments → fewer object-store PUTs). The `#[serde(default)]` gotcha required a `default_flush_interval_secs` fn (else omitted toml fields still deserialize to 0); `WriteBufferUserConfig` + `WalPerformanceConfig` defaults aligned.
- **Inline size-trigger on the live write path**: after a successful append (gated `!insert_only` so deletes never trigger), evaluate `FlushPolicy`; on a Size crossing, fire-and-forget `materialize_collection` via `spawn_inline_flush` (reuses the AutoFlushDriver recipe — **ONE materialization path**). Per-collection `Semaphore` guard collapses a burst of writes into one in-flight flush.
- **Concrete `AxisManager` global getter** (`get_global_axis_manager`) so the inline flush clears the in-memory AXIS projection exactly like the periodic/shutdown paths (prevents duplicate results for AXIS collections).
- **`flush_plan_from_collection_meta`** helper shared by inline/driver/shutdown.

## Investigation note
The flush-vs-concurrent-write "orphan race" flagged during design was **investigated and disproven**: both the `BatchCoordinator` (the search source — `get_unflushed_batches` reads here) and the inner `GlobalPartitionedMemtable` clear **only `is_flushed` batches**, so a batch appended mid-flush is never marked flushed and survives in both layers (stays searchable). The per-collection guard is sufficient; no id-keyed cleanup of the shared path was needed.

## Verification
- `cargo check --tests` passes (lib + test code compile).
- Unit tests `defaults_arm_time_trigger` / `wal_performance_defaults_arm_time_trigger` assert the new default (`needs_scheduler()==true`, `time_floor==300`).
- Empirical SIFT recall benchmark pending a stable local release build (the `release-server` profile's `lto="fat"`+`codegen-units=1` OOMs the root-crate compile on this 64GB box; the lighter `release` profile build was also killed by the background-task harness mid-build). Will run on merge / a beefier host and report the recall-recovery evidence.

## Follow-ups (TD-WAL-3)
- S1 dead-code removal (orphaned `flush_collection`/`trigger_background_flush`/`needs_global_flush`/`needs_flush`).
- S2 config-plumbing dedup (~22 misleading `MemtableConfig::default()` OnceLock no-ops → one `shared_wal()` helper) + flush-naming disambiguation.
- S3 placement hardening (SST reader-side FS bound to `data_directory` scheme; WAL object-store-scheme startup guardrail).
