### PR TITLE
test(pressure): restart/recovery pressure-test findings — 9 TDs + PAX write sub-phase timers

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -38,6 +38,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, bail};
 use proximadb_block_format::coalesced_rabitq::{
@@ -517,6 +518,36 @@ struct TwoLevelState {
     cell_end_blocks: Vec<u32>,
 }
 
+/// TD-COMPACT-1 S2: cumulative writer sub-phase timers, allocated only when
+/// `PROXIMADB_TRACE_PAX_WRITE` is set at writer construction. Buckets cover the
+/// per-record `add_record` work plus the finish-time coalesced region encodes;
+/// one summary line is emitted from [`PaxSegmentWriter::finish`]. Near-zero cost
+/// when the env is unset: a single `Option` discriminant check per span.
+#[derive(Default)]
+struct WriteTraceStats {
+    /// Coalesced Region A: per-record f32 buffering for `rabitq_vectors` +
+    /// the finish-time `encode_region` (fit + rotation + per-vector encode).
+    rabitq_encode: Duration,
+    /// Coalesced Region B: the finish-time `encode_sq8_region` (SQ8 rerank tier).
+    rerank_encode: Duration,
+    /// `PaxBlockWriter::add_record` row buffering (FlatRow extraction, msgpack
+    /// props, embedding clones, column pushes).
+    raw_buffer: Duration,
+    /// Every `flush_current_block` body: block serialize (stripes + codecs),
+    /// re-open for stats/zone summaries, and `file_buf` append.
+    block_cut_compress: Duration,
+    /// Centroid/radius accumulation (`accumulate_centroid`).
+    cluster_bookkeeping: Duration,
+    /// `add_record` remainder (size estimate, two-level boundary checks, ...).
+    other: Duration,
+    /// Blocks cut so far (size-triggered + cell-boundary + final flushes).
+    blocks_cut: u64,
+    /// Running f32 bytes buffered in `rabitq_vectors` for the coalesced regions.
+    rabitq_buf_bytes: usize,
+    /// Peak of `file_buf` + coalesced vector buffer observed at block cuts.
+    peak_buffered_bytes: usize,
+}
+
 pub struct PaxSegmentWriter {
     path: PathBuf,
     mode: BlockMode,
@@ -590,6 +621,9 @@ pub struct PaxSegmentWriter {
     /// dim + the quant/f32_tier/embedding_count config). Replaces the flat 1024
     /// that overestimated SQ8 blocks by ~4.5×. 0 = not yet computed.
     per_row_estimate: usize,
+    /// TD-COMPACT-1 S2: `Some` iff `PROXIMADB_TRACE_PAX_WRITE` was set when the
+    /// writer was constructed (read ONCE, here) — cumulative sub-phase timers.
+    write_trace: Option<Box<WriteTraceStats>>,
 }
 
 impl PaxSegmentWriter {
@@ -649,6 +683,9 @@ impl PaxSegmentWriter {
             rabitq_vectors: Vec::new(),
             two_level: None,
             per_row_estimate: 0,
+            write_trace: std::env::var_os("PROXIMADB_TRACE_PAX_WRITE")
+                .is_some()
+                .then(|| Box::new(WriteTraceStats::default())),
         }
     }
 
@@ -821,10 +858,34 @@ impl PaxSegmentWriter {
     ///
     /// Flushes the block automatically when it exceeds `block_size_threshold`.
     pub fn add_record(&mut self, record: &ProximaRecord) -> Result<()> {
+        // TD-COMPACT-1 S2: per-span timers, active only when the writer was
+        // constructed with `PROXIMADB_TRACE_PAX_WRITE` set (plain bool check +
+        // no `Instant::now` otherwise). Spans are accumulated into locals and
+        // merged into `write_trace` once at the end of this call.
+        let trace_on = self.write_trace.is_some();
+        let t_total = trace_on.then(Instant::now);
+        let flush_before = self
+            .write_trace
+            .as_deref()
+            .map(|tr| tr.block_cut_compress)
+            .unwrap_or_default();
+        let mut d_raw = Duration::ZERO;
+        let mut d_cluster = Duration::ZERO;
+        let mut d_rabitq = Duration::ZERO;
+        let mut rabitq_bytes = 0usize;
+
+        let t = trace_on.then(Instant::now);
         self.current_writer.add_record(record)?;
         self.row_count += 1;
+        if let Some(t) = t {
+            d_raw = t.elapsed();
+        }
         if self.compute_centroids {
+            let t = trace_on.then(Instant::now);
             self.accumulate_centroid(record);
+            if let Some(t) = t {
+                d_cluster = t.elapsed();
+            }
         }
         // ADR-062: buffer the embedding-0 f32 vector (in cluster/add order) for
         // the segment-level RaBitQ region. The caller has already reordered
@@ -834,7 +895,12 @@ impl PaxSegmentWriter {
             // f32 for the RaBitQ+SQ8 segment-level quantization. The old Fp32-only
             // extraction silently dropped non-Fp32 embeddings (e.g. after ingest-time
             // canonical-precision coercion) → garbage SQ8 params → 0.35% recall.
+            let t = trace_on.then(Instant::now);
             let v = record.embeddings.first().map(|e| e.values.to_fp32_owned());
+            if let Some(t) = t {
+                d_rabitq = t.elapsed();
+                rabitq_bytes = v.as_ref().map_or(0, |v| v.len() * 4);
+            }
             self.rabitq_vectors.push(v);
         }
 
@@ -881,6 +947,20 @@ impl PaxSegmentWriter {
                 tl.cell_end_blocks.push(block_count);
                 tl.next_boundary += 1;
             }
+        }
+        // TD-COMPACT-1 S2: merge this call's spans. Block flushes triggered above
+        // accounted themselves into `block_cut_compress` (see
+        // `flush_current_block`), so `other` = total − spans − flush delta:
+        // the size-estimate arithmetic + boundary checks + anything unattributed.
+        if let (Some(t0), Some(tr)) = (t_total, self.write_trace.as_deref_mut()) {
+            tr.raw_buffer += d_raw;
+            tr.cluster_bookkeeping += d_cluster;
+            tr.rabitq_encode += d_rabitq;
+            tr.rabitq_buf_bytes += rabitq_bytes;
+            let flush_delta = tr.block_cut_compress.saturating_sub(flush_before);
+            tr.other += t0
+                .elapsed()
+                .saturating_sub(d_raw + d_cluster + d_rabitq + flush_delta);
         }
         Ok(())
     }
@@ -952,6 +1032,9 @@ impl PaxSegmentWriter {
         if self.current_writer.is_empty() {
             return Ok(());
         }
+        // TD-COMPACT-1 S2: everything in this body (block serialize + codecs +
+        // stats/zone re-open + file_buf append) is the `block_cut_compress` bucket.
+        let t_flush = self.write_trace.is_some().then(Instant::now);
         // Capture timestamp bounds before flush (flush does not reset internal state).
         let min_ts = self.current_writer.min_ts();
         let max_ts = self.current_writer.max_ts();
@@ -997,6 +1080,17 @@ impl PaxSegmentWriter {
         // Reset writer for the next block (preserving the segment's quant + f32-tier +
         // rerank + shred-spec strategy — see `fresh_block_writer`).
         self.current_writer = self.fresh_block_writer();
+        if let Some(t) = t_flush {
+            let file_len = self.file_buf.len();
+            if let Some(tr) = self.write_trace.as_deref_mut() {
+                tr.block_cut_compress += t.elapsed();
+                tr.blocks_cut += 1;
+                let buffered = file_len + tr.rabitq_buf_bytes;
+                if buffered > tr.peak_buffered_bytes {
+                    tr.peak_buffered_bytes = buffered;
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1023,11 +1117,44 @@ impl PaxSegmentWriter {
             .map(|v| v.len())
             .unwrap_or(0) as u32;
 
-        if self.coalesced_rabitq && coalesced_dim > 0 {
+        let result = if self.coalesced_rabitq && coalesced_dim > 0 {
             self.finish_coalesced(coalesced_dim)
         } else {
             self.finish_legacy()
+        };
+        self.emit_write_trace();
+        result
+    }
+
+    /// TD-COMPACT-1 S2: emit ONE cumulative sub-phase summary line for this
+    /// segment write. No-op unless `PROXIMADB_TRACE_PAX_WRITE` was set when the
+    /// writer was constructed. Mirrored to stderr so it interleaves with the
+    /// S1 `[PAX write]` phase timers emitted by the flush/compaction entry.
+    fn emit_write_trace(&mut self) {
+        let row_count = self.row_count;
+        let file_len = self.file_buf.len();
+        let Some(tr) = self.write_trace.as_deref_mut() else {
+            return;
+        };
+        let buffered = file_len + tr.rabitq_buf_bytes;
+        if buffered > tr.peak_buffered_bytes {
+            tr.peak_buffered_bytes = buffered;
         }
+        let ms = |d: Duration| d.as_secs_f64() * 1e3;
+        let line = format!(
+            "[PAX write detail] records={} blocks_cut={} rabitq={:.0} ms rerank={:.0} ms raw_buffer={:.0} ms block={:.0} ms cluster={:.0} ms other={:.0} ms peak_buffered_bytes={}",
+            row_count,
+            tr.blocks_cut,
+            ms(tr.rabitq_encode),
+            ms(tr.rerank_encode),
+            ms(tr.raw_buffer),
+            ms(tr.block_cut_compress),
+            ms(tr.cluster_bookkeeping),
+            ms(tr.other),
+            tr.peak_buffered_bytes,
+        );
+        tracing::info!("{line}");
+        eprintln!("{line}");
     }
 
     /// Legacy `[blocks][SegmentIndex][SEGMENT_MAGIC]` layout (readability-preserving
@@ -1224,10 +1351,21 @@ impl PaxSegmentWriter {
         //    blocks at 0-based offsets (relative to the blocks region).
         let refs: Vec<Option<&[f32]>> = self.rabitq_vectors.iter().map(|o| o.as_deref()).collect();
         let seed = RABITQ_SEED_BASE ^ (col_id::EMBED_BASE as u64);
+        // TD-COMPACT-1 S2: the finish-time Region A encode (fit + rotation +
+        // per-vector RaBitQ) accumulates into the `rabitq` bucket, Region B
+        // (segment-level SQ8) into `rerank`.
+        let t = self.write_trace.is_some().then(Instant::now);
         let (region_bytes, _centroid) = encode_region(&refs, dim, seed)?;
+        if let (Some(t), Some(tr)) = (t, self.write_trace.as_deref_mut()) {
+            tr.rabitq_encode += t.elapsed();
+        }
         // ADR-065 Region B: the SQ8 rerank tier, hoisted out of blocks so survivor
         // rerank fetches read pure dense SQ8 (one segment-level Sq8Params fit).
+        let t = self.write_trace.is_some().then(Instant::now);
         let (sq8_region_bytes, sq8_params) = encode_sq8_region(&refs, dim)?;
+        if let (Some(t), Some(tr)) = (t, self.write_trace.as_deref_mut()) {
+            tr.rerank_encode += t.elapsed();
+        }
 
         // TD-RDSTRAT-8: geometry first — A0's byte length is deterministic from
         // (k_c, dim, n_comp), so every downstream offset is known BEFORE A0's

--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-2: L0→L1 compaction memory amplification OOM-kills the server (no input-size/memory guard)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Measured 2026-07-23 on SIFT 1M (develop @ 02725d81a, post #1161/#1163) during the restart/recovery pressure tests.
+| Priority | **P0** — the OOM takes down the whole server (all tenants, all collections), not just the compaction. On memory-constrained nodes (Spot instances, small pods) any 1M-scale compaction is a self-inflicted outage; jetsam/OOM-killer takes the process mid-compaction, which then also triggers the unclean-restart WAL-replay cost (TD-IVF-1).
+| Component | `src/storage/engines/sst/compaction.rs` (`perform_unified_vectorrecord_compaction`, lines ~890–1138); `src/core/search/mvcc_resolution.rs`; `compactor_impl.rs` (`k_way_merge`, `compact_level_tiered`, `retrain_pca_model_for_compaction`).
+| Evidence | macOS jetsam: `memorystatus: killing largest compressed process proximadb-server [15323] 125835 MB`. Input: 6 L0 `.pax` files, 763 MB on disk, 1M × 128-dim f32 (512 MB raw vectors). Server RSS was ~11 GB before the compaction; footprint ballooned to ~126 GB (compressed accounting) within ~2–4 min and the process was killed. Peak-RSS sweep below.
+|===
+
+== The finding
+
+Explicitly exercising the L0→L1 compaction path on a 1M-vector SIFT collection
+(763 MB across 6 L0 segments) ballooned the server's memory footprint from
+~11 GB RSS to a ~126 GB compressed jetsam kill. TD-COMPACT-1 recorded the same
+path as *slow* (666 s); under memory pressure it is *fatal*. The two findings
+share a root cause: the pipeline materializes everything, repeatedly.
+
+=== Memory-amplification mechanism (code trace)
+
+`perform_unified_vectorrecord_compaction` (`compaction.rs:890–1138`) holds
+**~5–7 simultaneous full materializations** of every input record — there is no
+streaming anywhere in the path:
+
+1. `:906/:948` — `all_vector_records: Vec<VectorRecord>`: every input file is
+   fully read and `extend`ed into one Vec (all 6 files at once).
+2. `:989` — `merged_vector_records`: dedup copy, live until the end.
+3. `:1013` — `canonical_records: Vec<ProximaRecord>`: full
+   `VectorRecord→ProximaRecord` round-trip copy #1.
+4. `:1017` — `MvccResolver::resolve_batch` builds an internal
+   `id_groups: HashMap<String, Vec<ProximaRecord>>`
+   (`mvcc_resolution.rs:51`) — another full copy.
+5. `:1081/:1084` — the merge loop clones each record **twice**
+   (`merged_vectors` + `vector_records`) while `resolved_records` is still live.
+6. `sort_vectors_for_compaction` (`:2010–2033`) does a **second** full
+   `VectorRecord→ProximaRecord→VectorRecord` round-trip.
+7. `:1110` — `sorted_vector_records: Vec<(String, VectorRecord)>`.
+
+The per-copy cost is inflated because `ProximaRecord`
+(`proximadb-records/src/lib.rs:776+`) is a heavyweight struct (embedding cells,
+principal vectors, provenance options, metadata maps): each conversion allocates
+KB-scale heap for a 512-byte SIFT vector. 1M records × 5–7 heavy copies × KB-scale
+per-record overhead ⇒ tens of GB resident.
+
+Additionally: `k_way_merge` (`compactor_impl.rs:583–631`) buffers everything into
+`id_versions: HashMap<String, Vec<ProximaRecord>>` on the other path, and
+`retrain_pca_model_for_compaction` (`compactor_impl.rs:1136`) trains PCA on the
+full in-memory slice.
+
+=== No guard exists
+
+There is **no memory or input-size bound** on compaction anywhere in
+`src/storage/engines/sst/`: the only byte budgets are read-side caches (survivor
+cache, block cache). `compact_level_tiered` (`compactor_impl.rs:1038`) compacts an
+entire level's file list in a single `compact_files` call — all 6 L0 files
+simultaneously — instead of bounded sub-batches.
+
+== Measured peak-RSS sweep (isolated single-collection server)
+
+Method: fresh server, ingest N in 6 chunks with an explicit flush per chunk
+(≈6 L0 files, mirroring the 1M run), final flush fires the inline threshold
+compaction; RSS sampled at 0.5 s cadence until the compaction completes or the
+process dies.
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| Compaction input (records) | Raw vector bytes | Base RSS | Peak RSS | Peak Δ | Outcome
+| 30,000 | 15 MB | 16.6 GB | 17.7 GB | +1.03 GB (~34 KB/record) | completed, 5→1 files in **12.3 s**
+| 120,000 | 61 MB (≈92 MB on disk, 6 files) | 4.06 GB | **55.6 GB** | +51.6 GB — **attributed to the concurrent AXIS trainer (see below)** | completed, 5→1 files in **880 s** (local SSD, 64 GB machine — deep in swap)
+| 1,000,000 | 512 MB (763 MB on disk, 6 files) | ~11 GB | >126 GB (compressed accounting) | n/a | **jetsam kill ~2–4 min in**
+|===
+
+**ATTRIBUTION (resolved by the AXIS-only control, 2026-07-23):** an AXIS-only
+control run (same 120k ingest, NO compaction) peaked at **55.59 GB** — equal to
+the compaction-window peak. The dominant memory consumer at 120k+ scale is the
+**insert-path AXIS clustering trainer (TD-IVF-2)**, which runs concurrently
+under default config, not the compaction pipeline itself. The compaction-only
+delta measured ~1 GB at 30k input (~34 KB/record) — the collect-everything
+copies traced above are real and scale linearly with heavyweight
+`ProximaRecord` conversions, but the 126 GB jetsam kill and the swap-driven
+880 s duration belong primarily to TD-IVF-2.
+
+Corollaries:
+
+* **Duration and memory unify.** PR #1166's phase timers measured ~8 s per
+  ~500k compaction when memory was calm; this sweep's 120k compaction took
+  880 s while the co-resident AXIS trainer pushed the process into swap (peak
+  55.6 GB on a 64 GB machine). TD-COMPACT-1's residual duration variance (and
+  the >3 min finalize stall seen in the #1166 session) is largely memory
+  pressure from TD-IVF-2, not compaction I/O pathology.
+* **Ordering of fixes:** gate the AXIS insert path (TD-IVF-2 S1) first — it
+  removes the OOM class for co-design collections; then bound compaction input
+  (S1 here) as the fail-safe and stream the merge (S2) so compaction memory is
+  O(write-buffer) for the collections that remain.
+
+== Direction
+
+S1 — **Bound the input (the user-visible guard, do first):** add a
+`max_compaction_input_bytes` budget enforced in
+`compact_level_tiered`/`compact_size_tiered`, defaulting to a fraction of
+detected available RAM (e.g. `available_ram / (K × measured_amplification)`
+with the amplification factor from the sweep table; conservatively ~1/8 of
+available RAM). A level whose files exceed the budget is compacted in
+sub-batches of files, never all at once. This makes worst-case compaction
+memory proportional to server memory instead of dataset size.
+
+S2 — **Stream the merge (the real fix):** replace the collect-everything design
+with a k-way heap merge that pulls one record per input iterator and writes
+straight to the PAX writer — MVCC/tombstone resolution happens incrementally
+per-key as the sorted streams converge. This eliminates `all_vector_records`,
+both `ProximaRecord` round-trips, and the dual clones; peak memory becomes
+O(write-buffer), not O(input).
+
+S3 — **Cheap interim cuts** (if S2 is deferred): drop
+`merged_vector_records`/`resolved_records` before building the sort input and
+remove the second round-trip in `sort_vectors_for_compaction` — cuts peak from
+~6× to ~2×. Train compaction-time PCA on a reservoir sample, not the full slice.
+
+== Relationship to existing TDs
+
+* TD-COMPACT-1 (666 s duration, recall dip, 0.0 MB/s metric) — same path,
+  different resource. The 2026-07-23 phase-timer measurement (PR #1166,
+  `PROXIMADB_TRACE_PAX_WRITE`) showed current-code compaction *duration* is
+  finalize/write-I/O-bound (~68% in `PaxSegmentWriter::finish()`), k-means
+  negligible, and ~8 s per ~500k on local SSD — so TD-COMPACT-1's S3/S4 are
+  redirected at finalize. **This TD is orthogonal: it is about peak memory,
+  which OOM-killed the server regardless of duration.** Note the same
+  measurement session saw a ~548k compaction stall in finalize for >3 min —
+  duration variance and memory growth compound on loaded hosts.
+* TD-COMPACT-3 (operator compaction trigger is a no-op stub for SST) — found in
+  the same session; without it there is no safe operator-driven way to compact
+  in bounded windows.
+* TD-IVF-1 — the OOM kill converts every oversized compaction into an unclean
+  restart, which then pays the WAL-replay AXIS retraining cost.

--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -83,6 +83,39 @@ copies traced above are real and scale linearly with heavyweight
 `ProximaRecord` conversions, but the 126 GB jetsam kill and the swap-driven
 880 s duration belong primarily to TD-IVF-2.
 
+**Rebased re-measurement (develop @ bcbcde710, trainer gated, PROXIMADB_TRACE_PAX_WRITE=1):**
+compaction-only at 120k input STILL balloons — peak RSS ~40.6 GB from a 1.17 GB
+base — and the phase timers localize it: `cluster_plan` 0.6 s, `finalize`
+3.6-3.8 s (both healthy), but **`encode` = 1,013-1,188 s (~10 ms/record)** vs
+the flush path's 1.07 s for 460k (~2.3 us/record) — a ~4,000x per-record gap
+on the same writer loop. The compaction-path RaBitQ re-encode inside
+`write_pax_segment_ordered` -> `PaxSegmentWriter::add_record` is BOTH the time
+and the memory monster; sub-phase instrumentation inside the writer is being
+added to pin the exact allocation site. Preferred fix upgraded accordingly:
+**carry-forward encoding** - compaction reuses the already-encoded RaBitQ codes
+from input segments (carrying the model per TD-COMPACT-1 S3) and re-orders
+bytes instead of re-encoding; eliminates the phase entirely. A per-collection
+"compaction encode strategy" tag (reuse|re-encode) is the operational valve -
+NOT a global encoding on/off switch, which would break the read cascade
+(coarse stage requires the RaBitQ region).
+
+**Sub-phase instrumentation verdict (2026-07-23, `[PAX write detail]`):** the
+compaction segment write of 105k records spent 381 s in per-record buffering
+(`FlatRow::from_record` props clone + msgpack + embedding clones — ~3.6 ms per
+record for microsecond-scale work) and 338 s in block compression (8 blocks,
+~42 s each), while RaBitQ/SQ8 encoding took 1.4 s and the writer's own peak
+buffer was **65 MB**. Refuted: block-cut storm, per-record quantizer
+construction, writer-held memory. Confirmed: the process holds ~40-52 GB
+during compaction (RSS), so every small allocation faults against swap —
+encode slowness is a SYMPTOM; the memory holder is the disease. The holder is
+upstream of the writer in the compaction pipeline (collect-everything copies,
+input-segment readers, or an expanded intermediate weighing ~100+ KB/record —
+naive copy math explains only ~2 GB, so one representation is far fatter than
+assumed). NEXT: heap-profile `perform_unified_vectorrecord_compaction` to pin
+the ~100 KB/record holder; the S2 streaming rewrite removes the entire class.
+Encode kernels are scalar (no NEON — separate, smaller lever; see TD-IVF-2
+S1b for the shared kernel direction).
+
 Corollaries:
 
 * **Duration and memory unify.** PR #1166's phase timers measured ~8 s per

--- a/docs/10-quality/td/TD-COMPACT-3-flight-compact-action-is-noop-stub.adoc
+++ b/docs/10-quality/td/TD-COMPACT-3-flight-compact-action-is-noop-stub.adoc
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-3: operator compaction trigger (Flight `compact_collection`) is a no-op stub for SST that reports success
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Found 2026-07-23 during the restart/recovery pressure tests (develop @ 02725d81a) while trying to drive L0→L1 compaction externally.
+| Priority | **P1** — compaction is the 3.2× query-latency lever (TD-COMPACT-1) and the only external trigger silently does nothing, while returning `success: true`. Operators (and test harnesses) believe they compacted and did not.
+| Component | `src/storage/engines/sst/trait_impl.rs:137–180` (`do_compact` stub); `src/network/arrow_ipc/service.rs:2236–2276` (`compact_collection` action); `src/storage/trait_components/compactor.rs:81–95`.
+| Evidence | Flight `compact_collection {"collection_id":"sift1m"}` on a 6-L0-file 1M collection returns `{"success":true,...}` in 0.24 s; server logs `🔄 SST: Starting compaction operation` then `✅ Compacted collection sift1m: 0 files created, 0 files processed`; the 6 L0 files are untouched. The real pipeline (`perform_unified_vectorrecord_compaction`) only fires inline from the flush path.
+|===
+
+== The finding
+
+The Arrow Flight `do_action` surface exposes `compact_collection` /
+`flush_and_compact` as the documented operator way to trigger compaction. The
+action chain — `service.rs:2255` → `unified_engine().compact_collection(id, None)`
+→ trait default (`compactor.rs:81–95`) → `SstEngine::do_compact`
+(`trait_impl.rs:137–180`) — terminates in a **stub** that logs
+"Starting compaction operation", does nothing, and returns
+`input_files: Some(0), output_files: Some(0)`, which the Flight handler
+translates into `success: true`.
+
+Consequences:
+
+1. **False success.** The operator-facing trigger reports success without
+   compacting. During the pressure tests this masked the fact that the actual
+   compaction (flush-path-triggered) was running concurrently and OOM'ing
+   (TD-COMPACT-2).
+2. **No completion signal.** Even when the real (flush-path) compaction runs,
+   the action returns immediately; the only way to observe completion is
+   log-grepping for `Level 0 complete`. There is no status/progress surface.
+3. `flush_collection` (`flush.rs:93`) *does* attempt inline compaction after the
+   WAL drain — so today the only functional external "compact now" is a flush
+   side-effect that swallows errors at `debug!` level.
+
+== Direction
+
+S1 — Wire `SstEngine::do_compact` to the real L0→L1 path
+(`check_compaction_needed` + `compact_level_tiered`), honoring the
+TD-COMPACT-2 input-size budget, and return real input/output file counts.
+
+S2 — Make the action's response honest: if compaction is intentionally
+asynchronous, return a job id and expose completion via the diagnostics
+route-health endpoint (or a `compaction_status` action) instead of
+`success: true` with zero work done.
+
+S3 — Promote flush-path compaction errors from `debug!` to `warn!` with the
+collection id — silent failure hid both the stub and the OOM during testing.

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-4: memory-aware cross-collection compaction admission control (queue + budget + query priority)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (2026-07-23, restart/recovery pressure tests). Ops-side complement to TD-COMPACT-2 (per-job memory) and TD-COMPACT-3 (trigger honesty).
+| Priority | **P1** — multi-collection servers can start several compactions concurrently (per-engine workers, `background_thread_count = 4`) with NO global admission control; measured single-job cost today is ~40 GB at 120k input, so even two concurrent mid-size compactions exceed a 64 GB node. Queries co-resident with a swapping compaction degrade ~6× (cold mean 148 ms → 880 s wall for the compaction window).
+| Component | `src/storage/engines/sst/compaction.rs` (`start_workers`/`schedule_compaction`), flush-path inline compaction (`services/operations/vectors/flush.rs`), a new global admission gate shared across collections/engines.
+| Evidence | Pressure tests 2026-07-23: one 120k-input compaction = ~40 GB peak / 17-20 min (rebased, trainer gated); 1M-input = jetsam kill at ~126 GB. Flush path runs compaction inline (awaited), so "compaction is async/internal" does not hold on that path today.
+|===
+
+== The finding
+
+Compaction scheduling is per-collection/per-engine with a thread-count cap
+only. There is no global controller that (a) bounds how many compactions run
+concurrently across ALL collections, (b) accounts for projected per-job
+memory, or (c) subordinates background work to query traffic. Under default
+config a busy multi-tenant node can therefore self-inflict memory exhaustion
+even after the per-job fixes land, and today a single unbounded job already
+does (TD-COMPACT-2).
+
+== Direction
+
+S1 — **Global admission gate**: one server-wide async semaphore for compaction
+jobs across all collections/engines. Default concurrency: min(2,
+cores/4). All entry points (threshold scheduler, flush-path inline call, the
+repaired operator trigger from TD-COMPACT-3) must acquire it — the inline
+flush-path call becomes "enqueue and return" (flush durability does not depend
+on compaction).
+
+S2 — **Memory-aware admission**: gate on projected job cost, not just count:
+`projected = input_bytes × amplification` (amplification from the measured
+sweep table in TD-COMPACT-2 until the streaming fix lands, then
+O(write-buffer)). Admit while `sum(projected of running jobs) + headroom <
+available_ram × fraction`; oversized single jobs are split per TD-COMPACT-2 S1
+(sub-batch by files) instead of admitted whole.
+
+S3 — **Priority + observability**: background jobs run at lower scheduling
+priority than query serving; expose `compaction_queue_depth`,
+`compaction_running`, `compaction_projected_bytes` as Prometheus gauges
+(TD-METRICS family) so operators can see the queue instead of inferring it
+from CPU/RSS.
+
+== Notes
+
+* Queue depth alone is NOT sufficient: with today's per-job cost a depth-1
+  queue still OOMs at 1M input — S2's budget (and TD-COMPACT-2's per-job fix)
+  carry the correctness burden; the queue carries stability under fan-out.
+* Interacts with #1164's cores-ratio compaction threads (CPU-side cap); this
+  TD adds the memory-side and cross-collection dimensions.

--- a/docs/10-quality/td/TD-FLUSH-3-segment-size-emergent-from-backend-latency.adoc
+++ b/docs/10-quality/td/TD-FLUSH-3-segment-size-emergent-from-backend-latency.adoc
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FLUSH-3: segment size is emergent from flush-latency×ingest-rate feedback, not policy — add a min-segment-bytes floor (object storage: 104 tiny files ⇒ 1812 GETs/query)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (2026-07-23, Azurite pressure test, develop @ bcbcde710 + azure feature).
+| Priority | **P1 (P0 for object-store deployments)** — file count is THE round-trip multiplier: identical config produced 6 L0 files locally (51 GETs/q at 1M) but **104 L0 files over Azurite → 1812 GETs/query, 12 s cold mean, and a survivor cache that can no longer hold its 100%-hit property (hot = 279 GETs/q, 805 ms vs 0 GETs/0.45 ms locally)**.
+| Component | WAL flush triggering (`memory_flush_size_bytes` check in the serialization strategy → `trigger_background_flush`), ADR-069 auto-flush driver; flush sizing policy.
+| Evidence | Azurite run: 1M ingested at 5,190 rec/s with default thresholds (16 MB / 100k vectors / 300 s) → **104 flushes, one per ~1.9 s, ~10k records ≈ 5 MB raw each**. Local run, same config, 15.7k rec/s → 6 large files. Neither hit the 100k-vector or 300 s triggers.
+|===
+
+== The finding
+
+Two compounding causes:
+
+1. **The 16 MB threshold measures serialized `ProximaRecord` bytes (~1.6 KB per
+   record), not payload** — so "16 MB" ≈ 10k vectors ≈ 5 MB of raw vector data.
+   The floor is ~6× smaller than intended for vector workloads.
+2. **Segment size is emergent, not chosen.** The background flush drains
+   whatever accumulated while the previous flush ran. When the flush backend is
+   fast relative to ingest (small objects to a nearby store, emulator, NVMe),
+   each drain is small → many small files. When the flush is slow, drains grow
+   → few large files. The same config therefore yields 6 files on one backend
+   and 104 on another. Nothing in the policy expresses "a segment should not be
+   smaller than X" — and on object storage X is the whole game, because
+   GETs/query ∝ file count (co-design round-trips term).
+
+Durability does NOT require flushing: the WAL/write buffer is local disk, so
+flush policy only trades memtable memory vs recovery-replay time. Small
+segments buy nothing and cost 35× on the read path.
+
+== Direction
+
+S1 — **Min-segment floor on PREDICTED bytes**: final on-disk size is unknowable
+pre-encode (compression varies), but it does not need to be known — the region
+layout is deterministic per collection config, so
+`predicted_segment_bytes ≈ N × dim × k(config)` where
+`k = 1/8 (RaBitQ) + 1 (SQ8) + 4·f32_tier` bytes/dim, plus props payload. Do
+not drain the memtable below the floor on predicted bytes unless (a) the RPO
+timer (`flush_interval_secs`, default 300 s) fires, or (b) memtable memory
+pressure (high watermark) forces it. Default floor per backend class: object
+storage 128–256 MB predicted (≈0.9–1.8M vectors at 128-dim RaBitQ+SQ8); local
+disk 32 MB. This is "flush after 5 min or memory pressure, whichever first" —
+with the predicted-size floor making the emergent-size problem impossible.
+
+S2 — **Fix the accounting**: the current `memory_flush_size_bytes` measures
+serialized `ProximaRecord` bytes (~1.6 KB/record) — a memtable-RAM bound, not
+a segment-size proxy. Keep it for memory pressure, but add the S1 predictor
+(`vector_count × dim × k` — cheap, exact for the dominant regions) as the
+flush-decision input; log the trigger reason (floor/count/timer/pressure) on
+every flush so cadence is diagnosable from logs.
+
+S3 — **Small-file self-healing**: when L0 accumulates >N small files (already
+the case for existing deployments), a cheap L0→L0 stitch (concatenate
+segments without re-encoding — same carry-forward machinery as TD-COMPACT-2's
+streaming direction) restores the file-count floor without paying the current
+compaction pathology.
+
+== Relationships
+
+* TD-RDSTRAT-11 (probe locality) reduces GETs per file; this TD reduces the
+  file count itself — multiplicative.
+* TD-RDSTRAT-10 S3 (pin the coarse tier) restores hot-path 0-GET even before
+  this lands, but cold queries still pay file-count × probe fan-out.
+* TD-COMPACT-2/4 gate the compaction that would otherwise fix file count.

--- a/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
+++ b/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
@@ -11,6 +11,36 @@
 | Evidence | Collection `sift1m` created via REST v2 with `index_specs: []` (verified by GET). Live ingest run: `🎯 Training clustering model for collection 1 with 634000 vectors` (14:20:59). Post-unclean-kill restart: recovery flushes correctly skip AXIS (zero training lines at boot — #1163 works), but ~2.5 min later the WAL-replayed inserts hit the AXIS incremental path: `Training PCA model: 916000 vectors` (1 s) then `🎯 Training clustering model for collection 1 with 1000000 vectors` — still ~90% CPU 13+ min later. Handoff Test 1's "idle CPU < 5%" assertion fails on unclean restarts because of this path.
 |===
 
+== Status update — develop @ bcbcde710 (2026-07-23, post #1164/#1167)
+
+Re-running the controls on the rebased binary **changes the trigger picture**:
+
+* AXIS-only control (identical 120k ingest, no `index_configs`): **zero
+  training fired**, RSS flat at 3.33 GB through the full watch window — on
+  `02725d81a` the same run ballooned to 55.6 GB. The per-collection gates
+  referenced by TD-IVF-1's #1167 status (EventLog consumer ack-and-skip +
+  gated IVF build path) are effective for the ingest-side trigger on current
+  develop.
+* Clean restart of the 1M bed on the rebased binary: **no retraining, idle
+  CPU 0.4%** — the handoff's Test 1 assertion passes.
+
+REMAINING scope (why this TD stays open at reduced priority):
+
+1. The ungated **feed** at `insert_vectors_direct` (legacy.rs:4095) still
+   buffers every record of every collection into AXIS (`insert_record` per
+   record after each WAL write) — dead-weight allocations and lock traffic on
+   the hot write path even when training never fires; apply the #1145
+   predicate at the feed.
+2. The trainer's **memory pathology stands** for collections that DO use
+   AXIS: +51 GB / non-completion at 120k is a property of the training path
+   itself (S1b profiling), measured on 02725d81a and not exercised on
+   bcbcde710 only because the trigger is now gated for co-design collections.
+3. The exact trigger chain that fired on 02725d81a (live-ingest train at
+   634k/120k, boot-rehydration train at 1M, SIGTERM-blocking) should be
+   pinned to the commit that closed it, so a regression test can guard it —
+   the death-spiral evidence below documents the failure mode to protect
+   against.
+
 == The finding
 
 #1163 (TD-IVF-1) gates the **flush-path** AXIS build on

--- a/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
+++ b/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
@@ -48,6 +48,17 @@ the #1145 gate "keeps AXIS build cost off co-design collections" holds for
 search/flush but not for insert-driven incremental training — the measurements
 above are all from a collection the gate classifies as co-design.
 
+=== Clean restarts are NOT immune (and SIGTERM is blocked)
+
+A graceful-shutdown restart of the 1M collection re-fired the full 1M
+clustering training ~60 s after boot (no unflushed WAL — the trainer is re-fed
+by boot-time rehydration, not only WAL replay), pinning ~1 core for the next
+~50 min until the process was killed. During training, SIGTERM was ignored
+(process had to be SIGKILLed), which converts every operator restart attempt
+into an *unclean* shutdown — whose next boot retrains again. Restart → retrain
+→ blocked shutdown → SIGKILL → retrain is a self-sustaining loop on any
+1M-scale co-design collection under default config.
+
 === Memory profile (controlled, 2026-07-23)
 
 AXIS-only control: fresh server, one collection (empty `index_specs`), ingest

--- a/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
+++ b/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IVF-2: insert-path AXIS IVF training fires for co-design collections with empty index_specs (+51 GB RSS at 120k, never completes — the primary OOM driver)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Measured 2026-07-23 during the restart/recovery pressure tests (develop @ 02725d81a, post #1163).
+| Priority | **P0 — this path is the primary memory-kill driver, not just a CPU tax.** Controlled measurement (single-collection server, NO compaction): ingesting 120k × 128-dim (61 MB raw) then letting the insert-path training fire took RSS from 4.35 GB to a **55.6 GB peak (+51.2 GB)** and the training **did not complete within 15.5 min** (64 GB machine, deep in swap). At 1M after an unclean restart it ran **>43 min at ~90–300% CPU, RSS 10→39.5 GB and climbing** until manually killed. The 126 GB jetsam kill originally attributed to compaction (TD-COMPACT-2) is predominantly THIS path — the compaction-window peak (55.6 GB) is indistinguishable from the AXIS-only control (55.59 GB). All of it on a collection that never asked for AXIS.
+| Component | `src/index/axis/management/manager.rs` (`insert_into_ivf` :2069, incremental train :2217); `src/index/axis/clustering.rs` (`train_model` :255); config `enable_axis_indexes` (`proximadb-config/src/lib.rs:939–963`, default **true**; also `config/config.toml:60`).
+| Evidence | Collection `sift1m` created via REST v2 with `index_specs: []` (verified by GET). Live ingest run: `🎯 Training clustering model for collection 1 with 634000 vectors` (14:20:59). Post-unclean-kill restart: recovery flushes correctly skip AXIS (zero training lines at boot — #1163 works), but ~2.5 min later the WAL-replayed inserts hit the AXIS incremental path: `Training PCA model: 916000 vectors` (1 s) then `🎯 Training clustering model for collection 1 with 1000000 vectors` — still ~90% CPU 13+ min later. Handoff Test 1's "idle CPU < 5%" assertion fails on unclean restarts because of this path.
+|===
+
+== The finding
+
+#1163 (TD-IVF-1) gates the **flush-path** AXIS build on
+`collection_config.index_configs` and correctly skips recovery flushes. But the
+**insert path** — `AxisManager::insert` → `insert_dense_vector_index` →
+`insert_into_ivf` (`manager.rs:2069`) — buffers vectors per-collection and, once
+the incremental threshold is crossed, trains a full IVF
+(`UnifiedIvfIndex::train` → `AxisClusteringEngine::train_model`, k-means over
+the entire buffered set). This path never consults the collection's
+`index_specs`; it is gated only by the global `enable_axis_indexes = true`
+default.
+
+So a co-design collection (empty `index_specs`, PAX cascade serving all reads)
+still pays:
+
+* **Live ingest:** k-means over ~634k vectors mid-ingest (minutes of CPU that
+  compete with the ingest itself).
+* **WAL replay after unclean restart:** the replayed inserts re-buffer the
+  entire collection into AXIS and re-train from scratch — 1M-vector k-means,
+  >13 min at ~90–100% CPU — for an index that no read will ever use
+  (`ADR-070`). Nothing is loaded from the persisted A0 model; nothing is
+  persisted that would prevent the next unclean restart from paying it again.
+
+=== Relationship to the existing gates (#1145, #1155, #1163, TD-AXIS-2)
+
+The per-collection gate (#1145, `use_axis_indexes = pax_off ||
+!index_configs.is_empty()` in `proximadb-storage-traits/src/query.rs`) governs
+the **search** route, and #1155/#1163 gate the **flush**-side AXIS build. This
+TD is the third leg: the **insert** path buffers vectors and trains without
+consulting either the per-collection predicate or the global flag. TD-AXIS-2
+(filed with #1164) notes `enable_axis_indexes` is read by nothing at boot —
+which also means #1164's default flip to `false` does NOT stop this path; the
+insert-side training continues regardless of the flag. TD-AXIS-2's premise that
+the #1145 gate "keeps AXIS build cost off co-design collections" holds for
+search/flush but not for insert-driven incremental training — the measurements
+above are all from a collection the gate classifies as co-design.
+
+=== Memory profile (controlled, 2026-07-23)
+
+AXIS-only control: fresh server, one collection (empty `index_specs`), ingest
+120k SIFT in one pass (no compaction — 1 L0), let the incremental trainer fire:
+
+* post-ingest RSS 4.35 GB → peak **55.6 GB** during training (**+51.2 GB** for
+  61 MB of raw vectors), training **still unfinished at 15.5 min** on a 64 GB
+  machine. At 30k-record scale the same composition peaks ~1 GB — the growth is
+  strongly superlinear.
+* The training loop itself (`train_kmeans`) holds only O(N + k·dim) state, and
+  `determine_optimal_k` is a closed-form heuristic — the resident blow-up is
+  therefore NOT an algorithmic matrix; prime suspect is per-call allocation
+  churn in `UnifiedDistanceCompute::calculate_distance` across
+  N × k × iterations (~10^9-10) invocations (also explains the non-completion:
+  allocator pressure + swap). Root-cause profiling is part of this TD.
+* Consequence for TD-COMPACT-2: the compaction-window peak at 120k (55.6 GB)
+  is indistinguishable from this AXIS-only control (55.59 GB) — the AXIS
+  trainer, not the compaction pipeline, is the dominant memory consumer in the
+  default configuration; compaction-only Δ measured ~1 GB at 30k input.
+
+== Direction
+
+S1 — Gate the AXIS insert path per-collection: skip buffering/training when the
+collection's `index_specs` is empty (same predicate the flush gate uses post
+#1163). The global `enable_axis_indexes` stays as a kill-switch. **This is the
+actual fix for the OOM class** — it removes the dominant memory consumer for
+co-design collections entirely. The exact feed point is
+`insert_vectors_direct` (`src/services/operations/vectors/legacy.rs:4095-4103`):
+after the WAL write it loops `axis_index_manager.insert_record(...)` for every
+record with no gate of any kind — apply the #1145 predicate there (and at any
+sibling insert path that feeds `AxisManager::insert_record`).
+
+S1b — Profile and fix the superlinear allocation in the trainer for
+collections that DO use AXIS (allocation churn in the distance kernel; reuse a
+scratch buffer / SIMD path that borrows instead of allocating).
+
+S2 — Flip the `enable_axis_indexes` default to false for co-design deployments
+(ADR-070 decision; update `config/config.toml` and the terraform ConfigMap
+together).
+
+S3 — For collections that DO want AXIS: on restart, load the persisted model
+(A0 region / `__model`) instead of re-training from replayed inserts —
+this is TD-IVF-1's "full fix" applied to the insert path.

--- a/docs/10-quality/td/TD-NET-1-hardcoded-internal-mux-port-cross-instance-hijack.adoc
+++ b/docs/10-quality/td/TD-NET-1-hardcoded-internal-mux-port-cross-instance-hijack.adoc
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-NET-1: hardcoded internal multiplexer upstream (127.0.0.1:15679) silently routes gRPC/Arrow Flight to another instance
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Found 2026-07-23 during the restart/recovery pressure tests: two instances on one host, disjoint configs/ports — instance B's Flight requests were served by instance A.
+| Priority | **P0 for any multi-instance host** — cross-instance request hijack. The unified port multiplexer forwards HTTP/2 (gRPC + Arrow Flight) to a fixed `127.0.0.1:15679` upstream; whichever instance bound 15679 first serves *every* co-hosted instance's gRPC/Flight traffic, against the wrong data, wrong tenants, wrong WAL. Combined with the fail-open action responses this is invisible to the caller: actions return `success: true` from the wrong database. Structural tenant/instance isolation (co-design mandate) is broken at the transport layer.
+| Component | `src/network/multi_server.rs:952–954` (`let internal_grpc_addr = "127.0.0.1:15679"` hardcoded); the second instance's own internal listener fails its bind with a log-only `ERROR Internal gRPC server error: transport error` and the multiplexer keeps forwarding to the foreign 15679.
+| Evidence | Instance A (`unified_port=5678`) bound 15679. Instance B (`unified_port=6678`, fully disjoint data/metadata/WAL paths) logged `gRPC + Arrow Flight Server starting on 127.0.0.1:15679 (internal)` + `Internal gRPC server error: transport error`, then served REST itself but forwarded all Flight `do_action` calls (verified: `flush_collection` on B appeared in A's log — 14 `Force flushing` entries — while B's log recorded none; `lsof -iTCP:15679` showed A's pid). B's flushes therefore "succeeded" against A's collections.
+|===
+
+== The finding
+
+In unified-port mode the TCP multiplexer terminates the public port and routes
+HTTP/2 to an internal gRPC + Arrow Flight listener. That upstream address is a
+compile-time constant `127.0.0.1:15679` — not derived from `unified_port`, not
+configurable, not instance-scoped. Consequences on a host with >1 instance:
+
+1. The second instance's internal listener fails to bind; the error is logged
+   and **ignored** — startup continues and reports
+   "Unified Server started successfully".
+2. The second instance's multiplexer happily forwards its gRPC/Flight traffic
+   to the first instance's internal listener. Callers get well-formed, `success`
+   responses computed by the wrong database instance.
+3. Interacts with TD-WAL-4 (shared cwd-relative write buffer): between the two
+   defects, two "isolated" instances shared both a WAL and a Flight backend,
+   which cost several pressure-test iterations to diagnose.
+
+== Direction
+
+S1 — Derive the internal upstream per-instance: `unified_port + fixed_offset`,
+an OS-assigned ephemeral port (bind :0, read the actual addr), or a Unix domain
+socket under `data_dir`. Any of these makes the upstream instance-unique.
+
+S2 — Make the internal bind failure **fatal** in unified mode: if the instance
+cannot own its internal listener, the multiplexer must not start (fail-closed),
+instead of forwarding to whoever owns the port.
+
+S3 — Add a startup self-check: do a loopback Flight `list_actions` through the
+public port and verify the responding instance id matches (cheap canary against
+any future routing split-brain).

--- a/docs/10-quality/td/TD-RDSTRAT-10-temperature-split-segment-objects.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-10-temperature-split-segment-objects.adoc
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-10: temperature-split the segment — hot coarse object (header+centroids+RaBitQ) vs Cool-tier rerank object (SQ8/fp32)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (2026-07-23, from the restart/recovery pressure-test floor analysis). Design-stage; no code yet.
+| Priority | **P1** — moves BOTH at-rest GB-month (the dominant at-rest term, ADR-036) and DRAM economics (~30× hot-tier density), using machinery that already exists (per-PUT access tier, survivor cache, region-coalesced layout).
+| Component | `crates/storage/proximadb-block-format` (segment writer/reader), `coalesced_rabitq.rs`, flush/compaction writers, `ObjectAccessTier`/`FileOptions.storage_class` plumbing, survivor cache budget.
+| Evidence (floor analysis) | SIFT 1M: coarse tier (header 40 B + centroids/PCA A0 + RaBitQ 1 bit/dim) ≈ **16 MB = ~2% of the 763 MB segment set**, touched by **every** query; SQ8 (~128 MB) + fp32 (~512 MB) touched only by rerank survivors (~200 KB/query). Survivor cache currently budgets ~600 MB/collection to make the hot path 0-GET; a fully-resident coarse tier costs 16 MB for the same coarse-phase effect.
+|===
+
+== First-principles finding
+
+The segment already separates temperatures logically (coalesced regions
+`[RaBitQ | SQ8 | fp32]`, ADR-065) but stores them in **one object**, so:
+
+* the whole 763 MB pays the Hot GB-month rate although ~98% of the bytes are
+  touched only by rerank survivors at ~200 KB/query;
+* the survivor cache must budget against region *ranges* of a large object
+  (~600 MB/collection) instead of simply pinning the small always-hot part;
+* per-object access tier (ADR-036: "the tier is the cost lever") cannot be
+  applied differentially — the coldest bytes ride the hottest tier.
+
+== Direction
+
+S1 — **Split at write time into two objects** (flush + compaction writers):
+`<seg>.hot.pax` = header-prefix + footer-index + A0 model + coalesced RaBitQ
+region; `<seg>.cold.pax` = SQ8 + fp32 (+ row) regions. Reader stitches via the
+footer-index (which already records region offsets — it gains an object
+discriminator). Mixed-read-safe per mandate #8: presence of the split marker in
+the footer selects the two-object reader; absent marker ⇒ legacy single-object
+path. Default-OFF until baked.
+
+S2 — **Tier per-PUT**: hot object ⇒ default (Hot); cold object ⇒
+`ObjectAccessTier::Cool` via the canonical `FileOptions.storage_class`
+(cloud-neutral, mapped at the I/O boundary — never per-cloud strings). At-rest
+cost for the ~98% cold bytes drops to the Cool GB-month rate; rerank reads pay
+Cool's per-GB read premium on ~200 KB/query, which the cost model must confirm
+nets positive (it does at any read:storage ratio seen in the traces).
+
+S3 — **Pin the coarse tier in DRAM**: replace range-level survivor caching for
+the coarse phase with whole-object residency of `<seg>.hot.pax`
+(16 MB/collection at 1M×128d). Every query's coarse phase becomes 0-GET
+structurally; the survivor cache budget then serves only rerank survivors.
+~30× more collections per GB of cache ⇒ direct multi-tenant density lever.
+
+S4 — **Meter it**: the split makes the storage bill legible per temperature
+(KSU by tier) and the io-trace already tags region reads — extend the
+per-query trace with hot/cold object attribution so the ComputeScheduler can
+cost routes from measured quantities.
+
+== Risks / notes
+
+* Two objects per segment doubles object count (PUT/LIST costs, orphan
+  recovery surface — reuse the existing same-key orphan logic, TD-OBJSTORE-4).
+* Cool-tier read latency/premium applies only to rerank survivor ranges;
+  Archive is out of scope (retrieval latency incompatible with query path).
+* Complements TD-RDSTRAT-6/7 (bytes term inside regions) and TD-RDSTRAT-11
+  (GETs term via probe locality); orthogonal to both.

--- a/docs/10-quality/td/TD-RDSTRAT-11-probe-locality-cell-placement.adoc
+++ b/docs/10-quality/td/TD-RDSTRAT-11-probe-locality-cell-placement.adoc
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RDSTRAT-11: probe-locality cell placement — order cells by co-probe affinity so nprobe ranges coalesce (51 → ~10 GETs/query)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed** (2026-07-23, from the restart/recovery pressure-test floor analysis). Design-stage; no code yet.
+| Priority | **P1** — GETs/query is the dominant round-trip cost term on object storage (co-design mandate); measured 51 GETs/q at 1M (ADR-065 evidence) vs a coalescing floor of ~5–10. Pure layout change: no recall impact, no new data structures.
+| Component | flush/compaction cell-ordering (`cluster_plan` in the PAX writer), `ObjectRangeCoalescePolicy`, coalesced-region layout (`coalesced_rabitq.rs`), segment footer cell directory.
+| Evidence (floor analysis) | A query probes `nprobe` cells; today cells are laid out in arbitrary (cluster-id) order, so probe sets translate to ~nprobe disjoint ranges (+ rerank ranges) ⇒ 51 GETs/q at 1M. Neighboring centroids are probed together by construction (a query's nprobe set = the k nearest centroids, which are mutually close), so ordering cells by centroid proximity makes typical probe sets *contiguous on disk* — the existing `ObjectRangeCoalescePolicy` then merges them into a handful of ranged GETs.
+|===
+
+== First-principles finding
+
+The round-trips term is set not by how MANY cells a query probes but by how
+many *disjoint byte ranges* those cells occupy. Probe sets are not random:
+they are k-NN sets in centroid space, i.e. clusters of mutually-near
+centroids. Placing near centroids' cells adjacently on disk converts most
+probe sets into 1–3 contiguous runs. This is the same insight as
+Morton-ordering rows within a cell (TD-RDSTRAT-4 / the sign-bit bootstrap),
+lifted one level: **order the cells themselves, not just the rows within
+them.**
+
+== Direction
+
+S1 — **Ordering heuristic at write time**: after training/loading centroids,
+compute a locality order over cells — options in ascending fidelity: (a)
+Morton/Hilbert code of the (PCA-projected) centroid, (b) greedy nearest-
+neighbor tour over the centroid k-NN graph, (c) recursive bisection of the
+centroid set. Write cells in that order in the coalesced region; record the
+order in the footer cell directory (readers are order-agnostic today — they
+look up offsets — so this is mixed-read-safe by construction and needs no
+format flag).
+
+S2 — **Measure with the existing harness**: SIFT 1M, IVF-on, report
+`range_gets/query` before/after (evidence ledger gate; the io-trace already
+counts it). Target: 51 → ≤15 at unchanged recall (ordering cannot change
+which cells are probed, only their adjacency — recall is provably invariant).
+
+S3 — **Tune the coalesce policy jointly**: with locality ordering, the
+`ObjectRangeCoalescePolicy` gap threshold becomes the knob trading wasted
+bytes (reading small gaps between near-adjacent cells) vs round-trips; sweep
+it on the measured trace and set per the cost model (a 50 ms GET buys a lot
+of gap bytes on object storage).
+
+S4 — **Compaction is the natural application point**: cell order is fixed at
+segment write, so the lever engages at flush for new segments and at
+compaction for existing ones — no migration needed; old segments simply keep
+their order until compacted (mixed-read-safe).
+
+== Risks / notes
+
+* Adjacency helps the *typical* probe set; adversarial queries whose probe
+  set spans distant centroids still pay ~nprobe ranges — the floor, not a
+  regression.
+* Interacts positively with TD-RDSTRAT-8 (two-level coarse probe): coarse-
+  cell super-clusters are exactly the locality groups to keep adjacent.
+* Orthogonal to TD-RDSTRAT-10 (temperature split): ordering applies within
+  each temperature object independently.

--- a/docs/10-quality/td/TD-WAL-4-cwd-relative-write-buffer-breaks-instance-isolation.adoc
+++ b/docs/10-quality/td/TD-WAL-4-cwd-relative-write-buffer-breaks-instance-isolation.adoc
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-WAL-4: cwd-relative `write_buffer_directory` (and sst/viper data dirs) silently breaks multi-instance isolation
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Proposed.** Found 2026-07-23 during the restart/recovery pressure tests: two servers with fully disjoint `data_dir`, `metadata_url`, and `storage_locations` cross-contaminated through a shared WAL write buffer.
+| Priority | **P1** — silent cross-instance WAL sharing corrupts recovery: each instance lists and replays the other's collections. Any host running two proximadb-server processes from the same working directory (CI, side-by-side test/prod, blue-green) hits this. Data-path config that ignores the configured storage roots also violates the DrPathBuilder/tenant-isolation posture (co-design mandate #3: isolation is structural).
+| Component | `WriteBufferUserConfig.write_buffer_directory` default (cwd-relative `data/write_buffer`); `SstConfig.data_directory` default (`sst_data`); `ViperConfig.data_directory` default (`data/viper_data`) — see the resolved-config dump in the server startup log.
+| Evidence | Server A: `-c config.toml` (all paths under `…/pdb/`). Server B: `-c config2.toml` (all paths under `…/pdb2/`, distinct ports). Both resolved `write_buffer_directory: "<cwd>/data/write_buffer"` because the TOMLs did not set the key. Result: `GET /api/v2/collections` on **each** server listed **both** servers' collections (`sift1m` from A, `sweep` from B); B's ingested records went into the shared global memtable/WAL; B's flush produced no files under B's own storage locations. Fixed for the test run only by explicitly setting `[storage.wal_config] write_buffer_directory` under the instance root.
+|===
+
+== The finding
+
+`data_dir`, `metadata_url`, and every `storage_locations` URL are configurable
+and were fully disjoint between the two instances — but the WAL write buffer
+(the singleton `GlobalPartitionedMemtable` backing store), the SST engine data
+directory, and the viper data directory default to **cwd-relative** paths that
+no top-level setting re-roots. Two instances launched from the same directory
+therefore share the physical WAL: collection metadata recovered from WAL leaks
+across instances, record batches land in a memtable another process may flush,
+and an instance's "own" storage locations stay empty while its data rides a
+foreign WAL.
+
+There is no warning at startup: each server logs the shared path buried in the
+resolved-config dump and proceeds.
+
+== Direction
+
+S1 — Derive the defaults from `server.data_dir` (e.g.
+`<data_dir>/write_buffer`, `<data_dir>/sst`, `<data_dir>/viper`) instead of
+cwd, so instance isolation follows the one knob operators actually set.
+
+S2 — At startup, fail (or at minimum `warn!`) when the write buffer directory
+is already locked by another live process (flock/pid file) — silent sharing is
+never intended.
+
+S3 — Audit for other cwd-relative data-path defaults (the resolved-config dump
+makes them findable: grep the startup log for paths outside `data_dir` and the
+storage locations).


### PR DESCRIPTION
## Summary

End-to-end restart/recovery pressure tests (SIFT1M, local + Azurite) on develop @ bcbcde710, executing the IVF/restart/recovery handoff test matrix. Files 9 TDs with measured evidence and ships the env-gated `[PAX write detail]` sub-phase timers (extends TD-COMPACT-1 S1) that localized the compaction pathology.

## Test matrix results (rebased binary, bare defaults)

| Test | Result |
|---|---|
| T1 clean restart (1M bed) | PASS — health 3 s, zero retraining, idle CPU 0.4% |
| T2 cold 200q | PASS — recall 0.9865, mean 148.5 ms, p99 168 ms (7 L0) |
| T3 hot 200q | PASS — 0.43 ms mean, 2172 QPS, `object_store_gets_total` delta = 0 |
| T4 concurrency | c10 2786 QPS peak; c50/c100 ~1350 QPS, graceful degradation |
| T5 kill -9 ×5 (100k) | PASS 5/5 — time-to-ready 1 s, recall 1.0, deterministic WAL recovery |
| T6 Azurite (adls://) | PASS w/ findings — kill -9 restart 27 s, recall 0.99; BUT 104 tiny L0 files → 1812 GETs/query cold, hot cache broken (279 GETs/q) |
| T7 codegraph CRUD | PASS — upsert/tombstone/insert all correct and persistent across restart |

## TDs filed (all with measured evidence)

- **TD-COMPACT-2** — compaction memory blow-up (126 GB jetsam kill at 1M; ~40-52 GB at 120k). Instrumented verdict: writer peak 65 MB, holder is upstream (collect-everything pipeline); encode slowness (381 s raw_buffer + 338 s block for 105k) is a swap symptom. Encode kernels are scalar (no NEON).
- **TD-COMPACT-3** — Flight `compact_collection` is a success-reporting no-op stub for SST.
- **TD-COMPACT-4** — memory-aware cross-collection compaction admission control (queue + projected-cost budget + query priority).
- **TD-IVF-2** — insert-path AXIS training ungated by `index_specs` (+51 GB / non-completion at 120k on 02725d81a; re-scoped after gates on current develop proved effective — feed still ungated at `insert_vectors_direct`).
- **TD-WAL-4** — cwd-relative `write_buffer_directory` breaks multi-instance isolation (two disjoint-config servers silently shared a WAL).
- **TD-NET-1** — hardcoded internal mux upstream 127.0.0.1:15679 routes gRPC/Flight to whichever instance bound it first (cross-instance hijack, fail-open).
- **TD-RDSTRAT-10** — temperature-split segment: hot coarse object (header+A0+RaBitQ, ~2% of bytes) vs Cool-tier rerank object; coarse tier DRAM-pinnable at 16 MB/collection.
- **TD-RDSTRAT-11** — probe-locality cell placement: order cells by centroid proximity so nprobe sets coalesce (51 → ~10 GETs/query floor, recall-invariant).
- **TD-FLUSH-3** — segment size is emergent from flush-latency×ingest-rate feedback; add a min-segment floor on predicted bytes (N×dim×k(config)) + RPO timer + pressure override.

## Code

- `crates/storage/proximadb-storage-common/src/pax_block.rs`: env-gated (`PROXIMADB_TRACE_PAX_WRITE`) cumulative sub-phase timers in `PaxSegmentWriter` — one `[PAX write detail]` line per segment; zero cost when unset. fmt + clippy -D warnings clean.

## Verification

- `cargo clippy -p proximadb-storage-common -- -D warnings` clean; `cargo fmt --check` clean; TD/ADR uniqueness guard clean (264 ids).
- All measurements in the TD tables were taken this session with the exact commands recorded in the session evidence ledger.