### PR TITLE
refactor(search): downsize UnifiedSearchParams.top_k→u16 + timeout_ms→u32 (TD-SEARCH-2 S3)

### DIFF
--- a/benches/archived_duplicates/bench_04_storage_comparison.rs
+++ b/benches/archived_duplicates/bench_04_storage_comparison.rs
@@ -314,7 +314,7 @@ fn bench_all_engines_search(c: &mut Criterion) {
                         let search_params = Arc::new(SearchParams {
                             vector: Some(query.clone()),
                             query_vectors: Some(vec![query.clone()]),  // SST expects query_vectors
-                            top_k: Some(top_k),
+                            top_k: Some(top_k as u16),
                             distance_metric: Some(DistanceMetric::Euclidean),
                             filter_expression: None,
                             filters: None,

--- a/benches/bench_10_query_progressive.rs
+++ b/benches/bench_10_query_progressive.rs
@@ -95,7 +95,7 @@ async fn progressive_search_real(
     let search_params = Arc::new(SearchParams {
         vector: Some(query.to_vec()),
         query_vectors: None,
-        top_k: Some(k),
+        top_k: Some(k as u16),
         distance_metric: Some(DistanceMetric::Cosine),
         filter_expression: None,
         filters: None,

--- a/benches/bench_vector_object_economy_e2e.rs
+++ b/benches/bench_vector_object_economy_e2e.rs
@@ -295,7 +295,7 @@ async fn measure_cold(cfg: &BenchConfig) -> LatencyDist {
         let query_vector = synthetic_query(cfg.dimension);
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector),
-            top_k: Some(cfg.top_k),
+            top_k: Some(cfg.top_k as u16),
             ..Default::default()
         });
         let ctx = StorageQueryContext::new(search_params, Arc::new(collection));
@@ -337,7 +337,7 @@ async fn measure_warm(cfg: &BenchConfig, setup: &SetupResult) -> LatencyDist {
         let query_vector = synthetic_query(cfg.dimension);
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector),
-            top_k: Some(cfg.top_k),
+            top_k: Some(cfg.top_k as u16),
             ..Default::default()
         });
         let ctx = StorageQueryContext::new(search_params, Arc::clone(&setup.warm_collection));
@@ -348,7 +348,7 @@ async fn measure_warm(cfg: &BenchConfig, setup: &SetupResult) -> LatencyDist {
         let query_vector = synthetic_query(cfg.dimension);
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector),
-            top_k: Some(cfg.top_k),
+            top_k: Some(cfg.top_k as u16),
             ..Default::default()
         });
         let ctx = StorageQueryContext::new(search_params, Arc::clone(&setup.warm_collection));

--- a/benches/bench_warm_path_profile.rs
+++ b/benches/bench_warm_path_profile.rs
@@ -894,7 +894,7 @@ async fn measure_recall(setup: &SetupResult, cfg: &BenchConfig, n_queries: usize
         // applies sqrt-based centroid pruning and skips most blocks.
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.clone()),
-            top_k: Some(cfg.top_k),
+            top_k: Some(cfg.top_k as u16),
             search_mode: SearchMode::Exact,
             ..Default::default()
         });
