### PR TITLE
docs(rfc): RFC-0001 — transactional ledger modality (atomic-CAS KV + TTL leases)

### DIFF
--- a/docs/rfcs/0000-template.adoc
+++ b/docs/rfcs/0000-template.adoc
@@ -1,0 +1,57 @@
+= RFC-XXXX: [Title]
+:author: [Your Name]
+:email: [your.email@example.com]
+:date: [YYYY-MM-DD]
+:status: Draft
+
+// Canonical RFC template. Copy to docs/rfcs/NNNN-short-title.adoc, allocate the next free
+// number (never reuse one on develop), and fill in. See the RFC process:
+// docs/_internal/roadmap/completed/103-rfc-process-documentation.adoc
+
+== Summary
+
+One paragraph explanation of the feature.
+
+== Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+=== Use Cases
+
+1. *Use Case 1*: Description
+2. *Use Case 2*: Description
+
+== Detailed Design
+
+The bulk of the RFC. Explain the design in enough detail for someone familiar with ProximaDB to
+understand, and for someone familiar with the implementation to implement.
+
+=== API Changes
+
+=== Storage Format Changes
+
+=== Migration Path
+
+== Drawbacks
+
+Why should we *not* do this?
+
+== Rationale and Alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered, and why were they not chosen?
+- What is the impact of not doing this?
+
+== Prior Art
+
+== Unresolved Questions
+
+== Future Possibilities
+
+== Implementation Plan
+
+=== Milestones
+
+=== Team
+
+=== Timeline

