### PR TITLE
feat(ledger): S2 durability — WAL-backed DurableLedger behind the trait (ADR-071)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,9 @@ jobs:
           # Other gated surfaces invisible to default CI:
           - { label: "cluster",             pkg: proximadb,        args: "--features cluster" }
           - { label: "enterprise-catalogs", pkg: proximadb,        args: "--features enterprise-catalogs" }
+          # Ledger modality durable backend (S2, ADR-071) — the WAL-backed impl is behind the
+          # non-default `durable` feature, so it is invisible to the default workspace check.
+          - { label: "ledger-durable",      pkg: proximadb-ledger, args: "--features durable" }
           # Refactor/move coverage: these configurations catch cfg drift hidden
           # by the default build. Keep them in the same mandatory matrix rather
           # than relying on a PR being correctly labelled as mechanical.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7490,6 +7490,11 @@ dependencies = [
 [[package]]
 name = "proximadb-ledger"
 version = "0.2.0"
+dependencies = [
+ "bincode",
+ "serde",
+ "tempfile",
+]
 
 [[package]]
 name = "proximadb-mcp"

--- a/crates/modalities/proximadb-ledger/Cargo.toml
+++ b/crates/modalities/proximadb-ledger/Cargo.toml
@@ -13,9 +13,18 @@ description = "ProximaDB transactional Ledger modality — OLTP atomic-CAS keyed
 name = "proximadb_ledger"
 path = "src/lib.rs"
 
-# S1 is deliberately ZERO-dependency: the correctness core is pure `std`, which keeps it
-# trivially testable, keeps the lean "ledger-only" deployment profile (ADR-071 §4) cheap to
-# carve out, and defers every substrate dependency (WAL, memtable, tenant) to S2/S3.
+# The default build is ZERO-dependency: the in-memory correctness core (S1) is pure `std`, which
+# keeps the lean "ledger-only" deployment profile (ADR-071 §4) cheap to carve out. The optional
+# `durable` feature (S2) adds a self-contained CRC-framed WAL behind the same `Ledger` trait; its
+# only deps are the repo-standard serializer. The eventual splice onto the shared ADR-069 record
+# WAL is S3 (a wiring concern), not a dependency of this crate.
+[features]
+default = []
+durable = ["dep:serde", "dep:bincode"]
+
 [dependencies]
+serde = { workspace = true, optional = true }
+bincode = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile.workspace = true