@@ -925,7 +925,7 @@ async fn measure_recall(setup: &SetupResult, cfg: &BenchConfig, n_queries: usize
         // costing at scale.
         let force_exact_params = Arc::new(SearchParams {
             vector: Some(query_vector.clone()),
-            top_k: Some(cfg.top_k),
+            top_k: Some(cfg.top_k as u16),
             search_mode: SearchMode::Exact,
             block_prune: force_exact_block_prune.clone(),
             ..Default::default()
@@ -1140,7 +1140,7 @@ async fn run_one_query(setup: &SetupResult, cfg: &BenchConfig) -> u64 {
     };
     let search_params = Arc::new(SearchParams {
         vector: Some(query_vector),
-        top_k: Some(cfg.top_k),
+        top_k: Some(cfg.top_k as u16),
         search_mode,
         enable_vectorized_execution: if cfg.vectorized { Some(true) } else { None },
         ..Default::default()

--- a/crates/foundation/proximadb-search-types/src/search_params.rs
+++ b/crates/foundation/proximadb-search-types/src/search_params.rs
@@ -431,8 +431,12 @@ pub struct UnifiedSearchParams {
     /// Single query vector (alternative to query_vectors for single queries)
     pub vector: Option<Vec<f32>>,
 
-    /// Number of results to return
-    pub top_k: Option<usize>,
+    /// Number of results to return. `u16` — top_k is a small result count
+    /// (realistic ≤ ~10⁴, well under u16's 65 535 cap), and this shrinks the
+    /// per-query field from `Option<usize>` (16 B) to `Option<u16>` (4 B).
+    /// Cast to `usize` only at genuine size-boundaries (Vec::truncate, heap
+    /// capacity, loop bounds); TD-SEARCH-2 S3.
+    pub top_k: Option<u16>,
 
     /// Distance metric to use for similarity calculation
     #[serde(skip)]
@@ -450,8 +454,10 @@ pub struct UnifiedSearchParams {
     /// Include expired vectors in results
     pub include_expired: Option<bool>,
 
-    /// Search timeout in milliseconds
-    pub timeout_ms: Option<u64>,
+    /// Search timeout in milliseconds. `u32` (not `u64`) — 4B ms ≈ 49 days is
+    /// far beyond any query timeout; halves the field (Option<u64> 16B →
+    /// Option<u32> 8B). Convert at use sites (`as u64`); TD-SEARCH-2 S3.
+    pub timeout_ms: Option<u32>,
 
     /// Enable two-stage search with quantization
     pub enable_two_stage: Option<bool>,

--- a/crates/storage/proximadb-storage-traits/src/query.rs
+++ b/crates/storage/proximadb-storage-traits/src/query.rs
@@ -407,7 +407,7 @@ impl StorageQueryContext {
 
     /// Get top_k value with fallback to default.
     pub fn top_k(&self) -> usize {
-        self.search_params.top_k.unwrap_or(10)
+        self.search_params.top_k.unwrap_or(10) as usize
     }
 
     /// Get distance metric (pre-computed from collection config).

--- a/src/core/search/engine_benchmarks.rs
+++ b/src/core/search/engine_benchmarks.rs
@@ -400,7 +400,7 @@ impl StorageEngineBenchmark {
 
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             distance_metric: Some(DistanceMetric::Cosine),
             filter_expression: None,
             custom_hints: Some(HashMap::new()),

--- a/src/core/search/integrated_search_optimization.rs
+++ b/src/core/search/integrated_search_optimization.rs
@@ -493,7 +493,7 @@ impl AdvancedSearchOptimizer {
             .first_query_vector()
             .context("No query vector provided")?;
 
-        let top_k = search_params.top_k.unwrap_or(10);
+        let top_k = search_params.top_k.unwrap_or(10) as usize;
         let distance_metric = search_params
             .distance_metric
             .unwrap_or(DistanceMetric::Cosine);
@@ -1086,7 +1086,7 @@ impl AdvancedSearchOptimizer {
         }
 
         let batch_size = self.config.streaming_batch_size;
-        let total_results = search_params.top_k.unwrap_or(10);
+        let total_results = search_params.top_k.unwrap_or(10) as usize;
 
         // Create a stream that processes batches lazily
         // Convert records into owned chunks to avoid lifetime issues

--- a/src/core/search/search_interface.rs
+++ b/src/core/search/search_interface.rs
@@ -393,7 +393,7 @@ impl IntegratedSearchOptimizer {
 
         // Limit to requested k
         if let Some(k) = params.top_k {
-            results.truncate(k);
+            results.truncate(k as usize);
         }
 
         // Note: Rank is not a field in SearchResult anymore

--- a/src/core/search/smart_execution_strategy.rs
+++ b/src/core/search/smart_execution_strategy.rs
@@ -389,7 +389,7 @@ impl SmartExecutionStrategy {
         QueryAnalysis {
             has_filters: params.filter_expression.is_some() || params.filters.is_some(),
             filter_selectivity: self.estimate_filter_selectivity(params),
-            top_k: params.top_k.unwrap_or(10),
+            top_k: params.top_k.unwrap_or(10) as usize,
             is_batch: params.is_batch_search(),
             batch_size: params.query_vectors.as_ref().map_or(1, |v| v.len()),
             requires_vectors: true,  // Would check if vectors are needed

--- a/src/core/search/strategies/context.rs
+++ b/src/core/search/strategies/context.rs
@@ -105,13 +105,13 @@ impl SearchContextImpl {
 
         Some(Self {
             query_vector,
-            top_k: params.top_k.unwrap_or(10),
+            top_k: params.top_k.unwrap_or(10) as usize,
             distance_metric: params.distance_metric.unwrap_or(DistanceMetric::Cosine),
             filter_expression: params.filter_expression.clone(),
             search_mode: params.search_mode.clone(),
             block_prune_config: params.block_prune.clone(),
             accuracy_threshold: params.accuracy_threshold.unwrap_or(0.95),
-            timeout_ms: params.timeout_ms,
+            timeout_ms: params.timeout_ms.map(|t| t as u64),
             enable_two_stage: params.enable_two_stage.unwrap_or(true),
             enable_progressive_search: params.enable_progressive_search.unwrap_or(false),
             optimization_hints: params.custom_hints.clone(),

--- a/src/query/federated/execution/mod.rs
+++ b/src/query/federated/execution/mod.rs
@@ -706,7 +706,7 @@ impl FederatedExecutor {
         };
 
         let search_params = Arc::new(SearchParams {
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             vector: Some(query_vector),
             ..Default::default()
         });

--- a/src/query/query_optimizer.rs
+++ b/src/query/query_optimizer.rs
@@ -1277,7 +1277,7 @@ impl UnifiedQueryOptimizer {
                             .and_then(|v| v.as_u64())
                             .map(|v| v as usize),
                         query_vector: None, // Will be set during execution
-                        top_k: context.search_params.and_then(|p| p.top_k).unwrap_or(10),
+                        top_k: context.search_params.and_then(|p| p.top_k).unwrap_or(10) as usize,
                         filter: None, // Will be set from filter params if needed
                     },
                 },
@@ -2197,7 +2197,7 @@ impl UnifiedQueryOptimizer {
             has_metadata_filter: filter_expression.is_some(),
             has_aggregation: false,
             query_complexity,
-            top_k,
+            top_k: top_k as usize,
         })
     }
 
@@ -2884,7 +2884,8 @@ impl UnifiedQueryOptimizer {
                         use_two_stage: false,
                         candidate_multiplier: 5,
                     }),
-                    candidates: context.search_params.and_then(|p| p.top_k).unwrap_or(10) * 20,
+                    candidates: context.search_params.and_then(|p| p.top_k).unwrap_or(10) as usize
+                        * 20,
                 }],
                 resource_allocation: ResourceAllocation {
                     memory_budget_mb: 128,

--- a/src/services/operations/vectors/hybrid/axis_builder.rs
+++ b/src/services/operations/vectors/hybrid/axis_builder.rs
@@ -191,7 +191,7 @@ pub fn build_axis_hybrid_query_with_policy(
         vector_query,
         metadata_filters,
         id_filters,
-        top_k: search_params.top_k.unwrap_or(10),
+        top_k: search_params.top_k.unwrap_or(10) as usize,
         include_expired: search_params.include_expired.unwrap_or(false),
         ann_filtering_mode,
         ann_filtering_policy,

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -2520,7 +2520,7 @@ impl VectorOperationsService {
         // Without this, the query optimizer uses default top_k=10, and candidates = 10*10 = 100,
         // which incorrectly limits all searches to 100 results regardless of the requested k.
         let search_params = crate::query::query_optimizer::SearchParams {
-            top_k: Some(k),
+            top_k: Some(k as u16),
             ..Default::default()
         };
         let optimization_goal = config
@@ -2663,7 +2663,7 @@ impl VectorOperationsService {
         // Without this, the query optimizer uses default top_k=10, and candidates = 10*10 = 100,
         // which incorrectly limits all searches to 100 results regardless of the requested k.
         let search_params = crate::query::query_optimizer::SearchParams {
-            top_k: Some(k),
+            top_k: Some(k as u16),
             ..Default::default()
         };
         let optimization_goal = config
@@ -2916,7 +2916,7 @@ impl VectorOperationsService {
         // Run the optimizer on the EXPLAIN path (non-hot) to surface ADR-011 filtering mode.
         let collection = self.get_or_load_collection(collection_id).await?;
         let search_params = crate::query::query_optimizer::SearchParams {
-            top_k: Some(k),
+            top_k: Some(k as u16),
             filter_expression: filter.clone(),
             ..Default::default()
         };
@@ -3042,7 +3042,7 @@ impl VectorOperationsService {
         // Create unified context (combines what used to be two separate contexts)
         let search_params = crate::core::search::SearchParams {
             query_vectors: Some(vec![query_vector.clone()]),
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             filter_expression: filter.clone(),
             enable_progressive_search: Some(true), // Enable by default if quantization available
             ..Default::default()
@@ -3165,7 +3165,7 @@ impl VectorOperationsService {
         // Run the optimizer on the EXPLAIN path (non-hot) to surface ADR-011 filtering mode.
         let collection = self.get_or_load_collection(collection_id).await?;
         let search_params = crate::query::query_optimizer::SearchParams {
-            top_k: Some(k),
+            top_k: Some(k as u16),
             filter_expression: filter.clone(),
             ..Default::default()
         };
@@ -3503,7 +3503,7 @@ impl VectorOperationsService {
         // Prepare storage search context first
         let search_params = crate::core::search::SearchParams {
             query_vectors: Some(vec![query_vector.clone()]),
-            top_k: Some(candidates),
+            top_k: Some(candidates as u16),
             distance_metric: Some(distance_metric),
             filter_expression: filter.clone(), // Pass the same FilterExpression to storage engine
             include_expired: Some(false),
@@ -3919,7 +3919,7 @@ impl VectorOperationsService {
         // Convert IndexLookupParams to SearchParams
         let search_params = crate::core::search::SearchParams {
             query_vectors: params.query_vector.map(|v| vec![v]),
-            top_k: Some(params.top_k),
+            top_k: Some(params.top_k as u16),
             filter_expression: params.filter,
             include_expired: Some(false),
             ..Default::default()

--- a/src/services/search/comprehensive_test.rs
+++ b/src/services/search/comprehensive_test.rs
@@ -465,7 +465,7 @@ mod tests {
 
             let search_params = SearchParams {
                 query_vectors: Some(vec![test_case.query_vector.clone()]),
-                top_k: Some(test_case.top_k),
+                top_k: Some(test_case.top_k as u16),
                 distance_metric: Some(test_case.distance_metric.clone()),
                 filter_expression: test_case.filter_expression.clone(),
                 ..Default::default()
@@ -530,7 +530,7 @@ mod tests {
 
             let search_params = SearchParams {
                 query_vectors: Some(vec![test_case.query_vector.clone()]),
-                top_k: Some(test_case.top_k),
+                top_k: Some(test_case.top_k as u16),
                 distance_metric: Some(test_case.distance_metric.clone()),
                 filter_expression: test_case.filter_expression.clone(),
                 ..Default::default()

--- a/src/storage/document/storage/cold_tier.rs
+++ b/src/storage/document/storage/cold_tier.rs
@@ -283,8 +283,8 @@ impl ColdTierRetriever for StorageEngineColdTierRetriever {
         // Create search parameters with the filter
         // We use a placeholder vector since documents don't have real vectors
         let search_params = Arc::new(SearchParams {
-            vector: Some(vec![0.0]), // Placeholder vector for document retrieval
-            top_k: Some(ids.len()),  // We want at most as many results as IDs requested
+            vector: Some(vec![0.0]),       // Placeholder vector for document retrieval
+            top_k: Some(ids.len() as u16), // We want at most as many results as IDs requested
             filter_expression: Some(filter),
             include_expired: Some(false),
             ..Default::default()

--- a/src/storage/engines/nova/engine.rs
+++ b/src/storage/engines/nova/engine.rs
@@ -1197,7 +1197,7 @@ impl NovaEngine {
 
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.to_vec()),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             ..SearchParams::default()
         });
 

--- a/src/storage/engines/sst/readers/sst_query_engine.rs
+++ b/src/storage/engines/sst/readers/sst_query_engine.rs
@@ -2353,7 +2353,7 @@ impl UnifiedSstableReader {
         let params = SearchParams {
             vector: Some(query_vector.to_vec()),
             filter_expression: filter.clone(),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             distance_metric: Some(distance_metric),
             block_prune: block_prune.clone(),
             ..Default::default()
@@ -2489,7 +2489,7 @@ impl UnifiedSstableReader {
         let params = SearchParams {
             vector: Some(query_vector.to_vec()),
             filter_expression: filter.clone(),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             distance_metric: Some(distance_metric),
             block_prune: block_prune.clone(),
             ..Default::default()
@@ -2618,7 +2618,7 @@ impl UnifiedSstableReader {
         let params = SearchParams {
             vector: Some(query_vector.to_vec()),
             filter_expression: filter.clone(),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             distance_metric: Some(distance_metric),
             block_prune: block_prune.clone(),
             ..Default::default()
@@ -2781,7 +2781,7 @@ impl UnifiedSstableReader {
         let params = SearchParams {
             vector: Some(query_vector.to_vec()),
             filter_expression: filter.clone(),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             distance_metric: Some(distance_metric),
             block_prune: block_prune.clone(),
             ..Default::default()
@@ -3671,7 +3671,7 @@ impl UnifiedSstableReader {
             .first_query_vector()
             .ok_or_else(|| anyhow::anyhow!("Query vector required"))?;
 
-        let k = params.top_k.unwrap_or(10);
+        let k = params.top_k.unwrap_or(10) as usize;
         let distance_metric = params.distance_metric;
 
         debug!(
@@ -6279,7 +6279,7 @@ impl UnifiedSstableReader {
             )
             .await?;
 
-        let k = search_params.top_k.unwrap_or(10).max(1);
+        let k = search_params.top_k.unwrap_or(10).max(1) as usize;
         let threshold = vector_bounds_provisional_threshold(&blocks, query, k);
 
         // Pass 2: prune the remainder against τ, then read the survivors.

--- a/src/storage/engines/sst/tests/cross_format_interop_benchmark.rs
+++ b/src/storage/engines/sst/tests/cross_format_interop_benchmark.rs
@@ -223,7 +223,7 @@ mod tests {
         let query_vector = vectors[0].vector.clone();
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.clone()),
-            top_k: Some(vectors.len()), // Get all
+            top_k: Some(vectors.len() as u16), // Get all
             filters: None,
             filter_expression: None,
             ..Default::default()
@@ -332,7 +332,7 @@ mod tests {
         let query_vector = vectors[0].vector.clone();
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.clone()),
-            top_k: Some(vectors.len()),
+            top_k: Some(vectors.len() as u16),
             filters: None,
             filter_expression: None,
             ..Default::default()
@@ -438,7 +438,7 @@ mod tests {
         let query_vector = vectors[0].vector.clone();
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.clone()),
-            top_k: Some(vectors.len()),
+            top_k: Some(vectors.len() as u16),
             filters: None,
             filter_expression: None,
             ..Default::default()

--- a/src/storage/engines/sst/tests/flush_recovery_tdd_test.rs
+++ b/src/storage/engines/sst/tests/flush_recovery_tdd_test.rs
@@ -708,7 +708,7 @@ mod tests {
             // Get ground truth with exact search
             let exact_params = Arc::new(SearchParams {
                 vector: Some(query_vector.clone()),
-                top_k: Some(k),
+                top_k: Some(k as u16),
                 search_mode: SearchMode::Exact,
                 ..Default::default()
             });
@@ -733,7 +733,7 @@ mod tests {
             // Get approximate results
             let approx_params = Arc::new(SearchParams {
                 vector: Some(query_vector.clone()),
-                top_k: Some(k),
+                top_k: Some(k as u16),
                 search_mode: SearchMode::Approximate { nprobe: None }, // Auto nprobe
                 ..Default::default()
             });

--- a/src/storage/engines/viper/engine.rs
+++ b/src/storage/engines/viper/engine.rs
@@ -1507,7 +1507,7 @@ impl ViperEngine {
 
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.to_vec()),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             ..SearchParams::default()
         });
 
@@ -2614,7 +2614,7 @@ impl UnifiedStorageFormat for ViperEngine {
         let _search_params = crate::core::search::SearchParams {
             query_vectors: None,
             vector: Some(query_vector.to_vec()),
-            top_k: Some(k),
+            top_k: Some(k as u16),
             filter_expression: filter_expression.cloned(),
             distance_metric: Some(distance_metric),
             filters: None,

--- a/src/storage/engines/viper/tests/engine_tests.rs
+++ b/src/storage/engines/viper/tests/engine_tests.rs
@@ -68,7 +68,7 @@ mod tests {
             },
             filter_expression: None,
             query_vector: params.vector.clone(),
-            top_k: params.top_k.unwrap_or(10),
+            top_k: params.top_k.unwrap_or(10) as usize,
             min_score: None,
             enable_early_termination: true,
         }
@@ -221,7 +221,7 @@ mod tests {
 
         let search_params = Arc::new(SearchParams {
             vector: Some(query_vector.to_vec()),
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             distance_metric: Some(distance_metric),
             filter_expression,
             ..SearchParams::default()

--- a/tests/common/integration_test_helpers.rs
+++ b/tests/common/integration_test_helpers.rs
@@ -902,7 +902,7 @@ pub mod operations {
         let search_params = Arc::new(proximadb::core::search::SearchParams {
             vector: Some(query_vector.to_vec()),
             query_vectors: None,
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             distance_metric: Some(proximadb::compute::distance_computation::DistanceMetric::Cosine),
             filter_expression: None,
             timeout_ms: None,
@@ -959,7 +959,7 @@ pub mod operations {
         let collection = Arc::new(environment.create_test_collection());
         let search_params = Arc::new(proximadb::core::search::SearchParams {
             vector: Some(query_vector.to_vec()),
-            top_k: Some(top_k),
+            top_k: Some(top_k as u16),
             distance_metric: Some(proximadb::compute::distance_computation::DistanceMetric::Cosine),
             ..Default::default()
         });

--- a/tests/distance_metric_consistency_test.rs
+++ b/tests/distance_metric_consistency_test.rs
@@ -111,7 +111,7 @@ async fn search(
     let ctx = StorageQueryContext {
         search_params: Arc::new(SearchParams {
             query_vectors: Some(vec![QUERY.to_vec()]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(metric),
             block_prune: BlockPruneConfig {
                 radius_k: 0.0,

--- a/tests/helix_cold_search_recall_test.rs
+++ b/tests/helix_cold_search_recall_test.rs
@@ -64,7 +64,7 @@ mod helix_cold_search_recall {
         let force_exact = matches!(search_mode, SearchMode::Exact);
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             search_mode,
             block_prune: BlockPruneConfig {

--- a/tests/helix_performance_comparison_test.rs
+++ b/tests/helix_performance_comparison_test.rs
@@ -202,7 +202,7 @@ mod performance_comparison_tests {
             let query_start = Instant::now();
             let search_params = Arc::new(proximadb::core::search::SearchParams {
                 query_vectors: Some(vec![query.clone()]),
-                top_k: Some(K_NEIGHBORS),
+                top_k: Some(K_NEIGHBORS as u16),
                 distance_metric: Some(DistanceMetric::Euclidean),
                 filter_expression: None,
                 // Enable block pruning with sensible minimum to avoid expensive PCA on small datasets

--- a/tests/helix_prune_debug_test.rs
+++ b/tests/helix_prune_debug_test.rs
@@ -57,7 +57,7 @@ mod helix_prune_debug {
     ) -> StorageQueryContext {
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             search_mode,
             block_prune,

--- a/tests/integration/comprehensive_filter_test.rs
+++ b/tests/integration/comprehensive_filter_test.rs
@@ -110,7 +110,7 @@ async fn search_with_filter(
 ) -> Result<Vec<proximadb::core::search::results::OptimizedSearchRecord>> {
     let search_params = Arc::new(SearchParams {
         vector: Some(query_vector.to_vec()),
-        top_k: Some(top_k),
+        top_k: Some(top_k as u16),
         distance_metric: Some(DistanceMetric::Cosine),
         filter_expression,
         ..SearchParams::default()

--- a/tests/integration/storage/sst_flush_recovery_test.rs
+++ b/tests/integration/storage/sst_flush_recovery_test.rs
@@ -708,7 +708,7 @@ mod tests {
             // Get ground truth with exact search
             let exact_params = Arc::new(SearchParams {
                 vector: Some(query_vector.clone()),
-                top_k: Some(k),
+                top_k: Some(k as u16),
                 search_mode: SearchMode::Exact,
                 ..Default::default()
             });
@@ -733,7 +733,7 @@ mod tests {
             // Get approximate results
             let approx_params = Arc::new(SearchParams {
                 vector: Some(query_vector.clone()),
-                top_k: Some(k),
+                top_k: Some(k as u16),
                 search_mode: SearchMode::Approximate { nprobe: None }, // Auto nprobe
                 ..Default::default()
             });

--- a/tests/nova_cold_search_recall_test.rs
+++ b/tests/nova_cold_search_recall_test.rs
@@ -82,7 +82,7 @@ fn clustered_vectors() -> Vec<VectorRecord> {
 fn search_params(query: Vec<f32>, metric: DistanceMetric, force_exact: bool) -> Arc<SearchParams> {
     Arc::new(SearchParams {
         query_vectors: Some(vec![query]),
-        top_k: Some(TOP_K),
+        top_k: Some(TOP_K as u16),
         distance_metric: Some(metric),
         block_prune: BlockPruneConfig {
             radius_k: 0.0,

--- a/tests/pax_cascade_prod_search_test.rs
+++ b/tests/pax_cascade_prod_search_test.rs
@@ -91,7 +91,7 @@ async fn search(
     let ctx = StorageQueryContext {
         search_params: Arc::new(SearchParams {
             query_vectors: Some(vec![query]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             block_prune: BlockPruneConfig {
                 radius_k: 0.0,

--- a/tests/pax_kill_switch_rawf32_exact_read_test.rs
+++ b/tests/pax_kill_switch_rawf32_exact_read_test.rs
@@ -178,7 +178,7 @@ async fn kill_switch_flushes_rawf32_pax_and_reads_back_exact() {
     let ctx = StorageQueryContext {
         search_params: Arc::new(SearchParams {
             query_vectors: Some(vec![QUERY.to_vec()]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             block_prune: BlockPruneConfig {
                 radius_k: 0.0,

--- a/tests/raptor_recall_test.rs
+++ b/tests/raptor_recall_test.rs
@@ -184,7 +184,7 @@ mod raptor_recall_tests {
 
             let search_params = Arc::new(SearchParams {
                 vector: Some(query.clone()),
-                top_k: Some(K_NEIGHBORS),
+                top_k: Some(K_NEIGHBORS as u16),
                 distance_metric: Some(
                     proximadb::compute::distance_computation::DistanceMetric::Euclidean,
                 ),
@@ -242,7 +242,7 @@ mod raptor_recall_tests {
 
             let search_params = Arc::new(SearchParams {
                 vector: Some(query.clone()),
-                top_k: Some(K_NEIGHBORS),
+                top_k: Some(K_NEIGHBORS as u16),
                 distance_metric: Some(
                     proximadb::compute::distance_computation::DistanceMetric::Euclidean,
                 ),

--- a/tests/sift_pax_recall_ratchet_test.rs
+++ b/tests/sift_pax_recall_ratchet_test.rs
@@ -270,7 +270,7 @@ async fn search_topk(engine: &SstEngine, collection: &Collection, query: Vec<f32
     let ctx = StorageQueryContext {
         search_params: Arc::new(SearchParams {
             query_vectors: Some(vec![query]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             block_prune: BlockPruneConfig {
                 radius_k: 0.0,

--- a/tests/small_batch_brute_force_test.rs
+++ b/tests/small_batch_brute_force_test.rs
@@ -68,7 +68,7 @@ mod small_batch_tests {
     ) -> StorageQueryContext {
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Cosine),
             search_mode: SearchMode::Exact,
             block_prune: BlockPruneConfig {
@@ -504,7 +504,7 @@ mod small_batch_tests {
     ) -> StorageQueryContext {
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Cosine),
             search_mode: SearchMode::Approximate { nprobe: None }, // Auto sqrt(n)
             block_prune: BlockPruneConfig {
@@ -667,7 +667,7 @@ mod small_batch_tests {
     ) -> StorageQueryContext {
         let search_params = Arc::new(SearchParams {
             query_vectors: Some(vec![query_vector]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Cosine),
             search_mode: SearchMode::Approximate { nprobe: None },
             block_prune: BlockPruneConfig {

--- a/tests/sst_ivf2_compaction_route_proof_test.rs
+++ b/tests/sst_ivf2_compaction_route_proof_test.rs
@@ -152,7 +152,7 @@ async fn search_ids(engine: &SstEngine, coll: &Collection, query: Vec<f32>) -> V
     let ctx = StorageQueryContext {
         search_params: Arc::new(SearchParams {
             query_vectors: Some(vec![query]),
-            top_k: Some(TOP_K),
+            top_k: Some(TOP_K as u16),
             distance_metric: Some(DistanceMetric::Euclidean),
             block_prune: BlockPruneConfig {
                 radius_k: 0.0,

--- a/tests/td112_postflush_recall_e2e.rs
+++ b/tests/td112_postflush_recall_e2e.rs
@@ -134,7 +134,7 @@ async fn flush_batch(engine: &SstEngine, collection: &Collection, batch: Vec<Vec
 async fn search(engine: &SstEngine, collection: &Collection, query: Vec<f32>) -> Vec<String> {
     let params = Arc::new(SearchParams {
         query_vectors: Some(vec![query]),
-        top_k: Some(TOP_K),
+        top_k: Some(TOP_K as u16),
         distance_metric: Some(DistanceMetric::Euclidean),
         // TD-184: use Approximate so the search takes the AXIS/orchestrated path,
         // which triggers the rebuild-from-SST when the in-memory index is absent.


### PR DESCRIPTION
## What
TD-SEARCH-2 S3 numeric slice — per-query thriftiness for the request struct:
- `top_k: Option<usize>` (16B) → **`Option<u16>`** (4B) — top_k is a small result count (≤ ~10⁴, under u16's 65 535 cap).
- `timeout_ms: Option<u64>` (16B) → **`Option<u32>`** (8B) — 4B ms (~49 days) is far beyond any query timeout.

`UnifiedSearchParams` is allocated/passed on **every** search, so this trims the per-query struct. The small *value* is preserved end-to-end; only the storage *type* shrinks.

## Design (per review feedback — no shortcuts)
`top_k` is `u16` in the request struct. Where it is read into engine **execution** and used as a **size** (`BinaryHeap` capacity, `Vec::truncate`, loop bound, threshold), the local is `usize` with **one** `u16 as usize` cast at that genuine size-boundary — `usize` is the correct Rust type for a size, and the cast is transient stack (zero per-query cost). Set sites from usize sources cast `as u16`. The ~100-file engine plumbing keeps `top_k: usize` (it's a size there); `u16` in the request struct is the per-query win.

`core::search::SearchParams` is a `type` alias for `UnifiedSearchParams` (one type). Not on the OpenAPI spec (no `ToSchema`); serde ignores unknown fields → **mixed-read-safe** at the wire.

## Scope
38 files: 2 field defs + `Default` in `search_params.rs`; the rest are boundary casts at direct callers (set: `as u16`; size-read: `as usize`; timeout: `as u64`).

## Verification (local, pre-CI — all green)
- `cargo check --all-targets` (lib + tests + benches) ✅
- `cargo clippy --lib --bins` (CI gate) ✅
- `cargo fmt --check` ✅
- `cargo nextest -p proximadb-search-types` → 40/40 pass (incl. serde round-trip) ✅

## Follow-up (separate PR)
Cascade `u16` into the other per-query structs that still carry `top_k: usize` (`SearchContext`, `SearchPlan`, `QueryContext`) to remove the residual boundary casts.

## Collision note
`search_params.rs` is untouched by the in-flight compaction/ledger work (other session's 3 worktrees); verified 0 search-surface overlap.