### PR TITLE
docs(design): modality compile-time composition — resolve review findings

### DIFF
--- a/docs/12-design/MODALITY_COMPILE_TIME_COMPOSITION_2026_07_24.adoc
+++ b/docs/12-design/MODALITY_COMPILE_TIME_COMPOSITION_2026_07_24.adoc
@@ -129,7 +129,7 @@ modality-vector       = ["dep:proximadb-vector"]
 modality-graph        = ["dep:proximadb-graph", "dep:proximadb-orion-engine"]
 modality-document     = ["dep:proximadb-document"]
 modality-relational   = ["datafusion-integration"]           # SQL/tables
-modality-observability= ["dep:proximadb-observability", "dep:proximadb-observability-engine"]
+modality-observability = ["dep:proximadb-observability", "dep:proximadb-observability-engine"]
 modality-timeseries   = ["modality-observability"]           # shares the obs family
 modality-event        = ["modality-observability"]
 modality-ledger       = ["dep:proximadb-ledger", "proximadb-ledger/durable"]  # == today's experimental-ledger

--- a/docs/12-design/MODALITY_COMPILE_TIME_COMPOSITION_2026_07_24.adoc
+++ b/docs/12-design/MODALITY_COMPILE_TIME_COMPOSITION_2026_07_24.adoc
@@ -7,16 +7,37 @@
 
 [.lead]
 Every modality (native, hybrid, support) and every cloud backend is a **compile-time-selectable
-feature**, so a deployment links only the code it actually serves — smaller binary, fewer static
-registries, less resident memory, no dead engine paths. Hybrid modalities declare **cargo-feature
+feature**, so a deployment links only the code it actually serves — smaller binary, smaller attack
+surface, no dead engine paths, and (where registries initialise eagerly — measured per modality, see
+§Memory-pressure accounting) less resident memory. Hybrid modalities declare **cargo-feature
 edges onto the native modalities they stack on**, so an illegal composition (e.g. fusion without
 vector) cannot compile. This generalizes the worked pattern from the transactional Ledger modality
 (link:adr/ADR-071-transactional-ledger-modality.adoc[ADR-071] /
 link:../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1]) to the whole
 modality surface, and hands each modality's migration to a parallel session.
 
-Status: **Design / handoff (proposed).** Additive and incremental — the `default` build is unchanged
-until each modality opts in. May be promoted to an ADR (the decision) + one TD per modality (the work).
+Status: **Design / handoff (proposed).** Additive and incremental. May be promoted to an ADR (the
+decision) + one TD per modality (the work).
+
+.The `default` story — stated once, referenced everywhere
+****
+Today's `default` (Cargo.toml `[features]`) is a **curated list** — `sql_frontend`,
+`graph-first-sks`, `unified-facade-routing`, `canonical-document-store`, `datafusion-integration`,
+`otlp-metering` — that already **excludes** `experimental-ledger`, `onnx`, `experimental-turboquant`,
+`experimental-engines`, `cluster`, and every cloud SDK. The migration touches it exactly one way:
+
+* **Already-gated surfaces** (`experimental-ledger`→`modality-ledger`, `onnx`→`support-onnx`,
+  `experimental-turboquant`→`support-quantization`, `aws`/`azure`/`gcp`→`cloud-*`) are **renames**
+  with a transition alias. They stay default-OFF; no reclaim is created — it already exists.
+* **Always-on natives** (vector, graph, document, fusion, entity, ranking, observability) get a
+  **new gate**, and that gate is **added to `default` in the same PR** — so the default build's
+  compiled surface stays byte-identical throughout the migration.
+* **Slimming `default`** (e.g. dropping `datafusion-integration` — see the Relational caveat) is a
+  separate, explicit **cutover ADR**, not part of this handoff.
+
+`edition-full` is a **new superset bundle** (all modalities + heavy optionals). It is *not* a synonym
+for today's `default`, which deliberately excludes the experimental/heavy surfaces above.
+****
 
 == Why compile-time, not runtime
 
