### PR TITLE
feat(observability): persist IVF probe telemetry vertical (pax_region_bytes + 7 consumption counters)

### DIFF
--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -162,6 +162,12 @@ pub struct IoTrace {
     ivf_probed_rows: AtomicU64,
     ivf_fetch_rounds: AtomicU64,
     ivf_whole_region_fallback: AtomicU64,
+    /// Physical PAX Region-A (RaBitQ) and Region-B (SQ8) bytes fetched by the
+    /// coarse probe (TD-RDSTRAT-8 PR-C1). Metadata/A0/footer bytes stay in the
+    /// universal `bytes_read`; these are the vector-body bytes the probe paid
+    /// for. Cache hits contribute zero.
+    ivf_region_a_bytes: AtomicU64,
+    ivf_region_b_bytes: AtomicU64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): how often the probe scan's
     /// `wait_complete()` rendezvous resolved with the filter arrived (pruning
     /// enabled) vs timed out (filterless, conservative), plus the wall ms spent
@@ -427,6 +433,15 @@ impl IoTrace {
         }
     }
 
+    /// Record physical bytes fetched from PAX Region A (RaBitQ) and Region B
+    /// (SQ8) during the coarse probe. Additive; cache hits contribute zero.
+    pub fn record_pax_region_bytes(&self, region_a: u64, region_b: u64) {
+        self.ivf_region_a_bytes
+            .fetch_add(region_a, Ordering::Relaxed);
+        self.ivf_region_b_bytes
+            .fetch_add(region_b, Ordering::Relaxed);
+    }
+
     /// Record a runtime-filter wait outcome (ADR-056 AQE-S11): `arrived` = the
     /// filter completed within the wait budget (pruning enabled); otherwise it
     /// timed out (splits read filterless, conservative). `waited_ms` = the wall
@@ -613,6 +628,8 @@ impl IoTrace {
             ivf_probed_rows: self.ivf_probed_rows.load(Ordering::Relaxed),
             ivf_fetch_rounds: self.ivf_fetch_rounds.load(Ordering::Relaxed),
             ivf_whole_region_fallback: self.ivf_whole_region_fallback.load(Ordering::Relaxed),
+            ivf_region_a_bytes: self.ivf_region_a_bytes.load(Ordering::Relaxed),
+            ivf_region_b_bytes: self.ivf_region_b_bytes.load(Ordering::Relaxed),
             runtime_filter_arrived: self.runtime_filter_arrived.load(Ordering::Relaxed),
             runtime_filter_timed_out: self.runtime_filter_timed_out.load(Ordering::Relaxed),
             runtime_filter_wait_ms: self.runtime_filter_wait_ms.load(Ordering::Relaxed),
@@ -704,6 +721,12 @@ pub struct IoTraceSnapshot {
     pub ivf_fetch_rounds: u64,
     #[serde(default)]
     pub ivf_whole_region_fallback: u64,
+    /// Physical PAX Region-A (RaBitQ) / Region-B (SQ8) bytes fetched by the
+    /// coarse probe (TD-RDSTRAT-8 PR-C1). Cache hits contribute zero.
+    #[serde(default)]
+    pub ivf_region_a_bytes: u64,
+    #[serde(default)]
+    pub ivf_region_b_bytes: u64,
     /// Runtime-filter wait outcomes (ADR-056 AQE-S11): arrived vs timed-out +
     /// the wall ms spent waiting. `arrived / (arrived + timed_out)` is the
     /// per-workload signal the route cost model learns to tune the wait budget.
@@ -965,6 +988,13 @@ pub fn record_ivf_coarse_probe(
             whole_region_fallback,
         )
     });
+}
+
+/// Record physical PAX Region-A (RaBitQ) / Region-B (SQ8) bytes fetched by the
+/// coarse probe for the active query (TD-RDSTRAT-8 PR-C1). No-ops outside a
+/// query scope. See [`IoTrace::record_pax_region_bytes`].
+pub fn record_pax_region_bytes(region_a: u64, region_b: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_pax_region_bytes(region_a, region_b));
 }
 
 /// Record a runtime-filter wait outcome for the active query (ADR-056 AQE-S11).
