### PR TITLE
feat(sst): [COMPACT mem] stage profile pins the compaction memory holder to the write phase (+40.5 GB inside PaxSegmentWriter)

### DIFF
--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -116,6 +116,27 @@ the ~100 KB/record holder; the S2 streaming rewrite removes the entire class.
 Encode kernels are scalar (no NEON — separate, smaller lever; see TD-IVF-2
 S1b for the shared kernel direction).
 
+**HOLDER PINNED (stage-boundary memory profile, `PROXIMADB_TRACE_COMPACTION_MEM`,
+2026-07-23):** at 105k records every pipeline stage is benign — input reads
+~112 MB, canonical conversion +139 MB, MVCC +194 MB, merge clones +83 MB, sort
++196 MB (total ≈ 440 MB; sampled record sizes vr=576 B / pr=692 B, ONE
+embedding — the fat-record and double-fp32 theories are refuted). Then:
+`stage=pre_write rss=4,356 MB` → `stage=write_done rss=44,834 MB,
+delta=+40,475 MB`. **The entire blow-up (+40.5 GB, ≈385 KB/record) happens
+inside the segment write call** (`write_pax_segment_ordered` →
+`PaxSegmentWriter`), while the writer's tracked buffers (`file_buf` + rabitq
+region) peak at 65 MB — the holder is the UNTRACKED block/stripe assembly:
+compaction writes only 8 giant cell-boundary blocks (~13k rows each) and each
+block takes ~42 s to cut/compress, vs the flush path's small blocks that never
+exhibit this. RSS grew 4.36 → 41.5 GB within the FIRST 15 s of the write
+(~2.5 GB/s). Also observed live: a second compaction started concurrently
+with the first's write (no admission control — direct TD-COMPACT-4 evidence).
+NEXT (one step from the fix): instrument/inspect the per-block stripe buffers
+in the block writer for the giant-block path — bound block row-count on the
+compaction path (cells ≠ blocks; a cell can span multiple bounded blocks) or
+stream stripes to the block buffer instead of materializing per-row
+`Option<Vec<f32>>` columns for 13k-row blocks.
+
 Corollaries:
 
 * **Duration and memory unify.** PR #1166's phase timers measured ~8 s per

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -43,6 +43,21 @@ priority than query serving; expose `compaction_queue_depth`,
 (TD-METRICS family) so operators can see the queue instead of inferring it
 from CPU/RSS.
 
+S4 — **Interim mitigation available today — uniform fan-3 leveled geometry**:
+`3× Lₙ₋₁ → 1× Lₙ` up to the existing `max_levels = 7`
+(`compaction_threshold` 5 → 3 / `level_multiplier` → 3, or per-collection
+`l0_threshold:` tag). Peak compaction memory scales superlinearly with input
+size (measured: ~1 GB at 30k input vs 40-52 GB at 120k), so smaller L0/L1
+quanta reduce peak disproportionately, and 3^7 ≈ 2,187 flush-units of
+capacity is ample. Caveats: (a) the per-compaction bound is `3 × 3ⁿ`
+flush-units — the geometry protects the shallow levels where today's pressure
+is, but deep-level merges are large regardless of fan-in, so S2's byte budget
+(or TD-COMPACT-2 S2 streaming) must still clamp the tail; (b) write
+amplification rises (~log₃ vs log₅ passes/record — more PUT/GET churn on
+object storage); (c) slower convergence to the few-large-files state
+TD-FLUSH-3 wants for the read path. Treat as a stopgap until S1/S2 and the
+TD-COMPACT-2 write-phase fix land.
+
 == Notes
 
 * Queue depth alone is NOT sufficient: with today's per-job cost a depth-1

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -62,6 +62,93 @@ use tracing::{debug, error, info, warn};
 /// Backwards-compat alias for [`SstCompactionTask`].
 pub type CompactionTask = SstCompactionTask;
 