@@ -25,19 +46,29 @@ compiled**; only a few surfaces are feature-gated (`experimental-engines`, `expe
 `experimental-turboquant`, `cluster`, the cloud backends `aws`/`azure`/`gcp`). The cost of
 "always-compiled" is not just binary size:
 
-* **Static footprint.** Each engine crate pulls its own `lazy_static`/`OnceCell` registries, index
-  factories, codec tables, and per-process caches — resident whether or not a request ever touches
-  that modality. link:adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] measured one
-  such path (AXIS HNSW/IVF) holding **~8.6 GB** for a workload the PAX scan already served; a runtime
-  flag still *links and can initialise* that code, a compile-time gate **removes it from the binary**.
+* **Static footprint — hypothesis, measured per modality.** Each engine crate pulls its own
+  `lazy_static`/`OnceCell` registries, index factories, codec tables, and per-process caches. The
+  **binary-size and link-tree** cost of those is reclaimed by a compile-time gate *by construction*.
+  The **idle-RSS** cost is reclaimed **only where those registries initialise eagerly** —
+  lazily-initialised code that is never called costs binary bytes and attack surface, not resident
+  memory. Whether each modality's registries are eager or lazy is exactly what the worked
+  `edition-<x>`-vs-`edition-full` boot measurement (§Memory-pressure accounting) establishes; this
+  document does not assume the answer.
 * **Dependency bloat.** DataFusion, ONNX runtime, the cloud SDKs, GPU/Metal, RocksDB, quantization
   kernels — each is a heavy transitive tree. A single-cloud, ledger-only node should not link three
   cloud SDKs and a query engine.
 * **Blast radius.** Code that isn't compiled can't panic, can't be a CVE surface, can't drift.
 
+NOTE: link:adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070]'s **~8.6 GB** AXIS
+figure is *runtime data duplication* — a second in-RAM copy (HNSW graph + quantized vectors) of data
+the PAX scan already serves — and it was reclaimed by the **runtime per-collection gate** (#1145),
+not by a compile-time gate. It is cited in this program as the archetype of the *meter-RAM,
+don't-assert* discipline, **not** as evidence of compile-time static waste.
+
 Runtime gating (an `if config.enabled` branch) leaves all of that linked and often initialised.
-**Compile-time gating (`#[cfg(feature = …)]`) is the only lever that actually reclaims the memory and
-the attack surface.** That is the thesis of this document.
+**Compile-time gating (`#[cfg(feature = …)]`) is the only lever that reclaims the binary, the link
+tree, and the attack surface — and the candidate lever for idle RSS, graduated per modality by
+measurement.** That is the thesis of this document.
 
 == Modality taxonomy
 
@@ -64,7 +95,18 @@ the attack surface.** That is the thesis of this document.
 
      Relational   Observability ── TimeSeries ── Event   Ledger
      (standalone) (standalone family)                    (standalone)
+
+     ═══════════════════════════════════════════════════════════════════
+     Always-on substrate (every edition, NOT feature-gated — §Feature model):
+     ADR-069 WAL · memtable · flush materializer · partition-lease ·
+     catalog · TenantContext/DrPathBuilder · observability/metering spine
 ----
+
+NOTE: Relational is "native" in the `DataModel` sense but owns no storage engine of its own — it is
+lowered onto the **DataFusion** OLAP engine (`modality-relational = ["datafusion-integration"]`), so
+its dominant cost term is the DataFusion link tree, not a storage engine. See the WARNING in
+§Editions: until `datafusion-integration` leaves `default`, this gate is a formalization, not a
+reclaim.
 
 Fusion and Entity are the interdependence the strategy must encode: they are **thin facades over the
 native ports** (the `FusionService` port takes `vector + graph + fulltext(document)`; the entity
@@ -76,7 +118,8 @@ natives, or they won't build.
 === Per-modality features
 
 One feature per modality, gating its engine crate dependency, its gRPC/REST service, its router
-registration, and its `DataModel` arm (mechanics in the next section):
+registration, and its `DataModel` **dispatch arms** — never the wire variant itself (mechanics in
+§Wire-gating):
 
 [source,toml]
 ----
@@ -106,19 +149,42 @@ Because `modality-fusion` *is defined as* `["modality-vector", "modality-graph",
 Cargo makes the interdependence **unforgeable**: you cannot compile Fusion without its natives, and a
 node that enables Fusion automatically links exactly (and only) what Fusion needs.
 
+=== The always-on substrate layer (deliberately not feature-gated)
+
+Per link:adr/ADR-071-transactional-ledger-modality.adoc[ADR-071] Decision 2, every modality rides the
+shared substrate: the **ADR-069 local-disk WAL**, the **memtable**, the **flush materializer**, the
+**fenced partition-lease single-writer**, **`TenantContext` + `DrPathBuilder`**, the **catalog**, and
+the **observability/metering spine**. These compile into **every** edition — including
+`edition-ledger` "lite" — and sit **outside the modality feature graph**: they are the amortized
+platform a new modality harvests instead of re-paying for (the co-design economy).
+
+Two rules keep the feature graph honest:
+
+* **Substrate code is modality-agnostic.** No `#[cfg(feature = "modality-<x>")]` inside WAL,
+  memtable, flush, lease, catalog, or tenancy code. Where the substrate needs per-modality behavior
+  (e.g. flush materialization), that is a **port method** the modality implements — never a cfg
+  branch in substrate code.
+* **No substrate→engine edges.** Substrate code must not reference an engine crate (or a gated
+  dispatch arm) in a way that transitively re-links it — otherwise `edition-ledger` silently drags
+  the vector/graph engines back in through the shared flush path. The per-edition **link-tree delta**
+  (§Memory-pressure accounting) is the CI guard for this: an edition whose transitive crate set
+  contains an unrequested engine crate fails its gate.
+
 === Cloud profiles — one cloud vs. many
 
-The cloud backends are already compile-time features (`object_store/aws`, `object_store/azure`, the
-`google-cloud-storage` dep for `gcp`). Formalize single- vs. multi-cloud as the memory lever it is —
-a single-cloud node must not link three SDKs:
+**This axis is a rename/formalization, not a new gate — the win already exists today.** The leaf
+features `aws`/`azure`/`gcp` and the `cloud-full = ["aws", "azure", "gcp"]` bundle are already in
+Cargo.toml, none of them is in `default`, and the zero-cloud local-filesystem default is already
+true. What this section adds is only the `cloud-*` naming (so the modality and cloud axes read
+uniformly) and the explicit single-vs-multi framing for the `edition-*` crosses:
 
 [source,toml]
 ----
-cloud-aws   = ["aws"]                  # object_store/aws + proximadb-catalog/aws
-cloud-azure = ["azure"]                # object_store/azure
-cloud-gcp   = ["gcp"]                  # google-cloud-storage
-cloud-multi = ["cloud-aws", "cloud-azure", "cloud-gcp"]   # == today's cloud-full
-# default: local filesystem object store only — zero cloud SDKs linked.
+cloud-aws   = ["aws"]                  # existing leaf: object_store/aws + proximadb-catalog/aws
+cloud-azure = ["azure"]                # existing leaf: object_store/azure
+cloud-gcp   = ["gcp"]                  # existing leaf: google-cloud-storage
+cloud-multi = ["cloud-aws", "cloud-azure", "cloud-gcp"]   # rename of existing `cloud-full` (alias during transition)
+# default: local filesystem object store only — zero cloud SDKs linked (ALREADY true today).
 ----
 
 Per link:adr/ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069], the **WAL stays on local disk on
@@ -136,11 +202,19 @@ the two compose: `edition-search + cloud-aws` is a distinct, minimal binary.
 | `edition-search` | vector + graph + document + `modality-fusion` + `modality-entity` + `modality-ranking` | RAG / knowledge-graph
 | `edition-observability` | `modality-observability` + timeseries + event | logs/metrics/traces
 | `edition-analytics` | `modality-relational` + `datafusion-integration` | SQL warehouse
-| `edition-full` | all modalities | the current always-on build
+| `edition-full` | all modalities + heavy optionals | a **superset** of today's `default` (which excludes ledger, ONNX, turboquant, cloud SDKs — see the "`default` story" sidebar, top of doc)
 |===
 
 Crossed with a cloud profile (`edition-search + cloud-aws`) these are the concrete images CI builds
 and ships — each linking only its slice.
+
+WARNING: `datafusion-integration` sits in today's `default` set (Cargo.toml), so **until it moves out
+of `default` — a cutover-ADR decision, not this handoff — `modality-relational` is a formalization,
+not a reclaim**: every edition built on top of `default` (including `edition-vector`) still links
+DataFusion, and `edition-analytics` measures no delta from it. The Relational gate becomes real the
+day `default` drops `datafusion-integration` and `edition-analytics` pulls it explicitly; the
+memory-pressure accounting below will show a zero link-tree delta for it until then, which is the
+honest number.
 
 == Wire-gating mechanics (the ledger-proven pattern)
 
@@ -150,18 +224,40 @@ is untouched.
 
 1. **Engine crate** → an `optional = true` dependency in the root `[dependencies]`, pulled by the
    modality feature (`dep:proximadb-<x>`).
-2. **`DataModel` variant** — gate the enum arm and every exhaustive `match`:
+2. **`DataModel` dispatch — gate the dispatch, never the wire variant.** `DataModel` is a
+   **proto-facing wire enum**: it appears in the v2 protos and in persisted catalog/WAL records.
+   Cfg-gating a *variant* would change the enum's shape per build — a wire-contract change across
+   editions that violates the mixed-read-safe mandate (Core Directive 8: old and new coexist,
+   detected by marker, **never a flag-day**) and breaks a mixed fleet: an `edition-vector` node must
+   still *parse* a shared catalog/WAL record that says `DataModel::Document`, even though it cannot
+   serve it. So the enum stays **full on every build**; what is gated is the *dispatch* into the
+   engine crate:
 +
 [source,rust]
 ----
-pub enum DataModel { Vector, Graph, /* … */ #[cfg(feature = "modality-ledger")] Ledger }
-// and at each exhaustive match:
-#[cfg(feature = "modality-ledger")] DataModel::Ledger => …,
+// The enum is edition-invariant — its wire/persisted shape never changes.
+pub enum DataModel { Vector, Graph, Document, /* … */ Ledger }
+
+// Gate the dispatch arm, with a defined error for the not-compiled case:
+match model {
+    #[cfg(feature = "modality-ledger")]
+    DataModel::Ledger => ledger_port.handle(req),
+    #[cfg(not(feature = "modality-ledger"))]
+    DataModel::Ledger => Err(Status::unimplemented(
+        "modality-ledger is not compiled into this edition",
+    )),
+    // …
+}
 ----
 +
-NOTE: This is the one genuinely invasive edit — ~7 exhaustive `match` sites per variant (audited for
-Ledger). Prefer a catch-all `_` where semantically safe; gate the arm where not. This is why the
-migration is *one modality per PR*.
+A request or record for an uncompiled modality gets a **defined error** (`Unimplemented` /
+`ModalityNotAvailable` — the caller can route or fail cleanly), never a parse failure and never a
+silent skip.
++
+NOTE: This is still the one genuinely invasive edit — ~7 exhaustive `match` sites per variant
+(audited for Ledger), each gaining a cfg'd arm *pair*. A catch-all `_` is acceptable only in
+**internal routing** where "not my modality" is semantically safe; it is **not** acceptable where it
+would swallow the defined-error contract above. This is why the migration is *one modality per PR*.
 3. **gRPC service** — `#[cfg(feature = "modality-<x>")] pub mod <x>_service;` in
    `src/network/grpc/v2/mod.rs`; the proto lives in `proto/proximadb/v2/<x>.proto` (regenerated via
    `PROXIMADB_REGEN_PROTO=1 cargo build -p proximadb-proto` — *verify the pristine regen reproduces
@@ -189,7 +285,7 @@ phase is provable before the next risk is taken on:
 | Phase | Work | Isolation
 | *S1 — core* | The engine/correctness logic in its own crate, behind a trait seam, **unit-tested against a conformance suite**. No wiring, minimal deps. | A crate; zero blast radius.
 | *S2 — durable* | Persistence behind the same trait (WAL/segment), replay-on-open, restart-survival tests. Feature-gated deps. | Same crate.
-| *S3 — wire* | The port + gRPC/REST service + `SharedServices` field + router registration + `DataModel` arm, all `#[cfg]`-gated. | Central files, tight cfg-blocks (this doc §Wire-gating).
+| *S3 — wire* | The port + gRPC/REST service + `SharedServices` field + router registration + `DataModel` **dispatch arms** (enum stays full — §Wire-gating), all `#[cfg]`-gated. | Central files, tight cfg-blocks (this doc §Wire-gating).
 | *S4 — integrate / HA* | Splice onto shared substrates (the ADR-069 record WAL, cluster/partition-lease), cross-modal edges, benchmark evidence, graduate from Experimental. | Core engine; wants owner review.
 |===
 
@@ -201,16 +297,18 @@ declared up front (§Feature model).
 
 Each row is an independent stream a session can own end-to-end. "Gated today?" = whether the code is
 already behind a feature; most natives are **always-on today** and the migration is to gate them
-additively (default keeps them on via an `edition-full`-style default until the cutover).
+additively — each new modality feature is added to `default` in its own gating PR, so the default
+build's compiled surface stays byte-identical (the "`default` story" sidebar, top of doc); slimming `default` is
+a separate cutover ADR.
 
 [cols="1,1,1,1,1,2", options="header"]
 |===
 | Modality | Class | Stacks on | Gated today? | Target feature | Phase / handoff notes
 | Ledger | native | — | ✅ `experimental-ledger` | `modality-ledger` | **S1–S3 done** (ADR-071). Next: S4 shared-WAL splice; rename feature `experimental-ledger`→`modality-ledger` (alias during transition).
-| Vector | native | — | ❌ always-on | `modality-vector` | Gate engine + service + `DataModel::Vector`. Watch: it is the most-referenced modality — many `match` sites. Do first (unblocks Fusion/Entity/Embedding).
+| Vector | native | — | ❌ always-on | `modality-vector` | Gate engine + service + `DataModel::Vector` **dispatch** (enum stays full). Watch: it is the most-referenced modality — many `match` sites. Do first (unblocks Fusion/Entity/Embedding) **and file the first worked boot measurement** (§Memory-pressure accounting).
 | Graph | native | — | ❌ always-on | `modality-graph` | Gate proximadb-graph + orion-engine. Do early (Fusion/Entity dep).
-| Document | native | — | ❌ (canonical-document-store gates *storage mode*, not the modality) | `modality-document` | Gate service + `DataModel::Document`. Fusion/Entity dep.
-| Relational | native | — | partial (`datafusion-integration`) | `modality-relational` | Mostly a rename/formalize over the existing datafusion gate + pgwire surface.
+| Document | native | — | ❌ (canonical-document-store gates *storage mode*, not the modality) | `modality-document` | Gate service + `DataModel::Document` **dispatch** (enum stays full). Fusion/Entity dep.
+| Relational | native | — | partial (`datafusion-integration`, **in `default`**) | `modality-relational` | Rename/formalize over the existing datafusion gate + pgwire surface. **Not a reclaim until `datafusion-integration` leaves `default`** (§Editions WARNING); expect and record a zero link-tree delta until that cutover.
 | Observability | native | — | partial (`otlp-metering`, io-trace) | `modality-observability` | Fold logs/metrics; timeseries + event ride this family.
 | TimeSeries | native | Observability | ❌ | `modality-timeseries` | `= ["modality-observability"]`.
 | Event | native | Observability | ❌ | `modality-event` | `= ["modality-observability"]`.
@@ -235,34 +333,50 @@ Per co-design (link:adr/ADR-052-analytics-execution-competitiveness-codesign.ado
 against the dominant cost term"), each gating PR should record the reclaimed footprint, not assert it:
 
 * **Binary delta** — `cargo bloat` / stripped-size before vs. after enabling only the target edition.
-* **RSS at idle** — resident memory of a booted server for `edition-<x>` vs. `edition-full` (the AXIS
-  ~8.6 GB figure in ADR-070 is the archetype of what a compile-time gate reclaims that a runtime flag
-  cannot).
+  Guaranteed nonzero for a real gate; a ~zero delta means the gate is a formalization (expected for
+  Relational until the `datafusion-integration` cutover — record it anyway, it is the honest number).
+* **RSS at idle** — resident memory of a booted server for `edition-<x>` vs. `edition-full`. This is
+  the **hypothesis test** for the static-footprint claim (§Why compile-time): the RSS win exists only
+  where a modality's registries initialise eagerly, so it is measured per modality, never asserted.
+  (ADR-070's ~8.6 GB is *runtime* data duplication reclaimed by the runtime per-collection gate — it
+  is the meter-don't-assert archetype, not a compile-time baseline.)
 * **Link-tree delta** — transitive crate/SDK count dropped (e.g. single-cloud drops two cloud SDKs).
+  Doubles as the **substrate-purity guard** (§Feature model): an edition whose transitive set
+  contains an unrequested engine crate has a substrate→engine edge to remove.
 
-File these into `BENCHMARK_EVIDENCE.toml`; a modality's gate "graduates" when the reclaimed footprint
-is measured, not claimed.
+File these into `BENCHMARK_EVIDENCE.toml`. **The measurement is blocking, not advisory**: the first
+gating PR (Vector) must include the worked `edition-vector`-vs-`edition-full` boot measurement that
+establishes the method, and no modality's gate graduates — nor is its `edition-*` image shipped —
+until its three deltas are filed. A gate whose measured reclaim is ~zero is not a failure; it is a
+finding (see the Relational caveat) that redirects the cutover discussion.
 
 == Risks & non-goals
 
-* *Risk — `DataModel` cfg sprawl.* Gating enum variants ripples into exhaustive matches (~7 sites per
-  variant). Mitigation: one modality per PR; prefer catch-all arms; a `cfg`-drift matrix row per
-  feature. This is the main reason the migration is incremental, not a big-bang.
+* *Risk — `DataModel` cfg sprawl.* Gating the dispatch ripples into exhaustive matches (~7 sites per
+  variant, each gaining a cfg'd arm *pair* — §Wire-gating). Mitigation: one modality per PR; a
+  `cfg`-drift matrix row per feature; catch-all arms only in internal routing where they cannot
+  swallow the defined-error contract. This is the main reason the migration is incremental, not a
+  big-bang.
 * *Risk — feature-combination explosion.* N modalities × 3 clouds is a large matrix. Mitigation: CI
   checks the **editions** (a curated handful) + each single-modality row, not the full power set.
 * *Non-goal — changing any modality's behavior or wire contract.* This is packaging/composition only;
-  each modality's semantics are unchanged. `default` stays `edition-full`-equivalent until an explicit
-  cutover ADR.
-* *Non-goal — runtime hot-swapping of modalities.* Composition is fixed at build time by design (that
-  is where the memory win is).
+  each modality's semantics are unchanged, and the `DataModel` wire enum stays **full on every
+  edition** (§Wire-gating) — which is precisely what keeps this non-goal true under Core Directive 8
+  (mixed-read-safe, never a flag-day). `default` keeps today's compiled surface byte-identical (new
+  modality gates land default-ON — the "`default` story" sidebar, top of doc) until an explicit cutover ADR;
+  `edition-full` is a superset of `default`, not its synonym.
+* *Non-goal — runtime hot-swapping of modalities.* Composition is fixed at build time by design —
+  that is where the binary/link-tree/attack-surface win comes from, and where any measured idle-RSS
+  win is banked.
 
 == References
 
 * link:adr/ADR-071-transactional-ledger-modality.adoc[ADR-071] /
   link:../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1] — the worked
   example this generalizes (S1 core → S2 durable → S3 wire → S4 HA, feature-gated, port/impl split).
-* link:adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] — the archetype of a
-  compiled-in-but-redundant RAM path a compile-time gate reclaims.
+* link:adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] — measured *runtime* RAM
+  duplication (AXIS re-indexing what the PAX scan serves), reclaimed by the runtime per-collection
+  gate; cited as the meter-RAM-don't-assert archetype, **not** as compile-time static waste.
 * link:adr/ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069] — WAL on local disk on every cloud
   profile; the cloud feature selects only the at-rest tier.
 * link:adr/ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] — meter the dominant


