### PR TITLE
docs(adr,td): S4 — ratify a dedicated ledger WAL; amend ADR-071 (drop the shared-WAL splice)

### DIFF
--- a/docs/10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc
+++ b/docs/10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc
@@ -9,7 +9,7 @@ toc::[]
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Draft / not started** (2026-07-23). Design gate only; no implementation yet. Ships **Experimental**, feature-gated (`experimental-ledger`), and graduates per `docs/SUPPORTED_SURFACE.adoc` once the conformance suite is green with filed benchmark evidence.
+| Status | **S1–S3 + v1 gaps shipped** (updated 2026-07-24). Correctness core (#1170), durable WAL (#1171), service port (#1174), gRPC proto+service (#1177), server registration (#1178), tenant-verified settle (#1182), background TTL sweeper (#1183), Total/Daily windows (#1185). Ships **Experimental**, feature-gated (`experimental-ledger`). **Amended 2026-07-24 (ADR-071):** durability is a **dedicated** ledger WAL, *not* the shared record WAL (queue-modality precedent) — see §Synthesis + §stacking table. Remaining: HA (S4), Monthly window, reflection descriptor (deferred).
 | Implements | link:../../12-design/adr/ADR-071-transactional-ledger-modality.adoc[ADR-071] / link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001]
 | Acceptance bar | the Sandhi `TD-0007` `EnforcementLedger` conformance suite (C1–C6)
 |===
@@ -46,9 +46,11 @@ ProximaDB's answer by mapping their lessons onto the substrate we already have (
 |===
 
 **Synthesis (the decision, ADR-071 §3).** The ledger is a **memtable-authoritative counter**
-(memcache/memsql read/write latency) made durable by an **append to the ADR-069 local-disk WAL**
-(sqlite-class durability, flat-cost, sub-ms fsync) with a **configurable sync policy** (the redis
-knob), reclaimed by a **timed TTL sweeper** (the memcache lease idea, made durable). Group-commit
+(memcache/memsql read/write latency) made durable by an **append to the ledger's dedicated
+ADR-069-style local-disk WAL** (sqlite-class durability, flat-cost, sub-ms fsync; *not* the shared
+record WAL — divergent access patterns, per the queue-modality precedent, amended 2026-07-24) with a
+**configurable sync policy** (the redis knob), reclaimed by a **timed TTL sweeper** (the memcache
+lease idea, made durable). Group-commit
 batches concurrent appends to amortize fsync. Crucially, **none of this is a new engine** — it is the
 existing `RecordStore::write_mutations` → `TableWalAppender::append_operations` → memtable path
 (`src/services/record_store.rs:1848`, `src/services/canonical_wal.rs:132`) with one new operation kind.
@@ -60,7 +62,7 @@ ADR-071 §2. The modality composes existing machinery; each row is cost *not* re
 [cols="2,2,2", options="header"]
 |===
 | Shared component (file) | Reused by the ledger for | Economic / coherence benefit
-| ADR-069 local-disk WAL (`canonical_wal.rs`) | per-op durability | no new durability path; flat-cost, sub-ms fsync, single-writer already assumed
+| ADR-069 local-disk WAL *pattern* — a **dedicated** ledger log, not `canonical_wal.rs` | per-op durability | reuses the ADR-069 *pattern* (flat-cost, sub-ms fsync), not the shared record log — divergent access patterns (queue-modality precedent, amended 2026-07-24)
 | memtable / partition (`src/storage/memtable/`) | the authoritative counter + live leases | O(1) read/write; restart via WAL replay — no bespoke persistence
 | partition-lease single-writer, CAS-fenced (`src/cluster/partition_lease.rs`) | HA + linearizable-per-scope | no per-op consensus; owner failover for free
 | `TenantContext` + `DrPathBuilder` | per-scope isolation & billing | fail-closed multi-tenancy at no extra cost

