### PR TITLE
feat(ledger): tenant-verified settle — close the bearer-capability gap (ADR-071)

### DIFF
--- a/crates/modalities/proximadb-ledger/src/durable.rs
+++ b/crates/modalities/proximadb-ledger/src/durable.rs
@@ -258,6 +258,10 @@ impl Ledger for DurableLedger {
     fn get(&self, key: &str) -> Option<(Version, i64)> {
         self.state.get(key)
     }
+
+    fn reservation_scope(&self, reservation_id: u64) -> Option<String> {
+        self.state.reservation_scope(reservation_id)
+    }
 }
 
 /// Apply one recovered log record to the in-memory state (the replay path — no re-logging).

--- a/crates/modalities/proximadb-ledger/src/lib.rs
+++ b/crates/modalities/proximadb-ledger/src/lib.rs
@@ -99,6 +99,11 @@ pub trait Ledger {
     /// The current `(version, value)` at a compare-and-swap key, or `None` if absent.
     fn get(&self, key: &str) -> Option<(Version, i64)>;
 
+    /// The scope of an in-flight reservation, or `None` if the id is unknown (already settled or
+    /// reclaimed). Lets a caller verify a settle against the reservation's owner — under the
+    /// tenant-scoped port the tenant is encoded in the scope, and it survives a restart via the WAL.
+    fn reservation_scope(&self, reservation_id: u64) -> Option<String>;
+
     /// Remaining headroom = `limit - spent - reserved` (saturating). Unlimited scopes report
     /// [`u64::MAX`].
     fn available(&self, scope: &str) -> u64 {

--- a/crates/modalities/proximadb-ledger/src/memory.rs
+++ b/crates/modalities/proximadb-ledger/src/memory.rs
@@ -191,6 +191,10 @@ impl Ledger for InMemoryLedger {
     fn get(&self, key: &str) -> Option<(Version, i64)> {
         self.kv.get(key).copied()
     }
+
+    fn reservation_scope(&self, reservation_id: u64) -> Option<String> {
+        self.leases.get(&reservation_id).map(|r| r.scope.clone())
+    }
 }
 
 #[cfg(test)]

--- a/crates/modalities/proximadb-ledger/src/service.rs
+++ b/crates/modalities/proximadb-ledger/src/service.rs
@@ -74,14 +74,32 @@ impl<L: Ledger> LedgerService<L> {
         outcome
     }
 
-    /// Settle a reservation by its id.
+    /// Settle a reservation by id, **verified against `tenant`**. Returns `true` if the settle was
+    /// applied (or was a harmless no-op for an unknown / already-settled / reclaimed id), and `false`
+    /// if the reservation belongs to a *different* tenant — a cross-tenant settle attempt, refused.
     ///
-    /// **v1 note:** settle is by opaque reservation id (a bearer capability the caller received from
-    /// [`reserve`](Self::reserve)); it is not re-verified against `tenant`. Cross-tenant isolation on
-    /// the persistent budget/flag data (scopes, CAS keys) *is* enforced by namespacing. A
-    /// tenant-verified settle (a reservation→tenant index) is a tracked follow-up.
-    pub fn settle(&self, reservation_id: u64, actual: u64) {
-        self.lock().settle(reservation_id, actual);
+    /// Closes the bearer-capability gap: a reservation's owning tenant is recovered from its
+    /// namespaced scope (WAL-durable, so it survives a restart), so a leaked or guessed id cannot
+    /// settle another tenant's lease. The lookup + settle are one locked (atomic) step.
+    pub fn settle(&self, tenant: &str, reservation_id: u64, actual: u64) -> bool {
+        let mut ledger = self.lock();
+        match ledger.reservation_scope(reservation_id) {
+            // A live reservation owned by another tenant — refuse without touching it.
+            Some(scope) if !Self::scope_belongs_to(&scope, tenant) => false,
+            // Owned by this tenant, or unknown (already settled / reclaimed → idempotent no-op).
+            _ => {
+                ledger.settle(reservation_id, actual);
+                true
+            }
+        }
+    }
+
+    /// Does a namespaced `scope` belong to `tenant` — i.e. is it exactly `tenant` + [`SEP`] + …?
+    fn scope_belongs_to(scope: &str, tenant: &str) -> bool {
+        scope
+            .strip_prefix(tenant)
+            .and_then(|rest| rest.chars().next())
+            == Some(SEP)
     }
 
     /// Reclaim expired leases across all tenants (the timed sweep — the caller/runtime schedules it).
@@ -169,7 +187,7 @@ mod tests {
         s.set_limit("globex", "team", Some(100), Policy::Block);
 
         let a = admitted(s.reserve("acme", "team", 90, NOW, TTL));
-        s.settle(a.id, 90);
+        assert!(s.settle("acme", a.id, 90));
         assert_eq!(s.spent("acme", "team"), 90);
         assert_eq!(
             s.spent("globex", "team"),
@@ -238,8 +256,28 @@ mod tests {
         // A crashed reserver's lease is swept by expiry.
         assert_eq!(s.reclaim_expired(TTL + 1), 1);
         assert_eq!(s.reserved("acme", "team"), 0);
-        // Settling the (now reclaimed) lease is a harmless no-op.
-        s.settle(r.id, 40);
+        // Settling the (now reclaimed) lease is a harmless no-op — unknown id, returns true.
+        assert!(s.settle("acme", r.id, 40));
         assert_eq!(s.spent("acme", "team"), 0);
+    }
+
+    #[test]
+    fn cross_tenant_settle_is_refused() {
+        // The bearer-capability gap, closed: a reservation id leaked/guessed by another tenant
+        // cannot settle the owner's lease.
+        let s = svc();
+        s.set_limit("acme", "team", Some(100), Policy::Block);
+        let r = admitted(s.reserve("acme", "team", 50, NOW, TTL));
+        // globex presents acme's reservation id — refused, and acme's lease is untouched.
+        assert!(!s.settle("globex", r.id, 50), "cross-tenant settle refused");
+        assert_eq!(s.reserved("acme", "team"), 50, "acme's lease still held");
+        assert_eq!(s.spent("acme", "team"), 0);
+        // The rightful owner settles fine…
+        assert!(s.settle("acme", r.id, 40));
+        assert_eq!(s.spent("acme", "team"), 40);
+        assert_eq!(s.reserved("acme", "team"), 0);
+        // …and settling an unknown id is a harmless no-op (idempotent), reported as applied.
+        assert!(s.settle("acme", 99_999, 10));
+        assert_eq!(s.spent("acme", "team"), 40);
     }
 }

--- a/src/network/grpc/v2/ledger_service.rs
+++ b/src/network/grpc/v2/ledger_service.rs
@@ -123,12 +123,17 @@ impl ProximaLedgerService for ProximaLedgerServiceImpl {
         &self,
         request: Request<pv2::SettleRequest>,
     ) -> Result<Response<pv2::SettleResponse>, Status> {
-        // Resolve tenant for auth even though settle is by opaque reservation id (v1 note in the
-        // port: the id is a bearer capability; a tenant-verified settle index is a follow-up).
-        let _tenant = grpc_auth::resolved_tenant_id(&request)?;
+        // Settle is verified against the caller's tenant: a reservation id belonging to another
+        // tenant is refused (the reservation's owner is recovered from its namespaced scope).
+        let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
-        self.ledger.settle(req.reservation_id, req.actual);
-        Ok(Response::new(pv2::SettleResponse {}))
+        if self.ledger.settle(&tenant, req.reservation_id, req.actual) {
+            Ok(Response::new(pv2::SettleResponse {}))
+        } else {
+            Err(Status::permission_denied(
+                "reservation does not belong to this tenant",
+            ))
+        }
     }
 
     async fn compare_and_swap(


### PR DESCRIPTION
First of the ledger v1-gap fixes. **Settle is now verified against the caller's tenant** — a leaked or guessed reservation id can no longer settle another tenant's lease.

## How
The reservation's owning tenant is **already encoded in its namespaced scope** (the S3a port namespaces every scope by tenant), and that scope is **WAL-durable** (survives a restart), so no separate index is needed:
- New `Ledger::reservation_scope(id) -> Option<String>` (from `InMemoryLedger`'s leases; `DurableLedger` delegates).
- `LedgerService::settle(tenant, id, actual) -> bool` — one **locked (atomic)** step: look up the reservation's scope, refuse (`false`) if it belongs to a different tenant; owned or unknown ids settle (`true` — an unknown id is a harmless idempotent no-op).
- gRPC `Settle` passes the resolved tenant and maps a refusal to `permission_denied`.

Isolation on the *persistent* budget/flag data was already enforced by namespacing; this hardens the **lease** side (the documented v1 gap).

## Tests
`cross_tenant_settle_is_refused` (globex can't settle acme's reservation; acme's lease untouched; owner settles fine; unknown-id no-op). Ledger crate **15/24 green**; `cargo check -p proximadb --features experimental-ledger` clean; fmt + clippy(-D warnings) clean; boundary/tenant-path/deterministic-commit guards pass. Root change is one gated file (`ledger_service.rs`).

Next v1 gaps: calendar windows, background reclaim sweeper, reflection-descriptor regen — then S4 (shared-WAL splice).