--- a/docs/rfcs/0001-transactional-ledger-modality.adoc
+++ b/docs/rfcs/0001-transactional-ledger-modality.adoc
@@ -1,0 +1,324 @@
+= RFC-0001: Transactional Ledger Modality — atomic-CAS keyed records with TTL leases
+:author: Vijaykumar Singh
+:email: vjdsingh@icloud.com
+:date: 2026-07-23
+:status: Draft
+:toc: left
+:toclevels: 3
+
+== Summary
+
+Add a new first-class **`Ledger` modality**: small keyed records with an **atomic conditional
+write** (reserve-a-ceiling / decrement-with-floor / compare-and-swap), **timed TTL leases**, and
+**idempotent settle-by-id**. This is the OLTP counterpart to ProximaDB's existing read/analytics
+modalities (vector, graph, document, observability). It fills the one gap a code audit surfaced:
+ProximaDB has **no store-backed, wire-reachable atomic conditional write today** — `StorageKV` has no
+atomicity, `put_if_absent` is create-only, and `MultiModelTransactionManager` is unwired with stub
+participants.
+
+The anchor consumer is an external one — the **Sandhi AI-usage gateway**, whose enforcement ledger
+reserves and settles token budgets on *every* model call and whose design docs (Sandhi ADR-0005,
+TD-0007) already define a precise **backend conformance contract (C1–C6)**. That contract becomes
+this modality's **acceptance bar**. But the modality is general: rate limiting, per-tenant quotas,
+feature flags with CAS, idempotency-key dedup, and session/lock leases are all small-record,
+atomic-CAS, TTL workloads.
+
+== Motivation
+
+ProximaDB is multi-model, but *every* current model is **read-optimized** — ANN search, graph
+traversal, document projection, analytical scan. There is no **OLTP transactional-KV surface**, and
+the pieces that look like one do not compose into an atomic decrement:
+
+* `crates/storage/proximadb-storage-kv/src/lib.rs:18` — `StorageKV::{put,get,delete}` is a
+  one-file-per-key config store with **no CAS, no versioning, no atomicity** (`put` unconditionally
+  truncates).
+* `crates/storage/proximadb-object-store/src/lib.rs:247` — `put_if_absent` is **create-only**
+  (`PutMode::Create`); it cannot conditionally *update* or decrement a counter. There is no generic
+  per-key compare-and-swap.
+* `crates/storage/proximadb-storage-transaction/` — `MultiModelTransactionManager` (Serializable
+  OCC) exists but is **not wired into anything** (no crate constructs it) and its
+  `prepare_participant`/`commit_participant`/`rollback_participant` are stubs
+  (`src/manager.rs:533,561,623`). So there is no reachable store-backed atomic read-check-write.
+
+The "one system for AI-native data" story therefore has a hole **exactly where control-plane state
+lives** — budgets, quotas, rate limits, flags, leases. Today an AI platform built on ProximaDB must
+bolt on Redis or etcd for that state, operating two systems.
+
+=== Use Cases
+
+1. *AI-gateway enforcement ledger (anchor)*: Sandhi reserves a conservative token **ceiling** before
+   a model call and **settles** the measured usage after, per scope (user/team). It must be
+   **linearizable per scope** for hard caps, **lease-based** (a crashed proxy must not leak
+   capacity), and **idempotent** under at-least-once retries. Sandhi TD-0007 codifies this as the
+   `EnforcementLedger` conformance suite (C1–C6). A ProximaDB ledger modality lets the gateway and
+   its budget state live on **one** store.
+2. *Rate limiting / token buckets*: atomic take-N-if-available with TTL refill windows.
+3. *Per-tenant quotas*: a durable, restart-surviving counter with a hard ceiling.
+4. *Feature flags & config*: read-mostly values mutated via `CompareAndSwap(key, expected_version,
+   new)` so concurrent writers don't clobber.
+5. *Idempotency-key dedup*: `put_if_absent`-style first-writer-wins with a TTL, but returning the
+   stored result.
+6. *Distributed leases / locks*: acquire a key with a TTL; auto-release on expiry (the primitive the
+   internal `partition_lease.rs` already needs and hand-rolls today).
+
+== Detailed Design
+
+=== The data model
+
+A `Ledger` collection holds two logical record kinds, both small and fixed-shape:
+
+* **Scope record** — the authoritative state for a budget/quota/counter key:
+  `{ scope, limit: Option<i64>, spent: i64, window, policy, version }`.
+* **Lease record** — one in-flight reservation:
+  `{ lease_id, scope, ceiling: i64, actual: i64, state: Reserved|Settled, valid_to_ns }`.
+
+These reuse the existing `ProximaRecord` temporal fields — `valid_to_ns`
+(`crates/foundation/proximadb-records/src/lib.rs:824`) carries the lease TTL — and are written under
+the existing WAL→memtable path (see *Consistency mechanism*).
+
+A new discriminator variant is added to the closed modality enum:
+
+[source,rust]
+----
+// crates/foundation/proximadb-data-model/src/lib.rs:72
+pub enum DataModel {
+    Vector, Document, Graph, Observability, Relational, TimeSeries, Event,
+    Ledger, // NEW
+}
+----
+
+=== The operation surface
+
+The modality exposes a *small, fixed* set of atomic operations (gRPC first; see API Changes):
+
+[cols="1,3", options="header"]
+|===
+| Operation | Semantics
+| `Reserve(scope, ceiling, ttl)` | Atomically admit iff `spent + reserved + ceiling ≤ limit`; return `Admitted(lease_id)` or `Denied`. A `Warn`-policy scope always admits (soft cap). **(C1)**
+| `Settle(lease_id, actual)` | `Reserved → Settled` state transition; records `actual` spend, releases the held ceiling. Guarded by state, so a replay is a **no-op**. **(C3)**
+| `CompareAndSwap(key, expected_version, new_value)` | Generic per-key conditional write for flags/config/quotas. **(C1)**
+| `SetLimit(scope, limit, window, policy)` | Configure a scope's cap + window + policy.
+| `Get(scope | key)` | Read the current authoritative state.
+|===
+
+Leases carry a TTL and are reclaimed on expiry **(C2)**.
+
+=== Consistency mechanism (the crux)
+
+The hard requirement (Sandhi C1/C4) is: the admit check and the lease write are **one linearizable
+operation per scope** — never a client-side read-then-write. The design reuses machinery ProximaDB
+already has rather than adding per-operation consensus:
+
+**Single-writer-per-scope via partition ownership.** Every operation for a given scope routes to the
+partition's **primary pod** (the primary-pod gate already gates writes —
+`src/network/grpc/v2/record_service.rs` `check_primary_pod_gate`), and ownership is fenced by the
+existing **partition lease** (`src/cluster/partition_lease.rs`, CAS-fenced via `put_if_absent`). At
+the owner, the atomic **check-and-append** is a *local* operation under the **partition memtable
+write lock**, WAL-ordered for durability through the existing path:
+
+----
+Reserve/Settle/CAS
+  → WriteIntent(WalRequired)                              // record_service.rs:1188
+  → WriteLaneRouter.route(&intent)                        // record_service.rs:1206
+  → RecordStore::write_mutations                          // src/services/record_store.rs:1848
+      → TableWalAppender::append_operations               // src/services/canonical_wal.rs:132
+      → partition.upsert_record / atomic ledger apply     // under the memtable write lock
+----
+
+This yields **linearizable-per-scope at sub-ms** without a consensus round-trip per operation; HA and
+failover come from the *existing* fenced partition lease (a new owner replays the WAL to rebuild the
+authoritative counter). It is the correct granularity: a budget scope is a single hot key, not a
+distributed multi-key transaction.
+
+=== New primitives this modality requires (honest accounting)
+
+The audit proved three capabilities are **absent** and are therefore genuine new work — not a
+re-skin of existing code:
+
+1. **Atomic conditional write in the storage engine.** A new
+   `CanonicalOperation::{LedgerReserve, LedgerSettle, CompareAndSwap}` applied under the partition
+   write lock and appended to the WAL. This is *not* the create-only object-store `put_if_absent`
+   and *not* the non-atomic `StorageKV`; it is a new op on the record write path
+   (`RecordStore::write_mutations`). A new `MultiModelOperation::LedgerOperation` variant is added to
+   `crates/storage/proximadb-storage-transaction/src/operations.rs:243` for the multi-key/cross-modal
+   case (see Future Possibilities); the single-scope hot path does **not** need the (currently
+   unwired) transaction manager.
+2. **Timed TTL lease reclaim.** Today `valid_to_ns` is enforced by **read-time filtering only**
+   (`is_dead`/`is_visible_at`, `crates/foundation/proximadb-records/src/lib.rs:922,966`); there is
+   **no background sweeper that physically releases expired durable records** (compaction drops
+   tombstones but has no TTL logic). A crashed reserver's lease would hold the cap until someone read
+   the scope — the exact capacity-leak C2 forbids. This modality adds a **background lease sweeper**
+   (per owned partition) plus **opportunistic reclaim on the next `Reserve` for a scope** as a
+   latency optimization (the pattern Sandhi's SQLite backend already uses).
+3. **Idempotent settle.** The `Reserved → Settled` transition is guarded by the lease's `state`
+   field; a replayed `Settle` matches zero rows and is a no-op. Built on primitive (1).
+
+=== Relationship to existing primitives (avoiding silent duplication)
+
+Per the co-design review rule ("watch for silent duplication of an existing primitive",
+`CLAUDE.md`), the modality **composes** rather than duplicates:
+
+* `StorageKV` (no atomicity) — may back the **cold/config** records; the hot atomic path does not use
+  it.
+* `put_if_absent` (create-only) — still the right primitive for **lease acquisition / first-writer**
+  semantics and remains used by `partition_lease.rs`; the ledger's *decrement* path needs the new
+  conditional write because create-only cannot mutate a counter.
+* `MultiModelTransactionManager` (Serializable OCC, currently unwired) — the substrate for **future
+  multi-key / cross-modal ledger transactions**, complementary to and out of scope for the v1
+  single-scope hot path.
+
+=== Acceptance bar
+
+The modality MUST pass the **Sandhi TD-0007 `EnforcementLedger` conformance suite**, treated here as
+the external acceptance contract:
+
+[cols="1,4", options="header"]
+|===
+| Invariant | Test this modality must be green on
+| **C1** atomic admit | `ceiling_reservation_prevents_overshoot`; a *genuinely concurrent* `concurrent_reservations_cannot_oversubscribe` (N clients race `Reserve`; sum admitted never breaches the cap).
+| **C2** timed TTL | `expired_lease_is_reclaimed_no_capacity_leak` — freed **without** a read touching the scope (the test lazy-expiry fails).
+| **C3** idempotent settle | `settle_is_idempotent_under_repeat`.
+| **C4** linearizable per scope | `partition_or_failover_does_not_double_admit` — under a simulated primary handoff / partition, no two owners admit against the same headroom.
+| **C5** sub-ms p99 | a point-write latency benchmark (see below).
+| **C6** caller fail policy | verified on the Sandhi side (`Block` fails closed, `Warn` fails open) — this modality's job is to *have* a defined error surface.
+|===
+
+Per the **measure-don't-assert** rule (`CLAUDE.md`), any latency/throughput claim (C5) is gated on
+`BENCHMARK_EVIDENCE.toml` with a **measured per-operation WAL+memtable trace**, not a microbenchmark.
+The modality ships **Experimental**, feature-gated (e.g. `experimental-ledger`), and is governed by
+`docs/SUPPORTED_SURFACE.adoc` until the suite is green and evidence is filed.
+
+=== API Changes
+
+[source,protobuf]
+----
+// proto/proximadb/v2/ledger.proto  (NEW; codegen → crates/foundation/proximadb-proto)
+service ProximaLedgerService {
+  rpc Reserve(ReserveRequest)   returns (ReserveResponse);   // Admitted(lease_id) | Denied
+  rpc Settle(SettleRequest)     returns (SettleResponse);    // idempotent by lease_id
+  rpc CompareAndSwap(CasRequest) returns (CasResponse);      // generic conditional write
+  rpc SetLimit(SetLimitRequest) returns (SetLimitResponse);
+  rpc GetScope(GetScopeRequest) returns (ScopeState);
+}
+----
+
+Wiring (mirrors how `ProximaRecordService` is added):
+
+* `.proto` service under `proto/proximadb/v2/`; generated into
+  `crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs`.
+* Server impl `src/network/grpc/v2/ledger_service.rs` (`ProximaLedgerServiceImpl` + `into_server`).
+* Router registration in `src/network/multi_server.rs` — a `canonical_ledger_grpc_service(...)`
+  builder + `.add_service(...)` line (as at `multi_server.rs:619`).
+* REST mirror `src/network/rest/v2/ledger.rs`.
+* New engine crate `crates/modalities/proximadb-ledger`.
+* `DataModel::Ledger`; `MultiModelOperation::LedgerOperation`; `CanonicalOperation::{LedgerReserve,
+  LedgerSettle, CompareAndSwap}`.
+
+**pgwire**: out of scope for v1 (pgwire is autocommit-only today; a `SELECT … FOR UPDATE`-style
+surface would need transaction control). gRPC/REST only in v1.
+
+=== Storage Format Changes
+
+* Two small fixed-shape record kinds (scope, lease) in a `Ledger` collection, written under the
+  co-design tenant path `DrPathBuilder` → `data/{tenant_id}/{namespace_id}/ledger/…`, with
+  `ObjectAccessTier` **hot** for active-scope counters (`CLAUDE.md` co-design mandate).
+* WAL frames for `LedgerReserve`/`LedgerSettle`/`CompareAndSwap`; the authoritative per-scope counter
+  is a memtable value rebuilt from WAL replay on owner failover; snapshot/flush persists it.
+* Lease TTL reuses `valid_to_ns`; the new sweeper is the physical reclaimer.
+
+=== Migration Path
+
+Purely additive — a new modality and new collection type; **no change** to existing vector/graph/
+document/observability collections or their formats. Feature-gated Experimental; off by default. No
+data migration.
+
+Every ledger I/O carries `TenantContext` (fail-closed — budget scopes are inherently per-tenant),
+satisfying the co-design isolation/billing invariant.
+
+== Drawbacks
+
+* **OLTP on a search/analytics-tuned engine.** The WAL→memtable→object-store write path carries more
+  per-op overhead than Redis's in-memory `INCR`; hitting C5 (sub-ms p99) is a real engineering bar,
+  not a given.
+* **New correctness-critical code on the write path** — the atomic op, the sweeper, and single-writer
+  routing are all new and sit under a hard budget cap; bugs here silently over- or under-admit.
+* **Operational surface** — a background sweeper + partition-owner routing add moving parts.
+* **Duplication risk with etcd/Redis** — these do leases/CAS well and are battle-tested; the modality
+  only earns its keep by delivering the *one-system* value at an acceptable latency.
+
+== Rationale and Alternatives
+
+* *Alt A — tell users to run Redis/etcd alongside.* Lowest effort; loses the single-store value.
+  (Sandhi TD-0007 already treats this as the default and even prefers **etcd**, whose Lease API is a
+  literal match for the reservation model. The modality only wins if it clears the same bar.)
+* *Alt B — wire the existing `MultiModelTransactionManager` and expose SQL transactions.* Heavier
+  (OCC read/write-set validation + 2PC per op), higher latency, over-general for a single hot key.
+  Right for multi-key/cross-modal; wrong for the hot path. Kept as the Future-Possibilities substrate.
+* *Alt C — extend `StorageKV` with CAS + TTL only (no modality).* Smaller, but reinvents lease
+  semantics ad hoc, skips the per-tenant `DrPathBuilder`/`TenantContext` discipline, and gains no
+  query/observability integration.
+* **Chosen — a dedicated modality on partition-ownership single-writer + WAL** because it delivers
+  linearizable-per-scope at sub-ms *without* per-op consensus, lands in the existing write path, and
+  presents as a first-class model alongside the others. Impact of not doing this: control-plane state
+  stays off-platform (a second system), and ProximaDB's "AI-native data platform" claim keeps a hole
+  where budgets/quotas/flags live.
+
+== Prior Art
+
+* **etcd** — Lease API (grant TTL → attach keys → auto-expire, `KeepAlive` heartbeat) is the closest
+  analogue to the reserve-lease model; MVCC `Txn(compare→then→else)` is the atomic admit.
+* **Redis** — Lua token-bucket + native key TTL; the throughput reference.
+* **DynamoDB** conditional writes; **FoundationDB** ordered KV transactions; **Envoy RLS** (central
+  rate-limit decision with fail-open shadow).
+* **External driver** — the Sandhi AI-gateway design docs `ADR-0005` (reservation-ceiling / lease /
+  idempotent-settle correctness) and `TD-0007` (the backend conformance suite this RFC adopts as its
+  acceptance bar).
+
+== Unresolved Questions
+
+* **Window/calendar semantics** — does the store own daily/monthly reset boundaries, or does the
+  client pass a window tag (Sandhi's SQLite backend aligns calendar windows in-store)? Proposed:
+  store-owned, UTC calendar-aligned.
+* **Sweeper cadence vs. opportunistic reclaim** — is a periodic sweep sufficient, or must every
+  owned partition run one continuously to bound capacity-leak latency for untouched scopes?
+* **pgwire exposure** — gRPC/REST-only for v1; is a SQL surface (needs transaction control) ever in
+  scope, or does the ledger stay a programmatic API?
+* **Numeric type & overflow** — `i64` counters; saturating vs. error on overflow.
+* **Multi-key ledger transactions** — v1 (via the transaction manager) or deferred?
+
+== Future Possibilities
+
+* Distributed **multi-key / cross-modal** ledger transactions by finally wiring
+  `MultiModelTransactionManager` (Serializable OCC) end-to-end.
+* First-class **token-bucket rate-limit** op (take-N-with-refill).
+* **Feature-flag / config** store with CAS + watch/subscribe.
+* **Idempotency-key** dedup service (first-writer-wins + stored-result return).
+* Cross-modal: attach budget/quota metadata directly to vector/document collections.
+
+== Implementation Plan
+
+=== Milestones
+
+1. [ ] *Phase 1 — data model + single-node atomic op.* `DataModel::Ledger`, `crates/modalities/
+   proximadb-ledger`, `CanonicalOperation::{LedgerReserve,LedgerSettle,CompareAndSwap}` under the
+   partition write lock, `ProximaLedgerService` (Reserve/Settle/CAS/SetLimit/GetScope). Green on
+   TD-0007 C1/C3/C6 single-node **and** the concurrent oversubscription test. Feature-gated
+   `experimental-ledger`.
+2. [ ] *Phase 2 — TTL leases + sweeper (C2).* Background reclaim + opportunistic-on-`Reserve`;
+   store-owned calendar windows. Green on C2 + window tests.
+3. [ ] *Phase 3 — HA / partition-failover (C4).* Single-writer routing via the primary-pod gate +
+   fenced partition lease; WAL replay rebuilds the counter on handoff. Green on the
+   partition/failover no-double-admit test; file C5 (sub-ms p99) evidence into
+   `BENCHMARK_EVIDENCE.toml`; graduate from Experimental per `SUPPORTED_SURFACE.adoc`.
+4. [ ] *Phase 4 — external adoption.* Sandhi adds a thin `ProximaLedger` arm behind its
+   `EnforcementLedger` trait once the suite is green (Sandhi-repo work; listed for traceability).
+
+=== Team
+
+* *Lead*: TBD
+* *Reviewers*: TBD (storage-engine + cluster/partition-lease owners)
+
+=== Timeline
+
+Estimated: Phases 1–3 over several iterations; not committed until the RFC is Accepted. No dates
+asserted (measure-don't-assert).


### PR DESCRIPTION
**Draft RFC — opens the review period per the RFC process; not for merge.**

Proposes a new first-class **`Ledger` modality**: small keyed records with an **atomic conditional write** (reserve-ceiling / decrement-with-floor / CAS), **timed TTL leases**, and **idempotent settle-by-id** — the OLTP counterpart to the existing vector/graph/document/observability modalities.

## Why

A code audit found ProximaDB has **no store-backed, wire-reachable atomic conditional write today**:
- `StorageKV` (`crates/storage/proximadb-storage-kv/src/lib.rs:18`) — no atomicity/CAS/versioning.
- `put_if_absent` (`crates/storage/proximadb-object-store/src/lib.rs:247`) — create-only; can't decrement.
- `MultiModelTransactionManager` — exists but **unwired**, participant prepare/commit/rollback are stubs (`src/manager.rs:533,561,623`).

So control-plane state (budgets, quotas, rate limits, flags, leases) has to live off-platform (Redis/etcd) — a second system.

## Design (grounded in existing seams)

- **Linearizable-per-scope via partition-ownership single-writer** + the existing WAL→memtable write path (`RecordStore::write_mutations` → `TableWalAppender::append_operations`), fenced by the existing partition lease — sub-ms, no per-op consensus; HA via WAL replay on owner failover.
- **Honestly flags the 3 new primitives** the audit proved absent: (1) the atomic conditional write on the record path, (2) a **timed TTL lease sweeper** (today `valid_to_ns` is read-time-filtered only — no durable-record sweeper), (3) idempotent settle.
- **Composes, not duplicates** existing primitives (addresses the co-design "silent duplication" review rule): `put_if_absent` stays the lease-acquire primitive; the unwired transaction manager is the *future* multi-key substrate.

## Acceptance bar

Adopts the external **Sandhi TD-0007 `EnforcementLedger` conformance suite (C1–C6)** — atomic admit, timed TTL, idempotent settle, per-scope linearizable (incl. a partition/failover no-double-admit test), sub-ms p99, caller fail policy. Ships **Experimental**, feature-gated; latency claims gated on `BENCHMARK_EVIDENCE.toml` (measure-don't-assert). Anchor consumer is the Sandhi AI-gateway enforcement ledger; a Phase-4 Sandhi `ProximaLedger` arm lands only after the suite is green.

Also adds the referenced-but-missing `docs/rfcs/0000-template.adoc` (this is the first RFC).

Docs-only. Requesting review from the storage-engine + cluster/partition-lease owners.