### PR TITLE
feat(ledger): S1 correctness core — in-memory atomic reserve/settle/CAS + TTL leases (ADR-071)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7488,6 +7488,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "proximadb-ledger"
+version = "0.2.0"
+
+[[package]]
 name = "proximadb-mcp"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "crates/modalities/proximadb-observability-engine",
     "crates/modalities/proximadb-embedding",
     "crates/modalities/proximadb-queue",
+    "crates/modalities/proximadb-ledger",
     "crates/modalities/proximadb-rank-core",
     "crates/modalities/proximadb-rank-features",
     "crates/modalities/proximadb-rank-expr",

--- a/crates/modalities/proximadb-ledger/Cargo.toml
+++ b/crates/modalities/proximadb-ledger/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "proximadb-ledger"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage = "https://github.com/anvai-labs/proximaDB"
+description = "ProximaDB transactional Ledger modality — OLTP atomic-CAS keyed records with TTL leases (ADR-071 / TD-LEDGER-1). S1: the in-memory correctness core."
+
+[lib]
+name = "proximadb_ledger"
+path = "src/lib.rs"
+
+# S1 is deliberately ZERO-dependency: the correctness core is pure `std`, which keeps it
+# trivially testable, keeps the lean "ledger-only" deployment profile (ADR-071 §4) cheap to
+# carve out, and defers every substrate dependency (WAL, memtable, tenant) to S2/S3.
+[dependencies]
+
+[dev-dependencies]

