### PR TITLE
fix(sst): scale IVF train sample with k (TD-COMPACT-1 — avoid underrepresentation at higher LSM levels)

### DIFF
--- a/src/storage/engines/sst/block_cluster.rs
+++ b/src/storage/engines/sst/block_cluster.rs
@@ -262,6 +262,31 @@ fn ivf_fine_cell_count(n_usable: usize, dim: usize) -> usize {
         .unwrap_or_else(|| ((n_usable * dim) / iop_target.max(1)).clamp(2, 4096))
 }
 
+/// k-means convergence floor: enough samples per centroid to estimate a stable
+/// centroid in the (low) PCA-projected dimension. k-means is well-converged by
+/// ~tens of samples/centroid; 64 is a generous margin.
+const IVF_MIN_SAMPLES_PER_CENTROID: usize = 64;
+
+/// Upper bound on the default train sample to keep PCA-fit + k-means cost
+/// bounded at extreme scale (cluster time is ~19% of compaction; finalize
+/// dominates, but we still don't want the sample to grow without limit).
+const IVF_TRAIN_SAMPLE_CAP: usize = 200_000;
+
+/// TD-COMPACT-1: default IVF train-sample floor, SCALED with the cell count `k`.
+/// Because `k ∝ N` ([`ivf_fine_cell_count`], one cell ≈ one IOP-sized block), a
+/// fixed sample means samples-per-centroid DECAYS as the LSM tree grows
+/// (L0→L1→L2…): at ~26M usable rows a fixed 50k sample drops below the k-means
+/// convergence floor and centroids become underrepresented → worse ordering →
+/// worse block-centroid prune → more GETs. Scaling the floor with `k` holds
+/// samples/centroid stable across levels. At small `k` this is just the 50k
+/// baseline (behavior unchanged for ≤~26M); at large `k` (higher levels / larger
+/// collections) it grows, capped to bound PCA/k-means cost.
+fn default_train_sample(k: usize) -> usize {
+    (50_000)
+        .max(k.saturating_mul(IVF_MIN_SAMPLES_PER_CENTROID))
+        .min(IVF_TRAIN_SAMPLE_CAP)
+}
+
 /// TD-WLP-4b: PCA projection dimensionality = max of two logarithmic terms
 /// (`a·log2 dim` intrinsic-dim, `b·log2 k` partition-granularity insurance),
 /// env-tunable (`PROXIMADB_IVF_NCOMP[_A|_B]`). See the sweep notes at the
@@ -370,11 +395,17 @@ pub fn cluster_plan_pca_ivf(records: &[ProximaRecord], idx: usize) -> Option<Clu
     // then project + assign ALL rows. Cuts pca_fit + kmeans ~N/sample (~20x at
     // SIFT1M) with negligible recall impact; project/assign still cover all N.
     // Deterministic stride (a physical layout must not depend on RNG).
+    //
+    // TD-COMPACT-1: the default floor scales with `k` (via
+    // [`default_train_sample`]) so samples-per-centroid stays above the k-means
+    // convergence floor as the LSM tree grows — a fixed 50k would underrepresent
+    // centroids at higher levels (k ∝ N). `PROXIMADB_IVF_TRAIN_SAMPLE` still
+    // overrides absolutely.
     let train_sample = std::env::var("PROXIMADB_IVF_TRAIN_SAMPLE")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
