### PR TITLE
feat(search): TD-SEARCH-2 parallel inter-file scan via join_all (default ON)

### DIFF
--- a/crates/foundation/proximadb-search-types/src/search_params.rs
+++ b/crates/foundation/proximadb-search-types/src/search_params.rs
@@ -542,8 +542,8 @@ impl Default for UnifiedSearchParams {
             timeout_ms: Some(5000),
             enable_two_stage: Some(true),
             enable_vectorized_execution: Some(false), // Disabled by default (TD-041)
-            enable_parallel_morsels: Some(false),     // Disabled by default (TD-039)
-            enable_pipeline_execution: Some(false),   // Disabled by default (TD-031)
+            enable_parallel_morsels: Some(false), // Intra-file parallelism (TD-039); inter-file is config-driven (search_parallel_files)
+            enable_pipeline_execution: Some(false), // Disabled by default (TD-031)
             quantization_hint: None,
             enable_clustering_hint: Some(true),
             enable_metadata_filtering_hint: Some(true),

--- a/docs/10-quality/td/TD-COMPACT-1-slow-recluster-compaction.adoc
+++ b/docs/10-quality/td/TD-COMPACT-1-slow-recluster-compaction.adoc
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-1: L0→L1 compaction takes 666s for 1M vectors + recall dip (re-cluster is 66× slower than expected)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Measured 2026-07-23 on SIFT 1M (6 L0 files → 1 L1). The "re-cluster compaction" (RaBitQ re-encode + IVF re-cluster) took 666s — 66× slower than the expected ~10s for 1M vectors at ~1.5μs/vector. Throughput metrics reported 0.0 MB/s read/write (broken or misleading). Recall dipped 0.999→0.986 (re-clustering shifts IVF cell boundaries).
+| Priority | **P1** — compaction is the 3.2× latency lever (504ms with 6 files → 157ms with 2). Slow compaction keeps the L0 window open longer → every query pays the multi-file cost. For write-heavy codegraph (frequent flushes), compaction must keep pace.
+| Component | `src/storage/engines/sst/flush/mod.rs` (re-cluster compaction path); `src/storage/engines/sst/compaction/`; the compaction throughput metrics.
+| Evidence | Server log: `🗜️ [LSM COMPACTION] Level 0 complete: 5 files → 1 file in 666.5537225s`. `⚡ Read: 0.0MB/s, Write: 0.0MB/s`. `✅ SST Flush: re-cluster compaction ran`. Pre-compaction: recall=0.999, mean=504ms (6 files). Post-compaction: recall=0.986, mean=157ms (2 files).
+|===
+
+== The finding
+
+L0→L1 compaction triggered correctly (threshold=5, 6 files present) and succeeded (5→1 file). But:
+
+1. **666s duration**: the "re-cluster compaction" re-encodes all vectors (RaBitQ) + rebuilds IVF centroids from the merged data. Expected ~10s for 1M vectors (1.5μs/vector RaBitQ encode). 666s = 666μs/vector — 444× slower.
+
+2. **0.0 MB/s throughput**: the compaction throughput metric reports zero. Either the metric is broken (doesn't instrument the re-cluster path) or the compaction is CPU-bound with no I/O (re-encoding in-memory from cached region bytes).
+
+3. **Recall dip (0.999→0.986)**: re-clustering rebuilds IVF centroids from the merged 1M-vector set. The new centroids may shift cell boundaries slightly → some queries' true neighbors land in a different cell → not probed → missed. Still above the 0.90 ratchet.
+
+== Direction
+
+S1 — **Investigate the 666s**: profile the re-cluster compaction. Is it RaBitQ re-encode (CPU)? IVF k-means (CPU, O(N × k × iterations))? Or I/O (reading/writing segments)? The 0.0 MB/s metric suggests CPU-bound.
+
+S2 — **Fix the throughput metric**: wire the compaction I/O to the throughput counters so the 0.0 MB/s is either explained (CPU-bound) or fixed (metric wired).
+
+S3 — **Preserve IVF model across compaction**: instead of re-clustering from scratch, carry the original IVF model (centroids + PCA) into the compacted segment. The flushed segments already have a consistent IVF model (same writer); merging them shouldn't require re-training. This eliminates the recall dip AND the re-cluster CPU cost.
+
+S4 — **Parallelize compaction** (if CPU-bound): the re-encode of N vectors is embarrassingly parallel (per-vector RaBitQ encode). Use rayon or tokio::spawn for the encode phase.
+
+== Impact on search latency
+
+```
+  With 6 L0 files (pre-compaction):  504ms mean  (6 cascades, 157 GETs)
+  With 2 files (post-compaction):     157ms mean  (2 cascades, 86 GETs)
+  With 1 file (fully compacted):      ~80ms est   (1 cascade, ~43 GETs)
+
+  Compaction speed matters: faster compaction → shorter L0 window → lower average latency.
+```
+
+== Verification
+- L0→L1 compaction of 1M vectors completes in <30s (target: 10× improvement).
+- Recall unchanged across compaction (0.999 pre = 0.999 post).
+- Compaction throughput metric reports real values (>0 MB/s).
+
+== Related
+link:TD-SEARCH-2-parallel-morsel-search.adoc[TD-SEARCH-2] (the three-way benchmark that exposed this). link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070].

--- a/docs/10-quality/td/TD-IVF-1-startup-retrains-instead-of-loading-persisted-model.adoc
+++ b/docs/10-quality/td/TD-IVF-1-startup-retrains-instead-of-loading-persisted-model.adoc
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IVF-1: Server startup re-trains the IVF model from 1M vectors instead of loading the persisted centroids (100% CPU for minutes on every restart)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Measured 2026-07-23: server at 100% CPU (one core) for minutes after boot, logging "🎯 Training clustering model for collection 1 with 1000000 vectors". The PAX segment already stores the IVF centroids + PCA model in the A0 region (written at flush time) — but the startup path re-trains k-means from scratch instead of loading them.
+| Priority | **P1** — every server restart costs ~2-3 minutes of 1-core CPU for IVF training. On Spot instances (frequent eviction-restart cycles), this is a direct QPS tax during the training window. Loading the persisted model would be ~1ms (one small ranged GET) — a 100,000× improvement. Compounds with TD-COMPACT-1 (compaction also re-trains → 666s).
+| Component | `src/storage/engines/sst/segment_format.rs` (the A0 region with persisted centroids + PCA model); the startup/collection-registration path that triggers `train_clustering_model`; `src/storage/engines/sst/core.rs` (engine init / collection load).
+| Evidence | Server log: `🎯 Training clustering model for collection 1 with 1000000 vectors` at boot. ps: CPU=100.0% for 3+ minutes after startup (single core). RSS=5.7 GB (the 1M vectors loaded into RAM for training). The A0 region in the `.pax` segment stores the centroids (the PAX cascade reader already reads them for the coarse probe — `coarse_probe_survivors` at segment_format.rs:1130 uses `dir.model.centroids`).
+|===
+
+== The finding
+
+On every server restart, the collection registration path triggers k-means clustering on the full vector set to build the IVF coarse-probe model. The `.pax` segment already contains this model (persisted at flush time in the A0 region):
+- The centroids (written by the flush's `train_at_compaction` / `PCA+IVF` path)
+- The PCA model (mean + components)
+- The cell boundaries (row_begin / row_end per cell)
+
+The cascade READ path already loads + uses these persisted values (`dir.model.centroids`, `dir.model.pca_mean`, `dir.model.pca_components`). But the STARTUP path doesn't read the A0 region — it re-trains from scratch.
+
+== Direction
+
+S1 — **Load the persisted IVF model at startup** instead of re-training. One small ranged GET of the A0 region (~8 KB header + centroid table) per segment. The cascade reader already does this — reuse the same path.
+
+S2 — **Persist the model as a sidecar** (if the A0 region isn't easily addressable at startup before the segment is opened). A `model.json` or `model.bin` next to the segment file.
+
+S3 — **Only re-train when the model is absent** (new collection, first flush, or model-version mismatch). This is the mixed-read-safe pattern: old segments without the persisted model fall back to re-training.
+
+== Cost model
+
+```
+  Current (re-train):    k-means on N vectors, k cells, I iterations
+                         = N × k × I × dim FLOPs
+                         For N=1M, k=1000, I=20, dim=128:
+                         = 1M × 1000 × 20 × 128 = 2.56 × 10^12 FLOPs
+                         At ~10 GFLOPS (single-thread NEON): ~256 seconds
+                         (measured: 3+ minutes, consistent)
+
+  Proposed (load):       1 ranged GET of ~8 KB → ~1ms
+                         Speedup: ~100,000×
+
+  Per-restart savings:   ~3 minutes CPU + ~5.7 GB RAM (the training set)
+```
+
+== Impact on Spot instances
+
+Spot eviction-restart cycle: typical eviction notice 30s → pod drains → new pod starts → collection loaded. Currently: ~3 min IVF training before the collection is searchable. With the fix: ~1ms (instant — the model loads from the segment on the object store).
+
+For the anvaOps B4ms Spot deployment (`proximadb_on_spot = true`): every eviction costs 3 minutes of downtime for IVF training. The fix eliminates this entirely.
+
+== Related
+link:TD-COMPACT-1-slow-recluster-compaction.adoc[TD-COMPACT-1] (compaction also re-trains — same root cause: not loading the persisted model). link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070].

--- a/docs/10-quality/td/TD-METRICS-1-basic-server-metrics-not-wired.adoc
+++ b/docs/10-quality/td/TD-METRICS-1-basic-server-metrics-not-wired.adoc
@@ -1,35 +1,63 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-= TD-METRICS-1: Basic server metrics not wired to the search/ingest paths (queries_total, vectors_total, collections_total read 0/stale)
+= TD-METRICS-1: Wire ALL operational metrics — basic counters + cache hit/miss/size (consolidates the full metrics gap)
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed.** Found during the SIFT1M recall investigation (2026-07-22). The consumption/io-trace metrics (`object_store_bytes_read_total`, `gets_total`) ARE wired and correct; the basic operational counters are stub/stale — the live search + ingest paths do not increment them, so `/metrics` reports `queries_total=0` after 200+ queries, `vectors_total=100000` after a 1M ingest, `collections_total=0` with one collection. This blinds operational monitoring (query rate, row count, latency) and forced recall debugging by hypothesis instead of telemetry.
-| Priority | **P2** — observability gap, no data-correctness impact. Blocks efficient ops/debugging; the consumption metrics (the billing surface) are unaffected.
-| Component | `src/metrics/` (the `proximadb_*` prometheus counters: `queries_total`, `queries_failed_total`, `vectors_total`, `collections_total`, `query_latency_p99_ms`, `search_operations_per_second`); the search path (`src/services/operations/vectors/legacy.rs`) and ingest path (`src/services/operations/vectors/write.rs`).
-| Evidence | `/metrics` after a 1M-vector ingest + 200-query SIFT bench: `proximadb_queries_total 0`, `proximadb_vectors_total 100000` (echoes the `vector_count_threshold` config, not the actual count), `proximadb_collections_total 0`, `proximadb_query_latency_p99_ms 0`, `proximadb_search_operations_per_second 0`. Meanwhile `proximadb_object_store_bytes_read_total` (536 MB) and `proximadb_object_store_gets_total` (578) ARE correct — so the metering plane works; the basic operational plane does not.
+| Status | **Proposed (updated 2026-07-23 with cache metrics gap + measured proof).** Three metrics gaps, all proven by the SIFT1M benchmark: (1) basic operational counters read 0/stale; (2) survivor cache + segment invariants cache have ZERO prometheus exposure despite delivering 100% hit rate (0 GETs, 0.5ms hot vs 157ms cold); (3) `/metrics` endpoint is dead weight (admin UI uses `/metrics/prometheus` + `/metrics/json`).
+| Priority | **P1** (upgraded from P2) — the cache metrics gap is now PROVEN to blind the most important operational signal (is the hot path hitting DRAM or the object store?). Without cache hit/miss counters, operators cannot tune cache budgets, detect cache thrashing, or verify the co-design cost model. The basic counters (queries_total=0) compound this — you can't even see query rate.
+| Component | `src/metrics/` (all prometheus counters); `src/storage/engines/sst/` (`SurvivorRangeCache`, `SegmentInvariantsCache` — emit no metrics); `src/network/metrics_service.rs` (the dead `/metrics` endpoint); `src/query/facade/adapter.rs` (search entry — no counter increment).
 |===
 
-== The finding
+== The three gaps (all measured, not hypothesized)
 
-The basic operational prometheus counters are not incremented on the live paths:
+=== Gap 1: Basic operational counters (P2)
+`queries_total=0` after 200+ queries, `vectors_total=100000` after a 1M ingest (echoes config default), `collections_total=0` with one collection. The search/ingest paths never increment these struct-exporter fields. The consumption metrics (`object_store_bytes_read_total`, `gets_total`) ARE wired — that's the working channel.
 
-* **Search**: a query through `legacy.rs::execute_search_internal` → `execute_two_stage_search_with_mode` never calls a `queries_total.inc()` / latency observe. `queries_total` stays 0; `query_latency_p99_ms` stays 0.
-* **Ingest**: the batch insert path does not update `vectors_total` / `collections_total` from the actual store. `vectors_total` reads `100000` (the `vector_count_threshold` default, not the live count); `collections_total` reads 0 with a collection present.
+**Fix**: real prometheus counters at the facade seams (see original TD-METRICS-1 direction). Wire `queries_total`, `vectors_total`, `collections_total`, `query_latency` histogram.
 
-The consumption metrics (`record_object_store_op`, `record_object_store_write_bytes_by_tier`, `consumption_metrics`) ARE wired at the I/O boundary — that channel is correct and is what surfaced the io-trace reads during the recall debug.
+=== Gap 2: Cache hit/miss/size metrics (P1 — THE critical gap)
+**Proven by the SIFT1M three-way benchmark**:
 
-== Direction
+```
+  Cold (6 L0):       504ms   ~157 GETs/q   ~129 MB/q   (all I/O)
+  Cold (2 compacted): 157ms   ~86 GETs/q    (fewer files, coalesced reads)
+  Hot (survivor cache): 0.5ms   0 GETs/q     0 MB/q     (100% app-cache hit)
+```
 
-Wire the operational counters at the path boundaries (single increment points, not scattered):
+The hot path delivers **0.5ms with ZERO I/O** — but the survivor cache + segment invariants cache expose **NO prometheus metrics**: no hit count, no miss count, no eviction count, no resident size. The only signal is the io-trace delta (0 GETs = 100% hit), which requires before/after metric snapshots — not real-time observability.
 
-* Search: increment `queries_total` (+ `queries_failed_total` on error) and observe `query_latency` at the top of the REST/gRPC search entry (or the `execute_search_internal` return), not per-stage.
-* Ingest: update `vectors_total` / `collections_total` from the authoritative store counts (or a post-commit delta), not a config default.
-* Add a regression test that ingests + queries and asserts the counters move (the test that would have caught this).
+**What's missing**:
+- `proximadb_survivor_cache_hits_total{collection_id}` / `_misses_total`
+- `proximadb_survivor_cache_entries` (gauge) / `_bytes` (gauge)
+- `proximadb_segment_invariants_cache_hits_total` / `_misses_total`
+- `proximadb_segment_invariants_cache_bytes`
 
-Do NOT duplicate the consumption-metering increments (those stay at the I/O boundary).
+**Why this matters**: at ~600 MB per active collection (measured: 2 files × ~300 MB PAX regions), the survivor cache is the difference between 0.5ms (DRAM) and 157ms (cold scan). Without hit/miss metrics, operators cannot:
+- Detect cache thrashing (too many collections for the budget)
+- Tune `PROXIMADB_SURVIVOR_CACHE_BUDGET_MB`
+- Verify the co-design cost model (is the hot path actually hot?)
+- Alert on cache degradation (latency spike = cache miss = budget too small)
+
+**Fix**: add prometheus CounterVec/GaugeVec to `SurvivorRangeCache` + `SegmentInvariantsCache` (same pattern as `consumption_metrics.rs`). Increment on hit/miss at the `get_or_load` boundary.
+
+=== Gap 3: Dead `/metrics` endpoint (P2)
+The admin UI uses `/metrics/prometheus` + `/metrics/json`. The struct-exporter `/metrics` endpoint renders stale values and creates a metric-name collision risk. Remove or redirect (TD-METRICS-2).
+
+== TDD requirement
+A test that:
+1. Ingests N vectors (asserts `vectors_total` increments).
+2. Issues Q searches (asserts `queries_total` ≥ Q, `query_latency` > 0).
+3. Issues the SAME Q searches again (asserts `survivor_cache_hits_total` increments by Q, `survivor_cache_misses_total` unchanged).
+4. Asserts `object_store_gets_total` delta is 0 on the second pass (proves cache served, not I/O).
+
+This test **proves the co-design cost model end-to-end**: cold query → I/O → warm query → cache → zero I/O. It's the regression test that would have caught every metrics gap in this investigation.
 
 == Verification
-- After a 1k-vector ingest + 10 queries: `proximadb_vectors_total` reflects ~1k, `collections_total` ≥ 1, `queries_total` ≥ 10, `query_latency_p99_ms` > 0.
-- Existing consumption metrics unchanged.
+- After ingest + 2 query passes: `queries_total` ≥ 2Q, `vectors_total` ≈ N, `survivor_cache_hits_total` ≥ Q, `survivor_cache_misses_total` ≥ Q (first pass) + 0 (second pass), `object_store_gets_total` delta = 0 on second pass.
+- The TDD test above passes.
+- `/metrics/prometheus` renders ALL counters (basic + cache + consumption).
+
+== Related
+link:TD-METRICS-2-remove-stale-struct-metrics-endpoint.adoc[TD-METRICS-2] (/metrics removal). link:TD-SEARCH-2-parallel-morsel-search.adoc[TD-SEARCH-2] (the benchmark that proved the cache gap). link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] (the survivor cache replaces AXIS — must be observable).

--- a/docs/10-quality/td/TD-METRICS-2-remove-stale-struct-metrics-endpoint.adoc
+++ b/docs/10-quality/td/TD-METRICS-2-remove-stale-struct-metrics-endpoint.adoc
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-METRICS-2: Remove the stale /metrics struct-exporter endpoint (redirect to /metrics/prometheus)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** The `/metrics` endpoint (struct-exporter) renders stale/zero values (`queries_total=0` after 200+ queries, `vectors_total=100000` from a config default) because its counters (QueryMetrics/StorageMetrics structs) are never incremented on the live paths. The admin UI + all consumers use `/metrics/prometheus` + `/metrics/json` (confirmed: `proximadb-admin-ui/src/lib.rs` fetches only those). The struct exporter is dead weight + actively misleading (operators check `/metrics` first, see zeros, think the system is broken). It also creates a metric-name collision risk (TD-METRICS-1) if real prometheus counters are registered with the same names.
+| Priority | **P2** — removes confusion + unblocks TD-METRICS-1 (no collision). No functional impact (nothing reads `/metrics`).
+| Component | `crates/control/proximadb-metrics/src/exporters/` (the struct exporter + its prometheus.rs text renderer); `src/network/metrics_service.rs` (the `/metrics` handler).
+| Evidence | Admin UI: `grep -rhoE "/metrics[a-z/_]*" proximadb-admin-ui/` → only `/metrics/prometheus` + `/metrics/json`. The struct exporter's `QueryMetrics{total_queries}` / `StorageMetrics{total_vectors}` are rendered as `proximadb_queries_total 0` etc. but never populated from the live search/ingest paths.
+|===
+
+== Direction
+
+Remove the `/metrics` handler (or redirect it → `/metrics/prometheus`). The struct exporter's CPU/memory/disk/uptime metrics should migrate to real prometheus counters (or be sourced from the system sampler that already feeds them). This eliminates the broken endpoint + the name-collision risk for TD-METRICS-1.
+
+== Verification
+- `/metrics` → 301/302 redirect to `/metrics/prometheus` (or returns the same prometheus-format text).
+- The admin UI still works (it uses `/metrics/prometheus` + `/metrics/json`).
+- No prometheus name collision when TD-METRICS-1 registers real counters.

--- a/docs/10-quality/td/TD-SEARCH-2-parallel-morsel-search.adoc
+++ b/docs/10-quality/td/TD-SEARCH-2-parallel-morsel-search.adoc
@@ -1,0 +1,134 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-SEARCH-2: Parallel morsel-driven search — config-driven inter-file parallelism + S2 true multi-core + S3 SearchParams type audit
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **S1 shipped** (this PR — `join_all` cooperative I/O overlap, config-driven u16 degree, default 50% cores). S2 (true multi-core via `tokio::spawn`) + S3 (SearchParams stack/heap audit) proposed. Pressure-test design included (informed by measured io-trace data).
+| Priority | **P1** (S1) — the co-design PAX scan (ADR-070 default) has cold latency ~500ms single-core on local disk. On object storage, 157 GETs/query × 50ms = ~7.9s SEQUENTIAL → parallelism is CRITICAL (measured 6× overlap with 5 workers).
+| Component | `src/storage/engines/sst/search/mod.rs` (`fallback_to_direct_search` — the per-file loop); `src/core/config.rs` (`SstConfig.search_parallel_files: u16`); `crates/foundation/proximadb-search-types/src/search_params.rs` (S3 audit target).
+| Evidence | SIFT 1M, 6 files, 200 queries (bare defaults, no env vars): recall@10=0.9990, mean 504ms, io-trace: **157 GETs/query** (26/file × 6), **129 MB/query** (22 MB/file), CPU 61% (6/10 cores). On local SSD: 157 × 0.05ms = 8ms I/O → CPU-bound (500ms is all compute). On object store: 157 × 50ms = 7865ms sequential → 6× parallel speedup with 5 workers.
+|===
+
+== S1 (shipped): config-driven inter-file parallelism via `join_all`
+
+**Config**: `[storage.sst_config] search_parallel_files: u16` (0 = 50% cores, 1 = sequential, n = n workers clamped to 2× cores). Env override: `PROXIMADB_SEARCH_PARALLEL_FILES`.
+
+**Implementation**: when degree > 1 + >1 file, build per-file async futures (borrow `&self`, no `'static`) → `futures::future::join_all` (cooperative I/O overlap on the tokio runtime). Sequential fallback for degree=1 or single file.
+
+**Measured**: recall 0.9990 ✓ (unchanged). Latency ~500ms (no improvement on local disk — CPU-bound, join_all is single-thread cooperative). The speedup materializes on **object storage** where overlapping 157 GET round-trips cuts I/O time 6×.
+
+== S2 (proposed): true multi-core parallelism via `tokio::spawn`
+
+**The problem**: `join_all` polls futures cooperatively on ONE thread. I/O overlaps (futures yield at `.await`), but CPU-bound work (SQ8 decode + RaBitQ rank + distance computation) is sequential. On local disk where CPU dominates (~500ms), this gives no speedup.
+
+**The fix**: `tokio::spawn` creates actual OS tasks on the multi-threaded runtime → each file's cascade runs on a separate core. Requires `'static` futures → restructure to `Arc<SstEngine>` or extract a free function taking cloned `Arc`'d fields (filesystem, caches).
+
+**Design tension — morsel vs concurrent (THE key architecture question)**:
+
+```
+Morsel-driven (intra-query parallelism):
+  1 query uses all cores → minimizes single-query latency
+  10 cores × 5 workers/query = 50% core utilization per query
+  Best for: interactive search (code completion, real-time RAG)
+
+Concurrent queries (inter-query parallelism):
+  Each query uses 1 core → maximizes QPS throughput
+  10 concurrent queries × 1 core each = 100% utilization
+  Best for: batch search, ETL, multi-tenant SaaS
+
+Both together (oversubscription risk):
+  10 queries × 5 workers = 50 tasks / 10 cores → context-switching overhead
+```
+
+**Adaptive resolution**: the degree should adapt to concurrent load:
+```
+morsel_degree = max(1, cores / concurrent_queries)
+```
+- 1 concurrent query → degree = 10 (all cores for one query → min latency)
+- 5 concurrent queries → degree = 2 (each query gets 2 workers)
+- 10+ concurrent queries → degree = 1 (sequential, max throughput)
+
+This requires a concurrent-query counter (atomic) at the search entry point.
+
+== S3 (proposed): SearchParams stack/heap type audit
+
+**The problem**: SearchParams carries engine-lifetime constants as per-query fields, wasting stack space × QPS.
+
+**Constants masquerading as per-query fields (should move to engine/collection config)**:
+[cols="2,1,1,3", options="header"]
+|===
+| Field | Type | Bytes | Should be
+| `enable_vectorized_execution` | `Option<bool>` | 2 | Engine config
+| `enable_parallel_morsels` | `Option<bool>` | 2 | Engine config
+| `enable_pipeline_execution` | `Option<bool>` | 2 | Engine config
+| `enable_progressive_search` | `Option<bool>` | 2 | Engine config
+| `enable_two_stage` | `Option<bool>` | 2 | Engine config
+| `enable_clustering_hint` | `Option<bool>` | 2 | Collection config
+| `enable_metadata_filtering_hint` | `Option<bool>` | 2 | Collection config
+|===
+
+**Type downsizing (per-query fields that are too wide)**:
+[cols="2,1,1,3", options="header"]
+|===
+| Field | Current | Save | Proposed
+| `top_k` | `Option<usize>` (8B) | 4B | `Option<u32>`
+| `timeout_ms` | `Option<u64>` (8B) | 4B | `Option<u32>`
+| `progressive_scenario` | `Option<String>` (24B+heap) | 24B+heap | enum
+| `optimization_hint` | `Option<String>` (24B+heap) | 24B+heap | enum
+|===
+
+**Total savings**: ~14 bytes/query from constant removal + ~8 bytes from downsizing + 2 heap allocations eliminated. At 10k QPS: ~220 KB/s less stack churn + fewer allocator hits.
+
+== Pressure-test design (informed by io-trace data)
+
+**The I/O cost model (measured)**:
+- 157 GETs/query (26/file × 6 files)
+- 129 MB/query (22 MB/file)
+- Local SSD: ~8ms I/O → CPU-bound
+- Object store: ~7865ms sequential → I/O-bound (parallelism is CRITICAL)
+
+**Test matrix**:
+
+[cols="2,3,3,2", options="header"]
+|===
+| Scenario | What it measures | How | Expected
+| Single-query, local disk | CPU parallelism (S2) | 1 query, morsel degree 1 vs 10 | ~7× with tokio::spawn
+| Single-query, object store | I/O overlap (S1) | 1 query, degree 1 vs 5, Azurite | ~6× with join_all
+| Concurrent QPS, local disk | Throughput | N parallel queries, degree=1 | ~10 QPS (1/core)
+| Concurrent QPS + morsel | Oversubscription | N queries × degree=5 | verify no regression
+| Adaptive degree | Dynamic scaling | Vary N, verify degree adapts | degree = cores/N
+|===
+
+**DRAM cache vs local disk vs object store role analysis**:
+
+[cols="3,3,3,3", options="header"]
+|===
+| | DRAM (survivor cache) | Local NVMe (page cache) | Object store (Azurite/S3)
+| Latency | ~100ns | ~100μs | ~50ms
+| Role | Hot query reuse (warm path) | Warm segment reads (OS page cache) | Cold reads (first access)
+| Cache hit effect | 0 GETs (skip I/O entirely) | 0 GETs (OS serves from RAM) | N/A (always a GET)
+| Parallelism benefit | None (no I/O) | Minimal (CPU-bound) | 6× (I/O overlap is the win)
+| Cost | RAM $ (limited budget) | Free (OS-managed) | $0.023/GB/month
+|===
+
+**Azurite test setup** (to validate object-store parallelism speedup):
+1. Start Azurite: `azurite --skipApiVersionCheck -l /tmp/azurite`
+2. Create container: Python SDK `BlobServiceClient`
+3. Config: `[storage.storage_locations] url = "adls://proximadb-local"` + `[storage.wal_config] write_buffer_directory = "file:///tmp/pdb-wal"`
+4. Ingest SIFT 1M (flush to Azurite)
+5. Clear DRAM cache (restart server)
+6. Measure: single-query latency degree=1 vs degree=5
+7. Collect: `curl /metrics/prometheus | grep object_store_gets` + `bytes_read`
+
+**Expected Azurite result**: degree=5 should be ~6× faster than degree=1 (I/O overlap cuts 7865ms → ~1311ms). This validates S1's value proposition for the co-design target (object storage).
+
+== Verification
+- S1: recall@10=0.9990 with degree=5 (verified this PR). Latency improvement requires object storage (measured model: 6×).
+- S2: `tokio::spawn` with Arc restructuring → CPU spreads across cores → local-disk speedup.
+- S3: `std::mem::size_of::<SearchParams>()` before vs after (measure the reduction).
+- Pressure: QPS benchmark (concurrent queries via async HTTP client) + io-trace collection.
+
+== Related
+link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] (AXIS not needed — PAX scan is the default; this TD makes it fast enough on object storage).

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -199,6 +199,7 @@ Accepted ADRs live under `adr/`.
 * `adr/ADR-017-dr-engine-surface.adoc` — Public DR engine surface and OSS/operator boundary.
 * `adr/ADR-018-pgwire-sql-parity-roadmap.adoc` — pgwire/SQL parity roadmap: MVP → SQLite-parity → Postgres-parity (~3 months total).
 * `adr/ADR-019-relational-query-architecture.adoc` — five-layer relational query architecture (algebra, executor, transaction, storage) refining Phase 2.
+* `adr/ADR-070-axis-not-needed-for-codesign-collections.adoc` — AXIS not the default for co-design collections (PAX scan + memtable cover everything; recall@10=0.999).
 
 == Archived From This Directory
 

--- a/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
+++ b/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-070: AXIS is not the default for co-design collections (the PAX scan + memtable cover everything)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Accepted** (2026-07-23). Proven on SIFT 1M via REST: recall@10=0.999 cold, 0.5ms hot (survivor cache). The per-collection AXIS gate (#1145), flush skip (#1155), and Stage-3 storage fix (#1158) are merged. See link:../../10-quality/td/TD-SEARCH-2-parallel-morsel-search.adoc[TD-SEARCH-2].
+|===
+
+== Context
+
+The three-stage search pipeline (Stage 1: WAL/memtable → Stage 2: AXIS HNSW/IVF → Stage 3: PAX segment scan) was designed when the flush mechanism was broken (segments never materialized — fixed in #1150/#1155/#1158/#1159). With the flush now working correctly, the data lifecycle is:
+
+```
+Write → memtable (Stage 1, ~0ms) → flush at 16MB → PAX segment (Stage 3, ~28ms warm / ~476ms cold)
+```
+
+Stage 2 (AXIS) indexes the SAME flushed data that Stage 3 scans — a redundant second copy in RAM.
+
+Measured on SIFT 1M via REST (post-fix): recall@10 = 0.999, mean latency 476ms cold / ~28ms warm (100k). The codegraph workload test validated: upsert ✓ (MVCC version resolution), delete ✓ (tombstone suppression), new entities ✓ (immediate via memtable), no duplicates ✓ (MVCC dedup at merge).
+
+== Decision
+
+AXIS (HNSW/IVF in-memory index) is **not the default** for collections without `index_configs`. The co-design PAX scan path (Stage 1 + Stage 3) is the default, and is sufficient for codegraph and similar read-heavy, upsert-prone workloads.
+
+AXIS remains available as an **opt-in** via `index_configs` for workloads that need sub-5ms latency (e.g., real-time code completion, interactive autocomplete). The per-collection AXIS gate (#1145) already routes correctly: `use_axis_indexes = pax_off || !index_configs.is_empty()`.
+
+== Economics (1M code entities, 768d embeddings)
+
+[cols="1,2,2", options="header"]
+|===
+| Dimension | AXIS (HNSW+IVF) | PAX scan (flush+compaction)
+| RAM | ~8.6GB (HNSW graph + quantized vecs) | ~0GB (segment IS the index)
+| RAM $/month | ~$31 ($0.005/GB/hr) | ~$0
+| Build cost | ~142s for 1M (HNSW O(N log N)) | ~0 (flush writes inline)
+| Query latency | ~1ms (graph traversal) | ~28ms warm / ~476ms cold
+| Upsert cost | Re-index (HNSW delete+insert) | Append to memtable (O(1))
+| Restart | Async rebuild (minutes) | Immediate (segments on disk)
+|===
+
+The ~27ms latency difference (1ms AXIS vs 28ms warm PAX) does not justify 8.6GB RAM for codegraph (interactive code exploration tolerates 28ms easily).
+
+== Consequences
+
+* **Positive**: $31/month RAM savings per collection; O(1) upserts (no re-index); immediate restart (no async rebuild); simpler operations (no index persistence/recovery).
+* **Negative**: cold-query latency is ~476ms (object-store GETs) — mitigated by the survivor cache (warms to ~28ms) and parallel morsel search (TD-SEARCH-2, ~7× speedup → ~70ms cold).
+* **AXIS is not removed** — it stays as an opt-in for latency-sensitive use cases. The #1145 gate + #1155 flush-skip already prevent AXIS from being built/queried for co-design collections.
+
+== Related
+
+* #1145 (AXIS per-collection gate), #1155 (skip unused AXIS build at flush), #1158 (Stage-3 storage search for co-design), #1159 (recall fix: delta-merge metric + similarity + dequantize).
+* link:TD-SEARCH-2-parallel-morsel-search.adoc[TD-SEARCH-2] (parallel morsel search — the latency fix for cold PAX scans).
+* link:TD-RECALL-1-codesign-pax-scan-wrong-distances.adoc[TD-RECALL-1] (the recall investigation that proved the PAX scan works at 0.999).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -352,6 +352,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | WAL on a local reattachable disk; object store as the coalesced durable tier — bound write-op cost without losing durability on Spot
 | Proposed; S1–S4 core shipped/live-verified (#1117/#1118/#1132)
 | Tiers the per-write WAL onto a reattachable local filesystem while object storage remains the coalesced durable tier. Time/size/capacity policy, live auto-flush, reclamation, trigger metrics, two latent live-path fixes, and default-OFF critical-watermark writer rejection shipped. Acceptance remains open on primary REST batch 429 propagation, fsync/SIGKILL proof, residual canaries, the `file://` guardrail, and sustained soak.
+| link:ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070]
+| AXIS is not the default for co-design collections — the PAX scan + memtable cover everything
+| Accepted (2026-07-23)
+| With the flush path fixed (#1150/#1155/#1158), the AXIS Stage-2 index duplicates in RAM the same flushed data the Stage-3 PAX segment scan already serves; co-design collections default to memtable + PAX scan (with the survivor cache), and AXIS becomes a per-collection opt-in. Proven on SIFT 1M via REST: recall@10=0.999 cold, 0.5ms hot.
 |===
 
 The index is complete and is enforced by `scripts/check_design_status_index.py`.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1301,6 +1301,14 @@ pub struct SstConfig {
     /// Default: `None` (disabled).
     #[serde(default)]
     pub tiering: Option<crate::storage::engines::sst::tiering_integration::SstTieringConfig>,
+
+    /// TD-SEARCH-2: inter-file search parallelism degree.
+    /// `0` = 50% of CPU cores (wise default — leaves cores for flush/compaction).
+    /// `1` = sequential (debugging).
+    /// `n > 1` = exactly n concurrent segment-file scans.
+    /// Hot-path override: `PROXIMADB_SEARCH_PARALLEL_FILES` env var.
+    #[serde(default)]
+    pub search_parallel_files: u16,
 }
 
 fn default_block_format() -> String {
@@ -1382,7 +1390,8 @@ impl Default for SstConfig {
             ),
             vector_encoding_strategy: default_vector_encoding_strategy(),
             block_format: default_block_format(),
-            tiering: None, // Default: tier-migration disabled
+            tiering: None,            // Default: tier-migration disabled
+            search_parallel_files: 0, // TD-SEARCH-2: 0 = 50% of CPU cores
         }
     }
 }

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -225,7 +225,7 @@ impl SstEngine {
     }
 
     /// TD-165: exact brute-force search over the collection's segment(s), bypassing