--- a/crates/modalities/proximadb-ledger/src/durable.rs
+++ b/crates/modalities/proximadb-ledger/src/durable.rs
@@ -1,0 +1,505 @@
+//! Self-contained **durable** ledger (S2) — the same [`Ledger`](crate::Ledger) contract, backed by
+//! an append-only, CRC-framed write-ahead log so accrued spend, caps, and in-flight leases **survive
+//! a restart** (the property the in-memory core lacks).
+//!
+//! This is the durability *core*, proven in isolation — exactly how the anchor consumer (Sandhi)
+//! reached durability (an in-memory ledger, then a self-contained durable impl behind the trait,
+//! then wiring). The design here is the OLTP synthesis from TD-LEDGER-1:
+//!
+//! - **memtable-authoritative counter** — the live state is an [`InMemoryLedger`]; reads/writes are
+//!   O(1) (memcache/memsql class).
+//! - **WAL for recovery** — every *decided* mutation (reserve / settle / CAS / set-limit) is appended
+//!   to the log *before* it is applied, and the log is replayed on open to rebuild the counter
+//!   (sqlite/memsql class durability). Reclaims are **not** logged — a lease carries its `expires_at`,
+//!   so replay reconstructs it and the normal sweeper reclaims it.
+//! - **configurable sync** ([`SyncPolicy`]) — per-op `fsync` for hard caps, deferred for throughput
+//!   (the redis `appendfsync` lever). Maps onto the consumer's fail-open/closed tiers.
+//!
+//! The production target for this WAL is the shared ADR-069 local-disk record WAL (S3 wiring); this
+//! module owns a private log file so the durability semantics can be tested standalone. Torn tails
+//! (a crash mid-append) are tolerated: replay stops at the first record whose length, CRC, or decode
+//! is short/bad — an un-acked write is simply not recovered.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader, ErrorKind, Read, Write};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Ledger;
+use crate::memory::InMemoryLedger;
+use crate::types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+
+/// When the WAL is flushed to stable storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncPolicy {
+    /// `fsync` after every append — strict durability (a hard `Block` cap that must never be lost).
+    PerOp,
+    /// Buffer appends; the OS flushes on its own schedule or on an explicit [`DurableLedger::flush`].
+    /// Higher throughput, a bounded loss window on power failure — appropriate for soft (`Warn`)
+    /// scopes. (Group-commit / interval fsync is a scheduling refinement tracked for S3.)
+    Deferred,
+}
+
+/// A single decided mutation, as persisted in the log. Reclaims are intentionally absent (re-derived
+/// on replay from each reservation's `expires_at_ns`).
+#[derive(Debug, Serialize, Deserialize)]
+enum LogRecord {
+    SetLimit {
+        scope: String,
+        limit: Option<u64>,
+        policy: u8,
+    },
+    Reserve {
+        id: u64,
+        scope: String,
+        ceiling: u64,
+        expires_at_ns: Nanos,
+    },
+    Settle {
+        id: u64,
+        actual: u64,
+    },
+    Cas {
+        key: String,
+        version: Version,
+        value: i64,
+    },
+}
+
+fn policy_to_u8(p: Policy) -> u8 {
+    match p {
+        Policy::Block => 0,
+        Policy::Warn => 1,
+    }
+}
+fn policy_from_u8(v: u8) -> Policy {
+    match v {
+        1 => Policy::Warn,
+        _ => Policy::Block,
+    }
+}
+
+/// IEEE CRC-32 (reflected, poly `0xEDB88320`). Inline so the crate needs no checksum dependency; it
+/// guards each record so a torn/corrupt tail is detected rather than mis-decoded into bad state.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+/// A durable ledger: an in-memory authoritative counter fronted by a CRC-framed append-only WAL.
+pub struct DurableLedger {
+    state: InMemoryLedger,
+    log: File,
+    sync: SyncPolicy,
+}
+
+impl DurableLedger {
+    /// Open (creating if absent) a durable ledger at `path`, replaying any existing log to recover
+    /// spend / caps / in-flight leases. The clock is never read here — expired leases are left for
+    /// the caller's [`reclaim_expired`](Ledger::reclaim_expired) sweep, keeping open deterministic.
+    pub fn open(path: impl AsRef<Path>, sync: SyncPolicy) -> io::Result<Self> {
+        let path = path.as_ref();
+        let mut state = InMemoryLedger::new();
+        if let Ok(file) = File::open(path) {
+            let mut reader = BufReader::new(file);
+            while let Some(record) = read_record(&mut reader)? {
+                apply_record(&mut state, record);
+            }
+        }
+        let log = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+        Ok(Self { state, log, sync })
+    }
+
+    /// Flush buffered appends to stable storage (a no-op under [`SyncPolicy::PerOp`], where each
+    /// append already synced). Call at a checkpoint or before shutdown under `Deferred`.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.log.sync_all()
+    }
+
+    /// Held (unsettled, unreclaimed) leases — for tests/introspection.
+    #[must_use]
+    pub fn active_leases(&self) -> usize {
+        self.state.active_leases()
+    }
+
+    fn append(&mut self, record: &LogRecord) -> io::Result<()> {
+        let payload = bincode::serialize(record).map_err(io::Error::other)?;
+        let len = u32::try_from(payload.len()).map_err(io::Error::other)?;
+        // Frame: [len u32-le][crc32 u32-le][payload]. The two headers let replay detect a torn tail.
+        self.log.write_all(&len.to_le_bytes())?;
+        self.log.write_all(&crc32(&payload).to_le_bytes())?;
+        self.log.write_all(&payload)?;
+        if self.sync == SyncPolicy::PerOp {
+            self.log.sync_all()?;
+        }
+        Ok(())
+    }
+}
+
+impl Ledger for DurableLedger {
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy) {
+        let record = LogRecord::SetLimit {
+            scope: scope.to_string(),
+            limit,
+            policy: policy_to_u8(policy),
+        };
+        if let Err(e) = self.append(&record) {
+            eprintln!("proximadb-ledger: set_limit append failed, not applied: {e}");
+            return;
+        }
+        self.state.set_limit(scope, limit, policy);
+    }
+
+    fn reserve(
+        &mut self,
+        scope: &str,
+        ceiling: u64,
+        now_ns: Nanos,
+        ttl_ns: Nanos,
+    ) -> ReserveOutcome {
+        // Decide first (no mutation)…
+        if let Err(denied) = self.state.check_admit(scope, ceiling) {
+            return ReserveOutcome::Denied(denied);
+        }
+        let reservation = Reservation {
+            id: self.state.peek_next_id(),
+            scope: scope.to_string(),
+            ceiling,
+            expires_at_ns: now_ns.saturating_add(ttl_ns),
+        };
+        // …persist the decision *before* applying it. A hard cap that cannot be durably recorded
+        // fails **closed** (deny) — never admit what a restart would forget.
+        let record = LogRecord::Reserve {
+            id: reservation.id,
+            scope: reservation.scope.clone(),
+            ceiling: reservation.ceiling,
+            expires_at_ns: reservation.expires_at_ns,
+        };
+        if let Err(e) = self.append(&record) {
+            eprintln!("proximadb-ledger: reserve append failed, denying (fail-closed): {e}");
+            return ReserveOutcome::Denied(Denied {
+                scope: scope.to_string(),
+                limit: self.state.limit(scope).unwrap_or(0),
+                spent: self.state.spent(scope),
+                reserved: self.state.reserved(scope),
+                requested_ceiling: ceiling,
+            });
+        }
+        self.state.apply_reserve(reservation.clone());
+        ReserveOutcome::Admitted(reservation)
+    }
+
+    fn settle(&mut self, reservation_id: u64, actual: u64) {
+        if let Err(e) = self.append(&LogRecord::Settle {
+            id: reservation_id,
+            actual,
+        }) {
+            // Settle is idempotent/retryable: skip applying so state never runs ahead of the WAL.
+            eprintln!("proximadb-ledger: settle append failed, not applied (retryable): {e}");
+            return;
+        }
+        self.state.settle(reservation_id, actual);
+    }
+
+    fn reclaim_expired(&mut self, now_ns: Nanos) -> usize {
+        // Not logged — a reservation carries its expiry, so replay + this sweep re-derive reclaims.
+        self.state.reclaim_expired(now_ns)
+    }
+
+    fn compare_and_swap(
+        &mut self,
+        key: &str,
+        expected: Option<Version>,
+        new_value: i64,
+    ) -> Result<Version, CasError> {
+        let version = self.state.check_cas(key, expected)?;
+        let record = LogRecord::Cas {
+            key: key.to_string(),
+            version,
+            value: new_value,
+        };
+        if let Err(e) = self.append(&record) {
+            // Could not persist: surface as "did not apply, retry" against the observed version.
+            eprintln!("proximadb-ledger: cas append failed, not applied: {e}");
+            return Err(CasError::VersionMismatch {
+                key: key.to_string(),
+                expected,
+                actual: self.state.get(key).map(|(v, _)| v),
+            });
+        }
+        self.state.apply_cas(key, version, new_value);
+        Ok(version)
+    }
+
+    fn limit(&self, scope: &str) -> Option<u64> {
+        self.state.limit(scope)
+    }
+    fn policy(&self, scope: &str) -> Policy {
+        self.state.policy(scope)
+    }
+    fn spent(&self, scope: &str) -> u64 {
+        self.state.spent(scope)
+    }
+    fn reserved(&self, scope: &str) -> u64 {
+        self.state.reserved(scope)
+    }
+    fn get(&self, key: &str) -> Option<(Version, i64)> {
+        self.state.get(key)
+    }
+}
+
+/// Apply one recovered log record to the in-memory state (the replay path — no re-logging).
+fn apply_record(state: &mut InMemoryLedger, record: LogRecord) {
+    match record {
+        LogRecord::SetLimit {
+            scope,
+            limit,
+            policy,
+        } => state.set_limit(&scope, limit, policy_from_u8(policy)),
+        LogRecord::Reserve {
+            id,
+            scope,
+            ceiling,
+            expires_at_ns,
+        } => state.apply_reserve(Reservation {
+            id,
+            scope,
+            ceiling,
+            expires_at_ns,
+        }),
+        LogRecord::Settle { id, actual } => state.settle(id, actual),
+        LogRecord::Cas {
+            key,
+            version,
+            value,
+        } => state.apply_cas(&key, version, value),
+    }
+}
+
+/// Read one framed record, or `None` at a clean EOF **or a torn/corrupt tail** (short read on any of
+/// the three fields, a CRC mismatch, or a decode failure) — an un-acked write is not recovered.
+fn read_record<R: Read>(reader: &mut R) -> io::Result<Option<LogRecord>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None), // clean EOF
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut crc_buf = [0u8; 4];
+    if reader.read_exact(&mut crc_buf).is_err() {
+        return Ok(None); // torn tail
+    }
+    let expected_crc = u32::from_le_bytes(crc_buf);
+    let mut payload = vec![0u8; len];
+    if reader.read_exact(&mut payload).is_err() {
+        return Ok(None); // torn tail
+    }
+    if crc32(&payload) != expected_crc {
+        return Ok(None); // corrupt tail
+    }
+    Ok(bincode::deserialize::<LogRecord>(&payload).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Seek;
+
+    const TTL: Nanos = 60_000_000_000; // 60s in ns
+    const NOW: Nanos = 0;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+    fn open(dir: &tempfile::TempDir) -> DurableLedger {
+        DurableLedger::open(dir.path().join("ledger.wal"), SyncPolicy::PerOp).unwrap()
+    }
+    fn admit(l: &mut DurableLedger, scope: &str, ceiling: u64) -> Reservation {
+        match l.reserve(scope, ceiling, NOW, TTL) {
+            ReserveOutcome::Admitted(r) => r,
+            ReserveOutcome::Denied(d) => panic!("expected admit, got {d:?}"),
+        }
+    }
+
+    #[test]
+    fn spend_and_caps_survive_reopen() {
+        // The property the in-memory ledger lacks: a restart must not zero accrued spend or caps.
+        let dir = tmp();
+        {
+            let mut l = open(&dir);
+            l.set_limit("g", Some(100), Policy::Block);
+            let r = admit(&mut l, "g", 50);
+            l.settle(r.id, 40);
+            assert_eq!(l.spent("g"), 40);
+        } // dropped — simulate a restart
+        let reopened = open(&dir);
+        assert_eq!(reopened.spent("g"), 40, "spend persists across restart");
+        assert_eq!(reopened.limit("g"), Some(100), "caps persist");
+        assert_eq!(reopened.policy("g"), Policy::Block);
+        assert_eq!(reopened.reserved("g"), 0);
+    }
+
+    #[test]
+    fn in_flight_lease_survives_reopen_and_still_settles() {
+        let dir = tmp();
+        let id = {
+            let mut l = open(&dir);
+            l.set_limit("g", Some(100), Policy::Block);
+            admit(&mut l, "g", 80).id // reserved but NOT settled before the "crash"
+        };
+        let mut reopened = open(&dir);
+        assert_eq!(
+            reopened.reserved("g"),
+            80,
+            "the in-flight lease is recovered"
+        );
+        assert_eq!(reopened.available("g"), 20);
+        // A cap check against the recovered lease still holds…
+        assert!(matches!(
+            reopened.reserve("g", 30, NOW, TTL),
+            ReserveOutcome::Denied(_)
+        ));
+        // …and the recovered lease settles by its original id.
+        reopened.settle(id, 55);
+        assert_eq!(reopened.spent("g"), 55);
+        assert_eq!(reopened.reserved("g"), 0);
+    }
+
+    #[test]
+    fn idempotent_settle_survives_reopen() {
+        // A settle replayed after a restart must not double-count (C3 across the durability boundary).
+        let dir = tmp();
+        let id = {
+            let mut l = open(&dir);
+            l.set_limit("g", Some(100), Policy::Block);
+            let r = admit(&mut l, "g", 50);
+            l.settle(r.id, 40);
+            r.id
+        };
+        let mut reopened = open(&dir);
+        reopened.settle(id, 999); // replayed settle on an already-settled (now absent) lease
+        assert_eq!(reopened.spent("g"), 40, "replayed settle is a no-op");
+    }
+
+    #[test]
+    fn cas_state_survives_reopen() {
+        let dir = tmp();
+        {
+            let mut l = open(&dir);
+            assert_eq!(l.compare_and_swap("flag", None, 10), Ok(1));
+            assert_eq!(l.compare_and_swap("flag", Some(1), 20), Ok(2));
+        }
+        let mut reopened = open(&dir);
+        assert_eq!(reopened.get("flag"), Some((2, 20)));
+        // The recovered version is authoritative: a stale-version write is refused, a matched one wins.
+        assert!(reopened.compare_and_swap("flag", Some(1), 30).is_err());
+        assert_eq!(reopened.compare_and_swap("flag", Some(2), 30), Ok(3));
+    }
+
+    #[test]
+    fn reclaimed_lease_does_not_survive_reopen() {
+        // Reclaims aren't logged; the sweep re-derives them from the recovered expiry.
+        let dir = tmp();
+        {
+            let mut l = open(&dir);
+            l.set_limit("g", Some(100), Policy::Block);
+            let _crashed = admit(&mut l, "g", 80);
+        }
+        let mut reopened = open(&dir);
+        assert_eq!(reopened.reserved("g"), 80, "recovered as in-flight");
+        assert_eq!(reopened.reclaim_expired(TTL + 1), 1, "swept by its expiry");
+        assert_eq!(reopened.reserved("g"), 0);
+        assert_eq!(reopened.available("g"), 100);
+    }
+
+    #[test]
+    fn torn_tail_is_ignored_on_replay() {
+        // A crash mid-append leaves a partial final record; replay must recover everything before it
+        // and silently drop the torn tail.
+        let dir = tmp();
+        let path = dir.path().join("ledger.wal");
+        {
+            let mut l = DurableLedger::open(&path, SyncPolicy::PerOp).unwrap();
+            l.set_limit("g", Some(100), Policy::Block);
+            let r = admit(&mut l, "g", 50);
+            l.settle(r.id, 40);
+        }
+        // Append 6 bytes of garbage — a plausible torn frame header/body.
+        {
+            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+            f.write_all(&[7, 0, 0, 0, 0, 0]).unwrap(); // claims len=7, then truncates
+            f.sync_all().unwrap();
+        }
+        let reopened = DurableLedger::open(&path, SyncPolicy::PerOp).unwrap();
+        assert_eq!(reopened.spent("g"), 40, "committed records recovered");
+        assert_eq!(reopened.limit("g"), Some(100));
+    }
+
+    #[test]
+    fn deferred_sync_persists_after_flush() {
+        let dir = tmp();
+        let path = dir.path().join("ledger.wal");
+        {
+            let mut l = DurableLedger::open(&path, SyncPolicy::Deferred).unwrap();
+            l.set_limit("g", Some(100), Policy::Block);
+            let r = admit(&mut l, "g", 30);
+            l.settle(r.id, 30);
+            l.flush().unwrap(); // explicit checkpoint under the deferred (throughput) policy
+        }
+        let reopened = DurableLedger::open(&path, SyncPolicy::Deferred).unwrap();
+        assert_eq!(reopened.spent("g"), 30);
+    }
+
+    #[test]
+    fn block_overshoot_prevented_on_durable_impl() {
+        // The C1 invariant holds identically on the durable backend (same decision seam).
+        let dir = tmp();
+        let mut l = open(&dir);
+        l.set_limit("g", Some(100), Policy::Block);
+        let r = admit(&mut l, "g", 100);
+        assert!(matches!(
+            l.reserve("g", 1, NOW, TTL),
+            ReserveOutcome::Denied(_)
+        ));
+        l.settle(r.id, 40);
+        assert!(l.spent("g") + l.reserved("g") <= 100);
+    }
+
+    #[test]
+    fn appends_are_framed_len_crc_payload() {
+        // Guard the on-disk frame shape so a later reader/format change is a conscious break.
+        let dir = tmp();
+        let path = dir.path().join("ledger.wal");
+        {
+            let mut l = DurableLedger::open(&path, SyncPolicy::PerOp).unwrap();
+            l.set_limit("s", Some(1), Policy::Warn);
+        }
+        let mut f = File::open(&path).unwrap();
+        f.rewind().unwrap();
+        let mut len_buf = [0u8; 4];
+        f.read_exact(&mut len_buf).unwrap();
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut crc_buf = [0u8; 4];
+        f.read_exact(&mut crc_buf).unwrap();
+        let mut payload = vec![0u8; len];
+        f.read_exact(&mut payload).unwrap();
+        assert_eq!(
+            crc32(&payload),
+            u32::from_le_bytes(crc_buf),
+            "framed crc matches payload"
+        );
+    }
+}