-        .unwrap_or(50_000)
+        .unwrap_or_else(|| default_train_sample(k))
         .min(usable.len());
     let sample_step = if usable.len() > train_sample {
         (usable.len() / train_sample).max(1)
@@ -730,6 +761,28 @@ fn sign_gray_key(v: &[f32], mean: &[f64]) -> Vec<u8> {
 mod tests {
     use super::*;
     use proximadb_records::EmbeddingCell;
+
+    #[test]
+    fn default_train_sample_scales_with_k_and_caps() {
+        // Small k (low LSM levels, ≤~26M rows): unchanged 50k baseline — the
+        // existing SIFT1M behavior is preserved.
+        assert_eq!(default_train_sample(16), 50_000);
+        assert_eq!(default_train_sample(100), 50_000);
+        assert_eq!(default_train_sample(500), 50_000);
+        // Large k (higher levels / bigger collections): scales so that
+        // samples-per-centroid stays ≥ the convergence floor.
+        for k in [1_000usize, 2_000, 3_000] {
+            let s = default_train_sample(k);
+            assert!(
+                s / k >= IVF_MIN_SAMPLES_PER_CENTROID,
+                "k={k}: sample={s} → {}/centroid < floor",
+                s / k
+            );
+        }
+        // Extreme k: capped to bound PCA/k-means cost.
+        assert_eq!(default_train_sample(10_000), IVF_TRAIN_SAMPLE_CAP);
+        assert!(default_train_sample(100_000) <= IVF_TRAIN_SAMPLE_CAP);
+    }
 
     fn rec(oid: &str, vec: Vec<f32>) -> ProximaRecord {
         let dim = vec.len() as u32;


### PR DESCRIPTION
## What

Scale the compaction IVF **train-sample floor with `k`** so samples-per-centroid stays above the k-means convergence floor as the LSM tree grows (`L0→L1→L2…`). Small, behavior-preserving for current scale; closes a latent underrepresentation bug at higher levels.

## Why (verified in code)

- `ivf_fine_cell_count` (`block_cluster.rs:255`): `k = (N·dim)/4 MiB` clamped to [2, 4096] → **k ∝ N** (one cell ≈ one IOP-sized block; IOP target = 4 MiB, `iops_budget.rs:214`).
- The train sample was a **fixed 50 000** (`block_cluster.rs:373`), `.min(usable.len())` — **not** scaled with `k`/`N`.

So samples-per-centroid = `50 000 / k` **decays** as you climb the tree:

| approx N | k | samples/centroid |
|---|---|---|
| 0.5 M (L0→L1) | 16 | 3 125 ✓ |
| 10 M | 305 | 164 ✓ |
| **~26 M** | ~800 | **64 ← floor** |
| 50 M | 1 525 | 33 ⚠️ |
| 100 M | 3 050 | 16 ❌ |

Below ~26 M the fixed 50 k is fine (hence SIFT 1 M recall@10 = 0.999). Above it, centroids are underrepresented → worse physical ordering → worse block-centroid prune → more GETs.

## Change

`block_cluster.rs` only (collision-free — not touched by #1164 or other in-flight worktrees):

```rust
const IVF_MIN_SAMPLES_PER_CENTROID: usize = 64;
const IVF_TRAIN_SAMPLE_CAP: usize = 200_000;
fn default_train_sample(k: usize) -> usize {
    (50_000).max(k.saturating_mul(IVF_MIN_SAMPLES_PER_CENTROID)).min(IVF_TRAIN_SAMPLE_CAP)
}
// train_sample = PROXIMADB_IVF_TRAIN_SAMPLE or default_train_sample(k), .min(N)
```

- Small `k` (≤~26 M): unchanged 50 k baseline — **no behavior change** for current SIFT/10 M-gate scale.
- Large `k` (higher levels / bigger collections): grows to hold samples/centroid ≥ 64.
- Capped at 200 k to bound PCA-fit + k-means cost (cluster time is ~19 % of compaction; finalize dominates per the TD-COMPACT-1 S1 measurement in #1166).

`PROXIMADB_IVF_TRAIN_SAMPLE` still overrides absolutely.

**Mixed-read-safe:** ordering-quality only — no on-disk format change (old + new segments coexist; the reader is indifferent to how ordering was produced).

## Verification
- `cargo check --lib` ✅
- `cargo clippy --lib` ✅
- `cargo fmt --check` ✅
- `cargo nextest run -p proximadb --lib default_train_sample` ✅ (`default_train_sample_scales_with_k_and_caps` PASS — asserts 50 k baseline at small k, samples/centroid ≥ floor at large k, and the cap)

## Related
- #1166 (TD-COMPACT-1 S1 write timers — produced the measurement showing finalize, not cluster, dominates).
- The deeper lever remains **TD-WLP-7** (persist + reuse the PCA/IVF model across compaction instead of re-training) — separate follow-up.