### PR TITLE
feat(ledger): S3b — gRPC ProximaLedgerService (proto + service impl, gated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,6 +821,9 @@ jobs:
           # Ledger modality durable backend (S2, ADR-071) — the WAL-backed impl is behind the
           # non-default `durable` feature, so it is invisible to the default workspace check.
           - { label: "ledger-durable",      pkg: proximadb-ledger, args: "--features durable" }
+          # Ledger modality gRPC service (S3, ADR-071) — the ProximaLedgerService + its port wiring
+          # are behind the non-default `experimental-ledger` feature on the root crate.
+          - { label: "experimental-ledger", pkg: proximadb,        args: "--features experimental-ledger" }
           # Refactor/move coverage: these configurations catch cfg drift hidden
           # by the default build. Keep them in the same mandatory matrix rather
           # than relying on a PR being correctly labelled as mechanical.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6779,6 +6779,7 @@ dependencies = [
  "proximadb-index-types",
  "proximadb-interner",
  "proximadb-kernel",
+ "proximadb-ledger",
  "proximadb-mcp",
  "proximadb-metrics",
  "proximadb-mongodb-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,8 @@ proximadb-orion-engine = { workspace = true }
 proximadb-graph = { path = "crates/modalities/proximadb-graph" }
 proximadb-observability = { path = "crates/modalities/proximadb-observability" }
 proximadb-observability-engine = { path = "crates/modalities/proximadb-observability-engine" }
+# Optional: the experimental transactional Ledger modality (gated by `experimental-ledger`).
+proximadb-ledger = { path = "crates/modalities/proximadb-ledger", optional = true }
 proximadb-embedding = { path = "crates/modalities/proximadb-embedding" }
 proximadb-queue = { path = "crates/modalities/proximadb-queue" }
 proximadb-rank-core = { path = "crates/modalities/proximadb-rank-core" }
@@ -690,6 +692,9 @@ tenant_access = []
 # Experimental storage engines (RAPTOR, SWIFT); disabled by default to prevent
 # server panics from unimplemented code paths. Enable for development/testing only.
 experimental-engines = ["proximadb-raptor-engine/experimental-engines"]
+# Experimental transactional Ledger modality (ADR-071 / TD-LEDGER-1): the durable atomic-CAS
+# KV + TTL-lease OLTP surface. Off by default; enables the durable backend + its gRPC service.
+experimental-ledger = ["dep:proximadb-ledger", "proximadb-ledger/durable"]
 # Experimental SIMD path; not enabled by default
 simd-experimental = ["proximadb-codec/simd-experimental"]
 # TD-160 / ADR-027 / ADR-030: gate the PERF-CLASS I/O-trace *emission* (the

--- a/clients/python/tests/unit/grpc_drift_baseline.json
+++ b/clients/python/tests/unit/grpc_drift_baseline.json
@@ -15,6 +15,8 @@
     "missing-stub:proto/proximadb/v1/observability.proto",
     "missing-stub:proto/proximadb/v1/ranking.proto",
     "missing-stub:proto/proximadb/v1/security.proto",
-    "missing-stub:proto/proximadb/v1/streaming.proto"
+    "missing-stub:proto/proximadb/v1/streaming.proto",
+    "missing-servicer:proto/proximadb/v2/ledger.proto::ProximaLedgerService",
+    "missing-stub:proto/proximadb/v2/ledger.proto"
   ]
 }