--- a/docs/12-design/adr/ADR-071-transactional-ledger-modality.adoc
+++ b/docs/12-design/adr/ADR-071-transactional-ledger-modality.adoc
@@ -5,11 +5,11 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Accepted** (2026-07-23). Formalizes link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001] (merged #1165). Implementation tracked under link:../../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1]; ships **Experimental**, feature-gated, until the conformance suite is green with filed benchmark evidence.
+| Status | **Accepted** (2026-07-23); **amended 2026-07-24**. Formalizes link:../../rfcs/0001-transactional-ledger-modality.adoc[RFC-0001] (merged #1165). Implementation tracked under link:../../10-quality/td/TD-LEDGER-1-transactional-ledger-modality.adoc[TD-LEDGER-1]; ships **Experimental**, feature-gated. S1–S3 + the v1 gaps (tenant-verified settle, background TTL sweeper, Total/Daily windows) shipped (#1170/#1171/#1174/#1177/#1178/#1182/#1183/#1185). **Amendment (2026-07-24):** Decisions 2–3 originally routed durability through the *shared* ADR-069 record WAL; that is superseded — the ledger keeps a **dedicated** ADR-069-style local-disk WAL (the `DurableLedger` built in S2), per the queue-modality precedent (divergent access patterns). See the revised decisions; the "S4 shared-WAL splice" is closed as a decision, not surgery.
 | Decider | Vijaykumar Singh (2026-07-23)
 | Date | 2026-07-23
 | Relates to | link:ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069] (the local-disk WAL durability substrate the ledger's per-op durability rides), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine — meter every dimension, design against the dominant cost term), link:ADR-027-unified-storage-and-metering-substrate.adoc[ADR-027] (the WAL→memtable→object-store spine), link:ADR-036-azure-objectstore-orientation.adoc[ADR-036] (object-store access tiers), link:ADR-067-consume-ai-usage-gateway-egress-metering.adoc[ADR-067] (the Sandhi neutral-usage contract — the anchor external consumer).
-| Refines | RFC-0001 — ratifies the modality and pins the two load-bearing decisions the RFC left as design: (a) durability rides ADR-069, not a new engine; (b) the modality is both *stacked* on the shared substrate and *independently launchable*.
+| Refines | RFC-0001 — ratifies the modality and pins the two load-bearing decisions the RFC left as design: (a) durability on a **dedicated** ADR-069-style local-disk WAL (amended 2026-07-24 — *not* the shared record WAL), not a new engine; (b) the modality is both *stacked* on the shared substrate and *independently launchable*.
 | Non-goals | A from-scratch storage engine (explicitly rejected — see Decision 2); distributed multi-key / cross-modal ledger transactions in v1 (deferred to wiring `MultiModelTransactionManager`); a pgwire SQL surface in v1 (gRPC/REST only); changing any existing modality's format or behavior.
 |===
 
@@ -38,21 +38,26 @@ operations: `Reserve(scope, ceiling, ttl) → Admitted(lease)|Denied` (condition
 `Settle(lease_id, actual)` (idempotent), and `CompareAndSwap(key, expected_version, new)` (generic
 conditional write) — plus TTL leases and store-owned windows. Details in RFC-0001 / TD-LEDGER-1.
 
-**2. Stack on the shared substrate; do NOT build a parallel engine.** The ledger's durability rides
-the **ADR-069 local-disk WAL** (flat-cost, sub-ms fsync, single-writer-per-collection); its
-authoritative counter lives in the **existing memtable** (O(1), rebuilt by WAL replay on failover);
-HA/linearizability comes from the **existing fenced partition-lease single-writer**; isolation and
-billing from `TenantContext` + `DrPathBuilder`; at-rest tiering from `ObjectAccessTier`; discovery and
-metrics from the catalog/observability spine. This is the co-design economy (ADR-052): **one
-durability path, one HA path, one tenancy path, amortized across all modalities** — a new modality
-harvests the platform instead of re-paying for it. A from-scratch OLTP engine is rejected: it would
-duplicate the WAL/HA/tenancy investment and fracture the operational surface.
+**2. Stack on the shared substrate; do NOT build a parallel engine — but keep a DEDICATED WAL**
+*(amended 2026-07-24)*. The ledger's durability rides a **dedicated ADR-069-style local-disk WAL**
+(flat-cost, sub-ms fsync, single-writer) — *not* the shared record WAL. This matches the **queue
+modality's precedent**, which keeps its own WAL "because the access patterns and stability
+requirements diverge": a ledger is millions of tiny hot counter mutations, categorically unlike bulk
+`ProximaRecord` ingest, and (as Redis/etcd show with a dedicated AOF/log) an OLTP counter log wants
+its own sync cadence and failure isolation. The **shared-substrate economy (ADR-052) is still real —
+just not through the log**: it comes from the shared *memtable model*, `TenantContext` +
+`DrPathBuilder` isolation/billing, `ObjectAccessTier` at-rest tiering, and the catalog/observability
+spine. A from-scratch OLTP *engine* is still rejected (that would duplicate HA/tenancy); a dedicated
+*log* is the right grain. Splicing ledger ops into the record WAL (`RecordStore::write_mutations` +
+a `CanonicalOperation::Ledger*` variant) is therefore **explicitly not pursued** — it is high-risk
+core-engine surgery for an optimization the divergent access patterns argue against.
 
-**3. Durability model (OLTP) = memtable-authoritative counter + WAL log + configurable sync.** The
-counter is in-memory for memcache/memsql-class read/write latency; every `Reserve`/`Settle`/`CAS`
-appends to the ADR-069 WAL for durability; the sync policy is a **per-scope knob** — per-op fsync for
-hard (`Block`) scopes (strict, a cap that must never be overshot), group-commit/interval for soft
-(`Warn`) scopes (throughput). The knob maps directly onto the consumer's fail-open/closed tiers
+**3. Durability model (OLTP) = memtable-authoritative counter + dedicated WAL + configurable sync**
+*(amended 2026-07-24)*. The counter is in-memory for memcache/memsql-class read/write latency; every
+`Reserve`/`Settle`/`CAS` appends to the ledger's **own** ADR-069-style local-disk WAL (CRC-framed,
+torn-tail-tolerant, replayed on open — the S2 `DurableLedger`); the sync policy is a knob — per-op
+fsync for hard (`Block`) scopes (strict, a cap that must never be overshot), deferred/group-commit for
+soft (`Warn`) scopes (throughput). The knob maps directly onto the consumer's fail-open/closed tiers
 (Sandhi C6). Rationale and the sqlite/redis/memsql/memcache derivation are in TD-LEDGER-1.
 
 **4. Launch-selectable: the modality is independently deployable.** A cargo feature


### PR DESCRIPTION
**S4 as a decision, not code.** After reviewing the tradeoff (see the PR discussion in-thread), we ratify the **dedicated ledger WAL** the S2 `DurableLedger` already built and amend ADR-071's aspiration to route durability through the *shared* record WAL.

## Why
- The **queue modality precedent**: it keeps its own WAL *"because the access patterns and stability requirements diverge."* The ledger is the identical case — millions of tiny hot counter mutations vs. bulk `ProximaRecord` ingest; Redis/etcd keep a dedicated AOF/log for exactly this reason (own sync cadence + failure isolation).
- The splice was the **highest-risk change** of the whole effort (new `CanonicalOperation::Ledger*` + `RecordStore::write_mutations` + replay routing — hot core-engine files owned by other active sessions) for an **optimization, not a correctness fix** (the ledger is already durable + restart-surviving on its own WAL).
- The **shared-substrate economy (ADR-052) is still real** — just not through the log: shared memtable model, `TenantContext`/`DrPathBuilder`, `ObjectAccessTier`, catalog/observability spine.

## Changes
- **ADR-071**: Decisions 2–3 revised (dedicated WAL, not shared record WAL); Status + Refines amended; the shared-WAL splice marked "explicitly not pursued."
- **TD-LEDGER-1**: Status updated to reflect S1–S3 + all v1 gaps shipped; durability synthesis + cross-modal stacking table (WAL row) corrected.

**Docs-only; no code change** — the S2 private WAL stands. Doc guards (td-adr-unique, design-status-index, status-as-of) pass.

This completes the ledger effort's decision surface. Remaining are tracked, lower-priority follow-ups: HA (multi-node partition-owner routing), Monthly window, reflection descriptor.