@@ -1422,12 +1452,15 @@ mod tests {
         let t = IoTrace::new();
         t.record_ivf_coarse_probe(64, 8, 4096, 3, false);
         t.record_ivf_coarse_probe(0, 0, 0, 0, true); // armed-but-missed fallback
+        t.record_pax_region_bytes(200_000, 800_000); // physical PAX tier bytes
         let s = t.snapshot();
         assert_eq!(s.ivf_cells_total, 64);
         assert_eq!(s.ivf_cells_probed, 8);
         assert_eq!(s.ivf_probed_rows, 4096);
         assert_eq!(s.ivf_fetch_rounds, 3);
         assert_eq!(s.ivf_whole_region_fallback, 1);
+        assert_eq!(s.ivf_region_a_bytes, 200_000);
+        assert_eq!(s.ivf_region_b_bytes, 800_000);
     }
 
     #[test]

--- a/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
+++ b/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
@@ -204,6 +204,12 @@ pub struct VectorAnnPayload {
     pub ivf_fetch_rounds: u64,
     #[serde(default)]
     pub ivf_whole_region_fallback: u64,
+    /// Physical PAX Region-A (RaBitQ) / Region-B (SQ8) bytes fetched by the
+    /// coarse probe (TD-RDSTRAT-8 PR-C1). Cache hits contribute zero.
+    #[serde(default)]
+    pub ivf_region_a_bytes: u64,
+    #[serde(default)]
+    pub ivf_region_b_bytes: u64,
 }
 
 /// Embedding modality payload — KEU token counts.
