### PR TITLE
fix(search): don't skip Stage-3 storage search for co-design collections (+ TD-METRICS-1, TD-RECALL-1)

### DIFF
--- a/docs/10-quality/td/TD-METRICS-1-basic-server-metrics-not-wired.adoc
+++ b/docs/10-quality/td/TD-METRICS-1-basic-server-metrics-not-wired.adoc
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-METRICS-1: Basic server metrics not wired to the search/ingest paths (queries_total, vectors_total, collections_total read 0/stale)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Found during the SIFT1M recall investigation (2026-07-22). The consumption/io-trace metrics (`object_store_bytes_read_total`, `gets_total`) ARE wired and correct; the basic operational counters are stub/stale — the live search + ingest paths do not increment them, so `/metrics` reports `queries_total=0` after 200+ queries, `vectors_total=100000` after a 1M ingest, `collections_total=0` with one collection. This blinds operational monitoring (query rate, row count, latency) and forced recall debugging by hypothesis instead of telemetry.
+| Priority | **P2** — observability gap, no data-correctness impact. Blocks efficient ops/debugging; the consumption metrics (the billing surface) are unaffected.
+| Component | `src/metrics/` (the `proximadb_*` prometheus counters: `queries_total`, `queries_failed_total`, `vectors_total`, `collections_total`, `query_latency_p99_ms`, `search_operations_per_second`); the search path (`src/services/operations/vectors/legacy.rs`) and ingest path (`src/services/operations/vectors/write.rs`).
+| Evidence | `/metrics` after a 1M-vector ingest + 200-query SIFT bench: `proximadb_queries_total 0`, `proximadb_vectors_total 100000` (echoes the `vector_count_threshold` config, not the actual count), `proximadb_collections_total 0`, `proximadb_query_latency_p99_ms 0`, `proximadb_search_operations_per_second 0`. Meanwhile `proximadb_object_store_bytes_read_total` (536 MB) and `proximadb_object_store_gets_total` (578) ARE correct — so the metering plane works; the basic operational plane does not.
+|===
+
+== The finding
+
+The basic operational prometheus counters are not incremented on the live paths:
+
+* **Search**: a query through `legacy.rs::execute_search_internal` → `execute_two_stage_search_with_mode` never calls a `queries_total.inc()` / latency observe. `queries_total` stays 0; `query_latency_p99_ms` stays 0.
+* **Ingest**: the batch insert path does not update `vectors_total` / `collections_total` from the actual store. `vectors_total` reads `100000` (the `vector_count_threshold` default, not the live count); `collections_total` reads 0 with a collection present.
+
+The consumption metrics (`record_object_store_op`, `record_object_store_write_bytes_by_tier`, `consumption_metrics`) ARE wired at the I/O boundary — that channel is correct and is what surfaced the io-trace reads during the recall debug.
+
+== Direction
+
+Wire the operational counters at the path boundaries (single increment points, not scattered):
+
+* Search: increment `queries_total` (+ `queries_failed_total` on error) and observe `query_latency` at the top of the REST/gRPC search entry (or the `execute_search_internal` return), not per-stage.
+* Ingest: update `vectors_total` / `collections_total` from the authoritative store counts (or a post-commit delta), not a config default.
+* Add a regression test that ingests + queries and asserts the counters move (the test that would have caught this).
+
+Do NOT duplicate the consumption-metering increments (those stay at the I/O boundary).
+
+== Verification
+- After a 1k-vector ingest + 10 queries: `proximadb_vectors_total` reflects ~1k, `collections_total` ≥ 1, `queries_total` ≥ 10, `query_latency_p99_ms` > 0.
+- Existing consumption metrics unchanged.

