### PR TITLE
feat(ledger): calendar spend windows — Total + Daily (ADR-071)

### DIFF
--- a/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
+++ b/crates/foundation/proximadb-proto/src/proto/proximadb.v2.rs
@@ -8476,6 +8476,9 @@ pub struct SetLimitRequest {
     pub limit: ::core::option::Option<u64>,
     #[prost(enumeration = "LedgerPolicy", tag = "3")]
     pub policy: i32,
+    /// absent/UNSPECIFIED = TOTAL
+    #[prost(enumeration = "LedgerWindow", tag = "4")]
+    pub window: i32,
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetLimitResponse {}
@@ -8585,6 +8588,40 @@ impl LedgerPolicy {
             "LEDGER_POLICY_UNSPECIFIED" => Some(Self::Unspecified),
             "LEDGER_POLICY_BLOCK" => Some(Self::Block),
             "LEDGER_POLICY_WARN" => Some(Self::Warn),
+            _ => None,
+        }
+    }
+}
+/// The window over which a scope's spend accrues before it resets (calendar-aligned, UTC).
+/// MONTHLY is reserved for a follow-up (needs civil-calendar math); TOTAL + DAILY ship now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LedgerWindow {
+    /// treated as TOTAL
+    Unspecified = 0,
+    /// never resets (lifetime cap)
+    Total = 1,
+    /// resets at each UTC midnight
+    Daily = 2,
+}
+impl LedgerWindow {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "LEDGER_WINDOW_UNSPECIFIED",
+            Self::Total => "LEDGER_WINDOW_TOTAL",
+            Self::Daily => "LEDGER_WINDOW_DAILY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "LEDGER_WINDOW_UNSPECIFIED" => Some(Self::Unspecified),
+            "LEDGER_WINDOW_TOTAL" => Some(Self::Total),
+            "LEDGER_WINDOW_DAILY" => Some(Self::Daily),
             _ => None,
         }
     }

--- a/crates/modalities/proximadb-ledger/src/durable.rs
+++ b/crates/modalities/proximadb-ledger/src/durable.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Ledger;
 use crate::memory::InMemoryLedger;
