### PR TITLE
fix(search): SIFT recall 0.35%->0.989 — delta-merge ranked the WAL delta on hardcoded Cosine (+ PAX writer dequantize, cascade similarity)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -830,10 +830,11 @@ impl PaxSegmentWriter {
         // the segment-level RaBitQ region. The caller has already reordered
         // records by `cluster_order_pca_ivf`, so this preserves survivor locality.
         if self.coalesced_rabitq {
-            let v = record.embeddings.first().and_then(|e| match &e.values {
-                EmbeddingValues::Fp32(v) => Some(v.clone()),
-                _ => None,
-            });
+            // Dequantize ANY EmbeddingValues variant (Fp32/Fp16/Bf16/Int8/UInt8) to
+            // f32 for the RaBitQ+SQ8 segment-level quantization. The old Fp32-only
+            // extraction silently dropped non-Fp32 embeddings (e.g. after ingest-time
+            // canonical-precision coercion) → garbage SQ8 params → 0.35% recall.
+            let v = record.embeddings.first().map(|e| e.values.to_fp32_owned());
             self.rabitq_vectors.push(v);
         }
 
@@ -842,10 +843,7 @@ impl PaxSegmentWriter {
         // (from the first record). This replaces the flat 1024 B/row estimate
         // that overestimated SQ8 blocks by ~4.5× (actual ~228 B/row for 128d).
         if self.per_row_estimate == 0
-            && let Some(dim) = record.embeddings.first().and_then(|e| match &e.values {
-                EmbeddingValues::Fp32(v) => Some(v.len()),
-                _ => None,
-            })
+            && let Some(dim) = record.embeddings.first().map(|e| e.dim as usize)
         {
             self.per_row_estimate = self.estimate_per_row_bytes(dim);
         }
@@ -892,9 +890,11 @@ impl PaxSegmentWriter {
     /// representation contributes; other variants are skipped (the block's
     /// centroid is the mean over its Fp32 rows).
     fn accumulate_centroid(&mut self, record: &ProximaRecord) {
-        let Some(EmbeddingValues::Fp32(v)) = record.embeddings.first().map(|e| &e.values) else {
+        // Dequantize ANY variant to f32 for the centroid sum (was Fp32-only).
+        let Some(cell) = record.embeddings.first() else {
             return;
         };
+        let v = cell.as_fp32_cow();
         if v.is_empty() {
             return;
         }
@@ -903,7 +903,7 @@ impl PaxSegmentWriter {
         }
         if self.cur_centroid_sum.len() == v.len() {
             let mut norm_sq = 0f64;
-            for (s, &x) in self.cur_centroid_sum.iter_mut().zip(v) {
+            for (s, &x) in self.cur_centroid_sum.iter_mut().zip(v.iter()) {
                 let x = x as f64;
                 *s += x;
                 norm_sq += x * x;

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -50,7 +50,7 @@ use proximadb_block_format::{
     BlockCompression, BlockMode, BlockStats, BlockZoneSource, ColumnMeta, FlatRow, PaxBlockReader,
     PaxBlockWriter, RowGroupBlock, VectorQuant, col_id, header::fnv1a_hash,
 };
-use proximadb_records::{EmbeddingValues, ProximaRecord};
+use proximadb_records::ProximaRecord;
 use serde::{Deserialize, Serialize};
 
 use crate::coarse_directory::{CoarseCellEntry, CoarseDirectory, CoarseModel};

--- a/docs/10-quality/td/TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc
+++ b/docs/10-quality/td/TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc
@@ -1,41 +1,31 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-= TD-RECALL-1: Co-design PAX scan reads the segments but returns wrong distances → near-zero recall (the remaining SIFT recall blocker)
+= TD-RECALL-1: Co-design SIFT recall collapse — root-caused: delta-merge ranked the WAL delta on a hardcoded Cosine scale (+ a benchmark-side parser artifact)
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed.** The dominant remaining recall blocker after the flush fixes (#1145/#1150/#1155, all merged) and the Stage-3 skip fix. Proven by io-trace (consumption metrics): the reader IS reading the segment data (~536 MB / 578 ranged GETs over 5 queries), yet recall@10 = 0.35%. So this is a decode/distance/coarse-probe defect, not a read or alignment defect.
-| Priority | **P1** — this is THE blocker for usable recall on co-design (no-index_configs) collections, which is the cost-optimized default route. Without it, the co-design PAX scan returns near-random results.
-| Component | `src/storage/engines/sst/object_economy_directory.rs` (`load_directory_for`, the VectorObjectEconomy route), `src/storage/engines/sst/segment_format.rs` (`PaxSegmentScanner`, RaBitQ/SQ8 region decode, `record_ivf_coarse_probe`), `src/storage/engines/sst/search/` (the scan + distance computation); `crates/storage/proximadb-block-format` (RaBitQ dequantize).
-| Evidence | SIFT 1M, co-design collection (no `index_configs`, euclidean, default RaBitQ segments). After the Stage-3 skip fix, the explain shows `merge_input_directory_records` scaling with `candidates` (storage contributes; was 10, now 100 at top_k=100) and `wal_delta_records_scanned=0` (all flushed). Recall@10 stays ~0.35% at BOTH top_k=10 and top_k=100 (so not an over-fetch issue). io-trace (`proximadb_object_store_bytes_read_total`=536 MB, `gets_total`=578 over 5 queries ≈ 107 MB/query ≈ 1/3 of the dataset) proves the reader fetches real segment data. Writer/reader alignment confirmed correct (self-describing: `SEGMENT_MAGIC` + region decode; `PROXIMADB_PAX_VECTOR_QUANT` is writer-side, default RaBitQ; the reader detects from the segment). So: reads the right bytes, produces wrong distances.
+| Status | **Resolved (root-caused + fixed).** Two independent defects stacked under the original "0.35% recall" symptom. (1) *Benchmark artifact:* the SIFT harness unpacked the whole `.fvecs` file as int32, shipping every f32 component's **bit pattern** as the vector value (`6.0` → `1086324736`) — the "corruption" chased through WAL/flush/PAX was garbage-in at the client; the server pipeline stored it faithfully (verified clean end-to-end with `PROXIMADB_CORRUPTION_DEBUG=1` dumps at WAL ingest + flush materialize + SQ8 encode). (2) *Real server defect:* with correct vectors, recall was still capped at the **memtable fraction** (12.7% with a 16k/100k unflushed tail) because `apply_delta_merge_with_explain` hardcoded `DistanceMetric::Cosine` for the WAL delta re-score — delta scores (~0.9 cosine scale) always displaced storage results (~0.005 on the Euclidean `1/(1+L2)` scale) in the score-descending merge.
+| Priority | **P1** — was THE blocker for usable recall on co-design (no-index_configs) collections whenever any unflushed writes exist (i.e. always, during ingest).
+| Component | `src/services/operations/vectors/legacy.rs` (`apply_delta_merge_with_explain` — the hardcoded metric; `optimized_to_proto_v1` — display fallback), `src/storage/engines/sst/search/mod.rs` (`try_pax_cascade` — `similarity: None`), `src/core/search/merge.rs` (score-desc merge that amplified the scale mismatch).
+| Evidence | Clean-parse SIFT 100k: storage-only search (empty memtable) returns EXACT brute-force top-5 for self-queries (v0/v10000/v50000) — the PAX cascade ranks correctly. Insert 50 unrelated records (true L2 ≈ 500 from the query) → they scored 0.86–0.93 (cosine) and displaced the exact match v0 (storage score 0.356 = 1/(1+1.8) SQ8-rerank). Server log: Stage-1/Stage-3 ran `metric=Euclidean`; the post-merge WAL re-scan ran `metric=Cosine` (`WAL: Enhanced search ... metric=Cosine`), proving the delta-merge was the only stage off-metric.
 |===
 
-== The finding
+== The fixes (this PR)
 
-The co-design PAX scan (the `vector_object_economy` route that #1145 sends no-`index_configs` collections down) reads the RaBitQ segments but returns non-nearest vectors:
-
-* **Reads the data** (io-trace: 536 MB / 578 GETs) — not a "not reading" defect.
-* **Writer/reader aligned** (self-describing RaBitQ) — not a format-mismatch defect.
-* **Returns wrong top-k** — recall@10 ≈ 0.35% at both top_k=10 and 100, so it is not candidate-budget starved.
-* ~107 MB read per query (≈1/3 of the dataset) is consistent with an A0 coarse-probe selecting a subset of blocks — *possibly the wrong subset*, or the RaBitQ dequantize/distance is off.
-
-== Suspects (to confirm by instrumentation, not hypothesis)
-
-1. **RaBitQ dequantize** returns garbage — dump a decoded vector vs its f32 original for a known segment; if they disagree, the decoder (or the encoder that wrote the codes) is wrong.
-2. **A0 coarse-probe selects the wrong blocks** — the IVF coarse-probe (`record_ivf_coarse_probe` at `segment_format.rs:1033`) picks blocks whose centroids are far from the query, so the true neighbors' blocks are never fetched. Check whether the probe-selected blocks contain the groundtruth neighbors.
-3. **Distance metric mismatch** — the collection is euclidean; confirm the scan computes euclidean (not cosine) on the dequantized vectors.
-
-== Direction
-
-Instrument-first (the lesson from this investigation — the io-trace/consumption metrics are the working channel):
-
-* Add a debug dump: for one query, log the probe-selected block ids + the fetched vectors' ids vs the groundtruth neighbor ids → localizes wrong-block vs wrong-distance.
-* Verify RaBitQ round-trip on a real segment (the `pax_cascade_prod_search_test` harness does this at small scale and passes at recall ≥ 0.90 — so compare its collection/ingest/flush/search setup to the live server's; the divergence is the bug). The proven path sets `PROXIMADB_PAX_VECTOR_SEGMENTS=1` + `PROXIMADB_PAX_VECTOR_QUANT=rabitq` and calls the SST engine directly; the live REST path may diverge in route/config.
+* `apply_delta_merge_with_explain` now derives the metric from the collection config via the shared `collection_distance_metric` helper (also used by `execute_two_stage_search_with_mode`) — every stage (Stage-1 WAL, Stage-2 AXIS, Stage-3 storage, delta re-score) ranks on the collection's metric, so all normalized scores share one scale.
+* `try_pax_cascade` populates `similarity` (was `None` → the response boundary's `similarity.unwrap_or(0.0)` rendered every cascade hit as score 0.0).
+* `optimized_to_proto_v1` display falls back to `score` (the cross-engine normalized similarity) instead of 0.0.
+* The SIFT harness parses `.fvecs` as `[int32 dim][dim × f32]` and `.ivecs` as int32 (was: whole-file int32).
 
 == Verification
-- SIFT 1M co-design collection over REST: recall@10 ≥ 0.90 (match `pax_cascade_prod_search_test`).
-- A co-design-PAX-scan e2e test (no `index_configs` collection, ingest + flush + search, assert recall) — the test gap that let this ship (the existing ratchets use `pax_vector_format:off` / direct-engine, not the live co-design REST route).
+- SIFT 100k co-design collection over REST (fresh ingest → flush → search, memtable non-empty): recall@10 ≥ 0.90.
+- Self-query invariant: an exact base vector query returns itself top-1 regardless of memtable population.
+- Follow-up test gap remains: a co-design-PAX-scan e2e recall ratchet over the live REST route (the existing ratchets use direct-engine harnesses that bypass the delta merge — which is exactly where this bug lived).
+
+== Lessons
+* A score-scale contract ("`score` = normalized similarity, one metric per collection") spans FOUR producers; nothing enforced it. See TD-SEARCH-1 for the consolidation debt (duplicate `SimilarityResult` structs, three parallel memtable search implementations, internal `_v1` DTO plumbing).
+* Instrument-first paid off: env-gated value dumps at each pipeline stage (ingest → materialize → encode) bisected the "corruption" to the client in one run.
 
 == Related
-The flush fixes that preceded this: link:TD-WAL-3-flush-mechanism-consolidation.adoc[TD-WAL-3]; the recall-investigation notes in the agent memory (`project_recall_search_path_blocker_2026_07_22`). The Stage-3 skip fix (this PR) is a prerequisite — without it, storage never runs at all.
+Flush fixes that preceded this: #1150/#1155/#1158; link:TD-WAL-3-flush-mechanism-consolidation.adoc[TD-WAL-3]; link:TD-SEARCH-1-search-path-score-scale-consolidation.adoc[TD-SEARCH-1] (consolidation follow-up).

--- a/docs/10-quality/td/TD-SEARCH-1-search-path-score-scale-consolidation.adoc
+++ b/docs/10-quality/td/TD-SEARCH-1-search-path-score-scale-consolidation.adoc
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-SEARCH-1: Search-path consolidation — one score-scale contract, one memtable search, one SimilarityResult
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Filed from the TD-RECALL-1 root-cause session: the recall bug was only possible because the score-scale contract is implicit and the search plumbing is duplicated.
+| Priority | **P2** — correctness hazard class (a future stage/engine can silently reintroduce a cross-scale merge), plus real maintenance cost.
+| Component | `src/services/operations/vectors/legacy.rs`, `src/storage/persistence/write_ahead_log/mod.rs`, `src/storage/memtable/` (specialized `wal_behavior.rs` + `implementations/global_partitioned.rs`), `crates/foundation/proximadb-distance-kernel`, `crates/modalities/proximadb-vector`.
+|===
+
+== The debt (observed while root-causing TD-RECALL-1)
+
+1. **Implicit score-scale contract.** `OptimizedSearchRecord.score` must be "normalized similarity in [0,1], higher = better, computed on the collection's metric" for the cross-stage merges (`merge_delta_with_directory_results`, the two-stage dedup sort) to be meaningful — but nothing enforces it. Four independent producers (WAL delta scan, memtable two-stage Stage-1, AXIS, SST cascade/generic scan) each construct scores by hand; one hardcoded metric (the TD-RECALL-1 bug) silently broke ranking. *Direction:* make the merge inputs carry `(metric, canonical_distance)` and normalize at ONE boundary, or at minimum a debug-assert that merged record sets were scored under the same metric.
+2. **Three parallel memtable search implementations:** `wal_behavior.rs:601 search_unflushed_vectors` (returns proto `SearchVectorRecord`, delegates to `global_partitioned.rs` `search_vectors`) and `write_ahead_log/mod.rs:2556 search_unflushed_vectors` (returns `OptimizedSearchRecord`, re-implements MVCC/tombstone/scoring inline). Only the latter is live on the two-stage + delta paths; the former pair is a divergence trap.
+3. **Two `SimilarityResult` structs**: `proximadb-distance-kernel/src/engine.rs:363` (live) and `proximadb-vector/src/distance.rs:63` (duplicate) — workspace-decomposition residue.
+4. **Internal `_v1` DTO plumbing** in the live search chain (`unified_search_v1*`, `optimized_results_to_proto_v1`, proto `SearchVectorRecord`/`VectorOperationResponse`) even though the external v1 surfaces are sunset — this is the TD-V1SUNSET-2 scope; the search chain is a high-value slice because the DTO conversion is where the display-score bug (similarity=None → 0.0) lived.
+
+== Verification
+* One memtable search entry point; the dead pair deleted or delegated.
+* A test that constructs a Euclidean collection, plants records in memtable + storage, and asserts the merged top-k equals brute force (the exact TD-RECALL-1 reproducer, kept as a ratchet).
+
+== Related
+link:TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc[TD-RECALL-1] (the bug this debt enabled); TD-V1SUNSET-2 (VectorRecord/ProximaRecord internal sunset).

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1711,7 +1711,14 @@ impl VectorOperationsService {
             return Ok((optimized_results, None));
         }
 
-        let distance_metric = crate::compute::distance_computation::DistanceMetric::Cosine;
+        // Use the COLLECTION's configured metric for the WAL delta re-score.
+        // This was hardcoded Cosine, which put delta scores on a different
+        // scale than the directory/storage results (Euclidean = 1/(1+L2) ≈
+        // 0.005 vs cosine ≈ 0.9 on SIFT-like data) — so ANY unflushed record
+        // displaced EVERY flushed result in the merged top-k and recall
+        // collapsed to the memtable fraction of the corpus (TD-RECALL-1).
+        let collection = self.get_or_load_collection(collection_id).await?;
+        let distance_metric = Self::collection_distance_metric(&collection);
         // Slice 5.10: fetch both LSN and ns watermarks so BoundedStale
         // can apply its time-bound check. When unavailable, fall back
         // to (0, 0) — the scan helper treats ns=0 as "time unknown"
@@ -3445,6 +3452,27 @@ impl VectorOperationsService {
         Ok(())
     }
 
+    /// Resolve a collection's configured distance metric (Cosine when unset /
+    /// Unspecified). Single source of truth for every internal search stage —
+    /// Stage-1 WAL, Stage-2 AXIS, Stage-3 storage, and the freshness delta
+    /// re-score MUST all rank on this same metric, or their normalized scores
+    /// land on incomparable scales and the cross-stage merge is garbage.
+    fn collection_distance_metric(
+        collection: &Collection,
+    ) -> crate::proto::proximadb_v1::DistanceMetric {
+        match collection.config.as_ref() {
+            Some(cfg) => match cfg.distance_metric.and_then(|metric| {
+                crate::proto::proximadb_v1::DistanceMetric::try_from(metric).ok()
+            }) {
+                Some(crate::proto::proximadb_v1::DistanceMetric::Unspecified) | None => {
+                    crate::proto::proximadb_v1::DistanceMetric::Cosine
+                }
+                Some(metric) => metric,
+            },
+            None => crate::proto::proximadb_v1::DistanceMetric::Cosine,
+        }
+    }
+
     async fn execute_two_stage_search_with_mode(
         &self,
         collection_id: &str,
@@ -3466,17 +3494,7 @@ impl VectorOperationsService {
 
         // Get collection for distance metric
         let collection = self.get_or_load_collection(collection_id).await?;
-        let distance_metric = match collection.config.as_ref() {
-            Some(cfg) => match cfg.distance_metric.and_then(|metric| {
-                crate::proto::proximadb_v1::DistanceMetric::try_from(metric).ok()
-            }) {
-                Some(crate::proto::proximadb_v1::DistanceMetric::Unspecified) | None => {
-                    crate::proto::proximadb_v1::DistanceMetric::Cosine
-                }
-                Some(metric) => metric,
-            },
-            None => crate::proto::proximadb_v1::DistanceMetric::Cosine,
-        };
+        let distance_metric = Self::collection_distance_metric(&collection);
 
         // Execute Stage 1 and Stage 2 in PARALLEL for maximum performance
         debug!(
@@ -4390,9 +4408,11 @@ impl VectorOperationsService {
     ) -> crate::proto::proximadb_v1::SearchVectorRecord {
         let metadata = crate::core::search::results::proxima_map_to_sql(result.metadata.clone());
 
-        // Use normalized similarity score for user-facing display (0-1 range, higher = better)
-        // Internal sorting uses result.score (raw distance), but users should see normalized values
-        let display_score = result.similarity.unwrap_or(0.0) as f64;
+        // Use normalized similarity score for user-facing display (0-1 range, higher = better).
+        // Fall back to `score` (the cross-engine normalized similarity used for ranking) when
+        // a producer didn't populate the optional `similarity` field — a 0.0 fallback rendered
+        // every such hit as "no match" at the API boundary.
+        let display_score = result.similarity.unwrap_or(result.score) as f64;
 
         // DEBUG: Log the values to understand what's happening
         tracing::debug!(

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -299,13 +299,15 @@ impl SstEngine {
                     let records = hits
                         .into_iter()
                         .map(|h| {
-                            let mut r = OptimizedSearchRecord::new(
-                                h.oid,
-                                OptimizedSearchRecord::standardized_distance_to_similarity(
-                                    h.distance,
-                                    &distance_metric,
-                                ),
+                            let sim = OptimizedSearchRecord::standardized_distance_to_similarity(
+                                h.distance,
+                                &distance_metric,
                             );
+                            let mut r = OptimizedSearchRecord::new(h.oid, sim);
+                            // `new` leaves `similarity: None`, and the response
+                            // boundary displays `similarity.unwrap_or(0.0)` — set
+                            // it so cascade hits don't render as score 0.0.
+                            r.similarity = Some(sim);
                             if let Some(v) = h.vector {
                                 r = r.add_vector(v);
                             }


### PR DESCRIPTION
## Root cause (TD-RECALL-1, resolved)

Two independent defects stacked under the \"0.35% recall\" symptom:

1. **Benchmark artifact** (not a server bug): the SIFT harness unpacked the whole `.fvecs` file as int32, shipping every f32 component's **bit pattern** as the vector value (`6.0` → `1086324736` — the \"corrupted [0,...,1.086e9] vectors\"). The server pipeline (WAL → materialize → SQ8 encode) was verified clean end-to-end with staged value dumps. Harness fixed (fvecs=f32, ivecs=int32).
2. **The real recall killer**: `apply_delta_merge_with_explain` hardcoded `DistanceMetric::Cosine` for the WAL-delta re-score. On a Euclidean collection, delta scores (~0.9 cosine scale) always displaced storage results (~0.005 on the `1/(1+L2)` scale) in the score-descending merge — recall collapsed to the memtable fraction of the corpus (measured 12.7% with a 16% unflushed tail). Stage-1/2/3 all used the collection's metric; only the delta re-score was off.

## Changes

- `apply_delta_merge_with_explain` derives the metric from the collection config via a shared `collection_distance_metric` helper (same derivation `execute_two_stage_search_with_mode` used) — every stage now ranks on one scale.
- `try_pax_cascade` populates `similarity` (was `None` → the response boundary's `similarity.unwrap_or(0.0)` rendered every cascade hit as score 0.0).
- `optimized_to_proto_v1` display falls back to `score` instead of 0.0.
- PAX writer dequantizes ALL `EmbeddingValues` variants (first commit; correct hardening, not the root cause) + drop its now-unused import (the clippy failure on this branch).
- TD-RECALL-1 updated to resolved-with-root-cause; TD-SEARCH-1 filed (implicit score-scale contract, 3 parallel memtable search impls, duplicate `SimilarityResult`, internal `_v1` DTO plumbing → TD-V1SUNSET-2 slice).

## Measured (SIFT 100k over REST e2e, mixed memtable+storage state)

- recall@10 = **0.9890** (matches the ADR-065 direct-engine 0.989 baseline); was 0.127 after the parser fix alone, 0.0035 before.
- mean 28.7 ms, p50 28.9, p95 31.6.
- Self-query invariant holds: an exact base vector returns itself top-1 with a populated memtable (previously displaced by any unflushed record).