--- a/crates/modalities/proximadb-ledger/src/lib.rs
+++ b/crates/modalities/proximadb-ledger/src/lib.rs
@@ -1,0 +1,103 @@
+//! # ProximaDB Ledger modality — S1 correctness core
+//!
+//! The **in-memory, wiring-free correctness core** of the transactional Ledger modality
+//! (link: `docs/12-design/adr/ADR-071` / `docs/10-quality/td/TD-LEDGER-1`). It is the pure atomic
+//! **reserve → settle** lease state machine plus a generic **compare-and-swap** keyspace — the
+//! OLTP primitives ProximaDB lacks today (`StorageKV` is non-atomic, `put_if_absent` is create-only,
+//! the transaction manager is unwired).
+//!
+//! This crate carries **no durability, no transport, and no windows** — those are S2 (the durable
+//! WAL, memtable counter, and TTL sweeper) and S3 (proto/gRPC/router). Per the TD build order, the
+//! correctness invariant is proven here *first*, in isolation, before any durability or wiring risk
+//! is taken on. Neutral units only — counts, never prices.
+//!
+//! ## The invariants (the acceptance bar — Sandhi TD-0007 C1–C3)
+//!
+//! - **C1 — atomic conditional admit.** [`Ledger::reserve`] holds a conservative `ceiling`; a
+//!   `Block` scope refuses a ceiling that would breach the cap, so `spent + reserved ≤ limit` holds
+//!   at every step. Under contention the operation is serialized (in production, by the partition
+//!   write lock; here, by the caller's `Mutex`), so concurrent reservers can never oversubscribe.
+//! - **C2 — TTL leases.** A reservation is a lease with an expiry; [`Ledger::reclaim_expired`] frees
+//!   a crashed reserver's held capacity on a **timed** basis — without a read having to touch the
+//!   scope. (The in-memory reclaim here becomes the durable sweeper in S2.)
+//! - **C3 — idempotent settle.** [`Ledger::settle`] is a `reserved → settled` transition keyed by
+//!   reservation id; a replay is a no-op, so at-least-once delivery never double-counts.
+//!
+//! [`compare_and_swap`](Ledger::compare_and_swap) extends the same atomic-admit discipline to a
+//! generic keyspace (feature flags, config, quotas): a write lands only if the caller's expected
+//! version matches the current one.
+
+mod memory;
+mod types;
+
+pub use memory::InMemoryLedger;
+pub use types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+
+/// The atomic ledger contract — the seam every backend implements.
+///
+/// `InMemoryLedger` is the reference implementation (this crate); the durable partition-WAL backend
+/// (S2/S3) will implement the same trait, so the conformance tests here become backend-agnostic. All
+/// mutating methods take `&mut self`: exclusive access *is* the serialization point (the caller holds
+/// the partition write lock — modeled in tests by a `Mutex`). Neutral units only — no pricing.
+pub trait Ledger {
+    /// Set (or clear, with `limit = None`) a scope's cap + policy.
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy);
+
+    /// Atomically admit a call by holding `ceiling` units as a lease expiring at `now_ns + ttl_ns`.
+    ///
+    /// The check is `spent + reserved + ceiling ≤ limit` for a `Block` scope; a `Warn` scope (soft
+    /// cap) and an unset scope always admit. Returns [`ReserveOutcome::Denied`] when a hard cap could
+    /// not fit — the call is never dispatched, so the cap cannot be overshot (C1).
+    fn reserve(
+        &mut self,
+        scope: &str,
+        ceiling: u64,
+        now_ns: Nanos,
+        ttl_ns: Nanos,
+    ) -> ReserveOutcome;
+
+    /// Idempotently settle a reservation to its actual usage, releasing the lease. A no-op if the id
+    /// is unknown (already settled, or reclaimed after expiry) — safe under at-least-once delivery
+    /// (C3). `actual = 0` releases the lease without recording spend (the failed/cancelled path).
+    fn settle(&mut self, reservation_id: u64, actual: u64);
+
+    /// Reclaim every lease expired at or before `now_ns`; returns how many were reclaimed. A
+    /// reclaimed lease releases its held ceiling **without** recording spend, on a timed basis (C2).
+    fn reclaim_expired(&mut self, now_ns: Nanos) -> usize;
+
+    /// Atomically write `new_value` at `key` iff the current version equals `expected`
+    /// (`expected = None` means "expect the key absent" — a create). Returns the new version on
+    /// success, or [`CasError::VersionMismatch`] carrying the observed version.
+    fn compare_and_swap(
+        &mut self,
+        key: &str,
+        expected: Option<Version>,
+        new_value: i64,
+    ) -> Result<Version, CasError>;
+
+    /// The configured cap for a scope (`None` = unset/unlimited).
+    fn limit(&self, scope: &str) -> Option<u64>;
+
+    /// The configured policy for a scope (`Block` when unset).
+    fn policy(&self, scope: &str) -> Policy;
+
+    /// Settled units recorded against a scope.
+    fn spent(&self, scope: &str) -> u64;
+
+    /// Units held by in-flight (unsettled, unexpired) leases.
+    fn reserved(&self, scope: &str) -> u64;
+
+    /// The current `(version, value)` at a compare-and-swap key, or `None` if absent.
+    fn get(&self, key: &str) -> Option<(Version, i64)>;
+
+    /// Remaining headroom = `limit - spent - reserved` (saturating). Unlimited scopes report
+    /// [`u64::MAX`].
+    fn available(&self, scope: &str) -> u64 {
+        match self.limit(scope) {
+            None => u64::MAX,
+            Some(limit) => {
+                limit.saturating_sub(self.spent(scope).saturating_add(self.reserved(scope)))
+            }
+        }
+    }
+}