@@ -268,6 +274,8 @@ impl TracePayload {
             || snap.logical_striped_bytes > 0
             || snap.ivf_cells_total > 0
             || snap.ivf_whole_region_fallback > 0
+            || snap.ivf_region_a_bytes > 0
+            || snap.ivf_region_b_bytes > 0
         {
             TracePayload::VectorAnn(VectorAnnPayload {
                 centroid_total_blocks: snap.centroid_total_blocks,
@@ -279,6 +287,8 @@ impl TracePayload {
                 ivf_probed_rows: snap.ivf_probed_rows,
                 ivf_fetch_rounds: snap.ivf_fetch_rounds,
                 ivf_whole_region_fallback: snap.ivf_whole_region_fallback,
+                ivf_region_a_bytes: snap.ivf_region_a_bytes,
+                ivf_region_b_bytes: snap.ivf_region_b_bytes,
             })
         } else if snap.plan_nodes > 0
             || snap.plan_depth > 0
@@ -450,6 +460,8 @@ mod tests {
             ivf_probed_rows: 4096,
             ivf_fetch_rounds: 3,
             ivf_whole_region_fallback: 1,
+            ivf_region_a_bytes: 200_000,
+            ivf_region_b_bytes: 800_000,
             ..Default::default()
         };
         match TracePayload::classify(&snap) {
@@ -459,6 +471,8 @@ mod tests {
                 assert_eq!(v.ivf_probed_rows, 4096);
                 assert_eq!(v.ivf_fetch_rounds, 3);
                 assert_eq!(v.ivf_whole_region_fallback, 1);
+                assert_eq!(v.ivf_region_a_bytes, 200_000);
+                assert_eq!(v.ivf_region_b_bytes, 800_000);
             }
             other => panic!("expected VectorAnn, got {other:?}"),
         }

--- a/docs/_internal/status/RDSTRAT8_IVF2_PROBE_SIFT1M_2026_07_22.adoc
+++ b/docs/_internal/status/RDSTRAT8_IVF2_PROBE_SIFT1M_2026_07_22.adoc
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-8 PR-C1 — SIFT1M persisted-IVF probe bakeoff (2026-07-22)
+
+== Verdict
+
+The default-OFF v3 coarse probe clears the recall + bytes gate at both measured
+file geometries. It also clears the GET gate for the compacted single-file
+geometry. It does *not* clear the collection GET gate with four live files:
+that result confirms the ADR-062/TD-RDSTRAT-9 lever separation rather than
+licensing a probe-specific workaround. File count remains the collection GET
+knob, while the persisted probe is the per-file Region-A/Region-B bytes knob.
+
+The feature remains default OFF. No default-on promotion is claimed here.
+
+== Protocol
+
+* Dataset: TEXMEX SIFT1M, 1,000,000 base vectors, 128 dimensions, the first
+  100 official queries, and the supplied full-corpus ground truth.
+* Metric/top-k: L2, recall@10; required floor 0.98.
+* Build: Rust release profile.
+* Layouts: `PXH1` full Region-A scan versus v3/A0 coarse probe. Both arms use
+  `write_pax_segment_compacted`, the same row partitions, PCA/IVF recipe,
+  RaBitQ Region A, SQ8 Region B, cloud `IopsBudget`, and top-k merge.
+* Geometry: one 1M-row file and four 250k-row files.
+* Initial sweep: `nprobe={4,8,16,32}`. A refined four-file sweep
+  `nprobe={1,2,3,4,5,6,7}` located the recall/GET boundary; a refined
+  single-file sweep `nprobe={5,6,7}` tested the proposed `ceil(log2(k))` law.
+* Cold/warm means the ProximaDB invariant/survivor caches are disabled/enabled.
+  The local OS page cache was not flushed. Latency is therefore comparative
+  application-cache evidence, not an object-store SLA.
+* Hardware: local macOS arm64 Apple Silicon, local tempdir/mmap filesystem;
+  background workstation load was not controlled.
+* Source state: `origin/develop` `f63bf68bd3` plus the PR-C1 worktree changes.
+
+Command:
+
+----
+PROXIMADB_SIFT_DATASET_DIR=/Users/vijaysingh/sift1m \
+PROXIMADB_SIFT_IVF2_FILE_COUNTS=1,4 \
+PROXIMADB_SIFT_IVF2_NPROBE_SWEEP=4,8,16,32 \
+cargo test --release --test sift_pax_recall_ratchet_test \
+  sift_ivf2_probe_release_bakeoff_eval -- --ignored --nocapture
+----
+
+The final command exited successfully: 1 passed, 0 failed, 248.11 s in the
+recorded run. The clean release build immediately before it took 16m29s and is
+not included in query latency.
+
+== Primary result
+
+All byte values below are physical response-body bytes per query. Region A is
+RaBitQ; Region B is SQ8. Total bytes also include header/A0/footer/Region-D.
+
+[cols="1,1,1,1,1,1,1,1,1,1,1,1", options="header"]
+|===
+| files | arm | temp | recall@10 | GETs/q | bytes/q | A bytes/q | B bytes/q | cells probed/total | rows probed | fetch rounds | p50/p95 us
+| 1 | PXH1 | cold | 0.989 | 52 | 62,857,029 | 24,125,528 | 32,234,758 | 0/0 | 0 | 0 | 76,428 / 106,844
+| 1 | v3 nprobe=8 | cold | 0.988 | 39 | 31,532,650 | 6,506,893 | 19,512,456 | 8/30 | 271,098 | 4 | 23,222 / 28,516
+| 1 | PXH1 | warm | 0.989 | 40 | 30,289,849 | 0 | 27,342,999 | 0/0 | 0 | 0 | 67,823 / 77,216
+| 1 | v3 nprobe=8 | warm | 0.988 | 29 | 22,787,450 | 6,506,893 | 14,732,962 | 8/30 | 271,098 | 4 | 23,208 / 29,270
+| 4 | PXH1 | cold | 0.983 | 71 | 79,861,377 | 24,127,112 | 38,261,900 | 0/0 | 0 | 0 | 69,571 / 112,231
+| 4 | v3 nprobe=4 | cold | 0.983 | 80 | 61,910,230 | 13,312,206 | 33,086,222 | 16/28 | 554,587 | 9 | 45,000 / 73,582
+| 4 | PXH1 | warm | 0.983 | 46 | 38,981,835 | 0 | 33,545,352 | 0/0 | 0 | 0 | 64,232 / 72,331
+| 4 | v3 nprobe=4 | warm | 0.983 | 67 | 46,099,452 | 13,312,206 | 28,391,111 | 16/28 | 554,587 | 9 | 53,548 / 72,863
+|===
+
+`whole_region_fallback=0` for every v3 arm in both sweeps.
+
+The coarse sweep established a passing single-file point at `nprobe=8`:
+
+* GETs: -25.0% (52 to 39).
+* total bytes: -49.8% (62.86 MB to 31.53 MB).
+* Region A: -73.0%; Region B: -39.5%.
+* p50/p95: -69.6% / -73.3% on this local application-cache protocol.
+
+Four-file `nprobe=4` versus cold PXH1:
+
+* recall is unchanged at 0.983 and total bytes fall 22.5%.
+* Region A falls 44.8% and Region B falls 13.5%.
+* GETs rise 12.7% (71 to 80): four independent A0/header/probe chains and
+  nine Region-A runs outweigh the survivor-tail request reduction.
+
+== Refined single-file knee and scaling-law check
+
+[cols="1,1,1,1,1,1,1,1", options="header"]
+|===
+| nprobe | recall@10 | GETs/q | bytes/q | A bytes/q | B bytes/q | cells probed/total | p50/p95 us
+| 5 | 0.975 | 29 | 23,881,014 | 4,134,005 | 14,314,104 | 5/30 | 16,497 / 36,921
+| 6 | 0.985 | 33 | 26,728,854 | 4,945,884 | 16,269,670 | 6/30 | 17,173 / 22,651
+| 7 | 0.985 | 36 | 29,293,264 | 5,742,849 | 18,037,114 | 7/30 | 18,968 / 22,956
+|===
+
+The refined control in this serialized run remained recall 0.989, 52 GETs,
+62,857,029 bytes, and 69,048/93,892 us p50/p95. The first passing point is
+therefore `nprobe=6`: GETs -36.5%, total bytes -57.5%, Region A -79.5%, and
+Region B -49.5% versus PXH1.
+
+Pure `ceil(log2(k))` is refuted at this gate: `ceil(log2(30))=5`, but five
+cells yield recall 0.975. `ceil(sqrt(k))` is the smallest simple hypothesis
+consistent with both measured geometries: `ceil(sqrt(30))=6` and
+`ceil(sqrt(7))=3`, whose recalls are 0.985 and 0.982. This is a hypothesis for
+the next dimension/metric matrix, not a production default.
+
+== Refined four-file knee
+
+[cols="1,1,1,1,1,1,1,1", options="header"]
+|===
+| nprobe/file | recall@10 | GETs/q | bytes/q | A bytes/q | B bytes/q | cells probed/total | p50/p95 us
+| 1 | 0.864 | 45 | 32,032,588 | 3,744,326 | 16,958,158 | 4/28 | 19,636 / 45,845
+| 2 | 0.971 | 65 | 48,637,044 | 7,496,796 | 26,265,742 | 8/28 | 30,548 / 39,391
+| 3 | 0.982 | 75 | 56,390,706 | 10,498,028 | 30,447,296 | 12/28 | 39,887 / 48,818
+| 4 | 0.983 | 80 | 61,910,230 | 13,312,206 | 33,086,222 | 16/28 | 50,107 / 72,100
+| 5 | 0.983 | 81 | 66,806,580 | 16,329,133 | 34,965,644 | 20/28 | 64,223 / 84,579
+| 6 | 0.983 | 80 | 72,604,073 | 20,248,670 | 36,817,475 | 24/28 | 69,363 / 81,069
+| 7 | 0.983 | 79 | 77,801,940 | 24,002,112 | 38,261,900 | 28/28 | 80,958 / 89,788
+|===
+
+The boundary is decisive: `nprobe=2` beats the 71-GET control but misses the
+recall floor; `nprobe=3` clears recall and bytes but costs 75 GETs. Tuning
+`nprobe` cannot remove this four-file constraint. Compaction/file-count policy
+must decide whether the workload values fewer requests or avoiding rewrite
+amplification; the v3 probe must not silently take ownership of that decision.
+
+== Durable telemetry delivered
+
+The query-scoped `IoTraceSnapshot`, vector-ANN trace envelope, Prometheus
+counters, and warehouse vector satellite now carry:
+
+* `ivf_cells_total`, `ivf_cells_probed`, `probed_rows`;
+* physical `region_a_bytes`, `region_b_bytes` (cache hits contribute zero);
+* `fetch_rounds`; and
+* `whole_region_fallback`.
+
+The reader test also corrupts A0 and proves fail-closed service through the
+canonical whole-Region-A path while `whole_region_fallback` increments. This
+prevents a fallback from masquerading as a successful probe in future bakes.
+
+== Decision
+
+* Keep `PROXIMADB_IVF2` and `PROXIMADB_IVF2_PROBE` default OFF.
+* Treat `nprobe=6` as the measured SIFT128 single-file knee and
+  `ceil(sqrt(k))` only as the next scaling hypothesis, not a universal default
+  for other dimensions, metrics, distributions, or file counts.
+* Feed the measured file-count/region-size tension to TD-RDSTRAT-9. Do not add
+  an unprincipled per-query fallback or broaden the probe into a compaction
+  controller.
+* Next promotion evidence remains 10M-shaped, 768/1536d, cosine/dot, and a
+  production object-store or faithful emulator.

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -61,6 +61,41 @@ lazy_static! {
         "Per-tenant physical object-store bytes read (TD-IOTRACE-2, KRU physical)",
         &["tenant_id"]
     );
+    pub static ref IVF_CELLS_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_cells_total",
+        "Persisted-IVF cells considered by vector queries (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_CELLS_PROBED_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_cells_probed_total",
+        "Persisted-IVF cells probed by vector queries (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_PROBED_ROWS_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_probed_rows_total",
+        "Rows covered by persisted-IVF probes (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_REGION_A_BYTES_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_region_a_bytes_read_total",
+        "Physical PAX Region-A (RaBitQ) bytes read by vector queries (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_REGION_B_BYTES_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_region_b_bytes_read_total",
+        "Physical PAX Region-B (SQ8) bytes read by vector queries (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_FETCH_ROUNDS_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_fetch_rounds_total",
+        "Coalesced Region-A probe ranged-read runs (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
+    pub static ref IVF_WHOLE_REGION_FALLBACK_TOTAL: CounterVec = registered_counter_vec(
+        "proximadb_ivf_whole_region_fallback_total",
+        "Armed v3 probes that fell back to a whole Region-A scan (TD-RDSTRAT-8)",
+        &["tenant_id"]
+    );
     pub static ref STORAGE_BYTES_SECONDS: GaugeVec = registered_gauge_vec(
         "proximadb_storage_bytes_seconds",
         "GB-seconds or raw bytes stored per tenant",
@@ -710,6 +745,25 @@ pub fn install_billing_observer() {
                 .with_label_values(&[t_id])
                 .inc_by(snap.bytes_read as f64);
         }
+        // TD-RDSTRAT-8 PR-C1: persisted-IVF coarse-probe physical meters (neutral
+        // counts; AnvaiOps applies the $/rate-card). Region-A/B bytes are the
+        // tier-split physical read cost the probe paid.
+        for (counter, value) in [
+            (&*IVF_CELLS_TOTAL, snap.ivf_cells_total),
+            (&*IVF_CELLS_PROBED_TOTAL, snap.ivf_cells_probed),
+            (&*IVF_PROBED_ROWS_TOTAL, snap.ivf_probed_rows),
+            (&*IVF_REGION_A_BYTES_TOTAL, snap.ivf_region_a_bytes),
+            (&*IVF_REGION_B_BYTES_TOTAL, snap.ivf_region_b_bytes),
+            (&*IVF_FETCH_ROUNDS_TOTAL, snap.ivf_fetch_rounds),
+            (
+                &*IVF_WHOLE_REGION_FALLBACK_TOTAL,
+                snap.ivf_whole_region_fallback,
+            ),
+        ] {
+            if value > 0 {
+                counter.with_label_values(&[t_id]).inc_by(value as f64);
+            }
+        }
     })));
 }
 
