### PR TITLE
feat(sst): TD-COMPACT-1 S1 PAX write phase timers (PROXIMADB_TRACE_PAX_WRITE)

### DIFF
--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -292,6 +292,7 @@ pub fn write_pax_segment_compacted(
     // path computes (no second quantizer); it falls back to the plain single-level
     // plan whenever the model can't be trained (fail-safe, never a worse segment).
     let coalesced = quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled();
+    let t_cluster_plan = std::time::Instant::now();
     let mut probe_model = None;
     let plan = if cluster {
         if coalesced && block_cluster::ivf_probe_enabled() {
@@ -308,6 +309,15 @@ pub fn write_pax_segment_compacted(
     } else {
         None
     };
+    // TD-COMPACT-1 S1: cluster-plan wall clock (encode/finalize are timed inside
+    // `write_pax_segment_ordered` under the same gate).
+    if pax_write_trace() {
+        eprintln!(
+            "[PAX write] n={n} kind=compaction | cluster_plan {ms:.0} ms",
+            n = records.len(),
+            ms = t_cluster_plan.elapsed().as_secs_f64() * 1e3,
+        );
+    }
     write_pax_segment_ordered(
         path,
         records,
@@ -367,6 +377,8 @@ fn write_pax_segment_ordered(
     if let Some(model) = two_level {
         writer = writer.with_two_level(model);
     }
+    let trace = pax_write_trace();
+    let t_encode = std::time::Instant::now();
     match &plan {
         Some(plan) => {
             let mut next_run = 1usize;
@@ -388,7 +400,26 @@ fn write_pax_segment_ordered(
             }
         }
     }
-    writer.finish()
+    let encode_ms = t_encode.elapsed().as_secs_f64() * 1e3;
+    let t_finalize = std::time::Instant::now();
+    let result = writer.finish();
+    let finalize_ms = t_finalize.elapsed().as_secs_f64() * 1e3;
+    // TD-COMPACT-1 S1: encode = per-record RaBitQ/SQ8 quantize; finalize =
+    // serialize regions + footer. Combined with `cluster_plan` (logged by the
+    // compaction entry under the same gate) and `PROXIMADB_TRACE_IVF_FLUSH`'s
+    // cluster internals, this accounts the full re-cluster wall clock.
+    if trace {
+        eprintln!(
+            "[PAX write] n={n} quant={q:?} coalesced={c} | encode {enc:.0} ms  finalize {fin:.0} ms  | total {tot:.0} ms",
+            n = records.len(),
+            q = quant,
+            c = quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled(),
+            enc = encode_ms,
+            fin = finalize_ms,
+            tot = encode_ms + finalize_ms,
+        );
+    }
+    result
 }
 
 fn lossless_clustered_enabled() -> bool {
@@ -413,6 +444,19 @@ fn lossless_scalar_enabled() -> bool {
             .as_deref(),
         Some("1") | Some("true") | Some("on") | Some("yes")
     )
+}
+
+/// TD-COMPACT-1 S1: env-gated (`PROXIMADB_TRACE_PAX_WRITE`) phase timer for the
+/// PAX segment WRITE path. Logs `cluster_plan` (the re-cluster ordering wall
+/// clock) + `encode` (per-record RaBitQ/SQ8 quantize) + `finalize` (serialize
+/// regions + footer to disk). Complements `PROXIMADB_TRACE_IVF_FLUSH`, which
+/// breaks the cluster plan into pca/project/kmeans/assign/order internals — the
+/// two together localize the L0→L1 re-cluster wall clock (observed 666s on SIFT
+/// 1M) to cluster-vs-encode-vs-finalize, which is the data needed to choose the
+/// fix (S3 preserve the IVF model vs S4 parallelize the re-encode). Off in prod
+/// (env unset): a single `var_os` check per write, zero formatting cost.
+fn pax_write_trace() -> bool {
+    std::env::var_os("PROXIMADB_TRACE_PAX_WRITE").is_some()
 }
 
 /// True only when every vector row in every input `.pax` segment has an exact
@@ -1688,6 +1732,19 @@ pub async fn rabitq_search_segment_coalesced(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pax_write_trace_defaults_off() {
+        // TD-COMPACT-1 S1: the write-path phase timer MUST be off in prod (env
+        // unset) so the eprintln + Instant bookkeeping never fires on the hot
+        // write path. Default-off is the safety property; the on-path is
+        // exercised end-to-end by setting PROXIMADB_TRACE_PAX_WRITE at the bench.
+        // No test in this binary sets the var, so the default read is deterministic.
+        assert!(
+            !pax_write_trace(),
+            "PROXIMADB_TRACE_PAX_WRITE must be unset by default"
+        );
+    }
 
     #[test]
     fn probe_range_coalescing_keeps_only_selected_cell_slices() {


### PR DESCRIPTION
## What

Env-gated phase timer (`PROXIMADB_TRACE_PAX_WRITE`) for the PAX segment **write** path, complementing `PROXIMADB_TRACE_IVF_FLUSH` (cluster-plan internals). TD-COMPACT-1 **S1** — localizes the L0→L1 re-cluster so the fix is chosen from data.

## Measured result (2026-07-23, SIFT 1M, local SSD, co-design RaBitQ, develop @ 02725d81a incl #1155/#1163)

`PROXIMADB_TRACE_PAX_WRITE=1 PROXIMADB_TRACE_IVF_FLUSH=1`. recall@10 = **0.9990** post-compaction. Phase split for a ~460k-vector compaction write:

| phase | ms | share | detail |
|---|---|---|---|
| **finalize** (segment write) | **5527** | **~68%** | serialize regions + footer → disk |
| cluster_plan | 1513 | ~19% | pca_fit 416 + **project 765** + kmeans 84 + assign 27 + order 190 |
| encode (RaBitQ) | 1074 | ~13% | per-record quantize |

Flush writes are consistent: finalize ~230 ms vs encode ~35 ms (**6.6×**).

### Conclusions
1. **finalize (write I/O) dominates** — ~68% of compaction wall clock. The TD-COMPACT-1 "0.0 MB/s ⇒ CPU-bound" guess was **wrong**; it's write-I/O-bound.
2. **k-means is negligible** (84 ms even at 548k vectors — the 50k-sample training works). ⇒ **S3 (preserve the IVF model) saves ~nothing.**
3. **encode is only ~13%.** ⇒ **S4 (parallelize re-encode) is minor.**
4. **The 666s is not reproducible** on current code — total is ~8 s per ~500k here. The 666s was measured *before* #1155/#1163 (AXIS-skip-at-flush + skip-recovery-retrain); it was inflated by AXIS/PCA work that's now gated off.

### Redirected fix direction
The proposed S3/S4 target the wrong phase. The real lever is **`PaxSegmentWriter::finish()`** (region/footer serialization + write) — and it will be *worse* on object storage (likely the actual source of any remaining large-N slowness on the VM). Follow-up TD should target finalize (batch/coalesce writes, async, compression placement) — to be filed once #1164 lands (it has the TD-COMPACT-1 doc open).

## Change

`src/storage/engines/sst/segment_format.rs` only (collision-free). Per compaction write, when `PROXIMADB_TRACE_PAX_WRITE` is set:

```
[PAX write] n=460000 quant=RaBitQ coalesced=true | encode 1074 ms  finalize 5527 ms  | total 6601 ms
[PAX write] n=548000 kind=compaction | cluster_plan 1513 ms
```

Default **OFF** (`var_os` check). Together with `PROXIMADB_TRACE_IVF_FLUSH` it accounts the full re-cluster wall clock.

## Verification
- `cargo check --lib` ✅ · `cargo clippy --lib` ✅ · `cargo fmt --check` ✅
- `cargo nextest run -pximadb --lib pax_write_trace` ✅
- Live measurement above (the data this PR exists to produce).

Observability-only: no write-path behavior change, no on-disk format change, no new deps.

## Follow-ups
- A standalone local run initially blocked because two ProximaDB servers can't coexist on one host — internal REST/gRPC ports are hardcoded to `127.0.0.1:15678`/`:15679` (`multi_server.rs:949`, `tcp_multiplexer.rs:91`). Worth a separate TD to make those configurable (unblocks local multi-instance generally).
- TD-COMPACT-1 doc S1 status flip + the redirected fix direction deferred until #1164 lands (it has the doc open).