### PR TITLE
feat(sst): coalesce IVF2 probe layout reads

### DIFF
--- a/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. **rev 3.1 (merged #1128 on 2026-07-21): PR-A landed** — A0 serde + header-prefix `layout_version=3` + additive footer section + compaction-only write path (`cluster_plan_ivf_probe` persists the existing IOP-derived plan; no second quantizer) + production-trigger route proof; default-OFF `PROXIMADB_IVF2=0`. **rev 3.2 (merged #1135 on 2026-07-21): PR-B landed** — `rabitq_search_segment_coalesced` ranks the `k_c` centroids in RAM, then range-reads only the `nprobe` nearest cells' Region-A extents instead of fetching the whole Region A. Default-OFF `PROXIMADB_IVF2_PROBE=0`; a synthetic recall/GET gate proves materially fewer bytes at comparable recall. Remaining: the qa-gate MEDIUM SIFT-scale absolute-recall test and durable Prometheus `ivf_*`/io-trace fields before any default-on promotion.
+| Status | Open — **rev 3 (2026-07-17): first-principles/code reconciliation.** Reuse and persist SST's existing compaction-time, IOP-derived PCA/IVF plan; do not train a second `sqrt(N)` quantizer. Host remains SST. **rev 3.1 (merged #1128 on 2026-07-21): PR-A landed** — A0 serde + header-prefix `layout_version=3` + additive footer section + compaction-only write path (`cluster_plan_ivf_probe` persists the existing IOP-derived plan; no second quantizer) + production-trigger route proof; default-OFF `PROXIMADB_IVF2=0`. **rev 3.2 (merged #1135 on 2026-07-21): PR-B landed** — `rabitq_search_segment_coalesced` ranks the `k_c` centroids in RAM, then range-reads only the `nprobe` nearest cells' Region-A extents. **rev 3.3 (merged #1144/#1148 on 2026-07-22): PR-C1 landed** — durable IVF engagement/fallback telemetry plus SIFT ratchets/evidence. **rev 3.4 (PR-C2 measured candidate):** a 64 KiB prefix, split invariant-metadata cache, and 1 MiB Region-A gap coalescing preserve SIFT1M recall and improve the joint request/byte score in single- and four-file geometry. All IVF2/layout gates remain default OFF. Remaining before promotion: production object-store validation and the 10M/high-dimension/multi-metric gates.
 | Priority | P2 → **P1 once any collection approaches ~2M vectors** — downstream, AnvaiOps ADR-0044 forbids >~5M-vector pooled onboarding until this re-measures (revenue + latency gate, successor to TD-RDSTRAT-6's role).
 | Severity | n/a (new capability, no regression). Default-OFF until gates pass.
 | Component | `src/storage/engines/sst/` — `segment_format.rs` (writer/reader), `block_cluster.rs` (clustering), `compaction.rs`/`compactor_impl.rs` (the only write path that clusters), `crates/storage/proximadb-storage-common/src/pax_block.rs` + `segment_layout.rs` (regions/footer), coalesce policy + `IopsBudget`. **NOVA is explicitly NOT the host** (rev 2).
@@ -319,8 +319,10 @@ ranged, fewer/cluster-local survivors shrink the Region-B/D reads for free.
   run unchanged — no hand-rolled decoder, no bitmap GET. Unit-gated
   (`rank_probed_rows_matches_region_rank`: one run over all rows reproduces
   `RaBitQRegion::rank` exactly; sub-runs restrict + map global indices).
-* *Coalescing.* Probed cells are read in `a_off` order and merged ONLY on strict
-  physical adjacency (gap 0) — never over-reading unprobed cells; Hilbert
+* *Coalescing.* The PR-B baseline merges only strict physical adjacency
+  (gap 0). PR-C2 adds a default-OFF, cost-aware range planner: it may physically
+  over-read a bounded gap while passing only the selected cell slices to the
+  ranker, so logical `nprobe`, rows, and results cannot change. Hilbert
   emission order already clusters near cells, so the nprobe nearest usually
   collapse to a few contiguous runs.
 * *Cache.* The probe bypasses the whole-region invariants cache (its whole point
@@ -334,10 +336,40 @@ ranged, fewer/cluster-local survivors shrink the Region-B/D reads for free.
   bytes** than the whole-region baseline, and **held recall vs the full scan**
   (probe recall ≥ baseline − 0.1 on clustered data). Diagnostic counters ride
   `PROXIMADB_TRACE_GETS` (`drain_get_trace` / `drain_probe_trace`).
-* *Follow-ups (tracked):* the SIFT-scale **absolute** recall/GET ratchet in the
-  qa-gate MEDIUM tier; promoting the probe counters into the durable Prometheus
-  `ivf_cells_total/probed`, `probed_rows`, `fetch_rounds`, `whole_region_fallback`
-  io_trace fields; A0/header caching; flip-to-default-ON after the SIFT gate bakes.
+* *Completed follow-ups:* #1144 promoted `ivf_cells_total/probed`,
+  `ivf_probed_rows`, `ivf_fetch_rounds`, and `ivf_whole_region_fallback` into
+  durable io-trace/Prometheus surfaces; #1148 landed the SIFT ratchets/evidence.
+  PR-C2 measures A0/header prefixing, split metadata caching, and Region-A
+  coalescing. Default-on still waits for production object-store and scale/
+  high-dimension/multi-metric gates.
+
+== PR-C2 delta (trace-derived control and Region-A layout proof, rev 3.4)
+
+PR-C1's full SIFT1M trace separated the v3 request budget into search control,
+footer metadata, Region A, Region B, and Region D. It showed that the v3 probe
+moved bytes but paid three small control reads per file and one Region-A read per
+selected cell. PR-C2 tests three independently gated reader changes:
+
+* a bounded prefix range supplies the prefix, A0, and RaBitQ parameters when
+  their extents fit, without moving the fixed-offset header contract;
+* small search-control/footer invariants may populate the byte-budgeted cache
+  even though the probe never fetches the complete Region A; and
+* `ObjectRangeCoalescePolicy` merges selected Region-A extents across a bounded
+  gap, retaining exact selected slices so over-read cannot broaden ranking.
+
+The release-profile 100-query SIFT1M proof retains the combined 64 KiB prefix +
+split metadata cache + 1 MiB Region-A gap (4 MiB maximum range). Recall is
+unchanged: `0.985` single-file (`nprobe=6`) and `0.982` four-file (`nprobe=3`).
+GETs/query move `33→30` cold and `24→19` warm single-file; `75→65` cold and
+`62→44` warm four-file. Under `20×GET + 5×MiB`, score improves 6.1–24.0%.
+A 4 MiB gap is rejected as non-robust: it buys at most one additional four-file
+warm GET while adding 3.59 MB/query and worsening the single-file cold tail.
+See `RDSTRAT8_IVF2_LAYOUT_COALESCING_SIFT1M_2026_07_22.adoc` and evidence claim
+`rdstrat8_ivf2_layout_coalescing_sift1m`.
+
+The trace also identifies the next independent term: Region B still consumes
+`22–42` GETs/query. Any successor work must optimize survivor-run geometry at
+fixed recall/`nprobe`; file count remains the collection-level GET knob.
 
 == Eval gates (ADR-062 pattern; eval doc in `docs/_internal/status/`)
 

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -80,6 +80,22 @@ version = "feat/adr069-s7-soak off develop @ 7d5a9e2cb"
 notes = "10-min bounded run (harness parameterized for multi-hour/nightly via --duration-s). wal_size_bytes is the cumulative on-disk WAL (plateaued = steady-state); the bounding input the gate guards is the unflushed memtable, which the backpressure engagements prove stayed within the critical line. Engagements concentrated in the warmup burst (steady-state flushes then kept up). Server exit was a clean flush-on-stop (slow shutdown, non-fatal). Indicative dev-machine evidence, not an SLA."
 
 [[claims]]
+id = "rdstrat8_ivf2_layout_coalescing_sift1m"
+claim = "TD-RDSTRAT-8 PR-C2 closes the v3 control/A0/Region-A GET fragmentation without changing recall. On full SIFT1M (100 official queries, top-10, Euclidean), the retained default-OFF policy combines a 64 KiB bounded prefix, independently cached probe metadata, and 1 MiB Region-A gap coalescing (4 MiB max range). Single-file nprobe=6 recall remains 0.985 while GETs/q fall 33 to 30 cold and 24 to 19 warm; four-file nprobe=3 recall remains 0.982 while GETs/q fall 75 to 65 cold and 62 to 44 warm. The object-store score 20*GET + 5*MiB improves 6.1-24.0%. A 4 MiB gap is rejected as a non-robust ~0.1% score gain that adds 3.59 MB/q in four-file geometry and worsens the single-file cold tail."
+metric = "recall@10 + physical range_gets_per_query + bytes_read_per_query by PAX region + cold/warm p50/p95 + object-store score"
+status = "measured"
+asserted_in = [
+  "docs/10-quality/td/TD-RDSTRAT-8-two-level-ivf-coarse-probe.adoc",
+]
+bench_source = "tests/sift_pax_recall_ratchet_test.rs"
+bench_command = "Single: PROXIMADB_SIFT_DATASET_DIR=<verified-sift> PROXIMADB_SIFT_IVF2_FILE_COUNTS=1 PROXIMADB_SIFT_IVF2_NPROBE_SWEEP=6 PROXIMADB_SIFT_IVF2_LAYOUT_PROOF=1 PROXIMADB_SIFT_IVF2_A_GAP_SWEEP=1048576 cargo test --release --test sift_pax_recall_ratchet_test sift_ivf2_probe_release_bakeoff_eval -- --ignored --nocapture; four-file: same with FILE_COUNTS=4 NPROBE_SWEEP=3"
+artifact = "docs/_internal/status/RDSTRAT8_IVF2_LAYOUT_COALESCING_SIFT1M_2026_07_22.adoc"
+hardware = "Local macOS arm64 (Apple Silicon), release profile; candidate arms serialized over the same generated files and 100 queries"
+date = "2026-07-22"
+version = "feat/rdstrat8-prc2-layout-proof rebased onto develop @ f21a60f5b (measured candidate)"
+notes = "Full TEXMEX SIFT1M (1,000,000 x 128d), first 100 official queries, supplied full-corpus GT. Retained 1 MiB combined arm: single cold baseline/treatment 33/30 GETs, 26,728,854/27,130,193 bytes, score 793.453/744.967, p50/p95 18,208/22,207 vs 17,182/22,817 us; single warm 24/19 GETs, 17,973,196/18,307,400 bytes, score 568.103/479.296. Four cold 75/65 GETs, 56,390,706/57,570,090 bytes, score 1777.692/1594.116, p50/p95 44,040/83,653 vs 47,074/61,607 us; four warm 62/44 GETs, 40,629,552/41,545,058 bytes, score 1434.537/1089.702. Recall is bit-identical per geometry; probe engaged; zero fallback. Region bytes are computed from the physical per-stage GET trace; durable query telemetry separately records IVF engagement/fallback. Candidate gates remain default OFF. Indicative dev-machine run, not an SLA."
+
+[[claims]]
 id = "object_economy_cpu_cost"
 claim = "Object-economy vector route building-block CPU costs (100/1K/10K/100K records) non-regression baseline"
 metric = "cpu_cost_ms"

--- a/docs/_internal/status/RDSTRAT8_IVF2_LAYOUT_COALESCING_SIFT1M_2026_07_22.adoc
+++ b/docs/_internal/status/RDSTRAT8_IVF2_LAYOUT_COALESCING_SIFT1M_2026_07_22.adoc
@@ -1,0 +1,110 @@
+= TD-RDSTRAT-8 PR-C2 — SIFT1M probe-layout coalescing proof (2026-07-22)
+
+== Decision
+
+Retain, default OFF, the combined v3 read policy:
+
+* one bounded 64 KiB prefix read supplies the segment prefix, A0, and the
+  Region-A RaBitQ header when those extents fit;
+* cache the small search-control/footer invariants independently of the full
+  Region-A payload; and
+* coalesce selected Region-A cell reads across gaps up to 1 MiB, with a 4 MiB
+  maximum physical range, while decoding/ranking only the selected cell slices.
+
+The policy is recall-invariant and improves the object-store cost score in both
+measured file geometries. A 4 MiB gap is rejected: its marginal request saving
+does not compensate robustly for its extra over-read and single-file cold-tail
+risk. The layout and on-disk format do not change.
+
+== Protocol
+
+Full TEXMEX SIFT1M (`1,000,000 × 128d`), first 100 official queries, supplied
+full-corpus ground truth, Euclidean/top-10, release profile, local macOS arm64.
+The same v3 files, `nprobe`, queries, and truth are used by baseline and
+treatment. The harness verifies that probing engaged and that every layout-only
+arm returns exactly the baseline result set/recall.
+
+The decision score follows the object-store spine used by ADR-062:
+
+----
+score/query = 20 × physical range GETs + 5 × MiB read
+----
+
+Single-file uses the measured recall knee `nprobe=6`; four-file uses
+`nprobe=3` per file. Candidate gates are explicit and default OFF.
+
+Reproduce the retained arm:
+
+----
+PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m \
+PROXIMADB_SIFT_IVF2_FILE_COUNTS=1,4 \
+PROXIMADB_SIFT_IVF2_NPROBE_SWEEP=3,6 \
+PROXIMADB_SIFT_IVF2_LAYOUT_PROOF=1 \
+PROXIMADB_SIFT_IVF2_A_GAP_SWEEP=1048576 \
+cargo test --release --test sift_pax_recall_ratchet_test \
+  sift_ivf2_probe_release_bakeoff_eval -- --ignored --nocapture
+----
+
+For the recorded geometry-specific runs, use `FILE_COUNTS=1` with
+`NPROBE_SWEEP=6`, then `FILE_COUNTS=4` with `NPROBE_SWEEP=3`.
+
+== Retained-arm results
+
+[cols="1,1,1,1,1,1,1,1,1", options="header"]
+|===
+| files | temperature | arm | recall@10 | GETs/q | bytes/q | Region A bytes/q | Region B bytes/q | p50/p95 us
+| 1 | cold | v3 baseline | 0.985 | 33 | 26,728,854 | 4,945,356 | 16,269,670 | 18,208 / 22,207
+| 1 | cold | combined 1 MiB | 0.985 | 30 | 27,130,193 | 5,290,919 | 16,269,670 | 17,182 / 22,817
+| 1 | warm | v3 baseline | 0.985 | 24 | 17,973,196 | 4,945,356 | 11,479,718 | 16,635 / 22,580
+| 1 | warm | combined 1 MiB | 0.985 | 19 | 18,307,400 | 5,290,919 | 11,479,718 | 16,907 / 21,094
+| 4 | cold | v3 baseline | 0.982 | 75 | 56,390,706 | 10,495,916 | 30,447,296 | 44,040 / 83,653
+| 4 | cold | combined 1 MiB | 0.982 | 65 | 57,570,090 | 11,441,525 | 30,447,296 | 47,074 / 61,607
+| 4 | warm | v3 baseline | 0.982 | 62 | 40,629,552 | 10,495,916 | 25,762,575 | 39,941 / 55,629
+| 4 | warm | combined 1 MiB | 0.982 | 44 | 41,545,058 | 11,441,525 | 25,762,575 | 41,947 / 52,242
+|===
+
+The joint score falls:
+
+* single cold: `793.453 → 744.967` (-6.1%);
+* single warm: `568.103 → 479.296` (-15.6%);
+* four-file cold: `1777.692 → 1594.116` (-10.3%); and
+* four-file warm: `1434.537 → 1089.702` (-24.0%).
+
+No whole-region fallback occurred. Probe engagement remains unchanged:
+single-file `6/30` cells and `206,056` rows/query; four-file `12/28` cells and
+`437,329` rows/query. Existing adjacent-range planning already needs only three
+Region-A physical rounds single-file; the 1 MiB policy retains those three and
+reduces four-file Region-A rounds from `8→7`.
+
+== Where the GETs moved
+
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+| geometry/temp | control | footer/meta | Region A | Region B | Region D | total
+| 1 cold baseline → retained | 3→1 | 1→1 | 3→3 | 22→22 | 3→3 | 33→30
+| 1 warm baseline → retained | 3→0 | 1→0 | 3→3 | 15→15 | 0→0 | 24→19
+| 4 cold baseline → retained | 12→4 | 4→4 | 8→7 | 42→42 | 8→8 | 75→65
+| 4 warm baseline → retained | 12→0 | 4→0 | 8→7 | 34→34 | 2→2 | 62→44
+|===
+
+Stage and total GETs are aggregate per-query counters rendered as whole values;
+independent truncation means a displayed stage row need not sum exactly to its
+displayed total.
+
+This closes the control/A0/Region-A fragmentation identified by PR-C1. Region B
+is now the largest remaining request term (`22–42` GETs/query); any next layout
+work should start from its survivor-run trace and must not broaden `nprobe` or
+conflate per-file probe geometry with collection file-count policy.
+
+== Rejected alternatives
+
+* `64 KiB` Region-A gap: safe, but leaves one additional GET single-file and
+  two additional GETs four-file compared with 1 MiB for only about 0.35–0.95 MB
+  less over-read. It is dominated under the stated object-store score.
+* `4 MiB` Region-A gap: only ~0.1% lower synthetic score than 1 MiB, but reads
+  3.59 MB/query more in four-file geometry and worsens the single-file cold
+  tail. The apparent win is below a robust promotion margin, so it is rejected.
+* prefix-only or cache-only: each improves its own stage and remains a useful
+  ablation, but the accepted operational policy is the combined arm.
+
+Indicative dev-machine evidence, not an object-store SLA.

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -703,6 +703,66 @@ fn plan_coalesced_row_ranges(
     out
 }
 
+/// One selected IVF cell's exact Region-A code slice. A coalesced physical
+/// range may contain gaps or unselected cells, but only these slices are ever
+/// handed to the RaBitQ ranker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProbeCellSlice {
+    start: u64,
+    end: u64,
+    row_start: usize,
+}
+
+/// One physical Region-A read containing one or more selected cell slices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProbeRangeFetch {
+    start: u64,
+    end: u64,
+    selected: Vec<ProbeCellSlice>,
+}
+
+/// Merge selected Region-A cell extents according to the provider-bounded
+/// range policy. The returned `selected` slices preserve the logical nprobe
+/// set, so gap over-read changes only physical I/O, never ranking semantics.
+fn plan_probe_cell_ranges(
+    cells: &[ProbeCellSlice],
+    policy: &crate::storage::engines::sst::readers::sst_query_engine::ObjectRangeCoalescePolicy,
+) -> Vec<ProbeRangeFetch> {
+    let mut sorted = cells.to_vec();
+    sorted.sort_by_key(|cell| cell.start);
+    let mut out: Vec<ProbeRangeFetch> = Vec::new();
+    for cell in sorted {
+        if cell.end <= cell.start {
+            continue;
+        }
+        let merged = match out.last_mut() {
+            Some(last) => {
+                let gap = cell.start.saturating_sub(last.end);
+                let merged_len = cell.end.saturating_sub(last.start);
+                let within_gap = gap <= policy.max_gap_bytes;
+                let within_max =
+                    policy.max_range_bytes == 0 || merged_len <= policy.max_range_bytes;
+                if within_gap && within_max {
+                    last.end = last.end.max(cell.end);
+                    last.selected.push(cell);
+                    true
+                } else {
+                    false
+                }
+            }
+            None => false,
+        };
+        if !merged {
+            out.push(ProbeRangeFetch {
+                start: cell.start,
+                end: cell.end,
+                selected: vec![cell],
+            });
+        }
+    }
+    out
+}
+
 /// Per-metric "lower = nearer" rerank score against a reconstructed vector.
 fn rerank_distance(metric: RankMetric, q: &[f32], v: &[f32]) -> f32 {
     match metric {
@@ -776,8 +836,10 @@ pub fn pax_rabitq_pool_for_top_k(k: usize, n: usize) -> usize {
 /// is the only way to reduce it — caching parsed structs downstream doesn't help).
 pub struct SegmentInvariants {
     pub header_bytes: Vec<u8>,
-    pub region_bytes: Arc<[u8]>,
+    pub region_bytes: Option<Arc<[u8]>>,
     pub footer_bytes: Vec<u8>,
+    pub a0_bytes: Option<Arc<[u8]>>,
+    pub rabitq_header_bytes: Option<Arc<[u8]>>,
 }
 
 /// Per-segment invariants cache, **byte-budgeted** (ADR-065 cache-co-design #35).
@@ -796,9 +858,17 @@ struct CacheInner {
     bytes_used: usize,
 }
 
-/// Bytes an invariants entry contributes (Region A dominates).
+/// Bytes an invariants entry contributes. Whole-scan entries are dominated by
+/// Region A; probe-only entries contain only small control metadata.
 fn inv_bytes(inv: &SegmentInvariants) -> usize {
-    inv.region_bytes.len() + inv.header_bytes.len() + inv.footer_bytes.len()
+    inv.region_bytes.as_ref().map_or(0, |bytes| bytes.len())
+        + inv.header_bytes.len()
+        + inv.footer_bytes.len()
+        + inv.a0_bytes.as_ref().map_or(0, |bytes| bytes.len())
+        + inv
+            .rabitq_header_bytes
+            .as_ref()
+            .map_or(0, |bytes| bytes.len())
 }
 
 impl SegmentInvariantsCache {
@@ -878,8 +948,12 @@ impl SegmentInvariantsCache {
 pub enum CacheTier {
     /// Region A (RaBitQ index scan): ~24 MB, re-read every query (hottest).
     InvariantIndex,
-    /// header / footer / SQ8 params: tiny, always-useful.
+    /// Header / A0 / RaBitQ parameters: the mandatory ANN control prefix.
+    SearchControl,
+    /// Tail footer / block map / SQ8 parameters: tiny, always-useful.
     InvariantMeta,
+    /// Selected Region-A IVF-cell code runs.
+    ProbeIndex,
     /// Region B survivor SQ8 ranges: variable, query-dependent.
     SurvivorPayload,
     /// Region D OID ranges: variable, query-dependent.
@@ -891,7 +965,9 @@ impl CacheTier {
     pub fn label(self) -> &'static str {
         match self {
             Self::InvariantIndex => "IdxA",
+            Self::SearchControl => "Ctl",
             Self::InvariantMeta => "Meta",
+            Self::ProbeIndex => "ProbeA",
             Self::SurvivorPayload => "Surv",
             Self::ResultPayload => "OID",
         }
@@ -900,10 +976,10 @@ impl CacheTier {
     /// pinned (a hit saves the most); query-dependent ranges are evicted first.
     pub fn evict_priority(self) -> u8 {
         match self {
-            Self::SurvivorPayload => 0,
+            Self::ProbeIndex | Self::SurvivorPayload => 0,
             Self::ResultPayload => 1,
             Self::InvariantMeta => 2,
-            Self::InvariantIndex => 3,
+            Self::InvariantIndex | Self::SearchControl => 3,
         }
     }
 }
@@ -1015,6 +1091,34 @@ struct CoarseProbeResult {
     cells_probed: u64,
     probed_rows: u64,
     fetch_rounds: u64,
+    a0_bytes: Arc<[u8]>,
+    rabitq_header_bytes: Arc<[u8]>,
+}
+
+fn prefetched_slice(prefix: &[u8], offset: u64, len: u64) -> Option<&[u8]> {
+    let start = usize::try_from(offset).ok()?;
+    let len = usize::try_from(len).ok()?;
+    let end = start.checked_add(len)?;
+    prefix.get(start..end)
+}
+
+fn prefix_prefetch_bytes() -> Option<u64> {
+    std::env::var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0)
+}
+
+fn split_probe_metadata_cache_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1" | "true" | "on" | "yes")
+    )
 }
 
 /// TD-RDSTRAT-8 PR-B: compute survivors from ONLY the `nprobe` nearest coarse
@@ -1031,6 +1135,8 @@ async fn coarse_probe_survivors(
     metric: RankMetric,
     k: usize,
     trace_on: bool,
+    cached: Option<&SegmentInvariants>,
+    prefix: &[u8],
 ) -> Result<Option<CoarseProbeResult>> {
     use proximadb_storage_common::coarse_directory::{CoarseDirectory, project_with_model};
 
@@ -1040,13 +1146,20 @@ async fn coarse_probe_survivors(
     }
 
     // 1. Region A0 (small, immediately after the header) — one ranged GET.
-    let a0_bytes = fs
-        .read_range(path, header.a0_off, header.a0_len)
-        .await
-        .map_err(|e| anyhow::anyhow!("coarse-probe A0 {path}: {e}"))?;
-    if trace_on {
-        record_get(CacheTier::InvariantMeta, header.a0_len);
-    }
+    let a0_bytes: Arc<[u8]> = if let Some(bytes) = cached.and_then(|inv| inv.a0_bytes.clone()) {
+        bytes
+    } else if let Some(bytes) = prefetched_slice(prefix, header.a0_off, header.a0_len) {
+        Arc::from(bytes.to_vec())
+    } else {
+        let bytes = fs
+            .read_range(path, header.a0_off, header.a0_len)
+            .await
+            .map_err(|e| anyhow::anyhow!("coarse-probe A0 {path}: {e}"))?;
+        if trace_on {
+            record_get(CacheTier::SearchControl, header.a0_len);
+        }
+        Arc::from(bytes)
+    };
     let Ok(dir) = CoarseDirectory::parse(&a0_bytes) else {
         return Ok(None);
     };
@@ -1090,48 +1203,84 @@ async fn coarse_probe_survivors(
 
     // 3. Region-A header (params + centroid) — one small ranged GET.
     let hdr_len = proximadb_block_format::region_header_len(dim as u32) as u64;
-    let hdr_bytes = fs
-        .read_range(path, header.rabitq_off, hdr_len)
-        .await
-        .map_err(|e| anyhow::anyhow!("coarse-probe region header {path}: {e}"))?;
-    if trace_on {
-        record_get(CacheTier::InvariantMeta, hdr_len);
-    }
+    let hdr_bytes: Arc<[u8]> =
+        if let Some(bytes) = cached.and_then(|inv| inv.rabitq_header_bytes.clone()) {
+            bytes
+        } else if let Some(bytes) = prefetched_slice(prefix, header.rabitq_off, hdr_len) {
+            Arc::from(bytes.to_vec())
+        } else {
+            let bytes = fs
+                .read_range(path, header.rabitq_off, hdr_len)
+                .await
+                .map_err(|e| anyhow::anyhow!("coarse-probe region header {path}: {e}"))?;
+            if trace_on {
+                record_get(CacheTier::SearchControl, hdr_len);
+            }
+            Arc::from(bytes)
+        };
     let Ok(rq_header) = proximadb_block_format::CoalescedRaBitQHeader::parse(&hdr_bytes) else {
         return Ok(None);
     };
 
-    // 4. Ranged-read the probed cells' Region-A code extents. Coalesce ONLY
-    //    physically-adjacent cells (gap 0) so we never over-read unprobed cells;
-    //    Hilbert emission order clusters near cells, so the nprobe nearest usually
-    //    collapse to a few contiguous runs.
+    // 4. Ranged-read the probed cells' Region-A code extents. The default
+    //    remains gap-zero. The proof gate can admit bounded gap over-read, but
+    //    the ranker receives only the selected slices so nprobe never changes.
     let stride = proximadb_block_format::code_stride(dim as u32) as u64;
-    let mut merged: Vec<(u64, u64, usize)> = Vec::new(); // (start, end, global row_start)
-    for &c in &probed {
-        let cell = &dir.cells[c];
-        let (s, e, rs) = (cell.a_off, cell.a_off + cell.a_len, cell.row_begin as usize);
-        match merged.last_mut() {
-            Some(last) if last.1 == s => last.1 = e, // contiguous → extend the run
-            _ => merged.push((s, e, rs)),
-        }
-    }
-    let mut run_bufs: Vec<(usize, Vec<u8>)> = Vec::with_capacity(merged.len());
-    let mut probed_rows: u64 = 0;
-    for (s, e, rs) in &merged {
-        let len = e - s;
+    let selected: Vec<ProbeCellSlice> = probed
+        .iter()
+        .map(|&cell_index| {
+            let cell = &dir.cells[cell_index];
+            ProbeCellSlice {
+                start: cell.a_off,
+                end: cell.a_off + cell.a_len,
+                row_start: cell.row_begin as usize,
+            }
+        })
+        .collect();
+    let max_gap_bytes = env_u64_or("PROXIMADB_PAX_A_COALESCE_GAP", 0);
+    let max_range_bytes = std::env::var("PROXIMADB_PAX_A_COALESCE_RANGE")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(0);
+    let policy =
+        crate::storage::engines::sst::readers::sst_query_engine::ObjectRangeCoalescePolicy {
+            max_gap_bytes,
+            max_range_bytes,
+        };
+    let fetches = plan_probe_cell_ranges(&selected, &policy);
+    let mut fetched = Vec::with_capacity(fetches.len());
+    let probed_rows: u64 = selected
+        .iter()
+        .map(|cell| (cell.end - cell.start) / stride)
+        .sum();
+    for fetch in fetches {
+        let len = fetch.end - fetch.start;
         let bytes = fs
-            .read_range(path, *s, len)
+            .read_range(path, fetch.start, len)
             .await
             .map_err(|err| anyhow::anyhow!("coarse-probe Region A {path}: {err}"))?;
         if trace_on {
-            record_get(CacheTier::SurvivorPayload, len);
+            record_get(CacheTier::ProbeIndex, len);
         }
-        // `stride = code_stride(dim) >= 9` (dim >= 1, guarded above) so the
-        // division is always well-defined.
-        probed_rows += len / stride;
-        run_bufs.push((*rs, bytes));
+        fetched.push((fetch, bytes));
     }
-    let runs: Vec<(usize, &[u8])> = run_bufs.iter().map(|(rs, b)| (*rs, b.as_slice())).collect();
+    let mut runs: Vec<(usize, &[u8])> = Vec::with_capacity(selected.len());
+    for (fetch, bytes) in &fetched {
+        for cell in &fetch.selected {
+            let rel = usize::try_from(cell.start.saturating_sub(fetch.start))
+                .map_err(|_| anyhow::anyhow!("coarse-probe slice offset exceeds usize"))?;
+            let len = usize::try_from(cell.end.saturating_sub(cell.start))
+                .map_err(|_| anyhow::anyhow!("coarse-probe slice length exceeds usize"))?;
+            let end = rel
+                .checked_add(len)
+                .ok_or_else(|| anyhow::anyhow!("coarse-probe slice end overflow"))?;
+            let slice = bytes
+                .get(rel..end)
+                .ok_or_else(|| anyhow::anyhow!("coarse-probe selected slice outside fetch"))?;
+            runs.push((cell.row_start, slice));
+        }
+    }
     let pool = pax_rabitq_pool_for_top_k(k, probed_rows as usize);
     let survivors =
         proximadb_block_format::rank_probed_rows(&rq_header, &runs, query, metric, pool.max(k))?;
@@ -1141,7 +1290,9 @@ async fn coarse_probe_survivors(
         cells_total: k_c as u64,
         cells_probed: probed.len() as u64,
         probed_rows,
-        fetch_rounds: merged.len() as u64,
+        fetch_rounds: fetched.len() as u64,
+        a0_bytes,
+        rabitq_header_bytes: hdr_bytes,
     }))
 }
 
@@ -1164,7 +1315,8 @@ pub async fn rabitq_search_segment_coalesced(
     // is set, every read_range in this path records its on-disk byte length; the
     // eval drains it to print the distribution (GET count = the same-region
     // billing metric; GET sizes = the latency metric). Off by default (zero cost).
-    let trace_on = std::env::var_os("PROXIMADB_TRACE_GETS").is_some();
+    let trace_on = std::env::var_os("PROXIMADB_TRACE_GETS").is_some()
+        || std::env::var_os("PROXIMADB_TRACE_PAX_STAGES").is_some();
 
     // PR2: check the per-segment invariants cache. On hit, skip the 3
     // read_range calls (header + region + footer) → 3 GETs → 0 (hot path).
@@ -1185,9 +1337,18 @@ pub async fn rabitq_search_segment_coalesced(
         // TD-RDSTRAT-8: fetch the v3 prefix length unconditionally (clamped to
         // file size) — the 16 extra bytes ride the same GET and cover both the
         // v1 (56 B) and v3 (72 B) forms; `parse` branches on the version byte.
-        fs.read_range(path, 0, (SEG_HEADER_PREFIX_V3_LEN as u64).min(size))
+        let read_len = prefix_prefetch_bytes()
+            .unwrap_or(SEG_HEADER_PREFIX_V3_LEN as u64)
+            .max(SEG_HEADER_PREFIX_V3_LEN as u64)
+            .min(size);
+        let bytes = fs
+            .read_range(path, 0, read_len)
             .await
-            .map_err(|e| anyhow::anyhow!("coalesced scan header {path}: {e}"))?
+            .map_err(|e| anyhow::anyhow!("coalesced scan header {path}: {e}"))?;
+        if trace_on {
+            record_get(CacheTier::SearchControl, bytes.len() as u64);
+        }
+        bytes
     };
     // A v3 (two-level) segment parses here too and falls through to the same
     // single-level whole-region scan: Regions A/B are byte-identical in format
@@ -1208,10 +1369,20 @@ pub async fn rabitq_search_segment_coalesced(
         && header.a0_len > 0
         && coarse_probe_enabled();
     let probe = if probe_armed {
-        coarse_probe_survivors(fs, path, &header, query, metric, k, trace_on)
-            .await
-            .ok()
-            .flatten()
+        coarse_probe_survivors(
+            fs,
+            path,
+            &header,
+            query,
+            metric,
+            k,
+            trace_on,
+            cached.as_deref(),
+            &header_bytes,
+        )
+        .await
+        .ok()
+        .flatten()
     } else {
         None
     };
@@ -1238,20 +1409,21 @@ pub async fn rabitq_search_segment_coalesced(
         if probe_armed {
             record_ivf_probe_durable(0, 0, 0, 0, true);
         }
-        let region_bytes: Arc<[u8]> = if let Some(inv) = cached.as_ref() {
-            inv.region_bytes.clone()
-        } else {
-            let bytes = fs
-                .read_range(path, header.rabitq_off, header.rabitq_len)
-                .await
-                .map_err(|e| anyhow::anyhow!("coalesced scan region {path}: {e}"))?;
-            // Trace the whole-region cost so the coarse probe's Region-A saving is
-            // observable (co-design: trace before you tune). Diagnostic-only.
-            if trace_on {
-                record_get(CacheTier::InvariantIndex, header.rabitq_len);
-            }
-            Arc::from(bytes)
-        };
+        let region_bytes: Arc<[u8]> =
+            if let Some(bytes) = cached.as_ref().and_then(|inv| inv.region_bytes.clone()) {
+                bytes
+            } else {
+                let bytes = fs
+                    .read_range(path, header.rabitq_off, header.rabitq_len)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("coalesced scan region {path}: {e}"))?;
+                // Trace the whole-region cost so the coarse probe's Region-A saving is
+                // observable (co-design: trace before you tune). Diagnostic-only.
+                if trace_on {
+                    record_get(CacheTier::InvariantIndex, header.rabitq_len);
+                }
+                Arc::from(bytes)
+            };
         let region = RaBitQRegion::from_bytes(&region_bytes)?;
         // ADR-062 PR2: adaptive survivor pool — scale M with the segment's rows.
         let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());
@@ -1265,26 +1437,51 @@ pub async fn rabitq_search_segment_coalesced(
     let footer_bytes: Vec<u8> = if let Some(inv) = cached.as_ref() {
         inv.footer_bytes.clone()
     } else {
-        fs.read_range(path, header.footer_off, header.footer_len)
+        let bytes = fs
+            .read_range(path, header.footer_off, header.footer_len)
             .await
-            .map_err(|e| anyhow::anyhow!("coalesced scan footer {path}: {e}"))?
+            .map_err(|e| anyhow::anyhow!("coalesced scan footer {path}: {e}"))?;
+        if trace_on {
+            record_get(CacheTier::InvariantMeta, bytes.len() as u64);
+        }
+        bytes
     };
     let footer = SegmentFooterIndex::parse(&footer_bytes)?;
 
-    // PR2: populate the cache on miss (the invariants parsed successfully →
-    // worth caching for hot repeat queries). Only on the whole-region path — the
-    // coarse probe never read the whole Region A, so there is nothing to cache
-    // here (its small A0/header/cell reads ride the survivor cache instead).
-    if cached.is_none()
-        && let Some(region_bytes) = region_bytes
-        && let Some(c) = cache
-    {
+    // Cache tiny ANN control metadata independently from the whole Region A.
+    // Probe queries therefore warm header/A0/RaBitQ params/footer without
+    // admitting a 24+ MiB invariant body they intentionally did not read.
+    let split_probe_meta = split_probe_metadata_cache_enabled();
+    let probe_a0 = if split_probe_meta {
+        probe.as_ref().map(|result| result.a0_bytes.clone())
+    } else {
+        None
+    };
+    let probe_rabitq_header = if split_probe_meta {
+        probe
+            .as_ref()
+            .map(|result| result.rabitq_header_bytes.clone())
+    } else {
+        None
+    };
+    let cached_region = cached.as_ref().and_then(|entry| entry.region_bytes.clone());
+    let cached_a0 = cached.as_ref().and_then(|entry| entry.a0_bytes.clone());
+    let cached_rabitq_header = cached
+        .as_ref()
+        .and_then(|entry| entry.rabitq_header_bytes.clone());
+    let cache_changed = (probe.is_none() && cached.is_none())
+        || (cached_region.is_none() && region_bytes.is_some())
+        || (cached_a0.is_none() && probe_a0.is_some())
+        || (cached_rabitq_header.is_none() && probe_rabitq_header.is_some());
+    if cache_changed && let Some(c) = cache {
         c.put(
             path.to_string(),
             Arc::new(SegmentInvariants {
                 header_bytes,
-                region_bytes,
+                region_bytes: region_bytes.or(cached_region),
                 footer_bytes,
+                a0_bytes: probe_a0.or(cached_a0),
+                rabitq_header_bytes: probe_rabitq_header.or(cached_rabitq_header),
             }),
         );
     }
@@ -1487,6 +1684,47 @@ pub async fn rabitq_search_segment_coalesced(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn probe_range_coalescing_keeps_only_selected_cell_slices() {
+        let selected = vec![
+            ProbeCellSlice {
+                start: 100,
+                end: 200,
+                row_start: 0,
+            },
+            ProbeCellSlice {
+                start: 250,
+                end: 350,
+                row_start: 10,
+            },
+            ProbeCellSlice {
+                start: 900,
+                end: 1_000,
+                row_start: 20,
+            },
+        ];
+        let policy =
+            crate::storage::engines::sst::readers::sst_query_engine::ObjectRangeCoalescePolicy {
+                max_gap_bytes: 64,
+                max_range_bytes: 512,
+            };
+
+        let planned = plan_probe_cell_ranges(&selected, &policy);
+
+        assert_eq!(planned.len(), 2, "the 50-byte gap should merge");
+        assert_eq!((planned[0].start, planned[0].end), (100, 350));
+        assert_eq!(planned[0].selected, selected[..2]);
+        assert_eq!(planned[1].selected, selected[2..]);
+        let fetched: u64 = planned.iter().map(|range| range.end - range.start).sum();
+        let useful: u64 = planned
+            .iter()
+            .flat_map(|range| &range.selected)
+            .map(|cell| cell.end - cell.start)
+            .sum();
+        assert_eq!(useful, 300);
+        assert_eq!(fetched - useful, 50, "only the merged gap is over-read");
+    }
     use crate::storage::engines::core::formats::proximablocks::BlockCompressionConfig;
     use proximadb_records::{EmbeddingCell, EmbeddingValues};
 
@@ -2516,11 +2754,19 @@ mod tests {
         }
         let _ = drain_get_trace();
         let _ = drain_probe_trace();
-        let probe = rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
-            .await
-            .unwrap()
-            .unwrap();
-        let probe_bytes: u64 = drain_get_trace().iter().map(|(_, b)| b).sum();
+        let (probe, probe_snapshot) = crate::observability::io_trace::scope(async {
+            let hits =
+                rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let snapshot = crate::observability::io_trace::snapshot()
+                .expect("reader probe test runs inside an io_trace scope");
+            (hits, snapshot)
+        })
+        .await;
+        let probe_gets = drain_get_trace();
+        let probe_bytes: u64 = probe_gets.iter().map(|(_, b)| b).sum();
         let ptrace = drain_probe_trace();
 
         // 1. The probe engaged: cells_probed strictly inside (0, cells_total).
@@ -2536,6 +2782,11 @@ mod tests {
             "probed {probed_rows} of {N} rows (a strict subset)"
         );
         assert!(fetch_rounds >= 1, "at least one Region-A ranged GET");
+        assert_eq!(probe_snapshot.ivf_cells_total, cells_total);
+        assert_eq!(probe_snapshot.ivf_cells_probed, cells_probed);
+        assert_eq!(probe_snapshot.ivf_probed_rows, probed_rows);
+        assert_eq!(probe_snapshot.ivf_fetch_rounds, fetch_rounds);
+        assert_eq!(probe_snapshot.ivf_whole_region_fallback, 0);
 
         // 2. Materially fewer bytes than the whole-region baseline.
         assert!(
@@ -2552,11 +2803,166 @@ mod tests {
             "probe recall@{K} = {probe_recall:.2} must hold vs baseline {base_recall:.2} (nprobe=6/16)"
         );
 
+        // PR-C2 proof: bounded Region-A gap over-read may reduce physical
+        // ranges, but it must rank exactly the same selected cells and rows.
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_A_COALESCE_GAP", "1048576");
+            std::env::set_var("PROXIMADB_PAX_A_COALESCE_RANGE", "4194304");
+        }
+        let _ = drain_get_trace();
+        let _ = drain_probe_trace();
+        let (coalesced, coalesced_snapshot) = crate::observability::io_trace::scope(async {
+            let hits =
+                rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let snapshot = crate::observability::io_trace::snapshot()
+                .expect("coalescing proof runs inside an io_trace scope");
+            (hits, snapshot)
+        })
+        .await;
+        let _ = drain_get_trace();
+        let _ = drain_probe_trace();
+        assert_eq!(
+            coalesced.iter().map(|hit| &hit.oid).collect::<Vec<_>>(),
+            probe.iter().map(|hit| &hit.oid).collect::<Vec<_>>(),
+            "physical gap over-read must not change logical survivors/results"
+        );
+        assert_eq!(coalesced_snapshot.ivf_cells_probed, cells_probed);
+        assert_eq!(coalesced_snapshot.ivf_probed_rows, probed_rows);
+        assert!(
+            coalesced_snapshot.ivf_fetch_rounds <= fetch_rounds,
+            "cost coalescing cannot add Region-A reads"
+        );
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_A_COALESCE_GAP");
+            std::env::remove_var("PROXIMADB_PAX_A_COALESCE_RANGE");
+        }
+
+        // PR-C2 proof: a bounded prefix read must replace the separate header,
+        // A0 and RaBitQ-parameter GETs with one physical control GET.
+        let baseline_control_gets = probe_gets
+            .iter()
+            .filter(|(tier, _)| *tier == CacheTier::SearchControl)
+            .count();
+        assert!(
+            baseline_control_gets >= 3,
+            "control baseline needs header+A0+params"
+        );
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES", "65536");
+        }
+        let _ = drain_get_trace();
+        let prefetched =
+            rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+                .await
+                .unwrap()
+                .unwrap();
+        let prefix_gets = drain_get_trace();
+        let _ = drain_probe_trace();
+        assert_eq!(
+            prefetched.iter().map(|hit| &hit.oid).collect::<Vec<_>>(),
+            probe.iter().map(|hit| &hit.oid).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            prefix_gets
+                .iter()
+                .filter(|(tier, _)| *tier == CacheTier::SearchControl)
+                .count(),
+            1,
+            "one prefix GET supplies header+A0+RaBitQ parameters"
+        );
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES");
+        }
+
+        // PR-C2 proof: metadata warms independently even though the probe never
+        // admits the complete Region A into the invariant cache.
+        unsafe {
+            std::env::set_var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE", "1");
+        }
+        let invariants = SegmentInvariantsCache::new(8 * 1024 * 1024);
+        let _ = drain_get_trace();
+        let _ = rabitq_search_segment_coalesced(
+            &fs,
+            p,
+            &query,
+            K,
+            RankMetric::L2,
+            Some(&invariants),
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let first_cached = drain_get_trace();
+        let _ = drain_probe_trace();
+        let _ = rabitq_search_segment_coalesced(
+            &fs,
+            p,
+            &query,
+            K,
+            RankMetric::L2,
+            Some(&invariants),
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let second_cached = drain_get_trace();
+        let _ = drain_probe_trace();
+        assert!(
+            first_cached.iter().any(|(tier, _)| matches!(
+                tier,
+                CacheTier::SearchControl | CacheTier::InvariantMeta
+            )),
+            "cold cache population reads control metadata"
+        );
+        assert!(
+            second_cached.iter().all(|(tier, _)| !matches!(
+                tier,
+                CacheTier::SearchControl | CacheTier::InvariantMeta
+            )),
+            "warm probe must not re-read cached control metadata"
+        );
+        unsafe {
+            std::env::remove_var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE");
+        }
+
+        // 4. Corrupt A0 fails closed to the canonical whole-Region-A scan and
+        //    makes that fallback visible in the durable query trace.
+        let mut corrupt = std::fs::read(&path).unwrap();
+        let corrupt_header = SegmentHeaderPrefix::parse(&corrupt).unwrap();
+        corrupt[corrupt_header.a0_off as usize] ^= 0x01;
+        std::fs::write(&path, corrupt).unwrap();
+        let (fallback, fallback_snapshot) = crate::observability::io_trace::scope(async {
+            let hits =
+                rabitq_search_segment_coalesced(&fs, p, &query, K, RankMetric::L2, None, None)
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let snapshot = crate::observability::io_trace::snapshot()
+                .expect("reader fallback test runs inside an io_trace scope");
+            (hits, snapshot)
+        })
+        .await;
+        assert!(
+            !fallback.is_empty(),
+            "A0 corruption fails closed, not empty"
+        );
+        assert_eq!(fallback_snapshot.ivf_cells_total, 0);
+        assert_eq!(fallback_snapshot.ivf_cells_probed, 0);
+        assert_eq!(fallback_snapshot.ivf_whole_region_fallback, 1);
         unsafe {
             std::env::remove_var("PROXIMADB_IVF2_PROBE");
             std::env::remove_var("PROXIMADB_IVF2_NPROBE");
             std::env::remove_var("PROXIMADB_TRACE_GETS");
             std::env::remove_var("PROXIMADB_IVF_K");
+            std::env::remove_var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES");
+            std::env::remove_var("PROXIMADB_PAX_A_COALESCE_GAP");
+            std::env::remove_var("PROXIMADB_PAX_A_COALESCE_RANGE");
+            std::env::remove_var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE");
         }
     }
 }

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -44,9 +44,17 @@ use proximadb::proto::proximadb_v1::{
     Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
 };
 use proximadb::storage::engines::sst::SstEngine;
+use proximadb::storage::engines::sst::segment_format::{
+    CacheTier, SegmentInvariantsCache, drain_get_trace, rabitq_search_segment_coalesced,
+    write_pax_segment_compacted,
+};
+use proximadb::storage::engines::sst::survivor_range_cache::SurvivorRangeCache;
+use proximadb::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
 use proximadb::storage::traits::{
     FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
 };
+use proximadb_block_format::{RankMetric, VectorQuant};
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -728,22 +736,464 @@ async fn sift_coalesced_rabitq_scan_rerank_eval() {
     }
 }
 
+#[derive(Debug)]
+struct Ivf2BakeMetrics {
+    recall: f64,
+    measured: usize,
+    snapshot: proximadb::observability::io_trace::IoTraceSnapshot,
+    p50_us: u64,
+    p95_us: u64,
+    get_trace: Vec<(CacheTier, u64)>,
+}
+
+fn ivf2_record(row: usize, vector: &[f32]) -> ProximaRecord {
+    ProximaRecord {
+        oid: vid(row as u32),
+        created_at_ns: 1_000 + row as i64,
+        updated_at_ns: 1_000 + row as i64,
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "sift1m".into(),
+            modality: "dense_vector".into(),
+            dim: vector.len() as u32,
+            values: EmbeddingValues::Fp32(vector.to_vec()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn csv_usize_env(name: &str, defaults: &[usize]) -> Vec<usize> {
+    let values = std::env::var(name)
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .filter_map(|value| value.trim().parse::<usize>().ok())
+                .filter(|value| *value > 0)
+                .collect::<Vec<_>>()
+        })
+        .filter(|values| !values.is_empty())
+        .unwrap_or_else(|| defaults.to_vec());
+    let mut values = values;
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
+fn percentile_us(sorted: &[u64], percentile: usize) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[(sorted.len() - 1) * percentile.min(100) / 100]
+}
+
+fn write_ivf2_geometry(
+    root: &Path,
+    base: &[Vec<f32>],
+    file_count: usize,
+    v3: bool,
+) -> Vec<PathBuf> {
+    unsafe {
+        std::env::set_var("PROXIMADB_PAX_COALESCED_RABITQ", "1");
+        std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1");
+        if v3 {
+            std::env::set_var("PROXIMADB_IVF2", "1");
+        } else {
+            std::env::remove_var("PROXIMADB_IVF2");
+        }
+    }
+    let rows_per_file = base.len().div_ceil(file_count);
+    let target_block =
+        proximadb_storage_common::iops_budget::IopsBudget::CLOUD.target_block_bytes() as usize;
+    let mut paths = Vec::new();
+    for file_index in 0..file_count {
+        let begin = file_index * rows_per_file;
+        if begin >= base.len() {
+            break;
+        }
+        let end = (begin + rows_per_file).min(base.len());
+        let records: Vec<ProximaRecord> = base[begin..end]
+            .iter()
+            .enumerate()
+            .map(|(local, vector)| ivf2_record(begin + local, vector))
+            .collect();
+        let path = root.join(format!(
+            "{}-{file_index:03}.pax",
+            if v3 { "v3" } else { "pxh1" }
+        ));
+        write_pax_segment_compacted(
+            &path,
+            &records,
+            "sift_ivf2_prc1",
+            1,
+            VectorQuant::RaBitQ,
+            VectorQuant::Sq8,
+            false,
+            Some(target_block),
+        )
+        .expect("write compacted bakeoff segment");
+        paths.push(path);
+    }
+    assert_eq!(paths.len(), file_count.min(base.len()));
+    paths
+}
+
+async fn search_ivf2_geometry(
+    fs: &LocalFileSystem,
+    paths: &[PathBuf],
+    query: &[f32],
+    invariants: Option<&SegmentInvariantsCache>,
+    survivors: Option<&SurvivorRangeCache>,
+) -> Vec<String> {
+    let mut hits = Vec::new();
+    for path in paths {
+        let path = path.to_str().expect("utf8 bakeoff path");
+        let segment_hits = rabitq_search_segment_coalesced(
+            fs,
+            path,
+            query,
+            TOP_K,
+            RankMetric::L2,
+            invariants,
+            survivors,
+        )
+        .await
+        .expect("coalesced segment search")
+        .expect("bakeoff segment is coalesced");
+        hits.extend(segment_hits);
+    }
+    hits.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+    hits.truncate(TOP_K);
+    hits.into_iter().map(|hit| hit.oid).collect()
+}
+
+async fn run_ivf2_bake_arm(
+    fs: &LocalFileSystem,
+    paths: &[PathBuf],
+    queries: &[Vec<f32>],
+    ground_truth: &[std::collections::HashSet<String>],
+    warm: bool,
+) -> Ivf2BakeMetrics {
+    let _ = drain_get_trace();
+    let invariants = warm.then(|| SegmentInvariantsCache::new(512 * 1024 * 1024));
+    let survivors = warm.then(|| SurvivorRangeCache::new(512 * 1024 * 1024));
+    if warm {
+        for query in queries {
+            let _ = search_ivf2_geometry(fs, paths, query, invariants.as_ref(), survivors.as_ref())
+                .await;
+        }
+        let _ = drain_get_trace();
+    }
+    let (recall, measured, snapshot, mut query_us) =
+        proximadb::observability::io_trace::scope(async {
+            let mut recall_sum = 0.0;
+            let mut measured = 0usize;
+            let mut query_us = Vec::with_capacity(queries.len());
+            for (query_index, query) in queries.iter().enumerate() {
+                let started = Instant::now();
+                let got =
+                    search_ivf2_geometry(fs, paths, query, invariants.as_ref(), survivors.as_ref())
+                        .await;
+                query_us.push(started.elapsed().as_micros() as u64);
+                if got.is_empty() {
+                    continue;
+                }
+                let got: std::collections::HashSet<String> = got.into_iter().collect();
+                recall_sum +=
+                    got.intersection(&ground_truth[query_index]).count() as f64 / TOP_K as f64;
+                measured += 1;
+            }
+            let recall = if measured == 0 {
+                0.0
+            } else {
+                recall_sum / measured as f64
+            };
+            let snapshot = proximadb::observability::io_trace::snapshot()
+                .expect("bakeoff io_trace scope active");
+            (recall, measured, snapshot, query_us)
+        })
+        .await;
+    let get_trace = drain_get_trace();
+    query_us.sort_unstable();
+    Ivf2BakeMetrics {
+        recall,
+        measured,
+        snapshot,
+        p50_us: percentile_us(&query_us, 50),
+        p95_us: percentile_us(&query_us, 95),
+        get_trace,
+    }
+}
+
+fn ivf2_stage(metrics: &Ivf2BakeMetrics, tier: CacheTier) -> (u64, u64) {
+    metrics
+        .get_trace
+        .iter()
+        .filter(|(observed, _)| *observed == tier)
+        .fold((0, 0), |(gets, bytes), (_, size)| (gets + 1, bytes + size))
+}
+
+fn ivf2_read_cost(metrics: &Ivf2BakeMetrics) -> f64 {
+    let q = metrics.measured.max(1) as f64;
+    let gets = metrics.snapshot.range_gets as f64 / q;
+    let mib = metrics.snapshot.bytes_read as f64 / q / (1024.0 * 1024.0);
+    20.0 * gets + 5.0 * mib
+}
+
+fn ivf2_region_a_bytes(metrics: &Ivf2BakeMetrics) -> u64 {
+    ivf2_stage(metrics, CacheTier::InvariantIndex).1 + ivf2_stage(metrics, CacheTier::ProbeIndex).1
+}
+
+fn env_enabled(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1" | "true" | "on" | "yes")
+    )
+}
+
+unsafe fn set_ivf2_layout_proof_arm(prefix_bytes: Option<u64>, gap: Option<u64>, split: bool) {
+    unsafe {
+        std::env::remove_var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES");
+        std::env::remove_var("PROXIMADB_PAX_A_COALESCE_GAP");
+        std::env::remove_var("PROXIMADB_PAX_A_COALESCE_RANGE");
+        std::env::remove_var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE");
+        if let Some(bytes) = prefix_bytes {
+            std::env::set_var("PROXIMADB_PAX_PREFIX_PREFETCH_BYTES", bytes.to_string());
+        }
+        if let Some(bytes) = gap {
+            std::env::set_var("PROXIMADB_PAX_A_COALESCE_GAP", bytes.to_string());
+            std::env::set_var("PROXIMADB_PAX_A_COALESCE_RANGE", "4194304");
+        }
+        if split {
+            std::env::set_var("PROXIMADB_PAX_SPLIT_PROBE_META_CACHE", "1");
+        }
+    }
+}
+
+fn print_ivf2_bake_metric(
+    files: usize,
+    layout: &str,
+    temperature: &str,
+    nprobe: usize,
+    metrics: &Ivf2BakeMetrics,
+) {
+    let q = metrics.measured.max(1) as u64;
+    let (control_gets, control_bytes) = ivf2_stage(metrics, CacheTier::SearchControl);
+    let (meta_gets, meta_bytes) = ivf2_stage(metrics, CacheTier::InvariantMeta);
+    let (full_a_gets, full_a_bytes) = ivf2_stage(metrics, CacheTier::InvariantIndex);
+    let (probe_a_gets, probe_a_bytes) = ivf2_stage(metrics, CacheTier::ProbeIndex);
+    let (region_b_gets, region_b_bytes) = ivf2_stage(metrics, CacheTier::SurvivorPayload);
+    let (region_d_gets, region_d_bytes) = ivf2_stage(metrics, CacheTier::ResultPayload);
+    eprintln!(
+        "BAKE_METRIC rdstrat8_prc1 files={files} layout={layout} temperature={temperature} nprobe={nprobe} recall_at_10={:.4} queries={} range_gets_per_query={} bytes_read_per_query={} region_a_bytes_per_query={} region_b_bytes_per_query={} ivf_cells_total_per_query={} ivf_cells_probed_per_query={} probed_rows_per_query={} fetch_rounds_per_query={} whole_region_fallback={} p50_us={} p95_us={} control_gets_per_query={} control_bytes_per_query={} meta_gets_per_query={} meta_bytes_per_query={} full_a_gets_per_query={} full_a_bytes_per_query={} probe_a_gets_per_query={} probe_a_bytes_per_query={} region_b_gets_per_query={} traced_region_b_bytes_per_query={} region_d_gets_per_query={} region_d_bytes_per_query={}",
+        metrics.recall,
+        metrics.measured,
+        metrics.snapshot.range_gets / q,
+        metrics.snapshot.bytes_read / q,
+        (full_a_bytes + probe_a_bytes) / q,
+        region_b_bytes / q,
+        metrics.snapshot.ivf_cells_total / q,
+        metrics.snapshot.ivf_cells_probed / q,
+        metrics.snapshot.ivf_probed_rows / q,
+        metrics.snapshot.ivf_fetch_rounds / q,
+        metrics.snapshot.ivf_whole_region_fallback,
+        metrics.p50_us,
+        metrics.p95_us,
+        control_gets / q,
+        control_bytes / q,
+        meta_gets / q,
+        meta_bytes / q,
+        full_a_gets / q,
+        full_a_bytes / q,
+        probe_a_gets / q,
+        probe_a_bytes / q,
+        region_b_gets / q,
+        region_b_bytes / q,
+        region_d_gets / q,
+        region_d_bytes / q,
+    );
+}
+
+/// TD-RDSTRAT-8 PR-C1 release-profile bakeoff. The control and treatment use
+/// the same compaction writer, PCA/IVF row order, file partitions, SQ8/RaBitQ
+/// tiers, queries, and ground truth. The only layout difference is PXH1 versus
+/// v3/A0; each v3 arm changes only `nprobe`.
+#[tokio::test]
+#[ignore = "SIFT1M PR-C1 eval — set PROXIMADB_SIFT_DATASET_DIR + run release profile"]
+async fn sift_ivf2_probe_release_bakeoff_eval() {
+    let base_path = match dataset_path("sift_base.fvecs") {
+        Some(path) if path.exists() => path,
+        _ if dataset_required() => panic!("SIFT1M dataset required but missing"),
+        _ => {
+            eprintln!("skip: PROXIMADB_SIFT_DATASET_DIR unset/missing");
+            return;
+        }
+    };
+    let base = read_vec_records_f32(&base_path, None).expect("read SIFT1M base");
+    assert_eq!(base.len(), 1_000_000, "PR-C1 headline requires full SIFT1M");
+    let query_path = dataset_path("sift_query.fvecs").expect("SIFT query path");
+    let queries = read_vec_records_f32(&query_path, Some(100)).expect("read 100 SIFT queries");
+    assert_eq!(queries.len(), 100, "PR-C1 headline requires 100 queries");
+    let gt_path = dataset_path("sift_groundtruth.ivecs").expect("SIFT ground-truth path");
+    let truth = read_vec_records_u32(&gt_path, Some(queries.len())).expect("read SIFT truth");
+    let ground_truth: Vec<std::collections::HashSet<String>> = truth
+        .into_iter()
+        .map(|row| row.into_iter().take(TOP_K).map(vid).collect())
+        .collect();
+    let recall_floor = 0.98;
+    let file_counts = csv_usize_env("PROXIMADB_SIFT_IVF2_FILE_COUNTS", &[1, 4]);
+    let nprobes = csv_usize_env("PROXIMADB_SIFT_IVF2_NPROBE_SWEEP", &[4, 8, 16, 32]);
+    let layout_proof = env_enabled("PROXIMADB_SIFT_IVF2_LAYOUT_PROOF");
+    let proof_prefix = std::env::var("PROXIMADB_SIFT_IVF2_PREFIX_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(64 * 1024);
+    let proof_gaps = csv_usize_env("PROXIMADB_SIFT_IVF2_A_GAP_SWEEP", &[1024 * 1024]);
+    let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+        .await
+        .expect("local filesystem");
+
+    for file_count in file_counts {
+        let dir = TempDir::new().expect("bakeoff tempdir");
+        let pxh1 = write_ivf2_geometry(dir.path(), &base, file_count, false);
+        let v3 = write_ivf2_geometry(dir.path(), &base, file_count, true);
+
+        unsafe {
+            std::env::remove_var("PROXIMADB_IVF2_PROBE");
+            std::env::remove_var("PROXIMADB_IVF2_NPROBE");
+            set_ivf2_layout_proof_arm(None, None, false);
+            std::env::set_var("PROXIMADB_TRACE_PAX_STAGES", "1");
+        }
+        let control_cold = run_ivf2_bake_arm(&fs, &pxh1, &queries, &ground_truth, false).await;
+        let control_warm = run_ivf2_bake_arm(&fs, &pxh1, &queries, &ground_truth, true).await;
+        print_ivf2_bake_metric(file_count, "pxh1", "cold", 0, &control_cold);
+        print_ivf2_bake_metric(file_count, "pxh1", "warm", 0, &control_warm);
+        assert!(
+            control_cold.recall >= recall_floor,
+            "PXH1 control recall {:.4} < {recall_floor} for {file_count} files",
+            control_cold.recall
+        );
+
+        let mut bytes_qualifying = false;
+        let mut joint_get_qualifying = false;
+        for nprobe in &nprobes {
+            unsafe {
+                set_ivf2_layout_proof_arm(None, None, false);
+                std::env::set_var("PROXIMADB_IVF2_PROBE", "1");
+                std::env::set_var("PROXIMADB_IVF2_NPROBE", nprobe.to_string());
+            }
+            let probe_cold = run_ivf2_bake_arm(&fs, &v3, &queries, &ground_truth, false).await;
+            let probe_warm = run_ivf2_bake_arm(&fs, &v3, &queries, &ground_truth, true).await;
+            print_ivf2_bake_metric(file_count, "v3_probe", "cold", *nprobe, &probe_cold);
+            print_ivf2_bake_metric(file_count, "v3_probe", "warm", *nprobe, &probe_warm);
+            assert!(
+                probe_cold.snapshot.ivf_cells_probed > 0,
+                "probe did not engage for files={file_count}, nprobe={nprobe}"
+            );
+            assert_eq!(
+                probe_cold.snapshot.ivf_whole_region_fallback, 0,
+                "probe silently fell back for files={file_count}, nprobe={nprobe}"
+            );
+            let q = probe_cold.measured.max(1) as u64;
+            let cq = control_cold.measured.max(1) as u64;
+            let clears_bytes = probe_cold.recall >= recall_floor
+                && probe_cold.snapshot.bytes_read / q < control_cold.snapshot.bytes_read / cq
+                && ivf2_region_a_bytes(&probe_cold) / q < ivf2_region_a_bytes(&control_cold) / cq;
+            bytes_qualifying |= clears_bytes;
+            joint_get_qualifying |= clears_bytes
+                && probe_cold.snapshot.range_gets / q < control_cold.snapshot.range_gets / cq;
+
+            if layout_proof {
+                let mut arms: Vec<(String, Option<u64>, Option<u64>, bool)> = vec![
+                    ("split_meta_cache".to_string(), None, None, true),
+                    (
+                        format!("prefix_{proof_prefix}"),
+                        Some(proof_prefix),
+                        None,
+                        false,
+                    ),
+                ];
+                for gap in &proof_gaps {
+                    arms.push((format!("a_gap_{gap}"), None, Some(*gap as u64), false));
+                    arms.push((
+                        format!("combined_gap_{gap}"),
+                        Some(proof_prefix),
+                        Some(*gap as u64),
+                        true,
+                    ));
+                }
+                for (label, prefix, gap, split) in arms {
+                    unsafe {
+                        set_ivf2_layout_proof_arm(prefix, gap, split);
+                    }
+                    let candidate_cold =
+                        run_ivf2_bake_arm(&fs, &v3, &queries, &ground_truth, false).await;
+                    let candidate_warm =
+                        run_ivf2_bake_arm(&fs, &v3, &queries, &ground_truth, true).await;
+                    print_ivf2_bake_metric(
+                        file_count,
+                        &format!("v3_{label}"),
+                        "cold",
+                        *nprobe,
+                        &candidate_cold,
+                    );
+                    print_ivf2_bake_metric(
+                        file_count,
+                        &format!("v3_{label}"),
+                        "warm",
+                        *nprobe,
+                        &candidate_warm,
+                    );
+                    assert!(
+                        (candidate_cold.recall - probe_cold.recall).abs() < f64::EPSILON,
+                        "layout-only arm {label} changed cold recall"
+                    );
+                    assert!(
+                        (candidate_warm.recall - probe_warm.recall).abs() < f64::EPSILON,
+                        "layout-only arm {label} changed warm recall"
+                    );
+                    let base_cold_cost = ivf2_read_cost(&probe_cold);
+                    let base_warm_cost = ivf2_read_cost(&probe_warm);
+                    let candidate_cold_cost = ivf2_read_cost(&candidate_cold);
+                    let candidate_warm_cost = ivf2_read_cost(&candidate_warm);
+                    eprintln!(
+                        "PROOF_GATE rdstrat8_prc2 files={file_count} nprobe={nprobe} arm={label} cold_cost={candidate_cold_cost:.3} baseline_cold_cost={base_cold_cost:.3} cold_accept={} warm_cost={candidate_warm_cost:.3} baseline_warm_cost={base_warm_cost:.3} warm_accept={}",
+                        candidate_cold_cost < base_cold_cost,
+                        candidate_warm_cost < base_warm_cost,
+                    );
+                }
+                unsafe {
+                    set_ivf2_layout_proof_arm(None, None, false);
+                }
+            }
+        }
+        eprintln!(
+            "BAKE_GATE rdstrat8_prc1 files={file_count} bytes_gate={bytes_qualifying} joint_get_gate={joint_get_qualifying}"
+        );
+        assert!(
+            bytes_qualifying,
+            "no v3 nprobe arm cleared recall/byte gates for {file_count} files"
+        );
+    }
+
+    unsafe {
+        std::env::remove_var("PROXIMADB_IVF2");
+        std::env::remove_var("PROXIMADB_IVF2_PROBE");
+        std::env::remove_var("PROXIMADB_IVF2_NPROBE");
+        std::env::remove_var("PROXIMADB_TRACE_PAX_STAGES");
+        set_ivf2_layout_proof_arm(None, None, false);
+    }
+}
+
 /// TD-RDSTRAT-8 PR-B SIFT-scale recall/GET gate for the two-level IVF coarse
-/// probe (the default-on ratchet). Mirrors `sift_coalesced_rabitq_scan_rerank_eval`
-/// but drives the v3 layout through the **production compaction trigger**
-/// (`workload_profile:append` + `l0_threshold:2` ⇒ compaction runs inline on the
-/// 2nd flush, the same path `sst_ivf2_compaction_route_proof_test` proves), then
-/// compares the coarse probe (ON) to the whole-region scan (OFF) on the SAME v3
-/// segment: the probe must hold recall while cutting range-GETs (the dominant
-/// cloud cost term).
-///
-/// Env (in addition to the coalesced harness's):
-///   PROXIMADB_SIFT_IVF_K          coarse cells (default 64); nprobe defaults to k_c/4
-///   PROXIMADB_SIFT_IVF2_RECALL_DROP max recall drop vs baseline (default 0.10)
-///
-/// Run: `PROXIMADB_SIFT_DATASET_DIR=$HOME/sift1m PROXIMADB_SIFT_N=100000 \
-///      cargo test --release --test sift_pax_recall_ratchet_test \
-///      sift_ivf2_coarse_probe_recall_ratchet -- --ignored --nocapture`
+/// probe. This drives v3 through the production compaction trigger, then
+/// compares probe ON with the whole-region scan over the same segment.
 #[ignore = "SIFT eval — set PROXIMADB_SIFT_DATASET_DIR + run with --ignored"]
 #[tokio::test]
 async fn sift_ivf2_coarse_probe_recall_ratchet() {
@@ -753,8 +1203,6 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
         std::env::set_var("PROXIMADB_PAX_BLOCK_CLUSTER", "1");
         std::env::set_var("PROXIMADB_PAX_COALESCED_RABITQ", "1");
         std::env::set_var("PROXIMADB_COUNT_FS_IO", "1");
-        // TD-RDSTRAT-8: arm the v3 compaction writer (the probe reader is toggled
-        // per-phase below). IVF_K sets the coarse-cell count.
         std::env::set_var("PROXIMADB_IVF2", "1");
         std::env::set_var(
             "PROXIMADB_IVF_K",
@@ -796,8 +1244,6 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
         None => base.iter().take(max_queries.min(n)).cloned().collect(),
     };
     let qcount = queries.len();
-    // Brute-force ground truth over the inserted subset (subset_n < 1M ⇒ no
-    // provided GT applies). Rayon-parallelised like the coalesced harness.
     let ground_truth: Vec<std::collections::HashSet<String>> = queries
         .iter()
         .map(|q| {
@@ -809,8 +1255,6 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
         .collect();
 
     let temp_dir = TempDir::new().unwrap();
-    // Armed AppendBulk + L0 threshold 2: the 2nd flush crosses L0 >= 2 and runs
-    // compaction INLINE (the production v3 trigger — sst_ivf2_compaction_route_proof).
     let collection = Collection {
         id: "sift_ivf2_gate".to_string(),
         config: Some(CollectionConfig {
@@ -829,7 +1273,6 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
     };
     let engine = SstEngine::new().await.unwrap();
 
-    // Flush the base in TWO batches ⇒ L0 crosses 2 ⇒ inline compaction ⇒ v3.
     let half = n / 2;
     let batch_a: Vec<VectorRecord> = base[..half]
         .iter()
@@ -862,8 +1305,6 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
         second.compaction_error
     );
 
-    // Measure recall + range-GETs for a query loop. `probe_on` toggles the
-    // coarse-probe reader; both phases search the SAME v3 segment.
     async fn measure(
         engine: &SstEngine,
         collection: &Collection,
@@ -944,35 +1385,18 @@ async fn sift_ivf2_coarse_probe_recall_ratchet() {
         measured_base > 0 && measured_probe > 0,
         "no queries measured"
     );
-    // 1. The probe engaged on the v3 segment (ranked the coarse cells, ranged
-    //    only nprobe of them). This is the PR-B reader-correctness gate.
     assert!(
         !probe_trace.is_empty(),
         "PROXIMADB_IVF2_PROBE=1 must engage the coarse probe on the v3 segment"
     );
-    // 2. Recall held vs the whole-region baseline (the meaningful PR-B claim —
-    //    robust to the absolute RaBitQ recall level the corpus/quantizer set).
     assert!(
         recall_probe >= recall_base - recall_drop,
         "probe recall@{TOP_K} = {recall_probe:.4} dropped > {recall_drop} vs baseline {recall_base:.4}"
     );
-    // 3. The probe reads a strict subset of Region-A bytes (it ranges only the
-    //    nprobe nearest cells, never the whole region). This is the probe's
-    //    bandwidth/GB-month win.
     assert!(
         bytes_probe < bytes_base,
         "probe bytes/q = {bytes_probe} must read fewer than baseline {bytes_base}"
     );
-    // NOTE (co-design finding, recorded not asserted): at this scale (N=100k,
-    // single-file) the coalesced whole-region baseline is ALREADY GET-optimal
-    // (~13 range-GETs/q — GETs grow ∝ N, ~9 at 100k / ~51 at 1M). The coarse
-    // probe FRAGMENTS Region-A into more, smaller ranged reads, so range_gets/q
-    // can be HIGHER with the probe even as bytes drop. GET round-trips are the
-    // dominant cloud cost term, so the probe's GET win manifests only at larger
-    // N (1M) where the baseline GET count is high enough to outweigh the
-    // fragmentation. A 1M-scale GET-cut gate is the follow-up; this gate proves
-    // reader correctness (recall held + probe engaged + bytes cut), not that
-    // default-on is justified at 100k — that decision waits for the 1M number.
     unsafe {
         std::env::remove_var("PROXIMADB_IVF2");
         std::env::remove_var("PROXIMADB_IVF2_PROBE");


### PR DESCRIPTION
## Summary

- coalesce v3 IVF probe control reads with an optional bounded 64 KiB prefix
- cache probe metadata independently from the full Region-A payload
- coalesce selected Region-A cell extents while ranking only exact selected slices
- add stage-level release proof/ratchets and record corrected SIFT1M evidence

All new reader policies remain default OFF:

- `PROXIMADB_PAX_PREFIX_PREFETCH_BYTES`
- `PROXIMADB_PAX_SPLIT_PROBE_META_CACHE`
- `PROXIMADB_PAX_A_COALESCE_GAP`
- `PROXIMADB_PAX_A_COALESCE_RANGE`

No storage-format change is introduced.

## SIFT1M proof

Release profile, full SIFT1M, 100 official queries, Euclidean top-10:

| geometry | temperature | recall | GETs/q baseline -> retained | bytes/q baseline -> retained | score improvement |
|---|---:|---:|---:|---:|---:|
| 1 file, nprobe=6 | cold | 0.985 | 33 -> 30 | 26,728,854 -> 27,130,193 | 6.1% |
| 1 file, nprobe=6 | warm | 0.985 | 24 -> 19 | 17,973,196 -> 18,307,400 | 15.6% |
| 4 files, nprobe=3/file | cold | 0.982 | 75 -> 65 | 56,390,706 -> 57,570,090 | 10.3% |
| 4 files, nprobe=3/file | warm | 0.982 | 62 -> 44 | 40,629,552 -> 41,545,058 | 24.0% |

Score is `20 * GET + 5 * MiB`. Probe engagement is confirmed and whole-region fallback is zero. The 1 MiB gap is retained; the 4 MiB gap is rejected because its ~0.1% marginal score change costs 3.59 MB/query in four-file geometry and worsens the single-file cold tail.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --lib --bins -- -D warnings`
- `cargo check --lib --tests`
- `cargo check -p proximadb-server`
- `cargo check --test sift_pax_recall_ratchet_test`
- focused selected-slice planner test
- focused coarse-probe recall/GET end-to-end test
- single- and four-file release-profile SIFT1M bakeoff, 100 queries
- `make work-commit-check`
- TD/ADR uniqueness, benchmark-evidence, and attribution guards

Closes the PR-C2 layout-proof slice of TD-RDSTRAT-8. Production object-store and 10M/high-dimension/multi-metric gates remain prerequisites for promotion.
