### PR TITLE
fix(sst): skip AXIS + PCA retraining on recovery flushes (TD-IVF-1 — 100% CPU at startup)

### DIFF
--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -66,8 +66,9 @@ impl SstEngine {
         // on the flush path via FlushParameters.collection_config so co-design
         // collections don't pay the build for an index that's never queried (this was
         // the flush-latency bottleneck: ~101s/21k vecs of pure HNSW build). The
-        // PROXIMADB_SKIP_AXIS_INDEXING=1 env remains as a global override; when
-        // collection_config is absent we conservatively build (old behavior).
+        // PROXIMADB_SKIP_AXIS_INDEXING=1 env remains as a global override. When
+        // collection_config is absent (recovery flushes), skip — co-design is the default
+        // per ADR-070, so "unknown collection" means "no AXIS" (not "train AXIS").
         let axis_needed = match params
             .collection_config
             .as_ref()
@@ -80,7 +81,7 @@ impl SstEngine {
                     .any(|t| t.trim().eq_ignore_ascii_case("pax_vector_format:off"));
                 pax_off || !c.index_configs.is_empty()
             }
-            None => true,
+            None => false,
         };
         if !axis_needed || std::env::var("PROXIMADB_SKIP_AXIS_INDEXING").as_deref() == Ok("1") {
             return;
@@ -228,9 +229,12 @@ impl SstEngine {
             )
             .await?;
 
-        // Train/update PCA model for Z-Order spatial encoding
-        // This is done after flush to ensure collection-level PCA model is up-to-date
-        if params.vector_records.len() >= 100 {
+        // Train/update PCA model for Z-Order spatial encoding.
+        // TD-IVF-1: skip during recovery flushes (collection_config absent) — the segments
+        // already have the persisted PCA/IVF model in the A0 region, and re-training loads
+        // the entire dataset into RAM (5.7 GB for 1M vectors, 100% CPU for minutes).
+        // The cascade reader loads centroids lazily from A0 at search time.
+        if params.vector_records.len() >= 100 && params.collection_config.is_some() {
             // Only train with enough samples
             match self
                 .train_and_cache_pca_model(


### PR DESCRIPTION
## Root cause
Server burned 100% CPU for minutes at startup, logging `"🎯 Training clustering model for collection 1 with 1000000 vectors"`. Two bugs:

**Bug 1** (`flush/mod.rs:83`): the AXIS gate used `None => true` — when `collection_config` was absent during recovery flushes, it conservatively TRAINED AXIS (k-means on the full 1M-vector dataset). Changed to `None => false` — co-design is the default per ADR-070, so "unknown collection" = "no AXIS".

**Bug 2** (`flush/mod.rs:233`): `train_and_cache_pca_model` ran unconditionally for every flush with ≥100 vectors — including recovery flushes that re-process already-flushed data. Gated on `collection_config.is_some()` so recovery flushes skip it. The persisted A0 region in `.pax` segments already has the model; the cascade reader loads centroids lazily.

## Fix (2 lines)
- Line 83: `None => true` → `None => false` (AXIS gate — recovery = co-design default)
- Line 233: added `&& params.collection_config.is_some()` (PCA gate — skip during recovery)

## WAL truncation: confirmed CORRECT (no changes)
- `materialize_collection(free_wal=true)` → `mark_flushed_and_delete_files` → **actually deletes WAL files** on disk
- Recovery only replays `WalEntryStatus::Active` entries — flushed entries are skipped (files deleted)
- No watermark needed — status-based filtering is sufficient

## Expected impact
| Metric | Before | After |
|--------|--------|-------|
| Startup time | ~minutes (k-means on 1M vectors) | ~seconds |
| Idle CPU | 100% (one core) | <5% |
| RSS | 5.7 GB (dataset loaded for training) | baseline |
| Recall | 0.999 (unchanged — cascade reads A0 lazily) | 0.999 |

## Verification (pending CI + local)
1. Boot server with existing compacted segments → NO "Training clustering model" log → CPU <5%
2. Search → recall ≥ 0.90 (cascade reads A0 centroids from persisted segment)
3. New collection first flush → trains PCA normally (collection_config present)