### PR TITLE
feat(ledger): background TTL reclaim sweeper (ADR-071 C2)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1636,6 +1636,28 @@ impl SharedServices {
             Arc::new(proximadb_ledger::LedgerService::new(durable))
         };
 
+        // Timed TTL reclaim (ADR-071 / TD-LEDGER-1, invariant C2): sweep expired ledger leases on a
+        // fixed cadence so a crashed reserver's held capacity is freed even when no request touches
+        // the scope. Server profile only; the sweep is idempotent and O(held leases) — cheap.
+        #[cfg(feature = "experimental-ledger")]
+        if profile.is_server() {
+            let sweeper = ledger_store.clone();
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    tick.tick().await;
+                    let now_ns = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos().min(i64::MAX as u128) as i64)
+                        .unwrap_or(0);
+                    let reclaimed = sweeper.reclaim_expired(now_ns);
+                    if reclaimed > 0 {
+                        tracing::debug!("ledger sweeper reclaimed {reclaimed} expired lease(s)");
+                    }
+                }
+            });
+        }
+
         // Create GraphOperationsService for native graph database operations
         // IMPORTANT: Pass the shared GraphCollectionService instance
         debug!(


### PR DESCRIPTION
Second ledger v1-gap fix. Makes the TTL lease reclaim **timed** in production, not just opportunistic-on-next-`reserve`.

## What
A **server-profile-only** tokio task in `SharedServices::new` sweeps expired ledger leases every 60s via `ledger_store.reclaim_expired(now)`, so a crashed reserver's held capacity is freed even when no request touches the scope (invariant **C2**). The sweep is idempotent and O(held leases) — cheap.

One `#[cfg(feature = "experimental-ledger")]` block, modeled on the file's existing `is_server()` + `tokio::spawn` cadence tasks (e.g. the recall-drift sweeper). **No ledger-crate changes** — fully independent of the other gap PRs.

## Verification
`cargo check -p proximadb --features experimental-ledger` clean; fmt + clippy(-D warnings) clean; boundary/deterministic-commit guards pass; default build untouched (cfg-gated). Single file (`shared_services.rs`).

Follow-up: tie the task to a graceful-shutdown signal (today it's detached for the server lifetime — fine, since reclaim is idempotent).

Next: calendar windows (the involved one — `settle`/`spent` gain `now_ns` + a proto `window` field), reflection-descriptor regen, then S4 (shared-WAL splice).