-use crate::types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+use crate::types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version, Window};
 
 /// When the WAL is flushed to stable storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +48,7 @@ enum LogRecord {
     SetLimit {
         scope: String,
         limit: Option<u64>,
+        window: u8,
         policy: u8,
     },
     Reserve {
@@ -59,6 +60,7 @@ enum LogRecord {
     Settle {
         id: u64,
         actual: u64,
+        settled_at_ns: Nanos,
     },
     Cas {
         key: String,
@@ -77,6 +79,19 @@ fn policy_from_u8(v: u8) -> Policy {
     match v {
         1 => Policy::Warn,
         _ => Policy::Block,
+    }
+}
+
+fn window_to_u8(w: Window) -> u8 {
+    match w {
+        Window::Total => 0,
+        Window::Daily => 1,
+    }
+}
+fn window_from_u8(v: u8) -> Window {
+    match v {
+        1 => Window::Daily,
+        _ => Window::Total,
     }
 }
 
@@ -149,17 +164,18 @@ impl DurableLedger {
 }
 
 impl Ledger for DurableLedger {
-    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy) {
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, window: Window, policy: Policy) {
         let record = LogRecord::SetLimit {
             scope: scope.to_string(),
             limit,
+            window: window_to_u8(window),
             policy: policy_to_u8(policy),
         };
         if let Err(e) = self.append(&record) {
             eprintln!("proximadb-ledger: set_limit append failed, not applied: {e}");
             return;
         }
-        self.state.set_limit(scope, limit, policy);
+        self.state.set_limit(scope, limit, window, policy);
     }
 
     fn reserve(
@@ -169,7 +185,9 @@ impl Ledger for DurableLedger {
         now_ns: Nanos,
         ttl_ns: Nanos,
     ) -> ReserveOutcome {
-        // Decide first (no mutation)…
+        // Roll the window first so the admit check sees the current window's spend (a hard cap must
+        // never be checked against stale spend), then decide (no mutation)…
+        self.state.roll(scope, now_ns);
         if let Err(denied) = self.state.check_admit(scope, ceiling) {
             return ReserveOutcome::Denied(denied);
         }
@@ -201,16 +219,17 @@ impl Ledger for DurableLedger {
         ReserveOutcome::Admitted(reservation)
     }
 
-    fn settle(&mut self, reservation_id: u64, actual: u64) {
+    fn settle(&mut self, reservation_id: u64, actual: u64, now_ns: Nanos) {
         if let Err(e) = self.append(&LogRecord::Settle {
             id: reservation_id,
             actual,
+            settled_at_ns: now_ns,
         }) {
             // Settle is idempotent/retryable: skip applying so state never runs ahead of the WAL.
             eprintln!("proximadb-ledger: settle append failed, not applied (retryable): {e}");
             return;
         }
-        self.state.settle(reservation_id, actual);
+        self.state.settle(reservation_id, actual, now_ns);
     }
 
     fn reclaim_expired(&mut self, now_ns: Nanos) -> usize {
@@ -270,8 +289,14 @@ fn apply_record(state: &mut InMemoryLedger, record: LogRecord) {
         LogRecord::SetLimit {
             scope,
             limit,
+            window,
             policy,
-        } => state.set_limit(&scope, limit, policy_from_u8(policy)),
+        } => state.set_limit(
+            &scope,
+            limit,
+            window_from_u8(window),
+            policy_from_u8(policy),
+        ),
         LogRecord::Reserve {
             id,
             scope,
@@ -283,7 +308,11 @@ fn apply_record(state: &mut InMemoryLedger, record: LogRecord) {
             ceiling,
             expires_at_ns,
         }),
-        LogRecord::Settle { id, actual } => state.settle(id, actual),
+        LogRecord::Settle {
+            id,
+            actual,
+            settled_at_ns,
+        } => state.settle(id, actual, settled_at_ns),
         LogRecord::Cas {
             key,
             version,
@@ -344,9 +373,9 @@ mod tests {
         let dir = tmp();
         {
             let mut l = open(&dir);
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             let r = admit(&mut l, "g", 50);
-            l.settle(r.id, 40);
+            l.settle(r.id, 40, NOW);
             assert_eq!(l.spent("g"), 40);
         } // dropped — simulate a restart
         let reopened = open(&dir);
@@ -361,7 +390,7 @@ mod tests {
         let dir = tmp();
         let id = {
             let mut l = open(&dir);
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             admit(&mut l, "g", 80).id // reserved but NOT settled before the "crash"
         };
         let mut reopened = open(&dir);
@@ -377,7 +406,7 @@ mod tests {
             ReserveOutcome::Denied(_)
         ));
         // …and the recovered lease settles by its original id.
-        reopened.settle(id, 55);
+        reopened.settle(id, 55, NOW);
         assert_eq!(reopened.spent("g"), 55);
         assert_eq!(reopened.reserved("g"), 0);
     }
@@ -388,13 +417,13 @@ mod tests {
         let dir = tmp();
         let id = {
             let mut l = open(&dir);
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             let r = admit(&mut l, "g", 50);
-            l.settle(r.id, 40);
+            l.settle(r.id, 40, NOW);
             r.id
         };
         let mut reopened = open(&dir);
-        reopened.settle(id, 999); // replayed settle on an already-settled (now absent) lease
+        reopened.settle(id, 999, NOW); // replayed settle on an already-settled (now absent) lease
         assert_eq!(reopened.spent("g"), 40, "replayed settle is a no-op");
     }
 
@@ -419,7 +448,7 @@ mod tests {
         let dir = tmp();
         {
             let mut l = open(&dir);
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             let _crashed = admit(&mut l, "g", 80);
         }
         let mut reopened = open(&dir);
@@ -437,9 +466,9 @@ mod tests {
         let path = dir.path().join("ledger.wal");
         {
             let mut l = DurableLedger::open(&path, SyncPolicy::PerOp).unwrap();
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             let r = admit(&mut l, "g", 50);
-            l.settle(r.id, 40);
+            l.settle(r.id, 40, NOW);
         }
         // Append 6 bytes of garbage — a plausible torn frame header/body.
         {
@@ -458,9 +487,9 @@ mod tests {
         let path = dir.path().join("ledger.wal");
         {
             let mut l = DurableLedger::open(&path, SyncPolicy::Deferred).unwrap();
-            l.set_limit("g", Some(100), Policy::Block);
+            l.set_limit("g", Some(100), Window::Total, Policy::Block);
             let r = admit(&mut l, "g", 30);
-            l.settle(r.id, 30);
+            l.settle(r.id, 30, NOW);
             l.flush().unwrap(); // explicit checkpoint under the deferred (throughput) policy
         }
         let reopened = DurableLedger::open(&path, SyncPolicy::Deferred).unwrap();
@@ -472,13 +501,13 @@ mod tests {
         // The C1 invariant holds identically on the durable backend (same decision seam).
         let dir = tmp();
         let mut l = open(&dir);
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let r = admit(&mut l, "g", 100);
         assert!(matches!(
             l.reserve("g", 1, NOW, TTL),
             ReserveOutcome::Denied(_)
         ));
-        l.settle(r.id, 40);
+        l.settle(r.id, 40, NOW);
         assert!(l.spent("g") + l.reserved("g") <= 100);
     }
 
@@ -489,7 +518,7 @@ mod tests {
         let path = dir.path().join("ledger.wal");
         {
             let mut l = DurableLedger::open(&path, SyncPolicy::PerOp).unwrap();
-            l.set_limit("s", Some(1), Policy::Warn);
+            l.set_limit("s", Some(1), Window::Total, Policy::Warn);
         }
         let mut f = File::open(&path).unwrap();
         f.rewind().unwrap();
@@ -505,5 +534,30 @@ mod tests {
             u32::from_le_bytes(crc_buf),
             "framed crc matches payload"
         );
+    }
+
+    #[test]
+    fn daily_window_config_and_spend_survive_reopen() {
+        const DAY: Nanos = 86_400_000_000_000;
+        let dir = tmp();
+        {
+            let mut l = open(&dir);
+            l.set_limit("g", Some(100), Window::Daily, Policy::Block);
+            let ReserveOutcome::Admitted(r) = l.reserve("g", 80, 0, TTL) else {
+                panic!("fits on day 0");
+            };
+            l.settle(r.id, 80, 0); // 80 spent on day 0
+        }
+        let mut reopened = open(&dir);
+        // Day 0 spend + the Daily window config are recovered: 80 already spent, so 80 more is denied.
+        assert!(matches!(
+            reopened.reserve("g", 80, 0, TTL),
+            ReserveOutcome::Denied(_)
+        ));
+        // Day 1: the recovered Daily window rolls → spend resets → 80 fits (a Total cap would deny).
+        assert!(matches!(
+            reopened.reserve("g", 80, DAY, TTL),
+            ReserveOutcome::Admitted(_)
+        ));
     }
 }

--- a/crates/modalities/proximadb-ledger/src/lib.rs
+++ b/crates/modalities/proximadb-ledger/src/lib.rs
@@ -40,7 +40,9 @@ mod types;
 pub use durable::{DurableLedger, SyncPolicy};
 pub use memory::InMemoryLedger;
 pub use service::LedgerService;
-pub use types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+pub use types::{
+    CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version, Window, window_start_ns,
+};
 
 /// The atomic ledger contract — the seam every backend implements.
 ///
@@ -49,14 +51,16 @@ pub use types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Ve
 /// mutating methods take `&mut self`: exclusive access *is* the serialization point (the caller holds
 /// the partition write lock — modeled in tests by a `Mutex`). Neutral units only — no pricing.
 pub trait Ledger {
-    /// Set (or clear, with `limit = None`) a scope's cap + policy.
-    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy);
+    /// Set (or clear, with `limit = None`) a scope's cap + window + policy. Spend accrues over the
+    /// [`Window`] and resets at each calendar boundary (`Total` never resets).
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, window: Window, policy: Policy);
 
     /// Atomically admit a call by holding `ceiling` units as a lease expiring at `now_ns + ttl_ns`.
     ///
-    /// The check is `spent + reserved + ceiling ≤ limit` for a `Block` scope; a `Warn` scope (soft
-    /// cap) and an unset scope always admit. Returns [`ReserveOutcome::Denied`] when a hard cap could
-    /// not fit — the call is never dispatched, so the cap cannot be overshot (C1).
+    /// The check is `spent + reserved + ceiling ≤ limit` for a `Block` scope, where `spent` is the
+    /// **current window's** spend (rolled to `now_ns` first); a `Warn` scope (soft cap) and an unset
+    /// scope always admit. Returns [`ReserveOutcome::Denied`] when a hard cap could not fit — the
+    /// call is never dispatched, so the cap cannot be overshot (C1).
     fn reserve(
         &mut self,
         scope: &str,
@@ -65,10 +69,11 @@ pub trait Ledger {
         ttl_ns: Nanos,
     ) -> ReserveOutcome;
 
-    /// Idempotently settle a reservation to its actual usage, releasing the lease. A no-op if the id
-    /// is unknown (already settled, or reclaimed after expiry) — safe under at-least-once delivery
-    /// (C3). `actual = 0` releases the lease without recording spend (the failed/cancelled path).
-    fn settle(&mut self, reservation_id: u64, actual: u64);
+    /// Idempotently settle a reservation to its actual usage, releasing the lease and accruing the
+    /// spend into the scope's **current window** (rolled to `now_ns`). A no-op if the id is unknown
+    /// (already settled, or reclaimed after expiry) — safe under at-least-once delivery (C3).
+    /// `actual = 0` releases the lease without recording spend (the failed/cancelled path).
+    fn settle(&mut self, reservation_id: u64, actual: u64, now_ns: Nanos);
 
     /// Reclaim every lease expired at or before `now_ns`; returns how many were reclaimed. A
     /// reclaimed lease releases its held ceiling **without** recording spend, on a timed basis (C2).
@@ -90,7 +95,10 @@ pub trait Ledger {
     /// The configured policy for a scope (`Block` when unset).
     fn policy(&self, scope: &str) -> Policy;
 
-    /// Settled units recorded against a scope.
+    /// Settled units in the scope's **current window**, as of the last `reserve`/`settle` (writes
+    /// roll the window). A read taken after a window boundary but before the next write may still
+    /// report the prior window's value until then; enforcement (`reserve`) always rolls first, so a
+    /// hard cap is never checked against stale spend.
     fn spent(&self, scope: &str) -> u64;
 
     /// Units held by in-flight (unsettled, unexpired) leases.

--- a/crates/modalities/proximadb-ledger/src/memory.rs
+++ b/crates/modalities/proximadb-ledger/src/memory.rs
@@ -7,11 +7,14 @@
 use std::collections::HashMap;
 
 use crate::Ledger;
-use crate::types::{CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version};
+use crate::types::{
+    CasError, Denied, Nanos, Policy, Reservation, ReserveOutcome, Version, Window, window_start_ns,
+};
 
 #[derive(Debug, Clone, Copy)]
 struct LimitSpec {
     limit: Option<u64>,
+    window: Window,
     policy: Policy,
 }
 
@@ -19,7 +22,9 @@ struct LimitSpec {
 #[derive(Debug, Default)]
 pub struct InMemoryLedger {
     limits: HashMap<String, LimitSpec>,
-    spent: HashMap<String, u64>,
+    /// scope → (current window start ns, spent within it). Writes (`reserve`/`settle`) roll it to the
+    /// current window; a read returns the last-rolled value (see `Ledger::spent`).
+    spent: HashMap<String, (Nanos, u64)>,
     reserved: HashMap<String, u64>,
     leases: HashMap<u64, Reservation>,
     next_id: u64,
@@ -46,6 +51,18 @@ impl InMemoryLedger {
     fn sub_reserved(&mut self, scope: &str, delta: u64) {
         let held = self.reserved.entry(scope.to_string()).or_insert(0);
         *held = held.saturating_sub(delta);
+    }
+
+    /// Roll `scope`'s spent bucket to the window containing `now_ns`, resetting it to 0 if the window
+    /// boundary has passed since the bucket was last touched. Every write (`reserve`/`settle`) rolls
+    /// first, so the current-window spend is fresh before it is checked or read.
+    pub(crate) fn roll(&mut self, scope: &str, now_ns: Nanos) {
+        let window = self.limits.get(scope).map(|s| s.window).unwrap_or_default();
+        let cur = window_start_ns(now_ns, window);
+        let bucket = self.spent.entry(scope.to_string()).or_insert((cur, 0));
+        if bucket.0 != cur {
+            *bucket = (cur, 0);
+        }
     }
 
     // --- check / apply seams --------------------------------------------------
@@ -113,9 +130,15 @@ impl InMemoryLedger {
 }
 
 impl Ledger for InMemoryLedger {
-    fn set_limit(&mut self, scope: &str, limit: Option<u64>, policy: Policy) {
-        self.limits
-            .insert(scope.to_string(), LimitSpec { limit, policy });
+    fn set_limit(&mut self, scope: &str, limit: Option<u64>, window: Window, policy: Policy) {
+        self.limits.insert(
+            scope.to_string(),
+            LimitSpec {
+                limit,
+                window,
+                policy,
+            },
+        );
     }
 
     fn reserve(
@@ -125,6 +148,9 @@ impl Ledger for InMemoryLedger {
         now_ns: Nanos,
         ttl_ns: Nanos,
     ) -> ReserveOutcome {
+        // Roll the window first so the admit check sees the *current* window's spend, not last
+        // window's — a hard cap must never be checked against stale spend.
+        self.roll(scope, now_ns);
         if let Err(denied) = self.check_admit(scope, ceiling) {
             return ReserveOutcome::Denied(denied);
         }
@@ -138,12 +164,15 @@ impl Ledger for InMemoryLedger {
         ReserveOutcome::Admitted(reservation)
     }
 
-    fn settle(&mut self, reservation_id: u64, actual: u64) {
+    fn settle(&mut self, reservation_id: u64, actual: u64, now_ns: Nanos) {
         let Some(lease) = self.leases.remove(&reservation_id) else {
             return; // unknown / already settled / reclaimed — idempotent no-op (C3).
         };
         self.sub_reserved(&lease.scope, lease.ceiling);
-        *self.spent.entry(lease.scope).or_insert(0) += actual;
+        self.roll(&lease.scope, now_ns);
+        if let Some(bucket) = self.spent.get_mut(&lease.scope) {
+            bucket.1 = bucket.1.saturating_add(actual);
+        }
     }
 
     fn reclaim_expired(&mut self, now_ns: Nanos) -> usize {
@@ -181,7 +210,7 @@ impl Ledger for InMemoryLedger {
     }
 
     fn spent(&self, scope: &str) -> u64 {
-        self.spent.get(scope).copied().unwrap_or(0)
+        self.spent.get(scope).map(|(_, s)| *s).unwrap_or(0)
     }
 
     fn reserved(&self, scope: &str) -> u64 {
@@ -224,12 +253,12 @@ mod tests {
     #[test]
     fn block_cap_prevents_overshoot() {
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let r = admit(&mut l, "g", 100);
         // A near-full cap admits nothing more — even 1 unit — before any usage is known.
         assert!(denied(&mut l, "g", 1));
         // Real usage came in under the ceiling; settle frees the difference.
-        l.settle(r.id, 40);
+        l.settle(r.id, 40, NOW);
         assert_eq!(l.spent("g"), 40);
         assert_eq!(l.reserved("g"), 0);
         assert_eq!(l.available("g"), 60);
@@ -242,12 +271,12 @@ mod tests {
     #[test]
     fn warn_scope_admits_over_cap_but_tracks_spend() {
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Warn);
+        l.set_limit("g", Some(100), Window::Total, Policy::Warn);
         let a = admit(&mut l, "g", 80);
-        l.settle(a.id, 80);
+        l.settle(a.id, 80, NOW);
         // 80 spent, cap 100 — an 80 ceiling would breach it, but a soft cap admits anyway.
         let b = admit(&mut l, "g", 80);
-        l.settle(b.id, 80);
+        l.settle(b.id, 80, NOW);
         assert_eq!(l.spent("g"), 160, "spend accrues past a warn cap");
     }
 
@@ -257,7 +286,7 @@ mod tests {
         assert_eq!(l.available("free"), u64::MAX);
         let r = admit(&mut l, "free", 1_000_000);
         assert_eq!(l.reserved("free"), 1_000_000);
-        l.settle(r.id, 999);
+        l.settle(r.id, 999, NOW);
         assert_eq!(l.spent("free"), 999);
     }
 
@@ -270,7 +299,7 @@ mod tests {
         ledger
             .lock()
             .unwrap()
-            .set_limit("g", Some(1000), Policy::Block);
+            .set_limit("g", Some(1000), Window::Total, Policy::Block);
 
         let handles: Vec<_> = (0..100)
             .map(|_| {
@@ -299,7 +328,7 @@ mod tests {
     #[test]
     fn expired_lease_is_reclaimed_without_reading_the_scope() {
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let _crashed = admit(&mut l, "g", 80); // reserver "crashes" — never settles
         assert_eq!(l.available("g"), 20);
         // Not yet expired.
@@ -316,10 +345,10 @@ mod tests {
     fn settle_after_reclaim_is_a_noop() {
         // Documents the TTL tradeoff: a settle arriving after reclaim is dropped (the lease is gone).
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let r = admit(&mut l, "g", 50);
         assert_eq!(l.reclaim_expired(TTL + 1), 1);
-        l.settle(r.id, 40); // too late
+        l.settle(r.id, 40, NOW); // too late
         assert_eq!(l.spent("g"), 0);
         assert_eq!(l.reserved("g"), 0);
     }
@@ -329,11 +358,11 @@ mod tests {
     #[test]
     fn settle_is_idempotent_under_repeat() {
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let r = admit(&mut l, "g", 50);
-        l.settle(r.id, 40);
-        l.settle(r.id, 40); // at-least-once repeat
-        l.settle(r.id, 999); // a replay must not overwrite or double-count
+        l.settle(r.id, 40, NOW);
+        l.settle(r.id, 40, NOW); // at-least-once repeat
+        l.settle(r.id, 999, NOW); // a replay must not overwrite or double-count
         assert_eq!(l.spent("g"), 40);
         assert_eq!(l.reserved("g"), 0);
     }
@@ -341,10 +370,10 @@ mod tests {
     #[test]
     fn zero_settle_releases_without_recording_spend() {
         let mut l = InMemoryLedger::new();
-        l.set_limit("g", Some(100), Policy::Block);
+        l.set_limit("g", Some(100), Window::Total, Policy::Block);
         let r = admit(&mut l, "g", 50);
         assert_eq!(l.reserved("g"), 50);
-        l.settle(r.id, 0); // the failed/cancelled path
+        l.settle(r.id, 0, NOW); // the failed/cancelled path
         assert_eq!(l.reserved("g"), 0);
         assert_eq!(l.spent("g"), 0);
     }
@@ -396,5 +425,31 @@ mod tests {
             .sum();
         assert_eq!(winners, 1, "exactly one create wins the race");
         assert_eq!(ledger.lock().unwrap().get("k").map(|(v, _)| v), Some(1));
+    }
+
+    #[test]
+    fn daily_window_resets_spend_at_the_boundary() {
+        const DAY: Nanos = 86_400_000_000_000;
+        let mut l = InMemoryLedger::new();
+        l.set_limit("g", Some(100), Window::Daily, Policy::Block);
+        // Day 0 (noon): spend 80 into today's window.
+        let noon0 = DAY / 2;
+        let ReserveOutcome::Admitted(r0) = l.reserve("g", 80, noon0, TTL) else {
+            panic!("first fits");
+        };
+        l.settle(r0.id, 80, noon0);
+        assert_eq!(l.spent("g"), 80);
+        // Same day: 80 spent + another 80 would breach the 100 cap → denied.
+        assert!(matches!(
+            l.reserve("g", 80, noon0, TTL),
+            ReserveOutcome::Denied(_)
+        ));
+        // Next day: the window rolled, spend reset, so 80 fits again (a Total cap would still deny).
+        let noon1 = DAY + DAY / 2;
+        let ReserveOutcome::Admitted(r1) = l.reserve("g", 80, noon1, TTL) else {
+            panic!("the daily window should have reset");
+        };
+        l.settle(r1.id, 80, noon1);
+        assert_eq!(l.spent("g"), 80, "spend reset at the day boundary");
     }
 }

--- a/crates/modalities/proximadb-ledger/src/service.rs
+++ b/crates/modalities/proximadb-ledger/src/service.rs
@@ -16,7 +16,7 @@
 use std::sync::Mutex;
 
 use crate::Ledger;
-use crate::types::{CasError, Nanos, Policy, ReserveOutcome, Version};
+use crate::types::{CasError, Nanos, Policy, ReserveOutcome, Version, Window};
 
 /// Namespace separator between tenant and scope/key. ASCII Unit Separator — not valid in the tenant
 /// ids or scope names the gateway mints, so the composed key is unambiguous.
@@ -48,9 +48,16 @@ impl<L: Ledger> LedgerService<L> {
     }
 
     /// Configure a scope's cap + policy, isolated to `tenant`.
-    pub fn set_limit(&self, tenant: &str, scope: &str, limit: Option<u64>, policy: Policy) {
+    pub fn set_limit(
+        &self,
+        tenant: &str,
+        scope: &str,
+        limit: Option<u64>,
+        window: Window,
+        policy: Policy,
+    ) {
         self.lock()
-            .set_limit(&Self::key(tenant, scope), limit, policy);
+            .set_limit(&Self::key(tenant, scope), limit, window, policy);
     }
 
     /// Reserve a ceiling for `tenant`'s `scope`. The returned reservation/denial carries the caller's
@@ -81,14 +88,14 @@ impl<L: Ledger> LedgerService<L> {
     /// Closes the bearer-capability gap: a reservation's owning tenant is recovered from its
     /// namespaced scope (WAL-durable, so it survives a restart), so a leaked or guessed id cannot
     /// settle another tenant's lease. The lookup + settle are one locked (atomic) step.
-    pub fn settle(&self, tenant: &str, reservation_id: u64, actual: u64) -> bool {
+    pub fn settle(&self, tenant: &str, reservation_id: u64, actual: u64, now_ns: Nanos) -> bool {
         let mut ledger = self.lock();
         match ledger.reservation_scope(reservation_id) {
             // A live reservation owned by another tenant — refuse without touching it.
             Some(scope) if !Self::scope_belongs_to(&scope, tenant) => false,
             // Owned by this tenant, or unknown (already settled / reclaimed → idempotent no-op).
             _ => {
-                ledger.settle(reservation_id, actual);
+                ledger.settle(reservation_id, actual, now_ns);
                 true
             }
         }
@@ -183,11 +190,11 @@ mod tests {
     fn tenants_are_isolated_on_the_same_scope_name() {
         let s = svc();
         // Same scope name "team", different tenants → independent caps + spend.
-        s.set_limit("acme", "team", Some(100), Policy::Block);
-        s.set_limit("globex", "team", Some(100), Policy::Block);
+        s.set_limit("acme", "team", Some(100), Window::Total, Policy::Block);
+        s.set_limit("globex", "team", Some(100), Window::Total, Policy::Block);
 
         let a = admitted(s.reserve("acme", "team", 90, NOW, TTL));
-        assert!(s.settle("acme", a.id, 90));
+        assert!(s.settle("acme", a.id, 90, NOW));
         assert_eq!(s.spent("acme", "team"), 90);
         assert_eq!(
             s.spent("globex", "team"),
@@ -210,7 +217,7 @@ mod tests {
     #[test]
     fn returned_reservation_carries_the_bare_scope() {
         let s = svc();
-        s.set_limit("acme", "team", Some(100), Policy::Block);
+        s.set_limit("acme", "team", Some(100), Window::Total, Policy::Block);
         let r = admitted(s.reserve("acme", "team", 10, NOW, TTL));
         assert_eq!(
             r.scope, "team",
@@ -250,14 +257,14 @@ mod tests {
     #[test]
     fn reserve_settle_reclaim_round_trip() {
         let s = svc();
-        s.set_limit("acme", "team", Some(100), Policy::Block);
+        s.set_limit("acme", "team", Some(100), Window::Total, Policy::Block);
         let r = admitted(s.reserve("acme", "team", 80, NOW, TTL));
         assert_eq!(s.reserved("acme", "team"), 80);
         // A crashed reserver's lease is swept by expiry.
         assert_eq!(s.reclaim_expired(TTL + 1), 1);
         assert_eq!(s.reserved("acme", "team"), 0);
         // Settling the (now reclaimed) lease is a harmless no-op — unknown id, returns true.
-        assert!(s.settle("acme", r.id, 40));
+        assert!(s.settle("acme", r.id, 40, NOW));
         assert_eq!(s.spent("acme", "team"), 0);
     }
 
@@ -266,18 +273,21 @@ mod tests {
         // The bearer-capability gap, closed: a reservation id leaked/guessed by another tenant
         // cannot settle the owner's lease.
         let s = svc();
-        s.set_limit("acme", "team", Some(100), Policy::Block);
+        s.set_limit("acme", "team", Some(100), Window::Total, Policy::Block);
         let r = admitted(s.reserve("acme", "team", 50, NOW, TTL));
         // globex presents acme's reservation id — refused, and acme's lease is untouched.
-        assert!(!s.settle("globex", r.id, 50), "cross-tenant settle refused");
+        assert!(
+            !s.settle("globex", r.id, 50, NOW),
+            "cross-tenant settle refused"
+        );
         assert_eq!(s.reserved("acme", "team"), 50, "acme's lease still held");
         assert_eq!(s.spent("acme", "team"), 0);
         // The rightful owner settles fine…
-        assert!(s.settle("acme", r.id, 40));
+        assert!(s.settle("acme", r.id, 40, NOW));
         assert_eq!(s.spent("acme", "team"), 40);
         assert_eq!(s.reserved("acme", "team"), 0);
         // …and settling an unknown id is a harmless no-op (idempotent), reported as applied.
-        assert!(s.settle("acme", 99_999, 10));
+        assert!(s.settle("acme", 99_999, 10, NOW));
         assert_eq!(s.spent("acme", "team"), 40);
     }
 }

--- a/crates/modalities/proximadb-ledger/src/types.rs
+++ b/crates/modalities/proximadb-ledger/src/types.rs
@@ -23,6 +23,32 @@ pub enum Policy {
     Warn,
 }
 
+/// The window over which a scope's spend accrues before it resets. Calendar-aligned in UTC.
+///
+/// `Monthly` is intentionally absent for now (it needs civil-calendar math); `Total` + `Daily` are
+/// pure integer arithmetic on the nanosecond clock, which keeps this crate dependency-free.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Window {
+    /// Never resets — a lifetime cap.
+    #[default]
+    Total,
+    /// Resets at each UTC midnight.
+    Daily,
+}
+
+/// Nanoseconds in a day.
+pub const NANOS_PER_DAY: Nanos = 86_400 * 1_000_000_000;
+
+/// The inclusive start (in ns) of the current window containing `now_ns`. Calendar-aligned in UTC
+/// (the Unix epoch is itself UTC midnight, so flooring to a day boundary *is* UTC midnight). `Total`
+/// returns 0 (all-time). `now_ns` is expected non-negative (a real wall clock).
+pub fn window_start_ns(now_ns: Nanos, window: Window) -> Nanos {
+    match window {
+        Window::Total => 0,
+        Window::Daily => (now_ns / NANOS_PER_DAY) * NANOS_PER_DAY,
+    }
+}
+
 /// A held reservation: a lease over `ceiling` units in `scope`, valid until `expires_at_ns`.
 ///
 /// `id` is opaque and assigned by the ledger; the caller settles by it or lets it expire.

--- a/proto/proximadb/v2/ledger.proto
+++ b/proto/proximadb/v2/ledger.proto
@@ -25,12 +25,21 @@ enum LedgerPolicy {
   LEDGER_POLICY_WARN = 2;        // soft cap — never refuse; spend still accrues
 }
 
+// The window over which a scope's spend accrues before it resets (calendar-aligned, UTC).
+// MONTHLY is reserved for a follow-up (needs civil-calendar math); TOTAL + DAILY ship now.
+enum LedgerWindow {
+  LEDGER_WINDOW_UNSPECIFIED = 0; // treated as TOTAL
+  LEDGER_WINDOW_TOTAL = 1;       // never resets (lifetime cap)
+  LEDGER_WINDOW_DAILY = 2;       // resets at each UTC midnight
+}
+
 // --- SetLimit -------------------------------------------------------------
 
 message SetLimitRequest {
   string scope = 1;
   optional uint64 limit = 2; // absent = clear the cap (unlimited but tracked)
   LedgerPolicy policy = 3;
+  LedgerWindow window = 4;   // absent/UNSPECIFIED = TOTAL
 }
 
 message SetLimitResponse {}

--- a/src/network/grpc/v2/ledger_service.rs
+++ b/src/network/grpc/v2/ledger_service.rs
@@ -16,7 +16,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tonic::{Request, Response, Status};
 
-use proximadb_ledger::{CasError, DurableLedger, LedgerService, Policy, ReserveOutcome};
+use proximadb_ledger::{CasError, DurableLedger, LedgerService, Policy, ReserveOutcome, Window};
 
 use crate::network::grpc::auth as grpc_auth;
 use crate::proto::proximadb_v2 as pv2;
@@ -45,6 +45,14 @@ fn policy_to_wire(policy: Policy) -> i32 {
     match policy {
         Policy::Block => pv2::LedgerPolicy::Block as i32,
         Policy::Warn => pv2::LedgerPolicy::Warn as i32,
+    }
+}
+
+/// Wire enum (`LedgerWindow`) → the port's [`Window`]. Unspecified/unknown ⇒ `Total`.
+fn window_from_wire(value: i32) -> Window {
+    match pv2::LedgerWindow::try_from(value) {
+        Ok(pv2::LedgerWindow::Daily) => Window::Daily,
+        _ => Window::Total,
     }
 }
 
@@ -77,8 +85,13 @@ impl ProximaLedgerService for ProximaLedgerServiceImpl {
         if req.scope.trim().is_empty() {
             return Err(Status::invalid_argument("scope is required"));
         }
-        self.ledger
-            .set_limit(&tenant, &req.scope, req.limit, policy_from_wire(req.policy));
+        self.ledger.set_limit(
+            &tenant,
+            &req.scope,
+            req.limit,
+            window_from_wire(req.window),
+            policy_from_wire(req.policy),
+        );
         Ok(Response::new(pv2::SetLimitResponse {}))
     }
 
@@ -127,7 +140,10 @@ impl ProximaLedgerService for ProximaLedgerServiceImpl {
         // tenant is refused (the reservation's owner is recovered from its namespaced scope).
         let tenant = grpc_auth::resolved_tenant_id(&request)?;
         let req = request.into_inner();
-        if self.ledger.settle(&tenant, req.reservation_id, req.actual) {
+        if self
+            .ledger
+            .settle(&tenant, req.reservation_id, req.actual, now_ns())
+        {
             Ok(Response::new(pv2::SettleResponse {}))
         } else {
             Err(Status::permission_denied(


### PR DESCRIPTION
Third ledger v1-gap: **calendar spend windows** — a cap can accrue over a `Window` that resets at the boundary. **Total** (lifetime) + **Daily** (UTC midnight) ship now; Daily is pure integer floor-math on the ns clock, so the ledger crate **stays zero-dependency** (Monthly needs civil-calendar math — tracked follow-up).

## Design — reduced ripple
Writes carry `now_ns` and **roll** the scope's spent bucket to the current window; `spent(&self)` reads the last-rolled value. **Enforcement (`reserve`) always rolls before the admit check**, so a hard cap is never checked against stale spend — only a bare read taken across a boundary *before the next write* is eventually-consistent (documented). This keeps `spent`/`available` signatures and most call sites unchanged.

## Layers
- **types**: `Window {Total, Daily}` + `window_start_ns` (Total→0, Daily→floor-to-UTC-day).
- **trait/core**: `set_limit(+window)`, `settle(+now_ns)`; `spent` stored as `(window_start, u64)`; a `roll` on every `reserve`/`settle`.
- **durable WAL**: `SetLimit` gains `window`, `Settle` gains `settled_at_ns`; replay applies settles at their recorded time so windowed spend **rebuilds correctly across a restart**.
- **port + gRPC**: `LedgerService::{set_limit,settle}` thread window/now; proto gains a `LedgerWindow` enum + `SetLimitRequest.window` (regenerated stubs, **additive +37/−0**; no new service → proto-drift baseline unchanged).

## Tests
`daily_window_resets_spend_at_the_boundary` (in-memory) + `daily_window_config_and_spend_survive_reopen` (durable). Ledger crate **16/26 green**; `cargo check -p proximadb --features experimental-ledger` clean; fmt + clippy(-D warnings) clean; boundary / deterministic-commit / **proto-drift** guards + default build all pass.

Next: reflection-descriptor regen, then S4 (shared-WAL splice).