--- a/crates/modalities/proximadb-ledger/src/lib.rs
+++ b/crates/modalities/proximadb-ledger/src/lib.rs
@@ -6,10 +6,12 @@
 //! OLTP primitives ProximaDB lacks today (`StorageKV` is non-atomic, `put_if_absent` is create-only,
 //! the transaction manager is unwired).
 //!
-//! This crate carries **no durability, no transport, and no windows** — those are S2 (the durable
-//! WAL, memtable counter, and TTL sweeper) and S3 (proto/gRPC/router). Per the TD build order, the
-//! correctness invariant is proven here *first*, in isolation, before any durability or wiring risk
-//! is taken on. Neutral units only — counts, never prices.
+//! The default build ([`InMemoryLedger`]) is the pure, zero-dependency correctness core (S1). The
+//! optional **`durable`** feature adds [`DurableLedger`] (S2): the same [`Ledger`] contract behind a
+//! CRC-framed write-ahead log, so spend / caps / in-flight leases survive a restart. **Transport and
+//! windows are still out** — the wire surface (proto/gRPC/router) and the splice onto the shared
+//! ADR-069 record WAL are S3. Per the TD build order, the correctness invariant is proven *first*, in
+//! isolation, before any wiring risk is taken on. Neutral units only — counts, never prices.
 //!
 //! ## The invariants (the acceptance bar — Sandhi TD-0007 C1–C3)
 //!