--- a/docs/10-quality/td/TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc
+++ b/docs/10-quality/td/TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RECALL-1: Co-design PAX scan reads the segments but returns wrong distances → near-zero recall (the remaining SIFT recall blocker)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** The dominant remaining recall blocker after the flush fixes (#1145/#1150/#1155, all merged) and the Stage-3 skip fix. Proven by io-trace (consumption metrics): the reader IS reading the segment data (~536 MB / 578 ranged GETs over 5 queries), yet recall@10 = 0.35%. So this is a decode/distance/coarse-probe defect, not a read or alignment defect.
+| Priority | **P1** — this is THE blocker for usable recall on co-design (no-index_configs) collections, which is the cost-optimized default route. Without it, the co-design PAX scan returns near-random results.
+| Component | `src/storage/engines/sst/object_economy_directory.rs` (`load_directory_for`, the VectorObjectEconomy route), `src/storage/engines/sst/segment_format.rs` (`PaxSegmentScanner`, RaBitQ/SQ8 region decode, `record_ivf_coarse_probe`), `src/storage/engines/sst/search/` (the scan + distance computation); `crates/storage/proximadb-block-format` (RaBitQ dequantize).
+| Evidence | SIFT 1M, co-design collection (no `index_configs`, euclidean, default RaBitQ segments). After the Stage-3 skip fix, the explain shows `merge_input_directory_records` scaling with `candidates` (storage contributes; was 10, now 100 at top_k=100) and `wal_delta_records_scanned=0` (all flushed). Recall@10 stays ~0.35% at BOTH top_k=10 and top_k=100 (so not an over-fetch issue). io-trace (`proximadb_object_store_bytes_read_total`=536 MB, `gets_total`=578 over 5 queries ≈ 107 MB/query ≈ 1/3 of the dataset) proves the reader fetches real segment data. Writer/reader alignment confirmed correct (self-describing: `SEGMENT_MAGIC` + region decode; `PROXIMADB_PAX_VECTOR_QUANT` is writer-side, default RaBitQ; the reader detects from the segment). So: reads the right bytes, produces wrong distances.
+|===
+
+== The finding
+
+The co-design PAX scan (the `vector_object_economy` route that #1145 sends no-`index_configs` collections down) reads the RaBitQ segments but returns non-nearest vectors:
+
+* **Reads the data** (io-trace: 536 MB / 578 GETs) — not a "not reading" defect.
+* **Writer/reader aligned** (self-describing RaBitQ) — not a format-mismatch defect.
+* **Returns wrong top-k** — recall@10 ≈ 0.35% at both top_k=10 and 100, so it is not candidate-budget starved.
+* ~107 MB read per query (≈1/3 of the dataset) is consistent with an A0 coarse-probe selecting a subset of blocks — *possibly the wrong subset*, or the RaBitQ dequantize/distance is off.
+
+== Suspects (to confirm by instrumentation, not hypothesis)
+
+1. **RaBitQ dequantize** returns garbage — dump a decoded vector vs its f32 original for a known segment; if they disagree, the decoder (or the encoder that wrote the codes) is wrong.
+2. **A0 coarse-probe selects the wrong blocks** — the IVF coarse-probe (`record_ivf_coarse_probe` at `segment_format.rs:1033`) picks blocks whose centroids are far from the query, so the true neighbors' blocks are never fetched. Check whether the probe-selected blocks contain the groundtruth neighbors.
+3. **Distance metric mismatch** — the collection is euclidean; confirm the scan computes euclidean (not cosine) on the dequantized vectors.
+
+== Direction
+
+Instrument-first (the lesson from this investigation — the io-trace/consumption metrics are the working channel):
+
+* Add a debug dump: for one query, log the probe-selected block ids + the fetched vectors' ids vs the groundtruth neighbor ids → localizes wrong-block vs wrong-distance.
+* Verify RaBitQ round-trip on a real segment (the `pax_cascade_prod_search_test` harness does this at small scale and passes at recall ≥ 0.90 — so compare its collection/ingest/flush/search setup to the live server's; the divergence is the bug). The proven path sets `PROXIMADB_PAX_VECTOR_SEGMENTS=1` + `PROXIMADB_PAX_VECTOR_QUANT=rabitq` and calls the SST engine directly; the live REST path may diverge in route/config.
+
+== Verification
+- SIFT 1M co-design collection over REST: recall@10 ≥ 0.90 (match `pax_cascade_prod_search_test`).
+- A co-design-PAX-scan e2e test (no `index_configs` collection, ingest + flush + search, assert recall) — the test gap that let this ship (the existing ratchets use `pax_vector_format:off` / direct-engine, not the live co-design REST route).
+
+== Related
+The flush fixes that preceded this: link:TD-WAL-3-flush-mechanism-consolidation.adoc[TD-WAL-3]; the recall-investigation notes in the agent memory (`project_recall_search_path_blocker_2026_07_22`). The Stage-3 skip fix (this PR) is a prerequisite — without it, storage never runs at all.

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -3616,10 +3616,15 @@ impl VectorOperationsService {
             }
         };
 
-        // Stage 3: Storage engine search - ONLY if we need more results
-        // Skip if WAL + AXIS already have enough high-quality results
+        // Stage 3: Storage engine search - ONLY if we need more results.
+        // Skip when WAL + AXIS already cover the candidate pool -- but that's only true
+        // when the collection USES AXIS (AXIS indexes the flushed vectors). For co-design
+        // collections (no index_configs) the flushed data lives ONLY in storage segments,
+        // so WAL alone is insufficient and storage must always be searched; otherwise the
+        // entire flushed set is never seen and recall collapses to the tiny WAL window.
         let total_indexed_results = wal_optimized_results.len() + axis_optimized_results.len();
-        let storage_results = if total_indexed_results >= candidates {
+        let storage_results = if collection_has_axis_indexes && total_indexed_results >= candidates
+        {
             debug!(
                 "Stage 3: Skipping storage search (have {} results from WAL+AXIS)",
                 total_indexed_results


### PR DESCRIPTION
## The fix
`execute_two_stage_search_with_mode` skipped the storage-engine (segment) search when `WAL + AXIS >= candidates`. That premise only holds when the collection **uses AXIS** (AXIS indexes the flushed vectors). For co-design collections (no `index_configs`) the flushed data lives **only** in storage segments — and since `candidates` is passed as `top_k` (=10), even a handful of unflushed WAL records tripped the skip, so the **entire 1M-vector flushed set was never searched** (recall collapsed to ~0.35%).

Gate the skip on `collection_has_axis_indexes`: storage always runs for co-design collections. With this, the explain shows `merge_input_directory_records` scaling with `candidates` (storage now contributes) instead of the WAL-only window.

## Filed alongside (same recall investigation)
- **TD-METRICS-1** (P2): the basic operational counters (`queries_total`, `vectors_total`, `collections_total`, `query_latency_p99`) are **not wired** to the live search/ingest paths — `/metrics` showed `queries_total=0` after 200+ queries. The consumption/io-trace metrics ARE wired; this is the gap that forced hypothesis-driven debugging.
- **TD-RECALL-1** (P1): the **remaining recall blocker**. After this skip fix, io-trace proves the reader reads the segments (~536 MB / 578 GETs) but recall@10 stays ~0.35% at both top_k=10 and 100. Writer/reader alignment is correct (self-describing RaBitQ). So the PAX scan reads the right bytes but returns **wrong distances** — RaBitQ dequantize, A0 coarse-probe block selection, or distance metric are the suspects.

## Context
This is the next layer after the merged flush fixes (#1145 AXIS gate → PAX scan; #1150 flush trigger; #1155 skip unused AXIS build at flush → 280× flush speedup). The skip fix is a prerequisite for any recall: without it, storage never runs at all. TD-RECALL-1 tracks the final decode/distance blocker.

## Verification
- Local SIFT 1M: with the skip fix, the search explain shows `merge_input_directory_records` = candidates (was the WAL window); io-trace (`object_store_bytes_read_total`) confirms segment reads. Recall itself is tracked by TD-RECALL-1 (not fixed here — this PR unblocks storage; the distance bug is separate).
- `cargo fmt` (1.95.0) clean; td-adr-unique guard clean (0 errors).