--- a/crates/modalities/proximadb-ledger/src/memory.rs
+++ b/crates/modalities/proximadb-ledger/src/memory.rs
@@ -1,0 +1,359 @@
+//! In-memory reference implementation of the [`Ledger`](crate::Ledger) contract.
+//!
+//! Correct under single-owner (`&mut self`) access; concurrency is provided by the caller holding a
+//! lock (a `Mutex` in tests; the partition write lock in production). This is the reference the
+//! durable partition-WAL backend (S2/S3) is checked against.
+
+use std::collections::HashMap;
+
+use crate::Ledger;
+use crate::types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+
+#[derive(Debug, Clone, Copy)]
+struct LimitSpec {
+    limit: Option<u64>,
+    policy: Policy,
+}
+
+/// In-memory reference ledger. Zero dependencies; deterministic (the clock is always passed in).
+#[derive(Debug, Default)]
+pub struct InMemoryLedger {
+    limits: HashMap<String, LimitSpec>,
+    spent: HashMap<String, u64>,
+    reserved: HashMap<String, u64>,
+    leases: HashMap<u64, Reservation>,
+    next_id: u64,
+    /// Generic compare-and-swap keyspace: key -> (version, value). Disjoint from the scope counters.
+    kv: HashMap<String, (Version, i64)>,
+}
+
+impl InMemoryLedger {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of currently-held (unsettled, unreclaimed) leases — for tests/introspection.
+    #[must_use]
+    pub fn active_leases(&self) -> usize {
+        self.leases.len()
+    }
+
+    fn add_reserved(&mut self, scope: &str, delta: u64) {
+        *self.reserved.entry(scope.to_string()).or_insert(0) += delta;
+    }
+
+    fn sub_reserved(&mut self, scope: &str, delta: u64) {
+        let held = self.reserved.entry(scope.to_string()).or_insert(0);
+        *held = held.saturating_sub(delta);
+    }
+}
+
+impl Ledger for InMemoryLedger {
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy) {
+        self.limits
+            .insert(scope.to_string(), LimitSpec { limit, policy });
+    }
+
+    fn reserve(
+        &mut self,
+        scope: &str,
+        ceiling: u64,
+        now_ns: Nanos,
+        ttl_ns: Nanos,
+    ) -> ReserveOutcome {
+        // A hard `Block` cap is the only thing that can refuse admission. `Warn` (soft cap) and an
+        // unset/unlimited scope always admit; spend still accrues via the lease so alerts can fire.
+        if let Some(spec) = self.limits.get(scope).copied()
+            && spec.policy == Policy::Block
+            && let Some(limit) = spec.limit
+        {
+            let spent = self.spent(scope);
+            let reserved = self.reserved(scope);
+            if spent.saturating_add(reserved).saturating_add(ceiling) > limit {
+                return ReserveOutcome::Denied(Denied {
+                    scope: scope.to_string(),
+                    limit,
+                    spent,
+                    reserved,
+                    requested_ceiling: ceiling,
+                });
+            }
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        let reservation = Reservation {
+            id,
+            scope: scope.to_string(),
+            ceiling,
+            expires_at_ns: now_ns.saturating_add(ttl_ns),
+        };
+        self.leases.insert(id, reservation.clone());
+        self.add_reserved(scope, ceiling);
+        ReserveOutcome::Admitted(reservation)
+    }
+
+    fn settle(&mut self, reservation_id: u64, actual: u64) {
+        let Some(lease) = self.leases.remove(&reservation_id) else {
+            return; // unknown / already settled / reclaimed — idempotent no-op (C3).
+        };
+        self.sub_reserved(&lease.scope, lease.ceiling);
+        *self.spent.entry(lease.scope).or_insert(0) += actual;
+    }
+
+    fn reclaim_expired(&mut self, now_ns: Nanos) -> usize {
+        let expired: Vec<u64> = self
+            .leases
+            .iter()
+            .filter(|(_, l)| l.expires_at_ns <= now_ns)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &expired {
+            if let Some(lease) = self.leases.remove(id) {
+                self.sub_reserved(&lease.scope, lease.ceiling);
+            }
+        }
+        expired.len()
+    }
+
+    fn compare_and_swap(
+        &mut self,
+        key: &str,
+        expected: Option<Version>,
+        new_value: i64,
+    ) -> Result<Version, CasError> {
+        let actual = self.kv.get(key).map(|(v, _)| *v);
+        if actual != expected {
+            return Err(CasError::VersionMismatch {
+                key: key.to_string(),
+                expected,
+                actual,
+            });
+        }
+        let next = actual.unwrap_or(0).saturating_add(1);
+        self.kv.insert(key.to_string(), (next, new_value));
+        Ok(next)
+    }
+
+    fn limit(&self, scope: &str) -> Option<u64> {
+        self.limits.get(scope).and_then(|s| s.limit)
+    }
+
+    fn policy(&self, scope: &str) -> Policy {
+        self.limits.get(scope).map(|s| s.policy).unwrap_or_default()
+    }
+
+    fn spent(&self, scope: &str) -> u64 {
+        self.spent.get(scope).copied().unwrap_or(0)
+    }
+
+    fn reserved(&self, scope: &str) -> u64 {
+        self.reserved.get(scope).copied().unwrap_or(0)
+    }
+
+    fn get(&self, key: &str) -> Option<(Version, i64)> {
+        self.kv.get(key).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    const TTL: Nanos = 60_000_000_000; // 60s in ns
+    const NOW: Nanos = 0;
+
+    fn admit(l: &mut InMemoryLedger, scope: &str, ceiling: u64) -> Reservation {
+        match l.reserve(scope, ceiling, NOW, TTL) {
+            ReserveOutcome::Admitted(r) => r,
+            ReserveOutcome::Denied(d) => panic!("expected admit, got denied: {d:?}"),
+        }
+    }
+    fn denied(l: &mut InMemoryLedger, scope: &str, ceiling: u64) -> bool {
+        matches!(
+            l.reserve(scope, ceiling, NOW, TTL),
+            ReserveOutcome::Denied(_)
+        )
+    }
+
+    // --- C1: atomic conditional admit ---------------------------------------
+
+    #[test]
+    fn block_cap_prevents_overshoot() {
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Block);
+        let r = admit(&mut l, "g", 100);
+        // A near-full cap admits nothing more — even 1 unit — before any usage is known.
+        assert!(denied(&mut l, "g", 1));
+        // Real usage came in under the ceiling; settle frees the difference.
+        l.settle(r.id, 40);
+        assert_eq!(l.spent("g"), 40);
+        assert_eq!(l.reserved("g"), 0);
+        assert_eq!(l.available("g"), 60);
+        assert!(
+            l.spent("g") + l.reserved("g") <= 100,
+            "invariant holds throughout"
+        );
+    }
+
+    #[test]
+    fn warn_scope_admits_over_cap_but_tracks_spend() {
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Warn);
+        let a = admit(&mut l, "g", 80);
+        l.settle(a.id, 80);
+        // 80 spent, cap 100 — an 80 ceiling would breach it, but a soft cap admits anyway.
+        let b = admit(&mut l, "g", 80);
+        l.settle(b.id, 80);
+        assert_eq!(l.spent("g"), 160, "spend accrues past a warn cap");
+    }
+
+    #[test]
+    fn unset_scope_is_unlimited_but_tracked() {
+        let mut l = InMemoryLedger::new();
+        assert_eq!(l.available("free"), u64::MAX);
+        let r = admit(&mut l, "free", 1_000_000);
+        assert_eq!(l.reserved("free"), 1_000_000);
+        l.settle(r.id, 999);
+        assert_eq!(l.spent("free"), 999);
+    }
+
+    #[test]
+    fn concurrent_reservations_cannot_oversubscribe() {
+        // The load-bearing C1 test: 100 threads race to reserve 100 units each against a 1000 cap.
+        // The `Mutex` models the partition write lock that serializes per-scope ops in production;
+        // exactly ten fit, and the held total never breaches the cap.
+        let ledger = Arc::new(Mutex::new(InMemoryLedger::new()));
+        ledger
+            .lock()
+            .unwrap()
+            .set_limit("g", Some(1000), Policy::Block);
+
+        let handles: Vec<_> = (0..100)
+            .map(|_| {
+                let l = Arc::clone(&ledger);
+                thread::spawn(move || {
+                    matches!(
+                        l.lock().unwrap().reserve("g", 100, NOW, TTL),
+                        ReserveOutcome::Admitted(_)
+                    )
+                })
+            })
+            .collect();
+
+        let admits: usize = handles
+            .into_iter()
+            .map(|h| h.join().unwrap() as usize)
+            .sum();
+        let guard = ledger.lock().unwrap();
+        assert_eq!(admits, 10, "exactly 1000/100 reservations fit");
+        assert_eq!(guard.reserved("g"), 1000);
+        assert!(guard.reserved("g") <= 1000, "never oversubscribed");
+    }
+
+    // --- C2: TTL leases -----------------------------------------------------
+
+    #[test]
+    fn expired_lease_is_reclaimed_without_reading_the_scope() {
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Block);
+        let _crashed = admit(&mut l, "g", 80); // reserver "crashes" — never settles
+        assert_eq!(l.available("g"), 20);
+        // Not yet expired.
+        assert_eq!(l.reclaim_expired(NOW), 0);
+        assert_eq!(l.available("g"), 20);
+        // Past the TTL → reclaimed on a timed basis, capacity restored — no read touched the scope.
+        assert_eq!(l.reclaim_expired(TTL + 1), 1);
+        assert_eq!(l.reserved("g"), 0);
+        assert_eq!(l.available("g"), 100);
+        assert_eq!(l.active_leases(), 0);
+    }
+
+    #[test]
+    fn settle_after_reclaim_is_a_noop() {
+        // Documents the TTL tradeoff: a settle arriving after reclaim is dropped (the lease is gone).
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Block);
+        let r = admit(&mut l, "g", 50);
+        assert_eq!(l.reclaim_expired(TTL + 1), 1);
+        l.settle(r.id, 40); // too late
+        assert_eq!(l.spent("g"), 0);
+        assert_eq!(l.reserved("g"), 0);
+    }
+
+    // --- C3: idempotent settle ----------------------------------------------
+
+    #[test]
+    fn settle_is_idempotent_under_repeat() {
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Block);
+        let r = admit(&mut l, "g", 50);
+        l.settle(r.id, 40);
+        l.settle(r.id, 40); // at-least-once repeat
+        l.settle(r.id, 999); // a replay must not overwrite or double-count
+        assert_eq!(l.spent("g"), 40);
+        assert_eq!(l.reserved("g"), 0);
+    }
+
+    #[test]
+    fn zero_settle_releases_without_recording_spend() {
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Policy::Block);
+        let r = admit(&mut l, "g", 50);
+        assert_eq!(l.reserved("g"), 50);
+        l.settle(r.id, 0); // the failed/cancelled path
+        assert_eq!(l.reserved("g"), 0);
+        assert_eq!(l.spent("g"), 0);
+    }
+
+    // --- compare-and-swap (generic atomic keyspace) -------------------------
+
+    #[test]
+    fn cas_create_then_version_conditional_update() {
+        let mut l = InMemoryLedger::new();
+        assert_eq!(l.get("k"), None);
+        // Create: expect-absent (None) succeeds, version starts at 1.
+        assert_eq!(l.compare_and_swap("k", None, 10), Ok(1));
+        assert_eq!(l.get("k"), Some((1, 10)));
+        // A second create is refused (key now exists).
+        assert!(matches!(
+            l.compare_and_swap("k", None, 5),
+            Err(CasError::VersionMismatch {
+                actual: Some(1),
+                ..
+            })
+        ));
+        // Version-matched update succeeds and bumps the version.
+        assert_eq!(l.compare_and_swap("k", Some(1), 20), Ok(2));
+        // A stale-version update is refused.
+        assert!(matches!(
+            l.compare_and_swap("k", Some(1), 30),
+            Err(CasError::VersionMismatch {
+                actual: Some(2),
+                expected: Some(1),
+                ..
+            })
+        ));
+        assert_eq!(l.get("k"), Some((2, 20)));
+    }
+
+    #[test]
+    fn concurrent_cas_create_has_exactly_one_winner() {
+        // N threads race to create the same key; the atomic version check admits exactly one.
+        let ledger = Arc::new(Mutex::new(InMemoryLedger::new()));
+        let handles: Vec<_> = (0..50)
+            .map(|i| {
+                let l = Arc::clone(&ledger);
+                thread::spawn(move || l.lock().unwrap().compare_and_swap("k", None, i).is_ok())
+            })
+            .collect();
+        let winners: usize = handles
+            .into_iter()
+            .map(|h| h.join().unwrap() as usize)
+            .sum();
+        assert_eq!(winners, 1, "exactly one create wins the race");
+        assert_eq!(ledger.lock().unwrap().get("k").map(|(v, _)| v), Some(1));
+    }
+}