@@ -27,9 +29,13 @@
 //! generic keyspace (feature flags, config, quotas): a write lands only if the caller's expected
 //! version matches the current one.
 
+#[cfg(feature = "durable")]
+mod durable;
 mod memory;
 mod types;
 
+#[cfg(feature = "durable")]
+pub use durable::{DurableLedger, SyncPolicy};
 pub use memory::InMemoryLedger;
 pub use types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
 

--- a/crates/modalities/proximadb-ledger/src/memory.rs
+++ b/crates/modalities/proximadb-ledger/src/memory.rs
@@ -47,6 +47,69 @@ impl InMemoryLedger {
         let held = self.reserved.entry(scope.to_string()).or_insert(0);
         *held = held.saturating_sub(delta);
     }
+
+    // --- check / apply seams --------------------------------------------------
+    //
+    // Splitting the *decision* (`check_*`) from the *mutation* (`apply_*` / `peek_next_id`) lets a
+    // durable backend log the decided record and only then apply it (WAL-before-state), while the
+    // in-memory `reserve`/`compare_and_swap` above stay a check-then-apply with no logic duplicated.
+    // `apply_*` are also the replay path: reconstructing state from a log of decided records.
+
+    /// The admission decision for a `Block` cap (pure — no mutation). `Ok(())` = admit.
+    pub(crate) fn check_admit(&self, scope: &str, ceiling: u64) -> Result<(), Denied> {
+        if let Some(spec) = self.limits.get(scope).copied()
+            && spec.policy == Policy::Block
+            && let Some(limit) = spec.limit
+        {
+            let spent = self.spent(scope);
+            let reserved = self.reserved(scope);
+            if spent.saturating_add(reserved).saturating_add(ceiling) > limit {
+                return Err(Denied {
+                    scope: scope.to_string(),
+                    limit,
+                    spent,
+                    reserved,
+                    requested_ceiling: ceiling,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// The id the next reservation will take (without consuming it). `apply_reserve` advances past it.
+    pub(crate) fn peek_next_id(&self) -> u64 {
+        self.next_id
+    }
+
+    /// Apply an already-decided reservation (from `reserve`, or from a log record on replay). Bumps
+    /// `next_id` past `r.id` so a replayed id and a live id can never collide.
+    pub(crate) fn apply_reserve(&mut self, r: Reservation) {
+        self.next_id = self.next_id.max(r.id.saturating_add(1));
+        self.add_reserved(&r.scope, r.ceiling);
+        self.leases.insert(r.id, r);
+    }
+
+    /// The version-match decision for a CAS (pure). `Ok(v)` = the version the write would take.
+    pub(crate) fn check_cas(
+        &self,
+        key: &str,
+        expected: Option<Version>,
+    ) -> Result<Version, CasError> {
+        let actual = self.kv.get(key).map(|(v, _)| *v);
+        if actual != expected {
+            return Err(CasError::VersionMismatch {
+                key: key.to_string(),
+                expected,
+                actual,
+            });
+        }
+        Ok(actual.unwrap_or(0).saturating_add(1))
+    }
+
+    /// Apply an already-decided CAS write (from `compare_and_swap`, or a log record on replay).
+    pub(crate) fn apply_cas(&mut self, key: &str, version: Version, value: i64) {
+        self.kv.insert(key.to_string(), (version, value));
+    }
 }
 
 impl Ledger for InMemoryLedger {
@@ -62,34 +125,16 @@ impl Ledger for InMemoryLedger {
         now_ns: Nanos,
         ttl_ns: Nanos,
     ) -> ReserveOutcome {
-        // A hard `Block` cap is the only thing that can refuse admission. `Warn` (soft cap) and an
-        // unset/unlimited scope always admit; spend still accrues via the lease so alerts can fire.
-        if let Some(spec) = self.limits.get(scope).copied()
-            && spec.policy == Policy::Block
-            && let Some(limit) = spec.limit
-        {
-            let spent = self.spent(scope);
-            let reserved = self.reserved(scope);
-            if spent.saturating_add(reserved).saturating_add(ceiling) > limit {
-                return ReserveOutcome::Denied(Denied {
-                    scope: scope.to_string(),
-                    limit,
-                    spent,
-                    reserved,
-                    requested_ceiling: ceiling,
-                });
-            }
+        if let Err(denied) = self.check_admit(scope, ceiling) {
+            return ReserveOutcome::Denied(denied);
         }
-        let id = self.next_id;
-        self.next_id += 1;
         let reservation = Reservation {
-            id,
+            id: self.peek_next_id(),
             scope: scope.to_string(),
             ceiling,
             expires_at_ns: now_ns.saturating_add(ttl_ns),
         };
-        self.leases.insert(id, reservation.clone());
-        self.add_reserved(scope, ceiling);
+        self.apply_reserve(reservation.clone());
         ReserveOutcome::Admitted(reservation)
     }
 
@@ -122,17 +167,9 @@ impl Ledger for InMemoryLedger {
         expected: Option<Version>,
         new_value: i64,
     ) -> Result<Version, CasError> {
-        let actual = self.kv.get(key).map(|(v, _)| *v);
-        if actual != expected {
-            return Err(CasError::VersionMismatch {
-                key: key.to_string(),
-                expected,
-                actual,
-            });
-        }
-        let next = actual.unwrap_or(0).saturating_add(1);
-        self.kv.insert(key.to_string(), (next, new_value));
-        Ok(next)
+        let version = self.check_cas(key, expected)?;
+        self.apply_cas(key, version, new_value);
+        Ok(version)
     }
 
     fn limit(&self, scope: &str) -> Option<u64> {


### PR DESCRIPTION
**Stacked on #1170 (S1)** — base is `feat/ledger-s1-core`; retarget to `develop` once S1 merges. The durability slice of the Ledger modality: the same `Ledger` contract, made **restart-surviving**, proven in isolation before the risky splice onto the shared ADR-069 record WAL (that's S3).

## Design — the TD-LEDGER-1 OLTP synthesis

- **memtable-authoritative counter** — the in-memory core is the live state (O(1) reads/writes).
- **WAL for recovery** — every *decided* mutation (reserve/settle/CAS/set-limit) is appended to a **CRC-framed append-only log before it is applied** (WAL-before-state), and the log is **replayed on open** to rebuild the counter. Reclaims are *not* logged — a lease carries its expiry, so replay + the normal sweep re-derive them.
- **`SyncPolicy` knob** — `PerOp` fsync (strict, hard caps) vs `Deferred`+`flush` (throughput, soft caps): the redis `appendfsync` lever mapped to the fail-open/closed tiers.
- **torn-tail tolerant** — a crash mid-append leaves a partial final frame; replay stops at the first short/CRC-bad/undecodable record, so an un-acked write is never recovered.
- **fail-closed** — `reserve` denies if the decision can't be durably recorded (never admit what a restart would forget).

`InMemoryLedger` was refactored to expose `check`/`apply` seams, so the durable impl reuses the **exact** decision logic (no duplication) and shares the replay path.

## Lean by default

The default build stays **zero-dependency** (the ADR-071 §4 lean ledger-only profile); `durable` pulls only `serde`+`bincode`, and CRC32 is inline. A CI feature-matrix row compile-checks the gated `durable` surface (invisible to the default workspace check).

## Tests

10 in-memory (unchanged) **+ 9 durable**: spend/caps/leases survive reopen, idempotent settle *across* the durability boundary, CAS survives reopen, reclaimed-lease re-derivation, **torn-tail tolerance**, deferred-sync flush, and an on-disk frame-shape guard. Green on both `default` and `--features durable`; `fmt` + `clippy -D warnings` clean on both; layering/OSS/tenant-path/deterministic-commit guards pass.

Next: **S3** — the wire surface (`DataModel::Ledger`, `ProximaLedgerService` proto/gRPC/router, the `experimental-ledger` gate + ledger-only launch profile) and the splice of this WAL onto the shared ADR-069 record path. That one touches the core engine (`RecordStore`/canonical ops), so it wants engine-owner coordination.