--- a/crates/foundation/proximadb-proto/build.rs
+++ b/crates/foundation/proximadb-proto/build.rs
@@ -31,16 +31,18 @@ fn main() {
     let document_proto = repo_root.join("proto/proximadb/v2/document.proto");
     let fusion_proto = repo_root.join("proto/proximadb/v2/fusion.proto");
     let entity_proto = repo_root.join("proto/proximadb/v2/entity.proto");
+    let ledger_proto = repo_root.join("proto/proximadb/v2/ledger.proto");
     let include = repo_root.join("proto");
     let out_dir = manifest_dir.join("src/proto");
 
     println!(
-        "cargo:warning=regenerating {} + {} + {} + {} + {} -> {}",
+        "cargo:warning=regenerating {} + {} + {} + {} + {} + {} -> {}",
         record_proto.display(),
         graph_proto.display(),
         document_proto.display(),
         fusion_proto.display(),
         entity_proto.display(),
+        ledger_proto.display(),
         out_dir.display()
     );
     tonic_prost_build::configure()
@@ -54,6 +56,7 @@ fn main() {
                 document_proto,
                 fusion_proto,
                 entity_proto,
+                ledger_proto,
             ],
             &[include],
         )

--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -8467,3 +8467,737 @@ pub mod proxima_entity_service_server {
         const NAME: &'static str = SERVICE_NAME;
     }
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetLimitRequest {
+    #[prost(string, tag = "1")]
+    pub scope: ::prost::alloc::string::String,
+    /// absent = clear the cap (unlimited but tracked)
+    #[prost(uint64, optional, tag = "2")]
+    pub limit: ::core::option::Option<u64>,
+    #[prost(enumeration = "LedgerPolicy", tag = "3")]
+    pub policy: i32,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetLimitResponse {}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReserveRequest {
+    #[prost(string, tag = "1")]
+    pub scope: ::prost::alloc::string::String,
+    /// conservative upper bound to hold as a lease
+    #[prost(uint64, tag = "2")]
+    pub ceiling: u64,
+    /// lease lifetime in nanoseconds (the server stamps `now`)
+    #[prost(int64, tag = "3")]
+    pub ttl_ns: i64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReserveResponse {
+    #[prost(bool, tag = "1")]
+    pub admitted: bool,
+    /// Set when admitted:
+    #[prost(uint64, tag = "2")]
+    pub reservation_id: u64,
+    #[prost(int64, tag = "3")]
+    pub expires_at_ns: i64,
+    /// Set when denied (admitted = false) — the cap snapshot that refused it:
+    #[prost(uint64, tag = "4")]
+    pub limit: u64,
+    #[prost(uint64, tag = "5")]
+    pub spent: u64,
+    #[prost(uint64, tag = "6")]
+    pub reserved: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SettleRequest {
+    #[prost(uint64, tag = "1")]
+    pub reservation_id: u64,
+    /// measured usage; 0 releases the lease without recording spend
+    #[prost(uint64, tag = "2")]
+    pub actual: u64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SettleResponse {}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CompareAndSwapRequest {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    /// absent = expect the key absent (create)
+    #[prost(uint64, optional, tag = "2")]
+    pub expected_version: ::core::option::Option<u64>,
+    #[prost(int64, tag = "3")]
+    pub value: i64,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CompareAndSwapResponse {
+    #[prost(bool, tag = "1")]
+    pub swapped: bool,
+    /// the new version when swapped
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    /// On mismatch (swapped = false), the observed version:
+    #[prost(bool, tag = "3")]
+    pub actual_present: bool,
+    #[prost(uint64, tag = "4")]
+    pub actual_version: u64,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetScopeRequest {
+    #[prost(string, tag = "1")]
+    pub scope: ::prost::alloc::string::String,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetScopeResponse {
+    #[prost(uint64, optional, tag = "1")]
+    pub limit: ::core::option::Option<u64>,
+    #[prost(uint64, tag = "2")]
+    pub spent: u64,
+    #[prost(uint64, tag = "3")]
+    pub reserved: u64,
+    #[prost(enumeration = "LedgerPolicy", tag = "4")]
+    pub policy: i32,
+}
+/// How a scope reacts when a reservation's ceiling would exceed its limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LedgerPolicy {
+    /// treated as BLOCK
+    Unspecified = 0,
+    /// hard cap — refuse an over-ceiling reserve
+    Block = 1,
+    /// soft cap — never refuse; spend still accrues
+    Warn = 2,
+}
+impl LedgerPolicy {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "LEDGER_POLICY_UNSPECIFIED",
+            Self::Block => "LEDGER_POLICY_BLOCK",
+            Self::Warn => "LEDGER_POLICY_WARN",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "LEDGER_POLICY_UNSPECIFIED" => Some(Self::Unspecified),
+            "LEDGER_POLICY_BLOCK" => Some(Self::Block),
+            "LEDGER_POLICY_WARN" => Some(Self::Warn),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+pub mod proxima_ledger_service_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// Transactional ledger service. Each RPC is a thin facade over the shared `LedgerService` port.
+    #[derive(Debug, Clone)]
+    pub struct ProximaLedgerServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProximaLedgerServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProximaLedgerServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProximaLedgerServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            ProximaLedgerServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn set_limit(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SetLimitRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SetLimitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaLedgerService/SetLimit",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("proximadb.v2.ProximaLedgerService", "SetLimit"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn reserve(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReserveRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ReserveResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaLedgerService/Reserve",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("proximadb.v2.ProximaLedgerService", "Reserve"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn settle(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SettleRequest>,
+        ) -> std::result::Result<tonic::Response<super::SettleResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaLedgerService/Settle",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("proximadb.v2.ProximaLedgerService", "Settle"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn compare_and_swap(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CompareAndSwapRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CompareAndSwapResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaLedgerService/CompareAndSwap",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "proximadb.v2.ProximaLedgerService",
+                        "CompareAndSwap",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_scope(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetScopeRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetScopeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proximadb.v2.ProximaLedgerService/GetScope",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("proximadb.v2.ProximaLedgerService", "GetScope"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod proxima_ledger_service_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ProximaLedgerServiceServer.
+    #[async_trait]
+    pub trait ProximaLedgerService: std::marker::Send + std::marker::Sync + 'static {
+        async fn set_limit(
+            &self,
+            request: tonic::Request<super::SetLimitRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SetLimitResponse>,
+            tonic::Status,
+        >;
+        async fn reserve(
+            &self,
+            request: tonic::Request<super::ReserveRequest>,
+        ) -> std::result::Result<tonic::Response<super::ReserveResponse>, tonic::Status>;
+        async fn settle(
+            &self,
+            request: tonic::Request<super::SettleRequest>,
+        ) -> std::result::Result<tonic::Response<super::SettleResponse>, tonic::Status>;
+        async fn compare_and_swap(
+            &self,
+            request: tonic::Request<super::CompareAndSwapRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CompareAndSwapResponse>,
+            tonic::Status,
+        >;
+        async fn get_scope(
+            &self,
+            request: tonic::Request<super::GetScopeRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetScopeResponse>,
+            tonic::Status,
+        >;
+    }
+    /// Transactional ledger service. Each RPC is a thin facade over the shared `LedgerService` port.
+    #[derive(Debug)]
+    pub struct ProximaLedgerServiceServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> ProximaLedgerServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for ProximaLedgerServiceServer<T>
+    where
+        T: ProximaLedgerService,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/proximadb.v2.ProximaLedgerService/SetLimit" => {
+                    #[allow(non_camel_case_types)]
+                    struct SetLimitSvc<T: ProximaLedgerService>(pub Arc<T>);
+                    impl<
+                        T: ProximaLedgerService,
+                    > tonic::server::UnaryService<super::SetLimitRequest>
+                    for SetLimitSvc<T> {
+                        type Response = super::SetLimitResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SetLimitRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaLedgerService>::set_limit(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SetLimitSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaLedgerService/Reserve" => {
+                    #[allow(non_camel_case_types)]
+                    struct ReserveSvc<T: ProximaLedgerService>(pub Arc<T>);
+                    impl<
+                        T: ProximaLedgerService,
+                    > tonic::server::UnaryService<super::ReserveRequest>
+                    for ReserveSvc<T> {
+                        type Response = super::ReserveResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ReserveRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaLedgerService>::reserve(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ReserveSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaLedgerService/Settle" => {
+                    #[allow(non_camel_case_types)]
+                    struct SettleSvc<T: ProximaLedgerService>(pub Arc<T>);
+                    impl<
+                        T: ProximaLedgerService,
+                    > tonic::server::UnaryService<super::SettleRequest>
+                    for SettleSvc<T> {
+                        type Response = super::SettleResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SettleRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaLedgerService>::settle(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SettleSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaLedgerService/CompareAndSwap" => {
+                    #[allow(non_camel_case_types)]
+                    struct CompareAndSwapSvc<T: ProximaLedgerService>(pub Arc<T>);
+                    impl<
+                        T: ProximaLedgerService,
+                    > tonic::server::UnaryService<super::CompareAndSwapRequest>
+                    for CompareAndSwapSvc<T> {
+                        type Response = super::CompareAndSwapResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CompareAndSwapRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaLedgerService>::compare_and_swap(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = CompareAndSwapSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proximadb.v2.ProximaLedgerService/GetScope" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetScopeSvc<T: ProximaLedgerService>(pub Arc<T>);
+                    impl<
+                        T: ProximaLedgerService,
+                    > tonic::server::UnaryService<super::GetScopeRequest>
+                    for GetScopeSvc<T> {
+                        type Response = super::GetScopeResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetScopeRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProximaLedgerService>::get_scope(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetScopeSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for ProximaLedgerServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "proximadb.v2.ProximaLedgerService";
+    impl<T> tonic::server::NamedService for ProximaLedgerServiceServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}

--- a/proto/proximadb/v2/ledger.proto
+++ b/proto/proximadb/v2/ledger.proto
@@ -1,0 +1,102 @@
+// ProximaDB v2 Ledger service (ADR-071 / TD-LEDGER-1).
+//
+// gRPC surface for the transactional Ledger modality — small keyed records with an atomic
+// conditional write (reserve-a-ceiling / decrement-with-floor / compare-and-swap), TTL leases, and
+// idempotent settle-by-id. The server delegates to the shared `LedgerService` port (crate
+// `proximadb-ledger`) and owns NO enforcement logic. Tenant isolation is structural (the
+// `x-tenant-id` header namespaces every scope + CAS key in the port), never a per-request predicate.
+//
+// Neutral units only — every quantity is a COUNT, never a price (measure-vs-price boundary, ADR-067).
+//
+// To regenerate the committed stubs after editing this file:
+//   PROXIMADB_REGEN_PROTO=1 cargo build -p proximadb-proto
+
+syntax = "proto3";
+
+package proximadb.v2;
+
+option java_package = "com.proximadb.v2.ledger";
+option go_package = "proximadb/v2;proximadbpb";
+
+// How a scope reacts when a reservation's ceiling would exceed its limit.
+enum LedgerPolicy {
+  LEDGER_POLICY_UNSPECIFIED = 0; // treated as BLOCK
+  LEDGER_POLICY_BLOCK = 1;       // hard cap — refuse an over-ceiling reserve
+  LEDGER_POLICY_WARN = 2;        // soft cap — never refuse; spend still accrues
+}
+
+// --- SetLimit -------------------------------------------------------------
+
+message SetLimitRequest {
+  string scope = 1;
+  optional uint64 limit = 2; // absent = clear the cap (unlimited but tracked)
+  LedgerPolicy policy = 3;
+}
+
+message SetLimitResponse {}
+
+// --- Reserve --------------------------------------------------------------
+
+message ReserveRequest {
+  string scope = 1;
+  uint64 ceiling = 2; // conservative upper bound to hold as a lease
+  int64 ttl_ns = 3;   // lease lifetime in nanoseconds (the server stamps `now`)
+}
+
+message ReserveResponse {
+  bool admitted = 1;
+  // Set when admitted:
+  uint64 reservation_id = 2;
+  int64 expires_at_ns = 3;
+  // Set when denied (admitted = false) — the cap snapshot that refused it:
+  uint64 limit = 4;
+  uint64 spent = 5;
+  uint64 reserved = 6;
+}
+
+// --- Settle ---------------------------------------------------------------
+
+message SettleRequest {
+  uint64 reservation_id = 1;
+  uint64 actual = 2; // measured usage; 0 releases the lease without recording spend
+}
+
+message SettleResponse {}
+
+// --- CompareAndSwap (generic atomic keyspace: flags / config / quotas) -----
+
+message CompareAndSwapRequest {
+  string key = 1;
+  optional uint64 expected_version = 2; // absent = expect the key absent (create)
+  int64 value = 3;
+}
+
+message CompareAndSwapResponse {
+  bool swapped = 1;
+  uint64 version = 2;        // the new version when swapped
+  // On mismatch (swapped = false), the observed version:
+  bool actual_present = 3;
+  uint64 actual_version = 4;
+}
+
+// --- GetScope -------------------------------------------------------------
+
+message GetScopeRequest {
+  string scope = 1;
+}
+
+message GetScopeResponse {
+  optional uint64 limit = 1;
+  uint64 spent = 2;
+  uint64 reserved = 3;
+  LedgerPolicy policy = 4;
+}
+
+// Transactional ledger service. Each RPC is a thin facade over the shared `LedgerService` port.
+service ProximaLedgerService {
+  rpc SetLimit(SetLimitRequest) returns (SetLimitResponse);
+  rpc Reserve(ReserveRequest) returns (ReserveResponse);
+  rpc Settle(SettleRequest) returns (SettleResponse);
+  rpc CompareAndSwap(CompareAndSwapRequest) returns (CompareAndSwapResponse);
+  rpc GetScope(GetScopeRequest) returns (GetScopeResponse);
+}

--- a/src/network/grpc/v2/ledger_service.rs
+++ b/src/network/grpc/v2/ledger_service.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 ProximaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+//! gRPC V2 ledger service — a thin facade over the shared `LedgerService` port
+//! (crate `proximadb-ledger`, ADR-071 / TD-LEDGER-1).
+//!
+//! Each RPC delegates to the port and owns **no** enforcement logic. Tenant isolation is
+//! structural: `resolved_tenant_id` namespaces every scope + CAS key in the port, never a
+//! per-request predicate. The server stamps `now` (the port/core stays clock-free and
+//! deterministic). Neutral units only — every quantity is a count, never a price.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tonic::{Request, Response, Status};
+
+use proximadb_ledger::{CasError, DurableLedger, LedgerService, Policy, ReserveOutcome};
+
+use crate::network::grpc::auth as grpc_auth;
+use crate::proto::proximadb_v2 as pv2;
+use crate::proto::proximadb_v2::proxima_ledger_service_server::{
+    ProximaLedgerService, ProximaLedgerServiceServer,
+};
+
+/// Wall-clock nanoseconds since the Unix epoch — the `now` the port stamps onto leases.
+fn now_ns() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+/// Wire enum (`LedgerPolicy`) → the port's [`Policy`]. Unspecified/unknown ⇒ `Block` (the safe cap).
+fn policy_from_wire(value: i32) -> Policy {
+    match pv2::LedgerPolicy::try_from(value) {
+        Ok(pv2::LedgerPolicy::Warn) => Policy::Warn,
+        _ => Policy::Block,
+    }
+}
+
+/// The port's [`Policy`] → the wire enum discriminant.
+fn policy_to_wire(policy: Policy) -> i32 {
+    match policy {
+        Policy::Block => pv2::LedgerPolicy::Block as i32,
+        Policy::Warn => pv2::LedgerPolicy::Warn as i32,
+    }
+}
+
+/// gRPC V2 ledger service — thin delegating facade over `LedgerService`.
+pub struct ProximaLedgerServiceImpl {
+    ledger: Arc<LedgerService<DurableLedger>>,
+}
+
+impl ProximaLedgerServiceImpl {
+    /// Build from the shared, durable ledger port (constructed once at startup, shared across
+    /// requests — never per-RPC).
+    pub fn new(ledger: Arc<LedgerService<DurableLedger>>) -> Self {
+        Self { ledger }
+    }
+
+    /// Convert to a tonic server.
+    pub fn into_server(self) -> ProximaLedgerServiceServer<Self> {
+        ProximaLedgerServiceServer::new(self)
+    }
+}
+
+#[tonic::async_trait]
+impl ProximaLedgerService for ProximaLedgerServiceImpl {
+    async fn set_limit(
+        &self,
+        request: Request<pv2::SetLimitRequest>,
+    ) -> Result<Response<pv2::SetLimitResponse>, Status> {
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
+        let req = request.into_inner();
+        if req.scope.trim().is_empty() {
+            return Err(Status::invalid_argument("scope is required"));
+        }
+        self.ledger
+            .set_limit(&tenant, &req.scope, req.limit, policy_from_wire(req.policy));
+        Ok(Response::new(pv2::SetLimitResponse {}))
+    }
+
+    async fn reserve(
+        &self,
+        request: Request<pv2::ReserveRequest>,
+    ) -> Result<Response<pv2::ReserveResponse>, Status> {
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
+        let req = request.into_inner();
+        if req.scope.trim().is_empty() {
+            return Err(Status::invalid_argument("scope is required"));
+        }
+        if req.ttl_ns <= 0 {
+            return Err(Status::invalid_argument("ttl_ns must be positive"));
+        }
+        let response =
+            match self
+                .ledger
+                .reserve(&tenant, &req.scope, req.ceiling, now_ns(), req.ttl_ns)
+            {
+                ReserveOutcome::Admitted(r) => pv2::ReserveResponse {
+                    admitted: true,
+                    reservation_id: r.id,
+                    expires_at_ns: r.expires_at_ns,
+                    limit: 0,
+                    spent: 0,
+                    reserved: 0,
+                },
+                ReserveOutcome::Denied(d) => pv2::ReserveResponse {
+                    admitted: false,
+                    reservation_id: 0,
+                    expires_at_ns: 0,
+                    limit: d.limit,
+                    spent: d.spent,
+                    reserved: d.reserved,
+                },
+            };
+        Ok(Response::new(response))
+    }
+
+    async fn settle(
+        &self,
+        request: Request<pv2::SettleRequest>,
+    ) -> Result<Response<pv2::SettleResponse>, Status> {
+        // Resolve tenant for auth even though settle is by opaque reservation id (v1 note in the
+        // port: the id is a bearer capability; a tenant-verified settle index is a follow-up).
+        let _tenant = grpc_auth::resolved_tenant_id(&request)?;
+        let req = request.into_inner();
+        self.ledger.settle(req.reservation_id, req.actual);
+        Ok(Response::new(pv2::SettleResponse {}))
+    }
+
+    async fn compare_and_swap(
+        &self,
+        request: Request<pv2::CompareAndSwapRequest>,
+    ) -> Result<Response<pv2::CompareAndSwapResponse>, Status> {
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
+        let req = request.into_inner();
+        if req.key.trim().is_empty() {
+            return Err(Status::invalid_argument("key is required"));
+        }
+        let response =
+            match self
+                .ledger
+                .compare_and_swap(&tenant, &req.key, req.expected_version, req.value)
+            {
+                Ok(version) => pv2::CompareAndSwapResponse {
+                    swapped: true,
+                    version,
+                    actual_present: false,
+                    actual_version: 0,
+                },
+                Err(CasError::VersionMismatch { actual, .. }) => pv2::CompareAndSwapResponse {
+                    swapped: false,
+                    version: 0,
+                    actual_present: actual.is_some(),
+                    actual_version: actual.unwrap_or(0),
+                },
+            };
+        Ok(Response::new(response))
+    }
+
+    async fn get_scope(
+        &self,
+        request: Request<pv2::GetScopeRequest>,
+    ) -> Result<Response<pv2::GetScopeResponse>, Status> {
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
+        let req = request.into_inner();
+        if req.scope.trim().is_empty() {
+            return Err(Status::invalid_argument("scope is required"));
+        }
+        Ok(Response::new(pv2::GetScopeResponse {
+            limit: self.ledger.limit(&tenant, &req.scope),
+            spent: self.ledger.spent(&tenant, &req.scope),
+            reserved: self.ledger.reserved(&tenant, &req.scope),
+            policy: policy_to_wire(self.ledger.policy(&tenant, &req.scope)),
+        }))
+    }
+}

--- a/src/network/grpc/v2/mod.rs
+++ b/src/network/grpc/v2/mod.rs
@@ -33,10 +33,14 @@ pub mod document_service;
 pub mod entity_service;
 pub mod fusion_service;
 pub mod graph_service;
+#[cfg(feature = "experimental-ledger")]
+pub mod ledger_service;
 pub mod record_service;
 
 pub use document_service::ProximaDocumentServiceImpl;
 pub use entity_service::ProximaEntityServiceImpl;
 pub use fusion_service::ProximaFusionServiceImpl;
 pub use graph_service::ProximaGraphServiceImpl;
+#[cfg(feature = "experimental-ledger")]
+pub use ledger_service::ProximaLedgerServiceImpl;
 pub use record_service::ProximaRecordServiceImpl;


### PR DESCRIPTION
**Not for auto-merge — flagging for your review** (touches proto + root crate). Second S3 slice: the gRPC **wire surface** for the Ledger modality, behind the non-default `experimental-ledger` feature (**off by default**). I kept the risky server-registration edits (`shared_services.rs`/`multi_server.rs`) out of this PR — that's the next slice.

## What

- **`proto/proximadb/v2/ledger.proto`** — `ProximaLedgerService` with `SetLimit` / `Reserve` / `Settle` / `CompareAndSwap` / `GetScope`. Committed stubs regenerated via `PROXIMADB_REGEN_PROTO=1` → `proximadb.v2.rs` **+734 lines, 0 deletions**. I verified the pristine toolchain (`tonic-prost 0.14.6`) reproduces the committed file byte-for-byte first, so this is **purely additive** — no churn to other services.
- **`src/network/grpc/v2/ledger_service.rs`** — `ProximaLedgerServiceImpl`, a thin facade over the shared `LedgerService` port (S3a, #1174). Tenant isolation is **structural** (`resolved_tenant_id` namespaces every scope/key); the server stamps `now` so the port/core stays clock-free and deterministic. Modeled directly on `fusion_service.rs`.
- **Root `Cargo.toml`** — optional `proximadb-ledger` dep + `experimental-ledger` feature (pulls `proximadb-ledger/durable`); module + a CI feature-matrix row gated on it.
- **Python drift baseline** — records the *deferred* Python stub for the new v2 service (gRPC-first; the Python client is out of v1 scope), the drift gate's intended mechanism.

## Known gaps (documented)

- **Not registered / not served yet** — the service compiles under the feature but isn't wired into the router; that's the next slice (`SharedServices` field + `multi_server` 3-site registration, which needs the deeper `SharedServices::new` construction).
- **gRPC reflection** — the checked-in `proximadb_descriptor.bin` can't be regenerated in-repo, so the service won't appear in reflection until that out-of-band step (works over the wire regardless).

## Verification

`cargo check -p proximadb --features experimental-ledger` clean (6m29s); `fmt` + `clippy -D warnings` clean on the gated feature; **proto-drift + openapi-contract Python tests pass**; layering/OSS/tenant-path/deterministic-commit guards pass. **Zero changes to the default build or any existing service.**

Next: **S3 slice 3** — the server registration (`SharedServices` ledger store + `multi_server` registration), which reaches into the central bootstrap and wants your review on the ledger-store construction (WAL path, lifecycle).