--- a/crates/modalities/proximadb-ledger/src/types.rs
+++ b/crates/modalities/proximadb-ledger/src/types.rs
@@ -1,0 +1,64 @@
+//! Core value types for the ledger correctness model (ADR-071 / TD-LEDGER-1).
+//!
+//! Neutral units only — every quantity here is a **count**, never a price (consistent with
+//! ADR-067). No dollars, tiers, or SKUs cross this boundary.
+
+/// Wall-clock time in **nanoseconds**. Chosen to match `proximadb-records`' `valid_to_ns`, so S2 can
+/// persist a lease's expiry without a unit conversion. The core never reads the system clock — every
+/// operation takes `now_ns` as an argument, which keeps the whole state machine deterministic and
+/// unit-testable (the property that makes the C1–C3 invariants provable without a real clock).
+pub type Nanos = i64;
+
+/// Monotonic version stamp for a compare-and-swap key. Starts at 1 on create; increments per write.
+pub type Version = u64;
+
+/// How a scope reacts when a reservation's ceiling would exceed its limit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Policy {
+    /// Hard cap — a ceiling that would breach the limit is **refused** before admission (a cap that
+    /// must never be overshot).
+    #[default]
+    Block,
+    /// Soft cap — never refused; spend still accrues so a downstream alert subsystem can notify.
+    Warn,
+}
+
+/// A held reservation: a lease over `ceiling` units in `scope`, valid until `expires_at_ns`.
+///
+/// `id` is opaque and assigned by the ledger; the caller settles by it or lets it expire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reservation {
+    pub id: u64,
+    pub scope: String,
+    pub ceiling: u64,
+    pub expires_at_ns: Nanos,
+}
+
+/// Why a [`reserve`](crate::Ledger::reserve) was refused: the ceiling did not fit under a hard cap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Denied {
+    pub scope: String,
+    pub limit: u64,
+    pub spent: u64,
+    pub reserved: u64,
+    pub requested_ceiling: u64,
+}
+
+/// Result of an atomic reserve: admitted (with the lease) or denied (over a hard cap).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReserveOutcome {
+    Admitted(Reservation),
+    Denied(Denied),
+}
+
+/// Why a [`compare_and_swap`](crate::Ledger::compare_and_swap) failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CasError {
+    /// The key's current version did not match `expected` — another writer got there first. Carries
+    /// the observed `actual` version (`None` = key absent) so the caller can retry against it.
+    VersionMismatch {
+        key: String,
+        expected: Option<Version>,
+        actual: Option<Version>,
+    },
+}


