### PR TITLE
docs: ADR-070 (AXIS not needed for co-design) + TD-SEARCH-2 (parallel morsel search)

### DIFF
--- a/docs/10-quality/td/TD-SEARCH-2-parallel-morsel-search.adoc
+++ b/docs/10-quality/td/TD-SEARCH-2-parallel-morsel-search.adoc
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-SEARCH-2: Parallel morsel-driven search — spawn one task per segment file, merge top-k
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** The search path (`fallback_to_direct_search`, search/mod.rs:968) iterates SSTable files SEQUENTIALLY in a for loop — one core pinned at 99% CPU. For SIFT 1M with 7 segments, this is ~7× slower than necessary. The fix is embarrassingly parallel: each segment's `try_pax_cascade` is independent → spawn N tokio tasks → k-way merge via the existing `BoundedPriorityQueue`.
+| Priority | **P1** — the co-design PAX scan (ADR-070's default path) has cold latency ~476ms (single-core). Parallel morsel drops this to ~70ms (7 segments / 7 cores). This is the difference between "acceptable for codegraph" and "competitive."
+| Component | `src/storage/engines/sst/search/mod.rs` (`fallback_to_direct_search` ~968, the per-file loop ~1069-1232); `src/storage/engines/sst/readers/morsel_scheduler.rs` (existing intra-file morsel infra); `SearchParams.enable_parallel_morsels` (exists but not wired).
+| Evidence | SIFT 1M via REST: CPU 99.99% (one core), mean latency 476ms, 7 segment files scanned sequentially. `enable_parallel_morsels` is a field on `SearchParams` (query_optimizer.rs) but is never read by the search path. A morsel scheduler EXISTS (`morsel_scheduler.rs`) but is scoped to intra-file chunks (4096 rows), NOT inter-file parallelism.
+|===
+
+== The finding
+
+The per-file loop in `fallback_to_direct_search` (search/mod.rs:~1069):
+
+```
+for sstable_path in &sstable_files {
+    let pax_cascade = try_pax_cascade(sstable_path, ...);  // sequential!
+    all_candidates.extend(pax_cascade);
+}
+```
+
+Each iteration is independent (no shared state between files). The results are accumulated into `all_candidates` + merged by score at the end. This is a textbook fork-join parallel pattern.
+
+== Direction
+
+**Morsel = one segment file.** Spawn N tokio tasks (bounded by CPU cores or a configurable `max_parallel_segments`):
+
+```
+                    ┌─ tokio::spawn ──► try_pax_cascade(file1) ──► top-k1 ─┐
+                    ├─ tokio::spawn ──► try_pax_cascade(file2) ──► top-k2 ─┤
+fallback_to_direct ├─ ...                                                    ┤
+  _search          └─ tokio::spawn ──► try_pax_cascade(fileN) ──► top-kN ─┘
+                                                              │
+                                                              ▼
+                                              k-way merge (BoundedPriorityQueue)
+```
+
+- Gate behind `SearchParams.enable_parallel_morsels` (already in the struct — wire it).
+- Default ON for collections with >1 segment file (single-file = no benefit).
+- Bounded parallelism: `min(N_files, available_parallelism())` or a config knob.
+- Error handling: if one task fails, log + treat as empty (don't fail the whole search).
+
+== Slices
+
+S1 — **Wire the flag + spawn tasks.** Read `enable_parallel_morsels` from `SearchParams`. When true + >1 file: spawn one `tokio::spawn` per file → `try_pax_cascade` → collect via `join_all`. Merge into `all_candidates`. Default: ON.
+
+S2 — **Bounded parallelism.** Add `max_parallel_segments` to SstConfig (default: `available_parallelism()`). Use a `Semaphore` to bound concurrent tasks.
+
+S3 — **Observability.** Log the parallelism degree + per-file timing under a debug target (like the existing `sst_warm_phase` trace).
+
+== Expected speedup
+~min(N_files, N_cores)×. For 7 files on 8 cores: 476ms → ~70ms cold; ~28ms → ~4ms warm.
+
+== Verification
+- SIFT 1M (7 segments) with `parallel_morsels=on`: CPU spreads across cores, latency drops ~7×.
+- Single-file collection: no regression (sequential fallback).
+- Recall unchanged (parallel scan is exact — same files, same cascade, just concurrent).
+
+== Related
+link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] (AXIS not needed — PAX scan is the default; this TD makes it fast enough to replace AXIS for latency-sensitive cases too).

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -199,6 +199,7 @@ Accepted ADRs live under `adr/`.
 * `adr/ADR-017-dr-engine-surface.adoc` — Public DR engine surface and OSS/operator boundary.
 * `adr/ADR-018-pgwire-sql-parity-roadmap.adoc` — pgwire/SQL parity roadmap: MVP → SQLite-parity → Postgres-parity (~3 months total).
 * `adr/ADR-019-relational-query-architecture.adoc` — five-layer relational query architecture (algebra, executor, transaction, storage) refining Phase 2.
+* `adr/ADR-070-axis-not-needed-for-codesign-collections.adoc` — AXIS not the default for co-design collections (PAX scan + memtable cover everything; recall@10=0.999).
 
 == Archived From This Directory
 

--- a/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
+++ b/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-070: AXIS is not the default for co-design collections (the PAX scan + memtable cover everything)
+
+Status:: Accepted (2026-07-23)
+
+== Context
+
+The three-stage search pipeline (Stage 1: WAL/memtable → Stage 2: AXIS HNSW/IVF → Stage 3: PAX segment scan) was designed when the flush mechanism was broken (segments never materialized — fixed in #1150/#1155/#1158/#1159). With the flush now working correctly, the data lifecycle is:
+
+```
+Write → memtable (Stage 1, ~0ms) → flush at 16MB → PAX segment (Stage 3, ~28ms warm / ~476ms cold)
+```
+
+Stage 2 (AXIS) indexes the SAME flushed data that Stage 3 scans — a redundant second copy in RAM.
+
+Measured on SIFT 1M via REST (post-fix): recall@10 = 0.999, mean latency 476ms cold / ~28ms warm (100k). The codegraph workload test validated: upsert ✓ (MVCC version resolution), delete ✓ (tombstone suppression), new entities ✓ (immediate via memtable), no duplicates ✓ (MVCC dedup at merge).
+
+== Decision
+
+AXIS (HNSW/IVF in-memory index) is **not the default** for collections without `index_configs`. The co-design PAX scan path (Stage 1 + Stage 3) is the default, and is sufficient for codegraph and similar read-heavy, upsert-prone workloads.
+
+AXIS remains available as an **opt-in** via `index_configs` for workloads that need sub-5ms latency (e.g., real-time code completion, interactive autocomplete). The per-collection AXIS gate (#1145) already routes correctly: `use_axis_indexes = pax_off || !index_configs.is_empty()`.
+
+== Economics (1M code entities, 768d embeddings)
+
+[cols="1,2,2", options="header"]
+|===
+| Dimension | AXIS (HNSW+IVF) | PAX scan (flush+compaction)
+| RAM | ~8.6GB (HNSW graph + quantized vecs) | ~0GB (segment IS the index)
+| RAM $/month | ~$31 ($0.005/GB/hr) | ~$0
+| Build cost | ~142s for 1M (HNSW O(N log N)) | ~0 (flush writes inline)
+| Query latency | ~1ms (graph traversal) | ~28ms warm / ~476ms cold
+| Upsert cost | Re-index (HNSW delete+insert) | Append to memtable (O(1))
+| Restart | Async rebuild (minutes) | Immediate (segments on disk)
+|===
+
+The ~27ms latency difference (1ms AXIS vs 28ms warm PAX) does not justify 8.6GB RAM for codegraph (interactive code exploration tolerates 28ms easily).
+
+== Consequences
+
+* **Positive**: $31/month RAM savings per collection; O(1) upserts (no re-index); immediate restart (no async rebuild); simpler operations (no index persistence/recovery).
+* **Negative**: cold-query latency is ~476ms (object-store GETs) — mitigated by the survivor cache (warms to ~28ms) and parallel morsel search (TD-SEARCH-2, ~7× speedup → ~70ms cold).
+* **AXIS is not removed** — it stays as an opt-in for latency-sensitive use cases. The #1145 gate + #1155 flush-skip already prevent AXIS from being built/queried for co-design collections.
+
+== Related
+
+* #1145 (AXIS per-collection gate), #1155 (skip unused AXIS build at flush), #1158 (Stage-3 storage search for co-design), #1159 (recall fix: delta-merge metric + similarity + dequantize).
+* link:TD-SEARCH-2-parallel-morsel-search.adoc[TD-SEARCH-2] (parallel morsel search — the latency fix for cold PAX scans).
+* link:TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc[TD-RECALL-1] (the recall investigation that proved the PAX scan works at 0.999).


### PR DESCRIPTION
## ADR-070: AXIS is not the default for co-design collections
The PAX scan (Stage 1 memtable + Stage 3 segment scan) covers everything — **recall@10 = 0.999** measured on SIFT 1M via REST. AXIS = redundant 8.6GB RAM (~$31/month) for 27ms latency saving. Remains opt-in via `index_configs` for sub-5ms use cases.

**Codegraph workload validated**: upsert (MVCC version resolution) ✓, delete (tombstone) ✓, new entities (immediate via memtable) ✓, no duplicates ✓ — all on the co-design PAX scan path, no AXIS needed.

## TD-SEARCH-2 (P1): Parallel morsel-driven search
The per-file loop in `fallback_to_direct_search` is sequential (99% = 1 core). Fix: spawn N tokio tasks (one per segment) → k-way merge via existing `BoundedPriorityQueue`. Infrastructure exists (`morsel_scheduler.rs`, `enable_parallel_morsels` flag — just not wired). **~7× speedup** for 7 segments (476ms → ~70ms cold).

## Test bench data cleaned
All `/tmp/pdb-*` dirs removed for fresh codegraph + append-bulk tests after these filings merge.