### PR TITLE
docs(adr,td): ADR-071 + TD-LEDGER-1 — formalize the ledger modality; accept RFC-0001

### DIFF
--- a/docs/10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc
+++ b/docs/10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-LEDGER-1: Transactional Ledger modality — technical design, OLTP-durability derivation, and build order
+:toc: macro
+:icons: font
+
+toc::[]
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Draft / not started** (2026-07-23). Design gate only; no implementation yet. Ships **Experimental**, feature-gated (`experimental-ledger`), and graduates per `docs/SUPPORTED_SURFACE.adoc` once the conformance suite is green with filed benchmark evidence.
+| Implements | link:../../12-design/adr/ADR-071-transactional-ledger-modality.adoc[ADR-071] / link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001]
+| Acceptance bar | the Sandhi `TD-0007` `EnforcementLedger` conformance suite (C1–C6)
+|===
+
+== Context — the gap, in code
+
+The audit that motivated ADR-071 found no store-backed, wire-reachable atomic conditional write:
+
+* `crates/storage/proximadb-storage-kv/src/lib.rs:18` — `StorageKV::{put,get,delete}`, no atomicity.
+* `crates/storage/proximadb-object-store/src/lib.rs:247` — `put_if_absent`, **create-only**; cannot
+  decrement a counter.
+* `crates/storage/proximadb-storage-transaction/src/manager.rs:533,561,623` —
+  `MultiModelTransactionManager` participants are stubs; the crate is constructed by nobody.
+* `crates/foundation/proximadb-records/src/lib.rs:922,966` — TTL (`valid_to_ns`) is enforced by
+  **read-time filtering only**; there is no background sweeper that physically releases expired
+  durable records.
+
+The three absences become the three new primitives (§4).
+
+== First principles — where does OLTP durability live?
+
+The load-bearing question. A ledger op is a **tiny, hot, correctness-critical write**: one keyed
+counter, twice per consumer request, on the critical path, where a lost or double-counted write breaks
+a hard cap. The reference OLTP/KV systems each answer "durability vs. latency" differently; we derive
+ProximaDB's answer by mapping their lessons onto the substrate we already have (ADR-069).
+
+[cols="1,2,2", options="header"]
+|===
+| System | Durability model | Lesson we take
+| *SQLite* | Single-writer; rollback/WAL journal; `fsync` at commit. Strong durability, but a single-writer throughput ceiling. | **Single-writer-per-scope** is the right serialization granularity for a hot key; ProximaDB's per-collection single-writer WAL (ADR-069) is the same shape. We do not need MVCC/OCC on the hot path.
+| *Redis* | In-memory; append-only file with `appendfsync = always \| everysec \| no`; periodic RDB snapshot. The durability/throughput trade is an explicit knob. | **Make the sync policy a knob** — per-op fsync vs. group-commit — and bind it to the caller's risk tier (hard cap = strict, soft cap = interval).
+| *MemSQL / SingleStore* | In-memory lock-free skiplist rowstore; durability via a write-ahead log + periodic snapshots; recovery replays the log. | **The in-memory structure is authoritative; the log is for recovery.** The memtable holds the live counter; the WAL is replayed on failover, not read on the hot path.
+| *Memcached* | Pure in-memory; **no durability**; LRU + native TTL. | The non-durable ceiling (the fail-open / `Warn` tier) *and* the **TTL-lease** primitive — expiry as a first-class, timed mechanism.
+|===
+
+**Synthesis (the decision, ADR-071 §3).** The ledger is a **memtable-authoritative counter**
+(memcache/memsql read/write latency) made durable by an **append to the ADR-069 local-disk WAL**
+(sqlite-class durability, flat-cost, sub-ms fsync) with a **configurable sync policy** (the redis
+knob), reclaimed by a **timed TTL sweeper** (the memcache lease idea, made durable). Group-commit
+batches concurrent appends to amortize fsync. Crucially, **none of this is a new engine** — it is the
+existing `RecordStore::write_mutations` → `TableWalAppender::append_operations` → memtable path
+(`src/services/record_store.rs:1848`, `src/services/canonical_wal.rs:132`) with one new operation kind.
+
+== Cross-modal stacking — what the ledger harvests (the shared economy)
+
+ADR-071 §2. The modality composes existing machinery; each row is cost *not* re-paid:
+
+[cols="2,2,2", options="header"]
+|===
+| Shared component (file) | Reused by the ledger for | Economic / coherence benefit
+| ADR-069 local-disk WAL (`canonical_wal.rs`) | per-op durability | no new durability path; flat-cost, sub-ms fsync, single-writer already assumed
+| memtable / partition (`src/storage/memtable/`) | the authoritative counter + live leases | O(1) read/write; restart via WAL replay — no bespoke persistence
+| partition-lease single-writer, CAS-fenced (`src/cluster/partition_lease.rs`) | HA + linearizable-per-scope | no per-op consensus; owner failover for free
+| `TenantContext` + `DrPathBuilder` | per-scope isolation & billing | fail-closed multi-tenancy at no extra cost
+| `ObjectAccessTier` (ADR-036) | cold ledger snapshots at rest | tiered at-rest cost lever
+| catalog + observability spine | scope discovery + metrics | operational surface inherited
+| `MultiModelTransactionManager` (future) | cross-modal multi-key txns | budgets/quotas attach to vector/doc collections
+|===
+
+Reverse pollination: once (7) is wired, a *vector* or *document* collection can carry a first-class
+budget/quota as ledger-backed metadata — the multi-model whole exceeds the sum.
+
+== Selective launch — run only the modality you need
+
+ADR-071 §4. Two composable gates:
+
+1. *Compile-time:* a cargo feature `experimental-ledger` gating the `crates/modalities/proximadb-ledger`
+   engine crate, the proto service, and the server impl. A build without it has zero ledger code.
+2. *Runtime:* a modality-enablement set consulted at service registration in
+   `src/network/multi_server.rs` (where `.add_service(canonical_*_grpc_service(...))` lines live). A
+   **ledger-only profile** registers only the ledger service and starts only WAL + memtable +
+   object-store — **no** AXIS/PAX/DataFusion/vector/graph engines.
+
+Result: one codebase, two shapes — the full multi-model store, or a lean *proximaDB-ledger* (a
+Redis/etcd-class OLTP-KV). The stacking (previous section) is what makes the lean profile a clean
+carve-out: the ledger depends only on the common lower layers, not on any search/analytics engine.
+
+== The three new primitives (the real work)
+
+1. *Atomic conditional write.* A new `CanonicalOperation::{LedgerReserve, LedgerSettle, CompareAndSwap}`
+   applied **under the partition memtable write lock** and appended to the WAL — check
+   `spent + reserved + ceiling ≤ limit` and mutate in one lock-held step. Not `put_if_absent`
+   (create-only), not `StorageKV` (non-atomic). A `MultiModelOperation::LedgerOperation` variant is
+   added at `crates/storage/proximadb-storage-transaction/src/operations.rs:243` for the *future*
+   multi-key path only.
+2. *Timed TTL lease reclaim.* A background sweeper per owned partition that physically releases expired
+   unsettled reservations (today there is no durable-record sweeper — `is_dead` only filters at read),
+   plus **opportunistic reclaim on the next `Reserve` for a scope** as a latency optimization.
+   Satisfies C2 ("freed without a read touching the scope").
+3. *Idempotent settle.* `Reserved → Settled` guarded by the lease state; a replay matches zero rows.
+   Built on (1).
+
+== Consistency mechanism
+
+Single-writer-per-scope via partition ownership (RFC-0001 §Consistency): every op for a scope routes
+to the partition's primary pod (`check_primary_pod_gate`), fenced by the partition lease; the atomic
+check-and-append runs locally under the memtable write lock, WAL-ordered. Linearizable-per-scope at
+sub-ms with **no per-op consensus**; a new owner replays the WAL to rebuild the counter. This is the
+correct granularity — a budget scope is one hot key, not a distributed transaction.
+
+== API surface (v1: gRPC/REST)
+
+`proto/proximadb/v2/ledger.proto` → `service ProximaLedgerService { Reserve; Settle; CompareAndSwap;
+SetLimit; GetScope; }`. Server impl `src/network/grpc/v2/ledger_service.rs`; router registration in
+`src/network/multi_server.rs`; REST mirror `src/network/rest/v2/ledger.rs`. pgwire is out of scope for
+v1 (autocommit-only today). Full shapes in RFC-0001 §API Changes.
+
+== Conformance gates (the acceptance ratchet)
+
+The modality graduates only as it turns these green (mirroring the Sandhi ledger's own suite):
+
+[cols="1,4", options="header"]
+|===
+| Invariant | Gate
+| C1 atomic admit | `ceiling_reservation_prevents_overshoot` + a **genuinely concurrent** oversubscription test (N clients race `Reserve`; sum admitted ≤ cap).
+| C2 timed TTL | `expired_lease_is_reclaimed_no_capacity_leak` — freed **without** a read touching the scope.
+| C3 idempotent settle | `settle_is_idempotent_under_repeat`.
+| C4 linearizable | `partition_or_failover_does_not_double_admit` under simulated primary handoff.
+| C5 sub-ms p99 | point-write latency benchmark, evidence filed in `BENCHMARK_EVIDENCE.toml` (measure-don't-assert).
+| C6 caller fail policy | a defined error surface (the `Block`=fail-closed / `Warn`=fail-open decision lives in the consumer).
+|===
+
+== Co-design compliance (mandatory)
+
+* *Dominant cost term:* this modality trades scan/search throughput (irrelevant here) for **point-write
+  latency + fsync amplification**. Every design choice (group-commit, per-tier sync, memtable-resident
+  counter) targets that term. Justification is a **measured per-op WAL+memtable trace**, not a kernel
+  microbenchmark (ADR-052 / `CLAUDE.md` measure-don't-assert).
+* *Tenancy:* every ledger I/O carries `TenantContext` (fail-closed — budget scopes are per-tenant) and
+  writes under `DrPathBuilder` (`data/{tenant}/{ns}/ledger/…`); `ObjectAccessTier` hot for active
+  counters.
+* *No silent duplication:* §"Cross-modal stacking" documents reuse-vs-build for each primitive.
+
+== Build order — do NOT durabilize or wire first
+
+Mirrors the anchor consumer's own sequencing (Sandhi ADR-0005: correctness core → durable → wire → HA):
+
+[cols="1,4,2", options="header"]
+|===
+| Stage | Work | Gate
+| *S1 — correctness core* | `crates/modalities/proximadb-ledger`: the pure atomic reserve/settle/CAS state machine + TTL-lease logic, **in-memory, no wiring**, behind a small trait. | C1/C3 + concurrent oversubscription green as unit tests.
+| *S2 — durability* | WAL op on the ADR-069 substrate + memtable-resident counter + replay-on-open; configurable sync (per-op / group-commit); the C2 sweeper + opportunistic reclaim. | C2 + restart-survives-spend green.
+| *S3 — wire surface* | `DataModel::Ledger`, `ProximaLedgerService` proto + gRPC/REST server + router registration; the `experimental-ledger` feature gate + ledger-only launch profile. | end-to-end gRPC reserve/settle; ledger-only build boots.
+| *S4 — HA* | partition-owner routing + WAL-replay failover; C4 no-double-admit test; C5 benchmark evidence filed; graduate per `SUPPORTED_SURFACE.adoc`. | C4 + C5 green; leaves Experimental.
+| *S5 — external adoption* | Sandhi adds a thin `ProximaLedger` arm behind its `EnforcementLedger` trait (Sandhi-repo work; listed for traceability). | Sandhi TD-0007 suite green on the ProximaDB backend.
+|===
+
+S1 is deliberately first and wiring-free: it is the correctness invariant, unit-testable in isolation,
+and the one part that must be provably right before any durability or transport risk is taken on.
+
+== Risks & non-goals
+
+* *Risk:* sub-ms p99 (C5) on an LSM/search engine is a real bar; group-commit + memtable-resident
+  counter are the mitigations, proven by trace, not assertion.
+* *Risk:* the sweeper + single-writer routing are new hot-path code under a hard cap; covered by the
+  C2/C4 gates before graduation.
+* *Non-goals (v1):* distributed multi-key/cross-modal ledger transactions (needs the transaction
+  manager wired); a pgwire SQL surface; any change to existing modality formats.
+
+== Unresolved questions
+
+* Store-owned vs. client-supplied window/calendar-reset semantics (proposed: store-owned, UTC-aligned).
+* Sweeper cadence vs. opportunistic-only reclaim (bounds capacity-leak latency for untouched scopes).
+* Exact numeric type + overflow policy (`i64`, saturating vs. error).
+* Whether the ledger-only profile ships as a distinct binary/image or a runtime flag on the same
+  binary.

--- a/docs/12-design/adr/ADR-071-transactional-ledger-modality.adoc
+++ b/docs/12-design/adr/ADR-071-transactional-ledger-modality.adoc
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-071: Adopt a transactional Ledger modality — OLTP atomic-CAS KV on the shared engine substrate
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Accepted** (2026-07-23). Formalizes link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001] (merged #1165). Implementation tracked under link:../../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1]; ships **Experimental**, feature-gated, until the conformance suite is green with filed benchmark evidence.
+| Decider | Vijaykumar Singh (2026-07-23)
+| Date | 2026-07-23
+| Relates to | link:ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069] (the local-disk WAL durability substrate the ledger's per-op durability rides), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine — meter every dimension, design against the dominant cost term), link:ADR-027-unified-storage-and-metering-substrate.adoc[ADR-027] (the WAL→memtable→object-store spine), link:ADR-036-azure-objectstore-orientation.adoc[ADR-036] (object-store access tiers), link:ADR-067-consume-ai-usage-gateway-egress-metering.adoc[ADR-067] (the Sandhi neutral-usage contract — the anchor external consumer).
+| Refines | RFC-0001 — ratifies the modality and pins the two load-bearing decisions the RFC left as design: (a) durability rides ADR-069, not a new engine; (b) the modality is both *stacked* on the shared substrate and *independently launchable*.
+| Non-goals | A from-scratch storage engine (explicitly rejected — see Decision 2); distributed multi-key / cross-modal ledger transactions in v1 (deferred to wiring `MultiModelTransactionManager`); a pgwire SQL surface in v1 (gRPC/REST only); changing any existing modality's format or behavior.
+|===
+
+== Context — first principles
+
+ProximaDB is multi-model, but every existing model is **read/search-optimized** (ANN, graph traversal,
+document projection, analytical scan). A code audit (RFC-0001 §Motivation) confirmed there is **no
+store-backed, wire-reachable atomic conditional write** today: `StorageKV` has no atomicity,
+`put_if_absent` is create-only, and `MultiModelTransactionManager` is unwired with stub participants.
+So control-plane state — budgets, quotas, rate limits, feature flags, leases, idempotency keys — the
+canonical **OLTP small-record, atomic-CAS, TTL** workload, has to live off-platform (Redis/etcd). The
+"one system for AI-native data" claim has a hole exactly where control state lives.
+
+The anchor consumer is external and concrete: the **Sandhi AI-usage gateway** reserves and settles
+token budgets on every model call and has already frozen a backend **conformance contract** (Sandhi
+ADR-0005 / TD-0007, invariants C1–C6). That contract is a precise, executable acceptance bar for this
+modality — we adopt it rather than invent one.
+
+The design question this ADR settles is **not "should we store counters"** — it is **"where does OLTP
+durability live, and how does a new modality earn its keep economically."**
+
+== Decision
+
+**1. Adopt `DataModel::Ledger` as a first-class modality** — small keyed records with three atomic
+operations: `Reserve(scope, ceiling, ttl) → Admitted(lease)|Denied` (conditional admit),
+`Settle(lease_id, actual)` (idempotent), and `CompareAndSwap(key, expected_version, new)` (generic
+conditional write) — plus TTL leases and store-owned windows. Details in RFC-0001 / TD-LEDGER-1.
+
+**2. Stack on the shared substrate; do NOT build a parallel engine.** The ledger's durability rides
+the **ADR-069 local-disk WAL** (flat-cost, sub-ms fsync, single-writer-per-collection); its
+authoritative counter lives in the **existing memtable** (O(1), rebuilt by WAL replay on failover);
+HA/linearizability comes from the **existing fenced partition-lease single-writer**; isolation and
+billing from `TenantContext` + `DrPathBuilder`; at-rest tiering from `ObjectAccessTier`; discovery and
+metrics from the catalog/observability spine. This is the co-design economy (ADR-052): **one
+durability path, one HA path, one tenancy path, amortized across all modalities** — a new modality
+harvests the platform instead of re-paying for it. A from-scratch OLTP engine is rejected: it would
+duplicate the WAL/HA/tenancy investment and fracture the operational surface.
+
+**3. Durability model (OLTP) = memtable-authoritative counter + WAL log + configurable sync.** The
+counter is in-memory for memcache/memsql-class read/write latency; every `Reserve`/`Settle`/`CAS`
+appends to the ADR-069 WAL for durability; the sync policy is a **per-scope knob** — per-op fsync for
+hard (`Block`) scopes (strict, a cap that must never be overshot), group-commit/interval for soft
+(`Warn`) scopes (throughput). The knob maps directly onto the consumer's fail-open/closed tiers
+(Sandhi C6). Rationale and the sqlite/redis/memsql/memcache derivation are in TD-LEDGER-1.
+
+**4. Launch-selectable: the modality is independently deployable.** A cargo feature
+(`experimental-ledger`) plus a runtime modality-enablement gate at service registration lets a
+deployment launch **ledger-only** — WAL + memtable + ledger service + object-store, with **no**
+AXIS/PAX/DataFusion/vector/graph footprint — a lean OLTP-KV competing with Redis/etcd, *or* run the
+ledger as one facet of the full multi-model store. **Same engine, dialed by deployment.** Decisions 2
+and 4 are complementary, not contradictory: reusing the common lower layers is exactly what makes the
+lean carve-out cheap.
+
+**5. Acceptance bar = Sandhi TD-0007 C1–C6.** Atomic admit (C1), timed-TTL lease reclaim (C2),
+idempotent settle (C3), per-scope linearizable incl. a partition/failover no-double-admit test (C4),
+sub-ms p99 point-write (C5), a defined error surface for the caller's fail policy (C6). Ships
+**Experimental**, feature-gated; per the measure-don't-assert mandate, C5 and all latency/throughput
+claims are gated on `BENCHMARK_EVIDENCE.toml` with a measured per-op WAL+memtable trace — not a
+microbenchmark — and graduation from Experimental is governed by `docs/SUPPORTED_SURFACE.adoc`.
+
+== Consequences
+
+* **Positive:** closes the control-plane hole — one system serves both AI-native data *and* its
+  budgets/quotas/flags/leases; a lean ledger-only build competes with Redis/etcd off the same
+  codebase; the shared-substrate stacking means the modality inherits durability, HA, tenancy, and
+  observability for near-free (the co-design economy).
+* **Cost:** OLTP on an LSM/search-tuned engine — hitting C5 (sub-ms p99) is a real engineering bar,
+  not a given; the atomic write op, the TTL sweeper (new — today TTL is read-time-only), and
+  single-writer routing are new correctness-critical code on the hot path under a hard cap.
+* **Boundary preserved:** neutral units only (the ledger stores counts, never prices — consistent
+  with ADR-067); every ledger I/O carries `TenantContext` (fail-closed) and writes under
+  `DrPathBuilder`; the dominant cost term is stated (point-write latency, not scan throughput) per
+  ADR-052.
+* **Reversibility:** feature-gated and Experimental; a modality that fails the conformance suite or
+  the C5 bar is disabled without touching any other modality.
+
+== Alternatives considered
+
+* *Tell users to run Redis/etcd alongside* — lowest effort, loses the one-system value. (Sandhi
+  TD-0007 already treats this as the default and even prefers etcd, whose Lease API matches the
+  reservation model. This modality only earns its keep by clearing the same bar with shared-substrate
+  economy + a lean standalone option.)
+* *A from-scratch OLTP storage engine inside ProximaDB* — rejected (Decision 2): duplicates the
+  WAL/HA/tenancy substrate and fractures operations.
+* *Extend `StorageKV` with CAS+TTL only (no modality)* — reinvents lease semantics ad hoc, skips the
+  per-tenant `DrPathBuilder`/`TenantContext` discipline, and gains no catalog/observability
+  integration or selective-launch story.
+* *Wire `MultiModelTransactionManager` and expose SQL transactions for the hot path* — heavier
+  (OCC/2PC per op), higher latency, over-general for a single hot key; kept as the future multi-key
+  substrate, not the v1 hot path.
+
+== References
+
+* link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001] — the full proposal.
+* link:../../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1] — technical
+  design, the OLTP-durability derivation (sqlite/redis/memsql/memcache), and the phased build order.
+* Sandhi `ADR-0005` (reservation-ledger correctness) and `TD-0007` (the C1–C6 backend conformance
+  suite adopted here as the acceptance bar).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -356,6 +356,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | AXIS is not the default for co-design collections — the PAX scan + memtable cover everything
 | Accepted (2026-07-23)
 | With the flush path fixed (#1150/#1155/#1158), the AXIS Stage-2 index duplicates in RAM the same flushed data the Stage-3 PAX segment scan already serves; co-design collections default to memtable + PAX scan (with the survivor cache), and AXIS becomes a per-collection opt-in. Proven on SIFT 1M via REST: recall@10=0.999 cold, 0.5ms hot.
+
+| link:ADR-071-transactional-ledger-modality.adoc[ADR-071]
+| Adopt a transactional Ledger modality — OLTP atomic-CAS KV on the shared engine substrate
+| Accepted (2026-07-23)
+| Formalizes RFC-0001 (#1165): a first-class `Ledger` modality (small keyed records with atomic conditional write / TTL leases / idempotent settle) for control-plane state — budgets, quotas, rate limits, flags, leases — the OLTP gap the audit found (StorageKV non-atomic, `put_if_absent` create-only, transaction manager unwired). Two load-bearing decisions: (a) durability **rides the ADR-069 local-disk WAL** with a memtable-authoritative counter + configurable sync (the sqlite/redis/memsql/memcache synthesis) — no new engine; (b) the modality both **stacks** on the shared substrate (WAL, memtable, partition-lease HA, TenantContext, object-store tiering — the co-design economy) **and is independently launchable** (a lean ledger-only OLTP-KV competing with Redis/etcd, or one facet of the full multi-model store). Acceptance = the Sandhi TD-0007 conformance suite (C1–C6); ships Experimental, feature-gated, C5 gated on BENCHMARK_EVIDENCE.toml. Tracked: TD-LEDGER-1.
 |===
 
 The index is complete and is enforced by `scripts/check_design_status_index.py`.

--- a/docs/rfcs/0001-transactional-ledger-modality.adoc
+++ b/docs/rfcs/0001-transactional-ledger-modality.adoc
@@ -2,7 +2,7 @@
 :author: Vijaykumar Singh
 :email: vjdsingh@icloud.com
 :date: 2026-07-23
-:status: Draft
+:status: Accepted
 :toc: left
 :toclevels: 3
 
@@ -166,6 +166,27 @@ Per the co-design review rule ("watch for silent duplication of an existing prim
 * `MultiModelTransactionManager` (Serializable OCC, currently unwired) — the substrate for **future
   multi-key / cross-modal ledger transactions**, complementary to and out of scope for the v1
   single-scope hot path.
+
+=== Modularity: shared-substrate stacking *and* selective launch
+
+Two design forces, deliberately held together:
+
+* **Stack, don't silo (shared economy).** The ledger modality **composes the existing engine
+  substrate** rather than building a parallel one — durability on the ADR-069 local-disk WAL, the
+  authoritative counter in the existing memtable, HA via the fenced partition-lease single-writer,
+  isolation/billing via `TenantContext`, at-rest tiering via `ObjectAccessTier`, and scope discovery
+  + metrics via the catalog/observability spine. One durability path, one HA path, one tenancy path,
+  **amortized across every modality**. This is the co-design economy (ADR-052): a new modality should
+  *harvest* the platform, not re-pay for it. Cross-pollination also runs the other way — once the
+  transaction manager is wired (Future Possibilities), budgets/quotas can attach to vector/document
+  collections as first-class cross-modal metadata.
+* **Launch only the modality you need (lean single-purpose).** The modality is independently
+  enablable — a cargo feature (`experimental-ledger`) plus a runtime modality-enablement gate at
+  service registration (`src/network/multi_server.rs`) — so a deployment can launch **ledger-only**
+  (WAL + memtable + ledger service + object-store; **no** AXIS/PAX/DataFusion/vector/graph footprint),
+  a lean OLTP-KV that competes directly with Redis/etcd, *or* run the ledger as one facet of the full
+  multi-model store. **Same engine, dialed by deployment.** The shared substrate makes the lean build
+  cheap to carve out precisely because the ledger reuses the common lower layers.
 
 === Acceptance bar
 


### PR DESCRIPTION
Accepts **RFC-0001** (#1165) and formalizes it as a proximaDB **ADR-071** + **TD-LEDGER-1**, incorporating the stacking / selective-launch design refinement.

## ADR-071 (Accepted) — the two load-bearing decisions

1. **Durability rides ADR-069, not a new engine.** The ledger is a **memtable-authoritative counter** (memcache/memsql read/write latency) made durable by an append to the **ADR-069 local-disk WAL** (sqlite-class durability, sub-ms fsync) with a **configurable sync policy** (the redis `appendfsync` knob), reclaimed by a **timed TTL sweeper** (the memcache lease idea, made durable). The sqlite/redis/memsql/memcache synthesis, derived in TD-LEDGER-1.
2. **Stack *and* selective-launch.** The modality **composes** the shared substrate (WAL, memtable, partition-lease HA, `TenantContext`, object-store tiering — the ADR-052 co-design economy: one durability/HA/tenancy path amortized across modalities) **and** is independently launchable — a cargo feature + runtime modality gate carve out a lean **ledger-only** OLTP-KV (no AXIS/PAX/DataFusion/vector/graph) that competes with Redis/etcd off the same codebase.

## TD-LEDGER-1 — the technical design

- The OLTP-durability derivation (sqlite single-writer+WAL / redis AOF knob / memsql in-mem-authoritative+log / memcache TTL) → the chosen model on the ADR-069 substrate.
- The **cross-modal stacking table** — what the ledger harvests (WAL, memtable, partition-lease, TenantContext, object-store tier, catalog/observability) and the economic benefit of each.
- The **selective-launch** gates (compile-time `experimental-ledger` + runtime modality-enablement in `multi_server.rs`).
- The **three new primitives** the audit proved absent (atomic conditional write, timed TTL sweeper, idempotent settle), each with its `file:line` seam.
- The **C1–C6 conformance gates** (adopted from Sandhi TD-0007) and a **build order that does the correctness core first** — do not durabilize or wire first.

Ships **Experimental**, feature-gated; C5 (sub-ms p99) gated on `BENCHMARK_EVIDENCE.toml` per measure-don't-assert. Doc guards (`td-adr-unique`, `design-status-index`, `status-as-of`) pass locally. Docs-only.

Next: S1 implementation — the pure `crates/modalities/proximadb-ledger` correctness core (atomic reserve/settle/CAS + TTL leases, in-memory, unit-tested against C1/C3 + concurrent oversubscription), wiring-free.