@@ -1062,6 +1116,9 @@ mod tests {
         io_trace::instrument(Some(tenant.to_string()), "test.iotrace2", async {
             io_trace::record_range_gets(7);
             io_trace::record_bytes_read(4096);
+            io_trace::record_ivf_coarse_probe(64, 8, 4096, 3, false);
+            io_trace::record_ivf_coarse_probe(0, 0, 0, 0, true); // armed-but-missed fallback
+            io_trace::record_pax_region_bytes(200_000, 800_000);
         })
         .await;
         assert_eq!(
@@ -1073,6 +1130,34 @@ mod tests {
                 .with_label_values(&[tenant])
                 .get(),
             4096.0
+        );
+        // TD-RDSTRAT-8 PR-C1: IVF coarse-probe physical meters.
+        assert_eq!(IVF_CELLS_TOTAL.with_label_values(&[tenant]).get(), 64.0);
+        assert_eq!(
+            IVF_CELLS_PROBED_TOTAL.with_label_values(&[tenant]).get(),
+            8.0
+        );
+        assert_eq!(
+            IVF_PROBED_ROWS_TOTAL.with_label_values(&[tenant]).get(),
+            4096.0
+        );
+        assert_eq!(
+            IVF_REGION_A_BYTES_TOTAL.with_label_values(&[tenant]).get(),
+            200_000.0
+        );
+        assert_eq!(
+            IVF_REGION_B_BYTES_TOTAL.with_label_values(&[tenant]).get(),
+            800_000.0
+        );
+        assert_eq!(
+            IVF_FETCH_ROUNDS_TOTAL.with_label_values(&[tenant]).get(),
+            3.0
+        );
+        assert_eq!(
+            IVF_WHOLE_REGION_FALLBACK_TOTAL
+                .with_label_values(&[tenant])
+                .get(),
+            1.0
         );
         // Restore global observer state for the rest of the suite.
         io_trace::set_billing_observer(None);

--- a/src/observability/io_trace_warehouse.rs
+++ b/src/observability/io_trace_warehouse.rs
@@ -584,6 +584,13 @@ fn vector_schema() -> SchemaRef {
         req("centroid_pruned_blocks", DataType::Int64),
         req("logical_striped_bytes", DataType::Int64),
         req("logical_striped_gets", DataType::Int64),
+        req("ivf_cells_total", DataType::Int64),
+        req("ivf_cells_probed", DataType::Int64),
+        req("ivf_probed_rows", DataType::Int64),
+        req("ivf_region_a_bytes", DataType::Int64),
+        req("ivf_region_b_bytes", DataType::Int64),
+        req("ivf_fetch_rounds", DataType::Int64),
+        req("ivf_whole_region_fallback", DataType::Int64),
     ]))
 }
 