### PR DESCRIPTION
First implementation slice of the transactional **Ledger modality** (ADR-071 / TD-LEDGER-1, #1168) — the **wiring-free correctness core**. Per the TD build order, the atomic invariant is proven in isolation *before* any durability (S2) or transport (S3) risk.

## What

A new **zero-dependency** crate `crates/modalities/proximadb-ledger`:
- `Ledger` trait (the backend seam the S2/S3 durable partition-WAL impl will also satisfy) + `InMemoryLedger` reference impl.
- Atomic **`reserve`** (holds a conservative ceiling; `Block` refuses over-cap, `Warn` soft-admits) → idempotent **`settle`** by lease id; **`reclaim_expired`** (timed TTL lease release); generic **`compare_and_swap`** keyspace for flags/config/quotas.
- Timestamps are `i64` nanoseconds (matches `proximadb-records` `valid_to_ns`, so S2 persists expiry without conversion) and **the clock is always passed in** — the whole machine is deterministic, so the invariants are unit-provable without a real clock.

## Why zero-dependency

The correctness core is pure `std`: trivially testable, and it keeps the lean **ledger-only** deployment profile (ADR-071 §4) cheap to carve out. Every substrate dependency (WAL, memtable, tenant) is deferred to S2/S3.

## Tests — the Sandhi TD-0007 acceptance bar (C1–C3)

10 tests, all green:
- **C1** — overshoot prevention + a genuinely **concurrent 100-thread oversubscription** test (the `Mutex` models the partition write lock; exactly 10/1000 admit, held total never breaches).
- **C2** — expired lease reclaimed **on a timed basis without a read touching the scope**; settle-after-reclaim is a no-op.
- **C3** — idempotent settle under replay; zero-settle releases without recording.
- CAS create → version-conditional update, and a single-winner concurrent-create race.

## Scope

No `DataModel`/proto/router/WAL changes (S2/S3). Neutral units only. `fmt` + `clippy -D warnings` clean; `check_workspace_boundaries` (layering, `--strict`), OSS-boundary, tenant-path, and deterministic-commit guards all pass locally.

Next: **S2** — durability (WAL op on the ADR-069 substrate + memtable-resident counter + replay + the timed sweeper), then **S3** — the wire surface (`DataModel::Ledger`, `ProximaLedgerService`, router registration, the `experimental-ledger` gate).