+/// Stage-boundary process-RSS checkpoints for the unified compaction pipeline
+/// (memory-holder triage: the PAX writer's own peak buffer is ~65 MB while the
+/// process grows by tens of GB at N=120k, so the holder is an intermediate
+/// stage — pin it by measuring, not assuming).
+///
+/// Zero work unless `PROXIMADB_TRACE_COMPACTION_MEM` is set (read once per
+/// process). When enabled, each pipeline stage boundary emits ONE line to both
+/// `tracing::info!` and stderr:
+///
+/// `[COMPACT mem] stage=<name> records=<n> rss_mb=<resident MB> delta_mb=<since previous stage>`
+///
+/// plus a one-time per-record deep-size sample at the canonical-conversion
+/// boundary:
+///
+/// `[COMPACT mem] sample vr_bytes=<..> pr_bytes=<..> emb_count=<..>`
+struct CompactionMemTrace {
+    /// `Some` only when tracing is enabled (holds the sysinfo handle so the
+    /// disabled path allocates nothing and refreshes nothing).
+    sys: Option<Box<sysinfo::System>>,
+    pid: sysinfo::Pid,
+    last_rss_mb: i64,
+}
+
+impl CompactionMemTrace {
+    fn enabled() -> bool {
+        static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ON.get_or_init(|| {
+            std::env::var("PROXIMADB_TRACE_COMPACTION_MEM")
+                .map(|v| !v.is_empty() && v != "0")
+                .unwrap_or(false)
+        })
+    }
+
+    /// Construct the tracer; captures the baseline RSS when enabled so the
+    /// first stage's `delta_mb` is relative to compaction entry.
+    fn new() -> Self {
+        let pid = sysinfo::Pid::from_u32(std::process::id());
+        let mut tracer = Self {
+            sys: Self::enabled().then(|| Box::new(sysinfo::System::new())),
+            pid,
+            last_rss_mb: 0,
+        };
+        tracer.last_rss_mb = tracer.current_rss_mb().unwrap_or(0);
+        tracer
+    }
+
+    /// Refresh ONLY the current process (cheap at stage granularity) and
+    /// return its resident set in MB. `None` when tracing is disabled.
+    fn current_rss_mb(&mut self) -> Option<i64> {
+        let sys = self.sys.as_mut()?;
+        sys.refresh_process_specifics(self.pid, sysinfo::ProcessRefreshKind::new().with_memory());
+        sys.process(self.pid)
+            .map(|p| (p.memory() / (1024 * 1024)) as i64)
+    }
+
+    /// Emit one stage-boundary checkpoint line. No-op when disabled.
+    fn stage(&mut self, stage: &str, records: usize) {
+        let Some(rss_mb) = self.current_rss_mb() else {
+            return;
+        };
+        let delta_mb = rss_mb - self.last_rss_mb;
+        self.last_rss_mb = rss_mb;
+        let line = format!(
+            "[COMPACT mem] stage={stage} records={records} rss_mb={rss_mb} delta_mb={delta_mb}"
+        );
+        tracing::info!("{line}");
+        eprintln!("{line}");
+    }
+
+    /// One-time per-record deep-size sample at the canonical-conversion stage:
+    /// serialized (bincode) sizes of the same record in both forms, so the
+    /// per-record weight is measured rather than assumed. No-op when disabled.
+    fn sample_record(&self, vr: &VectorRecord, pr: &ProximaRecord) {
+        if self.sys.is_none() {
+            return;
+        }
+        let vr_bytes = bincode::serialize(vr).map(|b| b.len()).unwrap_or(0);
+        let pr_bytes = bincode::serialize(pr).map(|b| b.len()).unwrap_or(0);
+        let emb_count = pr.embeddings.len();
+        let line = format!(
+            "[COMPACT mem] sample vr_bytes={vr_bytes} pr_bytes={pr_bytes} emb_count={emb_count}"
+        );
+        tracing::info!("{line}");
+        eprintln!("{line}");
+    }
+}
+
 /// Compaction task to be processed by background workers
 #[derive(Debug, Clone)]
 pub struct SstCompactionTask {
@@ -902,6 +989,9 @@ impl Compaction {
         );
         let start_time = std::time::Instant::now();
 
+        // Stage-boundary RSS checkpoints (env-gated, PROXIMADB_TRACE_COMPACTION_MEM).
+        let mut memtrace = CompactionMemTrace::new();
+
         // OPTIMIZATION: Direct VectorRecord collection, no SstRecord conversions
         let mut all_vector_records: Vec<VectorRecord> = Vec::new();
         let mut bytes_read = 0u64;
@@ -930,6 +1020,9 @@ impl Compaction {
             // OPTIMIZED: Direct VectorRecord extraction (no SstRecord conversions)
             match self.read_all_records_from_file_unified(&input_path).await {
                 Ok(records) => {
+                    // Per-file checkpoint: catches reader-side residue (decoded
+                    // blocks, whole-file byte copies) accumulating across files.
+                    memtrace.stage("input_file_read", records.len());
                     info!(
                         "✅ Extracted {} VectorRecords from {} (no conversions)",
                         records.len(),
@@ -957,6 +1050,7 @@ impl Compaction {
             }
         }
 
+        memtrace.stage("all_records_extended", all_vector_records.len());
         info!(
             "✅ Collected {} total VectorRecords from {} input files (no conversions)",
             all_vector_records.len(),
@@ -983,6 +1077,7 @@ impl Compaction {
                 other => other,
             }
         });
+        memtrace.stage("input_sorted", all_vector_records.len());
 
         // OPTIMIZED: Merge-deduplicate legacy SST records directly, then lower
         // through canonical ProximaRecord for MVCC resolution.
@@ -1004,6 +1099,7 @@ impl Compaction {
             }
         }
 
+        memtrace.stage("dedup", merged_vector_records.len());
         info!(
             "🔍 UNIFIED COMPACTION: Merged to {} unique VectorRecords after deduplication",
             merged_vector_records.len()
@@ -1014,11 +1110,17 @@ impl Compaction {
             .iter()
             .map(ProximaRecord::from)
             .collect();
+        // One-time per-record deep-size sample: same record in both forms.
+        if let (Some(vr), Some(pr)) = (merged_vector_records.first(), canonical_records.first()) {
+            memtrace.sample_record(vr, pr);
+        }
+        memtrace.stage("canonical_convert", canonical_records.len());
         let resolved_records: Vec<VectorRecord> = resolver
             .resolve_batch(canonical_records)
             .into_iter()
             .map(VectorRecord::from)
             .collect();
+        memtrace.stage("mvcc_resolved", resolved_records.len());
         info!(
             "🔍 UNIFIED COMPACTION: MVCC resolution: {} records after resolution",
             resolved_records.len()
@@ -1084,6 +1186,9 @@ impl Compaction {
                 vector_records.push(vector_record.clone());
             }
         }
+        // After the :1081/:1084 merge clones (merged_vectors + vector_records are
+        // BOTH full clones while resolved_records is still alive = 3 copies).
+        memtrace.stage("merge_clones", vector_records.len());
 
         // Log cleanup statistics
         if expired_records_count > 0 || tombstones_removed_count > 0 {
@@ -1101,6 +1206,7 @@ impl Compaction {
         );
         let (sorted_vectors, sort_stats) =
             Self::sort_vectors_for_compaction(vector_records).await?;
+        memtrace.stage("sort_return", sorted_vectors.len());
         info!(
             "✅ UNIFIED COMPACTION: Sorted records (estimated compression improvement: {:.1}%)",
             sort_stats.compression_estimate * 100.0
@@ -1164,6 +1270,7 @@ impl Compaction {
         for (key, record) in sorted_vector_records {
             btree_records.insert(key, record);
         }
+        memtrace.stage("pre_write", btree_records.len());
 
         // M1-3 (ADR-049): the legacy ProximaBlocks write arms (which needed a
         // block size + a writer-local filesystem factory + compression config)
@@ -1259,6 +1366,7 @@ impl Compaction {
                         .unwrap_or_else(|_| "default".to_string());
                     let records: Vec<ProximaRecord> =
                         btree_records.values().map(ProximaRecord::from).collect();
+                    memtrace.stage("write_input_converted", records.len());
                     if let Some(parent) = staging_file_path.parent() {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
@@ -1317,6 +1425,7 @@ impl Compaction {
                     // boundary from legacy SST compaction records.
                     let mut records: Vec<ProximaRecord> =
                         btree_records.values().map(ProximaRecord::from).collect();
+                    memtrace.stage("write_input_converted", records.len());
                     if let Some(target) = task.precision_hint {
                         for record in &mut records {
                             for cell in &mut record.embeddings {
@@ -1393,6 +1502,7 @@ impl Compaction {
                         .unwrap_or_else(|_| "default".to_string());
                     let records: Vec<ProximaRecord> =
                         btree_records.values().map(ProximaRecord::from).collect();
+                    memtrace.stage("write_input_converted", records.len());
                     if let Some(parent) = task.output_file.parent() {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
@@ -1451,6 +1561,7 @@ impl Compaction {
                     // boundary from legacy SST compaction records.
                     let mut records: Vec<ProximaRecord> =
                         btree_records.values().map(ProximaRecord::from).collect();
+                    memtrace.stage("write_input_converted", records.len());
                     if let Some(target) = task.precision_hint {
                         for record in &mut records {
                             for cell in &mut record.embeddings {
@@ -1479,6 +1590,7 @@ impl Compaction {
             })?;
             metadata.size
         };
+        memtrace.stage("write_done", vector_records_len);
 
         debug!(
             "Wrote {} bytes to output file {}",


### PR DESCRIPTION
## Summary

Follow-up to #1172: env-gated (`PROXIMADB_TRACE_COMPACTION_MEM`) stage-boundary memory checkpoints in `perform_unified_vectorrecord_compaction`, plus the measured verdict they produced.

## The measurement (SIFT, 105k-record compaction, 64 GB machine)

| stage | RSS | delta |
|---|---|---|
| input_file_read ×5 | 3.69 GB | ~112 MB total |
| canonical_convert | 3.85 GB | +139 MB |
| mvcc_resolved | 4.04 GB | +194 MB |
| merge_clones / sort | 4.32 GB | +83 / +196 MB |
| pre_write | 4.36 GB | +37 MB |
| **write_done** | **44.8 GB** | **+40,475 MB** |

Sampled record sizes: `vr_bytes=576 pr_bytes=692 emb_count=1` — the pipeline copies and fat-record theories are refuted; the entire blow-up (~385 KB/record) happens **inside the segment write**, while the writer's tracked buffers peak at 65 MB (`[PAX write detail]`, #1172). The untracked holder is the block/stripe assembly on the giant cell-boundary blocks the compaction path produces (8 blocks ≈ 13k rows each, ~42 s/block to cut/compress). A second compaction was also observed starting concurrently with the first's write — live evidence for TD-COMPACT-4's missing admission control.

## TD updates

- **TD-COMPACT-2**: pinned-holder verdict + concrete next step — bound block row-count on the compaction path (a cell can span multiple bounded blocks) or stream stripes instead of materializing per-row `Option<Vec<f32>>` columns for 13k-row blocks.
- **TD-COMPACT-4**: interim mitigation — uniform fan-3 leveled geometry (3× Lₙ₋₁ → 1× Lₙ, n ≤ 7) with the depth caveat (protects shallow levels; deep merges still need the byte budget).
- **TD-FLUSH-3**: flush floor refined to predicted segment bytes (`N × dim × k(config)`) instead of serialized-record bytes.

## Verification

`cargo check --lib` clean on latest develop; `cargo fmt --check` clean; TD/ADR uniqueness guard clean (264 ids). Instrumentation is zero-cost when the env var is unset.