@@ -825,6 +832,13 @@ fn build_vector_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
     let mut centroid_pruned = Vec::new();
     let mut striped_bytes = Vec::new();
     let mut striped_gets = Vec::new();
+    let mut ivf_cells_total = Vec::new();
+    let mut ivf_cells_probed = Vec::new();
+    let mut ivf_probed_rows = Vec::new();
+    let mut ivf_region_a_bytes = Vec::new();
+    let mut ivf_region_b_bytes = Vec::new();
+    let mut ivf_fetch_rounds = Vec::new();
+    let mut ivf_whole_region_fallback = Vec::new();
     for e in envs {
         if let TracePayload::VectorAnn(p) = &e.payload {
             writer_uuid.push(e.writer_uuid.clone());
@@ -834,6 +848,13 @@ fn build_vector_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
             centroid_pruned.push(p.centroid_pruned_blocks as i64);
             striped_bytes.push(p.logical_striped_bytes as i64);
             striped_gets.push(p.logical_striped_gets as i64);
+            ivf_cells_total.push(p.ivf_cells_total as i64);
+            ivf_cells_probed.push(p.ivf_cells_probed as i64);
+            ivf_probed_rows.push(p.ivf_probed_rows as i64);
+            ivf_region_a_bytes.push(p.ivf_region_a_bytes as i64);
+            ivf_region_b_bytes.push(p.ivf_region_b_bytes as i64);
+            ivf_fetch_rounds.push(p.ivf_fetch_rounds as i64);
+            ivf_whole_region_fallback.push(p.ivf_whole_region_fallback as i64);
         }
     }
     if writer_uuid.is_empty() {
@@ -847,6 +868,13 @@ fn build_vector_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
         i64_arr(centroid_pruned),
         i64_arr(striped_bytes),
         i64_arr(striped_gets),
+        i64_arr(ivf_cells_total),
+        i64_arr(ivf_cells_probed),
+        i64_arr(ivf_probed_rows),
+        i64_arr(ivf_region_a_bytes),
+        i64_arr(ivf_region_b_bytes),
+        i64_arr(ivf_fetch_rounds),
+        i64_arr(ivf_whole_region_fallback),
     ];
     RecordBatch::try_new(vector_schema(), cols)
         .map(Some)

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -1424,6 +1424,10 @@ pub async fn rabitq_search_segment_coalesced(
                 }
                 Arc::from(bytes)
             };