### PR DESCRIPTION
Applies the 7 prioritized revisions from the first-principles / extreme co-design review of `MODALITY_COMPILE_TIME_COMPOSITION_2026_07_24.adoc` (kimi-k3 review, 2026-07-24), in dependency order. Doc-only; no code changes.

## What changed

1. **Default story unified** (was self-contradictory across lines 18/204/255): a single `default` story sidebar states that today's default is the curated Cargo.toml set (already excluding ledger/ONNX/turboquant/cloud); already-gated surfaces are **renames** with transition aliases; always-on natives get **new gates added to `default` in the same PR** so the compiled surface stays byte-identical; slimming `default` is a separate cutover ADR. `edition-full` is a superset bundle, not a synonym for `default`.
2. **Always-on substrate layer** added to the feature model and the dependency graph (ADR-069 WAL, memtable, flush materializer, partition-lease, catalog, TenantContext/DrPathBuilder, observability spine — per ADR-071 Decision 2), with two rules: substrate code is modality-agnostic (port methods, never cfg branches), and no substrate→engine edges (the per-edition link-tree delta is the CI guard).
3. **DataModel wire-safety hole fixed**: the enum stays **full on every edition** — cfg-gating a proto-facing variant is a wire-contract change across editions that violates Core Directive 8 (mixed-read-safe, never a flag-day) and breaks mixed fleets. What is gated is the **dispatch**, with a defined `Unimplemented` error for uncompiled modalities; catch-all arms restricted to internal routing.
4. **Relational/DataFusion reconciled**: `datafusion-integration` is in today's `default`, so `modality-relational` is a formalization, not a reclaim, until a cutover ADR moves it out — stated in an Editions WARNING, a taxonomy note, and the handoff row (zero link-tree delta recorded as the honest number).
5. **Static-footprint claim downgraded to hypothesis**: binary/link-tree/attack-surface wins are guaranteed by construction; idle-RSS wins exist only where registries initialise eagerly. The `edition-<x>`-vs-`edition-full` boot measurement is now **blocking**: the first worked measurement lands with the Vector gating PR, and no gate graduates (nor ships its edition image) until its three deltas are filed in `BENCHMARK_EVIDENCE.toml`.
6. **ADR-070 citation corrected** in §Why, §Memory-pressure accounting, and §References: the ~8.6 GB is *runtime* data duplication (AXIS re-indexing what the PAX scan serves), reclaimed by the runtime per-collection gate (#1145) — cited as the meter-don't-assert archetype, not compile-time static waste.
7. **Cloud axis reframed as rename/formalization**: `aws`/`azure`/`gcp` leaves and the `cloud-full` bundle already exist outside `default` (Cargo.toml:738-740, 816); `cloud-multi` is an alias of `cloud-full`; the zero-cloud default is already true today.

Verified: `asciidoctor` renders with no warnings; all cross-references (`§Wire-gating`, `§Editions`, `§Memory-pressure accounting`, the default-story sidebar) resolve against the revised section set; claims checked against Cargo.toml `[features]`, ADR-070, ADR-071, and Core Directive 8.

