### PR TITLE
feat(ledger): S3c — register ProximaLedgerService into the server (ADR-071)

### DIFF
--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -199,6 +199,19 @@ impl MultiServer {
         .into_server()
     }
 
+    /// Build the canonical v2 ledger gRPC service (ADR-071 / TD-LEDGER-1). Experimental — compiled
+    /// only under the `experimental-ledger` feature. Shares the node-level ledger port constructed
+    /// once in `SharedServices`.
+    #[cfg(feature = "experimental-ledger")]
+    fn canonical_ledger_grpc_service(
+        services: &SharedServices,
+    ) -> crate::proto::proximadb_v2::proxima_ledger_service_server::ProximaLedgerServiceServer<
+        crate::network::grpc::v2::ProximaLedgerServiceImpl,
+    > {
+        crate::network::grpc::v2::ProximaLedgerServiceImpl::new(services.ledger_store.clone())
+            .into_server()
+    }
+
     /// Build the canonical v2 entity gRPC service.
     ///
     /// EntityService is an orchestration facade over graph + vector + document,
@@ -623,6 +636,13 @@ impl MultiServer {
                 .add_service(Self::canonical_fusion_grpc_service(&services))
                 .add_service(Self::canonical_entity_grpc_service(&services))
                 .add_service(standard_health_server);
+
+            // Experimental transactional ledger service (ADR-071 / TD-LEDGER-1): registered only
+            // under the `experimental-ledger` feature (off by default).
+            #[cfg(feature = "experimental-ledger")]
+            {
+                server = server.add_service(Self::canonical_ledger_grpc_service(&services));
+            }
 
             // Optional grpc.reflection.v1.ServerReflection for runtime discovery.
             if self.config.grpc_config.enable_reflection {
@@ -1154,6 +1174,13 @@ impl MultiServer {
                 .add_service(flight_server)
                 .add_service(standard_health_server);
 
+            // Experimental transactional ledger service (ADR-071 / TD-LEDGER-1): registered only
+            // under the `experimental-ledger` feature (off by default).
+            #[cfg(feature = "experimental-ledger")]
+            {
+                server = server.add_service(Self::canonical_ledger_grpc_service(&services));
+            }
+
             // Optional grpc.reflection.v1.ServerReflection for runtime discovery.
             if self.config.grpc_config.enable_reflection {
                 debug!("Adding gRPC reflection service (unified mode)");
@@ -1514,6 +1541,13 @@ impl MultiServer {
                 .add_service(Self::canonical_fusion_grpc_service(&services))
                 .add_service(Self::canonical_entity_grpc_service(&services))
                 .add_service(standard_health_server);
+
+            // Experimental transactional ledger service (ADR-071 / TD-LEDGER-1): registered only
+            // under the `experimental-ledger` feature (off by default).
+            #[cfg(feature = "experimental-ledger")]
+            {
+                server = server.add_service(Self::canonical_ledger_grpc_service(&services));
+            }
 
             // Optional grpc.reflection.v1.ServerReflection for runtime discovery.
             if self.config.grpc_config.enable_reflection {

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -352,6 +352,13 @@ pub struct SharedServices {
     /// (graph: tracing-only; pgwire: opens its own appender locally).
     pub canonical_wal_appender: Option<Arc<crate::services::FramedTableWalAppender>>,
 
+    /// Experimental transactional ledger store (ADR-071 / TD-LEDGER-1) — the durable, tenant-scoped
+    /// ledger port shared with the gRPC `ProximaLedgerService`. Node-level (one store per node;
+    /// tenants are namespaced *inside* the keys, not by separate stores), with its WAL on local disk
+    /// (ADR-069). Present only under the `experimental-ledger` feature.
+    #[cfg(feature = "experimental-ledger")]
+    pub ledger_store: Arc<proximadb_ledger::LedgerService<proximadb_ledger::DurableLedger>>,
+
     /// The single canonical WAL-backed record store, built + WAL-recovered ONCE here and
     /// shared across ALL surfaces — the REST/gRPC `DmlService` and the pgwire direct-write
     /// path both route relational tables through this instance — so a write on any protocol
@@ -1601,6 +1608,34 @@ impl SharedServices {
             None
         };
 
+        // Experimental transactional ledger store (ADR-071 / TD-LEDGER-1): a node-level durable
+        // ledger shared with the gRPC `ProximaLedgerService`. Its WAL lives on LOCAL disk (ADR-069:
+        // the per-write log belongs on a reattachable local volume, not object storage); when the
+        // metadata store is object-backed (no `file://`), the ledger WAL falls back to a local
+        // `data/ledger` directory. One store per node — tenants are namespaced inside the keys.
+        #[cfg(feature = "experimental-ledger")]
+        let ledger_store = {
+            let ledger_url = join_storage_url(&storage_config.metadata_url, "ledger/ledger.wal");
+            let ledger_path = match ledger_url.strip_prefix("file://") {
+                Some(local) => std::path::PathBuf::from(local),
+                None => std::path::PathBuf::from("data/ledger/ledger.wal"),
+            };
+            if let Some(parent) = ledger_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating ledger WAL dir {}", parent.display()))?;
+            }
+            let durable = proximadb_ledger::DurableLedger::open(
+                &ledger_path,
+                proximadb_ledger::SyncPolicy::PerOp,
+            )
+            .with_context(|| format!("opening ledger WAL at {}", ledger_path.display()))?;
+            info!(
+                "✅ SharedServices: experimental ledger store opened at {}",
+                ledger_path.display()
+            );
+            Arc::new(proximadb_ledger::LedgerService::new(durable))
+        };
+
         // Create GraphOperationsService for native graph database operations
         // IMPORTANT: Pass the shared GraphCollectionService instance
         debug!(
@@ -2563,6 +2598,8 @@ impl SharedServices {
                 // share the same next_sequence counter.
                 canonical_wal_appender,
                 canonical_record_store,
+                #[cfg(feature = "experimental-ledger")]
+                ledger_store,
                 // TD-064 / LLD §5: per-collection recall-probe gate. Empty
                 // at startup; populated as the stats refresher / search path
                 // observe probe outcomes. Route-health surfaces per-scope


### PR DESCRIPTION
Final S3 transport slice: **wire the gRPC ledger service into the server**, behind `experimental-ledger` (off by default). With this, the modality is constructed, durable, and served end-to-end.

## What

- **`SharedServices`** gains a node-level `ledger_store: Arc<LedgerService<DurableLedger>>`, opened in `SharedServices::new`. **Design decision for your review:** its WAL lives on **local disk** (ADR-069 — the per-write log belongs on a reattachable local volume, not object storage). The path is derived from the metadata store's `file://` location (`{local}/ledger/ledger.wal`), or falls back to a local `data/ledger` dir when the metadata store is object-backed. **One store per node**; tenants are namespaced *inside* the keys (by the S3a port), not by separate stores.
- **`multi_server.rs`** registers a `canonical_ledger_grpc_service` builder + `.add_service(...)` at all **three** startup modes (`start` / `start_unified` / `start_with_cluster`), all cfg-gated.

## Safety

Every edit is a tight `#[cfg(feature = "experimental-ledger")]` block. Verified:
- `cargo check -p proximadb --features experimental-ledger` — clean (6m18s).
- **Plain default build** (`cargo check -p proximadb`) — clean (6m10s): the cfg-gating leaves the standard build untouched.
- `fmt` + `clippy -D warnings` clean on the feature; boundary / tenant-path / deterministic-commit guards pass.

Only 2 files changed (`shared_services.rs`, `multi_server.rs`).

## Known follow-ups (not blockers)

- **Reflection**: the checked-in `proximadb_descriptor.bin` has no in-repo regen, so the service is reachable over the wire but not yet listed in gRPC reflection.
- **S4** (separate): splice the ledger's durability onto the shared ADR-069 *record* WAL (currently its own local WAL file) — an internal optimization with the same external contract, touching `RecordStore`/`canonical_wal`.
- Tenant-verified `Settle`, calendar windows, and a background reclaim sweeper remain the tracked v1 gaps.