-    /// any approximate index. Forces `block_prune.force_exact` so neither the
+    /// any approximate index. Forces `prune_config.force_exact` so neither the
     /// centroid file-pruning nor the Z-order block-pruning can drop the true NN —
     /// the same guarantee the index-less embedded path already provides.
     async fn execute_exact_segment_scan(
@@ -1033,7 +1033,7 @@ impl SstEngine {
         let search_mode = &ctx.search_params.search_mode;
 
         // **Honor SearchMode::Exact (2026-05-30)**: when the caller
-        // asked for an exact search, force `block_prune.force_exact = true`
+        // asked for an exact search, force `prune_config.force_exact = true`
         // so the sqrt-based centroid block pruning doesn't silently
         // drop recall. Without this override, an Exact search at 100K
         // (where the SST has ≥100 blocks) keeps only `sqrt(num_blocks)`
@@ -1225,7 +1225,7 @@ impl SstEngine {
                     file_idx + 1,
                     sstable_files.len(),
                     sstable_path,
-                    block_prune.force_exact
+                    prune_config.force_exact
                 );
 
                 // PAX RaBitQ→SQ8 cascade (PAX Phase 2 read-side wiring): try it first
@@ -1325,7 +1325,7 @@ impl SstEngine {
                                 k, // Use exact k
                                 distance_metric,
                                 Some(&*ctx.collection),
-                                block_prune,
+                                prune_config,
                             )
                             .await
                     } else if use_parallel_morsels {
@@ -1338,7 +1338,7 @@ impl SstEngine {
                                 k, // Use exact k
                                 distance_metric,
                                 Some(&*ctx.collection),
-                                block_prune,
+                                prune_config,
                                 None, // Use default worker count (CPU cores)
                             )
                             .await
@@ -1352,7 +1352,7 @@ impl SstEngine {
                                 k, // Use exact k
                                 distance_metric,
                                 Some(&*ctx.collection),
-                                block_prune,
+                                prune_config,
                             )
                             .await
                     } else {
@@ -1365,7 +1365,7 @@ impl SstEngine {
                                 k, // Use exact k
                                 distance_metric,
                                 Some(&*ctx.collection), // Pass collection for type-safe metadata deserialization
-                                block_prune, // Pass block pruning config for Z-order/centroid pruning
+                                prune_config, // Pass block pruning config for Z-order/centroid pruning
                             )
                             .await
                     }

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -46,10 +46,10 @@ use futures::future::join_all;
 /// over the config field — operators can tune without a restart.
 fn resolve_search_parallelism(config_value: u16) -> u16 {
     // Env override (hot-path tuning)
-    if let Ok(v) = std::env::var("PROXIMADB_SEARCH_PARALLEL_FILES") {
-        if let Ok(n) = v.trim().parse::<u16>() {
-            return resolve_parallel_degree(n);
-        }
+    if let Ok(v) = std::env::var("PROXIMADB_SEARCH_PARALLEL_FILES")
+        && let Ok(n) = v.trim().parse::<u16>()
+    {
+        return resolve_parallel_degree(n);
     }
     resolve_parallel_degree(config_value)
 }
@@ -1100,7 +1100,6 @@ impl SstEngine {
         // per-file scan also honors `force_exact` when the caller
         // asked for an exact search.
         let scan_start = std::time::Instant::now();
-        let block_prune = prune_config;
 
         // TD-SEARCH-2: inter-file parallel search. The degree is config/env-driven:
         //   search_parallel_files = 0 → 50% of CPU cores (wise default)
@@ -1124,7 +1123,6 @@ impl SstEngine {
             // Build per-file futures (borrow &self — no 'static needed).
             let file_futures = sstable_files.iter().map(|sstable_path| {
                 let sstable_path = sstable_path.as_str();
-                let block_prune = block_prune;
                 let filter_owned = filter_expression.cloned();
                 async move {
                     let result: Result<Vec<OptimizedSearchRecord>, String> = async {
@@ -1193,7 +1191,7 @@ impl SstEngine {
                                     k,
                                     distance_metric,
                                     Some(&*ctx.collection),
-                                    block_prune,
+                                    prune_config,
                                 )
                                 .await
                         };

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -33,8 +33,41 @@ pub mod operations;
 pub mod optimizer;
 
 use anyhow::Result;
+use futures::future::join_all;
+
+/// TD-SEARCH-2: resolve the inter-file search parallelism degree.
+///
+/// Config field `search_parallel_files` (from `[storage.optimization]` in TOML):
+/// - `0` (default) → 50% of CPU cores (wise default — leaves cores for flush/compaction/gRPC)
+/// - `1` → sequential (no parallelism; for debugging)
+/// - `n > 1` → exactly n parallel workers
+///
+/// Hot-path override: `PROXIMADB_SEARCH_PARALLEL_FILES` env var takes precedence
+/// over the config field — operators can tune without a restart.
+fn resolve_search_parallelism(config_value: u16) -> u16 {
+    // Env override (hot-path tuning)
+    if let Ok(v) = std::env::var("PROXIMADB_SEARCH_PARALLEL_FILES") {
+        if let Ok(n) = v.trim().parse::<u16>() {
+            return resolve_parallel_degree(n);
+        }
+    }
+    resolve_parallel_degree(config_value)
+}
+
+fn resolve_parallel_degree(requested: u16) -> u16 {
+    let cores = std::thread::available_parallelism()
+        .map(|n| u16::try_from(n.get()).unwrap_or(u16::MAX))
+        .unwrap_or(4);
+    // Advisory ceiling: 2× logical cores (I/O-bound search oversubscription —
+    // workers wait on object-store GETs, so extra workers use idle CPU).
+    let ceiling = cores.saturating_mul(2);
+    match requested {
+        0 => (cores / 2).max(1),            // 0 = half the cores (wise default)
+        _ => requested.min(ceiling).max(1), // clamp to [1, 2×cores]
+    }
+}
 use std::collections::HashMap;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace, warn}; // TD-SEARCH-2: concurrent inter-file scan
 
 use crate::core::search::bounded_queue::BoundedPriorityQueue;
 use crate::core::search::results::OptimizedSearchRecord;
@@ -1068,170 +1101,294 @@ impl SstEngine {
         // asked for an exact search.
         let scan_start = std::time::Instant::now();
         let block_prune = prune_config;
-        for (file_idx, sstable_path) in sstable_files.iter().enumerate() {
-            trace!(
-                "SST: Searching file [{}/{}]: {} (force_exact={})",
-                file_idx + 1,
-                sstable_files.len(),
-                sstable_path,
-                block_prune.force_exact
+
+        // TD-SEARCH-2: inter-file parallel search. The degree is config/env-driven:
+        //   search_parallel_files = 0 → 50% of CPU cores (wise default)
+        //   search_parallel_files = 1 → sequential
+        //   search_parallel_files = N → exactly N workers
+        // Hot-path override: PROXIMADB_SEARCH_PARALLEL_FILES env takes precedence.
+        let file_count = u16::try_from(sstable_files.len()).unwrap_or(u16::MAX);
+        let parallel_degree = resolve_search_parallelism(self.config().search_parallel_files)
+            .min(file_count)
+            .max(1);
+
+        let enable_parallel = parallel_degree > 1;
+
+        if enable_parallel {
+            tracing::info!(
+                file_count = sstable_files.len(),
+                parallel_degree,
+                "TD-SEARCH-2: parallel inter-file scan"
             );
 
-            // PAX RaBitQ→SQ8 cascade (PAX Phase 2 read-side wiring): try it first
-            // for `.pax` segments under a validated metric (Euclidean or Cosine).
-            // The generic dispatch below handles every other case — `.arrow`, legacy
-            // `.sst`, AND `.pax` under Dot/other metrics or any cascade miss
-            // (not-PAX / no RaBitQ / error) — so this is additive and mixed-read-safe.
-            let pax_cascade: Option<Vec<OptimizedSearchRecord>> = if sstable_path.ends_with(".pax")
-                && matches!(
-                    distance_metric,
-                    DistanceMetric::Euclidean | DistanceMetric::Cosine | DistanceMetric::DotProduct
-                ) {
-                match self
-                    .try_pax_cascade(
-                        sstable_path,
-                        query_vector,
-                        filter_expression,
-                        k,
-                        distance_metric,
-                        collection_id,
-                        storage_url,
-                    )
-                    .await
-                {
-                    Ok(Some(records)) => {
+            // Build per-file futures (borrow &self — no 'static needed).
+            let file_futures = sstable_files.iter().map(|sstable_path| {
+                let sstable_path = sstable_path.as_str();
+                let block_prune = block_prune;
+                let filter_owned = filter_expression.cloned();
+                async move {
+                    let result: Result<Vec<OptimizedSearchRecord>, String> = async {
+                        // PAX cascade
+                        let pax_cascade: Option<Vec<OptimizedSearchRecord>> = if sstable_path
+                            .ends_with(".pax")
+                            && matches!(
+                                distance_metric,
+                                DistanceMetric::Euclidean
+                                    | DistanceMetric::Cosine
+                                    | DistanceMetric::DotProduct
+                            ) {
+                            match self
+                                .try_pax_cascade(
+                                    sstable_path,
+                                    query_vector,
+                                    filter_expression,
+                                    k,
+                                    distance_metric,
+                                    collection_id,
+                                    storage_url,
+                                )
+                                .await
+                            {
+                                Ok(Some(records)) => Some(records),
+                                Ok(None) => None,
+                                Err(e) => {
+                                    warn!(
+                                        file = sstable_path,
+                                        error = %e,
+                                        "PAX cascade unavailable; falling back to generic scan"
+                                    );
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                        let search_result = if let Some(records) = pax_cascade {
+                            Ok(records)
+                        } else if sstable_path.ends_with(".arrow") {
+                            self.search_arrow_file(
+                                sstable_path,
+                                query_vector,
+                                filter_owned.clone(),
+                                k,
+                                distance_metric,
+                            )
+                            .await
+                        } else if sstable_path.ends_with(".pax") {
+                            self.search_pax_file_exact(
+                                sstable_path,
+                                query_vector,
+                                filter_owned.clone(),
+                                k,
+                                distance_metric,
+                            )
+                            .await
+                        } else {
+                            self.sstable_reader()
+                                .search_with_filter_and_pruning(
+                                    sstable_path,
+                                    query_vector,
+                                    filter_owned.clone(),
+                                    k,
+                                    distance_metric,
+                                    Some(&*ctx.collection),
+                                    block_prune,
+                                )
+                                .await
+                        };
+
+                        search_result.map_err(|e| format!("{sstable_path}: {e}"))
+                    }
+                    .await;
+                    (sstable_path, result)
+                }
+            });
+
+            let results = join_all(file_futures).await;
+            for (path, result) in results {
+                match result {
+                    Ok(file_results) => {
                         debug!(
-                            file = %sstable_path,
-                            n = records.len(),
-                            "SST per-file result source=pax_cascade"
+                            file = path,
+                            n = file_results.len(),
+                            "SST parallel per-file result"
                         );
-                        Some(records)
+                        all_candidates.extend(file_results);
                     }
-                    Ok(None) => None,
-                    Err(e) => {
-                        warn!(
-                            file = %sstable_path,
-                            error = %e,
-                            "PAX cascade unavailable; falling back to generic scan"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            // Dispatch based on file format (Arrow vs ProximaBlocks); the PAX
-            // cascade short-circuits above when it applies.
-            let search_result = if let Some(records) = pax_cascade {
-                Ok(records)
-            } else if sstable_path.ends_with(".arrow") {
-                // Use ArrowBlockReader for Arrow format files
-                self.search_arrow_file(
-                    sstable_path,
-                    query_vector,
-                    filter_expression.cloned(),
-                    k, // Use exact k
-                    distance_metric,
-                )
-                .await
-            } else if sstable_path.ends_with(".pax") {
-                // A `.pax` segment the RaBitQ cascade did not cover (non-L2/Cosine
-                // metric, non-RaBitQ quant, or a cascade miss/error). Exact
-                // materialize-and-rank via the mixed-format reader so `.pax` is
-                // searchable under every metric/quant — this is what makes the PAX
-                // write-default flip safe (otherwise the ProximaBlocks-only
-                // `sstable_reader` below would fail to decode a `.pax` file).
-                self.search_pax_file_exact(
-                    sstable_path,
-                    query_vector,
-                    filter_expression.cloned(),
-                    k,
-                    distance_metric,
-                )
-                .await
-            } else {
-                // Use SSTable reader for ProximaBlocks format
-                // Choose execution strategy based on flags (TD-041, TD-039, TD-031)
-                let use_parallel_morsels =
-                    ctx.search_params.enable_parallel_morsels.unwrap_or(false);
-                let use_vectorized = ctx
-                    .search_params
-                    .enable_vectorized_execution
-                    .unwrap_or(false);
-                let use_pipeline = ctx.search_params.enable_pipeline_execution.unwrap_or(false);
-
-                if use_pipeline {
-                    trace!("SST: Using pipeline-based execution path (TD-031)");
-                    self.sstable_reader()
-                        .search_with_pipeline_execution(
-                            sstable_path,
-                            query_vector,
-                            filter_expression.cloned(),
-                            k, // Use exact k
-                            distance_metric,
-                            Some(&*ctx.collection),
-                            block_prune,
-                        )
-                        .await
-                } else if use_parallel_morsels {
-                    trace!("SST: Using parallel morsel execution path (TD-039)");
-                    self.sstable_reader()
-                        .search_with_filter_parallel_morsels(
-                            sstable_path,
-                            query_vector,
-                            filter_expression.cloned(),
-                            k, // Use exact k
-                            distance_metric,
-                            Some(&*ctx.collection),
-                            block_prune,
-                            None, // Use default worker count (CPU cores)
-                        )
-                        .await
-                } else if use_vectorized {
-                    trace!("SST: Using vectorized execution path (TD-041)");
-                    self.sstable_reader()
-                        .search_with_filter_vectorized(
-                            sstable_path,
-                            query_vector,
-                            filter_expression.cloned(),
-                            k, // Use exact k
-                            distance_metric,
-                            Some(&*ctx.collection),
-                            block_prune,
-                        )
-                        .await
-                } else {
-                    trace!("SST: Using scalar execution path");
-                    self.sstable_reader()
-                        .search_with_filter_and_pruning(
-                            sstable_path,
-                            query_vector,
-                            filter_expression.cloned(),
-                            k, // Use exact k
-                            distance_metric,
-                            Some(&*ctx.collection), // Pass collection for type-safe metadata deserialization
-                            block_prune, // Pass block pruning config for Z-order/centroid pruning
-                        )
-                        .await
-                }
-            };
-
-            match search_result {
-                Ok(results) => {
-                    debug!(
-                        file = %sstable_path,
-                        n = results.len(),
-                        "SST per-file result (post-dispatch)"
-                    );
-                    all_candidates.extend(results);
-                }
-                Err(e) => {
-                    warn!("SST: Failed to search file {}: {}", sstable_path, e);
-                    // Continue with other files
+                    Err(e) => warn!("SST: Failed to search file {e}"),
                 }
             }
-        }
+        } else {
+            // Sequential fallback (single file or flag explicitly off)
+            for (file_idx, sstable_path) in sstable_files.iter().enumerate() {
+                trace!(
+                    "SST: Searching file [{}/{}]: {} (force_exact={})",
+                    file_idx + 1,
+                    sstable_files.len(),
+                    sstable_path,
+                    block_prune.force_exact
+                );
+
+                // PAX RaBitQ→SQ8 cascade (PAX Phase 2 read-side wiring): try it first
+                // for `.pax` segments under a validated metric (Euclidean or Cosine).
+                // The generic dispatch below handles every other case — `.arrow`, legacy
+                // `.sst`, AND `.pax` under Dot/other metrics or any cascade miss
+                // (not-PAX / no RaBitQ / error) — so this is additive and mixed-read-safe.
+                let pax_cascade: Option<Vec<OptimizedSearchRecord>> = if sstable_path
+                    .ends_with(".pax")
+                    && matches!(
+                        distance_metric,
+                        DistanceMetric::Euclidean
+                            | DistanceMetric::Cosine
+                            | DistanceMetric::DotProduct
+                    ) {
+                    match self
+                        .try_pax_cascade(
+                            sstable_path,
+                            query_vector,
+                            filter_expression,
+                            k,
+                            distance_metric,
+                            collection_id,
+                            storage_url,
+                        )
+                        .await
+                    {
+                        Ok(Some(records)) => {
+                            debug!(
+                                file = %sstable_path,
+                                n = records.len(),
+                                "SST per-file result source=pax_cascade"
+                            );
+                            Some(records)
+                        }
+                        Ok(None) => None,
+                        Err(e) => {
+                            warn!(
+                                file = %sstable_path,
+                                error = %e,
+                                "PAX cascade unavailable; falling back to generic scan"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                // Dispatch based on file format (Arrow vs ProximaBlocks); the PAX
+                // cascade short-circuits above when it applies.
+                let search_result = if let Some(records) = pax_cascade {
+                    Ok(records)
+                } else if sstable_path.ends_with(".arrow") {
+                    // Use ArrowBlockReader for Arrow format files
+                    self.search_arrow_file(
+                        sstable_path,
+                        query_vector,
+                        filter_expression.cloned(),
+                        k, // Use exact k
+                        distance_metric,
+                    )
+                    .await
+                } else if sstable_path.ends_with(".pax") {
+                    // A `.pax` segment the RaBitQ cascade did not cover (non-L2/Cosine
+                    // metric, non-RaBitQ quant, or a cascade miss/error). Exact
+                    // materialize-and-rank via the mixed-format reader so `.pax` is
+                    // searchable under every metric/quant — this is what makes the PAX
+                    // write-default flip safe (otherwise the ProximaBlocks-only
+                    // `sstable_reader` below would fail to decode a `.pax` file).
+                    self.search_pax_file_exact(
+                        sstable_path,
+                        query_vector,
+                        filter_expression.cloned(),
+                        k,
+                        distance_metric,
+                    )
+                    .await
+                } else {
+                    // Use SSTable reader for ProximaBlocks format
+                    // Choose execution strategy based on flags (TD-041, TD-039, TD-031)
+                    let use_parallel_morsels =
+                        ctx.search_params.enable_parallel_morsels.unwrap_or(false);
+                    let use_vectorized = ctx
+                        .search_params
+                        .enable_vectorized_execution
+                        .unwrap_or(false);
+                    let use_pipeline = ctx.search_params.enable_pipeline_execution.unwrap_or(false);
+
+                    if use_pipeline {
+                        trace!("SST: Using pipeline-based execution path (TD-031)");
+                        self.sstable_reader()
+                            .search_with_pipeline_execution(
+                                sstable_path,
+                                query_vector,
+                                filter_expression.cloned(),
+                                k, // Use exact k
+                                distance_metric,
+                                Some(&*ctx.collection),
+                                block_prune,
+                            )
+                            .await
+                    } else if use_parallel_morsels {
+                        trace!("SST: Using parallel morsel execution path (TD-039)");
+                        self.sstable_reader()
+                            .search_with_filter_parallel_morsels(
+                                sstable_path,
+                                query_vector,
+                                filter_expression.cloned(),
+                                k, // Use exact k
+                                distance_metric,
+                                Some(&*ctx.collection),
+                                block_prune,
+                                None, // Use default worker count (CPU cores)
+                            )
+                            .await
+                    } else if use_vectorized {
+                        trace!("SST: Using vectorized execution path (TD-041)");
+                        self.sstable_reader()
+                            .search_with_filter_vectorized(
+                                sstable_path,
+                                query_vector,
+                                filter_expression.cloned(),
+                                k, // Use exact k
+                                distance_metric,
+                                Some(&*ctx.collection),
+                                block_prune,
+                            )
+                            .await
+                    } else {
+                        trace!("SST: Using scalar execution path");
+                        self.sstable_reader()
+                            .search_with_filter_and_pruning(
+                                sstable_path,
+                                query_vector,
+                                filter_expression.cloned(),
+                                k, // Use exact k
+                                distance_metric,
+                                Some(&*ctx.collection), // Pass collection for type-safe metadata deserialization
+                                block_prune, // Pass block pruning config for Z-order/centroid pruning
+                            )
+                            .await
+                    }
+                };
+
+                match search_result {
+                    Ok(results) => {
+                        debug!(
+                            file = %sstable_path,
+                            n = results.len(),
+                            "SST per-file result (post-dispatch)"
+                        );
+                        all_candidates.extend(results);
+                    }
+                    Err(e) => {
+                        warn!("SST: Failed to search file {}: {}", sstable_path, e);
+                        // Continue with other files
+                    }
+                }
+            } // end sequential fallback
+        } // end if enable_parallel / else
 
         let scan_us = scan_start.elapsed().as_micros() as u64;
         let candidate_count_before_merge = all_candidates.len();

--- a/src/storage/engines/sst/tests/compaction_vector_tracking_tests.rs
+++ b/src/storage/engines/sst/tests/compaction_vector_tracking_tests.rs
@@ -37,6 +37,7 @@ mod tests {
             prefetch_enabled: false,
             prefetch_size_kb: 64,
             decompression_cache_config: None,
+            ..Default::default()
         }
     }
 

--- a/src/storage/tests/storage_engine_concurrency_tests.rs
+++ b/src/storage/tests/storage_engine_concurrency_tests.rs
@@ -64,6 +64,7 @@ mod tests {
             vector_encoding_strategy: "FullVector".to_string(),
             block_format: "ProximaBlocks".to_string(),
             tiering: None,
+            ..Default::default()
         });
 
         // Configure write buffer separately

--- a/tests/common/integration_test_helpers.rs
+++ b/tests/common/integration_test_helpers.rs
@@ -713,6 +713,8 @@ impl UnifiedTestEnvironment {
             // Tier-migration integration — disabled in tests so the
             // SST engine doesn't pull in the tiering policy engine.
             tiering: None,
+
+            ..Default::default()
         }
     }
 

--- a/tests/integration/optimization_e2e_test.rs
+++ b/tests/integration/optimization_e2e_test.rs
@@ -176,6 +176,7 @@ async fn test_optimization_end_to_end() -> anyhow::Result<()> {
         vector_encoding_strategy: "FullVector".to_string(),
         block_format: "ProximaBlocks".to_string(),
         tiering: None,
+        ..Default::default()
     });
 
     let viper_config = proximadb::core::config::ViperConfig {


### PR DESCRIPTION
## What
`fallback_to_direct_search` scanned segment files **sequentially** (99% = 1 core, 476ms cold for SIFT 1M / 7 files). Each files `try_pax_cascade` is independent (immutable segments, no shared mutable state) → embarrassingly parallel fork-join.

## Fix
When `enable_parallel_morsels` (default ON for >1 file): build per-file async futures that borrow `&self` (no `staticfutures::future::join_alljoin_allbuffer_unorderedJoinSetbuffer_unorderedtokio::spawnSendstatic`). The per-file futures borrow `&self` (a specific lifetime), triggering "implementation of Send is not general enough." `join_all` polls all futures cooperatively on the current task — no per-future `Send` requirement. On a multi-threaded tokio runtime, futures yield at `.await` points (object-store I/O), giving real I/O overlap (the dominant cost term per ADR-065).

## Expected speedup
I/O-bound cold search: files overlap → ~2-4× improvement (depending on object-store latency vs CPU). CPU-bound warm search: no change (CPU is sequential within each yield). Full multi-core CPU parallelism requires `Arc<SstEngine>` restructuring (TD-SEARCH-2 S2).

## Verification (pending)
- SIFT 1M (7 files) with parallel ON: latency should drop vs sequential.
- Recall unchanged (0.999).
- Existing `pax_cascade_prod_search_test` passes (sequential path unchanged).