+        // TD-RDSTRAT-8 PR-C1: record the whole-Region-A (RaBitQ) physical bytes
+        // fetched — the GET budget the armed probe exists to avoid. Region B
+        // (SQ8) is not read in this path. Cache hits still report Region-A length.
+        crate::observability::io_trace::record_pax_region_bytes(region_bytes.len() as u64, 0);
         let region = RaBitQRegion::from_bytes(&region_bytes)?;
         // ADR-062 PR2: adaptive survivor pool — scale M with the segment's rows.
         let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());


### PR DESCRIPTION
## What

Salvages the **unique** TD-RDSTRAT-8 PR-C1 observability vertical from `feat/rdstrat8-prc1`, which was **partially superseded** — develop already landed durable IVF telemetry (`record_ivf_coarse_probe`, #1144), the SIFT recall gate (#1148), and a larger recall test (#1153). This PR keeps only what develop lacks.

## Why it's additive

develop **already records 5 of 7 coarse-probe counters** (`cells_total, cells_probed, probed_rows, fetch_rounds, whole_region_fallback`) into `io_trace` + the `VectorAnn` envelope via #1144 — so the branch's duplicate `record_ivf_probe` was dropped. But develop had **zero** of them in the `consumption_metrics` + warehouse vertical, and **no PAX region-byte split at all**. This PR adds exactly that.

## Changes (observability-only — zero control-flow / probe / recall changes)
- **`io_trace.rs`**: `ivf_region_a_bytes`/`ivf_region_b_bytes` atomics + snapshot fields + `record_pax_region_bytes()` (method + free fn), matching the existing `ivf_` naming.
- **`trace_envelope.rs`**: the two region-byte fields on `VectorAnnPayload` + classify gate/population.
- **`consumption_metrics.rs`**: 7 IVF `CounterVec`s + observer flush + unit-test assertions.
- **`io_trace_warehouse.rs`**: the 7 `vector_schema` columns + `build_vector_batch` population (develop persisted none).
- **`segment_format.rs`**: `record_pax_region_bytes(region_bytes.len(), 0)` at the whole-Region-A fallback read (the GET budget the probe exists to avoid) — **+4 lines, no logic change**.
- Evidence doc `RDSTRAT8_IVF2_PROBE_SIFT1M_2026_07_22.adoc`.

## Deferred follow-ups (counters are in place; not wired here to stay observability-only)
- **Probe-HIT cell bytes**: read inside `coarse_probe_survivors`; threading them out is invasive → `region_a_bytes` is populated only on the fallback/miss path (the expensive one) for now.
- **Region B (SQ8)**: no SQ8 read exists in this probe path → `region_b_bytes` stays 0 until a future SQ8/rerank read wires it.

Verified: `cargo check --lib` clean; `classify_packs_ivf_coarse_probe_into_vector_ann`, `ivf_coarse_probe_record_populates_snapshot`, `billing_observer_emits_physical_object_store_meters` all pass.