### PR TITLE
docs(rfc,adr,td): P5 tier-split delete — MVCC + deletion vectors (D14)

### DIFF
--- a/docs/10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc
+++ b/docs/10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc
@@ -9,7 +9,7 @@ toc::[]
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Draft / design gate — P4 research-calibrated** (2026-07-24). No implementation yet. Additive + feature-gated; graduates per `docs/SUPPORTED_SURFACE.adoc` with filed benchmark evidence. Revised after the three-model review reconciliation (P2), calibration against 10 research papers (P3), and per-modality vector/graph/TS calibration (P4, D13) — see link:../../12-design/adr/ADR-072-foundational-contract-consolidation.adoc[ADR-072 §Design-gate revision (P2)/(P3)] and RFC-0002 §_Research calibration_ / §_Modality calibration_.
+| Status | **Draft / design gate — P5 research-calibrated** (2026-07-24). No implementation yet. Additive + feature-gated; graduates per `docs/SUPPORTED_SURFACE.adoc` with filed benchmark evidence. Revised after the three-model review reconciliation (P2), calibration against 10 research papers (P3), per-modality vector/graph/TS calibration (P4, D13), and tier-split delete representation (P5, D14 — MVCC + deletion vectors) — see link:../../12-design/adr/ADR-072-foundational-contract-consolidation.adoc[ADR-072 §Design-gate revision] and RFC-0002 §_Research calibration_ / §_Modality calibration_.
 | Implements | link:../../12-design/adr/ADR-072-foundational-contract-consolidation.adoc[ADR-072] / link:../../rfcs/0002-foundational-modality-consolidation.adoc[RFC-0002]
 | Acceptance bar | the composite-natural-PK MVP passes **fenced** atomic-uniqueness under concurrency + serverless restart (exactly-one winner, idempotent retry distinguished from real conflict); PK-`UPDATE`/`DELETE`-reclaim leaves no orphaned slot; the typed-identity codec passes collision / order-preserving / NULL property tests; no modality regresses; reclaimed-footprint/latency evidence filed
 |===
@@ -80,6 +80,11 @@ single-writer + CRC-framed torn-tail-tolerant replay) is the reference. Extract 
     (resolved by `version ≤ snapshot`), reclaimed behind an oldest-active-reader watermark — it never
     delete-then-reinserts a durable slot. This dissolves the reclaim race and largely subsumes the
     explicit fence into MVCC ordering (cMVBT; unanimous with BatchWeave/DSQL — ADR-072 §P3).
+    **Tier-split physical delete (D14):** MVCC is the *visibility/uniqueness* model; its physical delete
+    is row-level MVCC in the hot/local-WAL tier and **deletion vectors / merge-on-read** in the immutable
+    cold columnar tier (a hot tombstone flushes to a DV, purged at compaction behind the same watermark).
+    A DV encodes deletes but does **not** enforce uniqueness — that stays with MVCC + this index. Build
+    split: hot MVCC = F1d; cold deletion vectors = F3v.
   * **Capability-typed scope:** each impl *declares* its atomic scope/granularity (ScalarDB Atomicity
     Unit; not a boolean), so callers never assume uniform atomicity.
 - **Two impls behind it (ADR-072 D4/D5 — revised):**
@@ -136,8 +141,9 @@ the storage layer**, serverless-capable — replacing the op-lock crutch.
 | *F0* | **Typed composite `Identity` codec** (ADR-072 D9) — replace `oid: String` + `encode_primary_key_tuple` string-join with a length-delimited, order-preserving, NULL-explicit, type-tagged, tenant-scoped key; `oid`/`local_id` derive from it. Property-tested. Foundational prerequisite for F1.
 | *F1* | Extract the **fenced** `ConditionalKeyStore` + the **generation-fenced local-WAL impl** (default) and the object-store escape-hatch impl; ledger CAS re-expressed as a consumer (proves the shared primitive, fence preserved).
 | *F2* | **MVP:** composite-natural-PK uniqueness on the relational insert path via F0/F1 (row-keyed-by-PK); op-lock **retained** (secondary UNIQUE/FK stay in it); `oltp-integrity` feature.
-| *F3* | Re-express ledger/queue/TS dedicated WALs as impls of the WAL contract (stop off-contract silos); siloed modalities consume the shared tiering contract instead of their own tiers.
-| *F4* | Finish document's canonical-store migration; onboard vector reads-side where the shared scan suffices (keep ANN as an extension operator).
+| *F3* | Re-express ledger/queue/TS dedicated WALs as impls of the WAL contract (stop off-contract silos); siloed modalities consume the shared tiering contract instead of their own tiers; standardize the record-store substrate on columnar/PAX (D13).
+| *F3v* | **Deletion vectors / merge-on-read (D14)** — cold-tier physical delete for immutable columnar objects (roaring-bitmap DV per data file, Iceberg-v3/Delta style); hot-tier MVCC tombstone → DV on flush; DV-purge at compaction behind the reader watermark; CoW fallback for read-heavy files. Parallel to the critical path. Depends on F1d + F3.
+| *F4* | Finish document's canonical-store migration; onboard vector reads-side where the shared scan suffices (keep ANN as an extension operator). Depends on F3v (cold-tier delete path).
 | *F5* | FK / referential integrity (phase 2, `get` on `ConditionalKeyStore`); then HTAP — native compute (Volcano/DataFusion) TPC-H over atomically-consistent data.
 |===
 

--- a/docs/12-design/adr/ADR-072-foundational-contract-consolidation.adoc
+++ b/docs/12-design/adr/ADR-072-foundational-contract-consolidation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed — P3 research-calibrated** (2026-07-24). Formalizes link:../../rfcs/0002-foundational-modality-consolidation.adoc[RFC-0002]; build plan in link:../../10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc[TD-FOUNDATION-1]. Additive + feature-gated; `default` behavior unchanged until each modality opts in. **P2: D3/D5 amended + D9/D10 added after a three-model adversarial review (Kimi, GLM-5.2, DeepSeek) reconciled against the code. P3: D11/D12 added + D3/D5/D1 refined after calibrating against 10 research papers. P4: D13 added — per-modality calibration (columnar/PAX substrate, per-modality identity, vector-RLS, graph-address WAL) from 5 vector/graph/field-report papers + TS systems. See _Design-gate revision (P3)_ and _Research bibliography_.**
+| Status | **Proposed — P3 research-calibrated** (2026-07-24). Formalizes link:../../rfcs/0002-foundational-modality-consolidation.adoc[RFC-0002]; build plan in link:../../10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc[TD-FOUNDATION-1]. Additive + feature-gated; `default` behavior unchanged until each modality opts in. **P2: D3/D5 amended + D9/D10 added after a three-model adversarial review (Kimi, GLM-5.2, DeepSeek) reconciled against the code. P3: D11/D12 added + D3/D5/D1 refined after calibrating against 10 research papers. P4: D13 added — per-modality calibration (columnar/PAX substrate, per-modality identity, vector-RLS, graph-address WAL) from 5 vector/graph/field-report papers + TS systems. P5: D14 added — delete representation is tier-split (MVCC visibility model + deletion vectors in the immutable cold tier). See _Design-gate revision (P3)_ and _Research bibliography_.**
 | Decider | Vijaykumar Singh (2026-07-24)
 | Date | 2026-07-24
 | Relates to | link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (DataFusion swappable behind the read IR — the compute half of the storage⊥compute decoupling), link:ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069] (local-disk WAL substrate), link:ADR-071-transactional-ledger-modality.adoc[ADR-071] (ledger dedicated WAL — the "divergent access ⇒ own impl behind the contract" precedent), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine).
@@ -195,7 +195,9 @@ retry-vs-conflict — Cornus `LogOnce` returns the settled state <<biblio-cornus
 **capability-typed** — each impl **declares its atomic scope/granularity** (ScalarDB's *Atomicity Unit*
 <<biblio-scalardb>>; CCaaS's row-vs-txn granularity leak <<biblio-ccaas>>), not a boolean `supports_cas`.
 Non-unique secondary indexes are **blind-writes keyed by the PK** (no conflict check); only `UNIQUE`
-takes the coordinated path (DSQL <<biblio-dsql>>).
+takes the coordinated path (DSQL <<biblio-dsql>>). _(Refined P5 — D14: MVCC here is the *visibility /
+uniqueness* model; its *physical* delete representation is tier-split — deletion vectors in the immutable
+cold tier.)_
 
 **D12 — Metamodel: identity is family-parameterized, graph edges are first-class, logical splits from
 physical.** (Refines D1.) U-Schema <<biblio-uschema>> — the most complete unified metamodel in the
@@ -256,6 +258,30 @@ TS systems) confirm D12 with primary sources and add one architectural refinemen
   in scope. Vector/TS-as-first-class-modalities have no field-consensus cover — justified here on the
   engineering evidence above.
 
+**D14 — Delete representation is tier-split: MVCC model everywhere, deletion vectors in the immutable
+cold tier.** (P5 refinement of D11/D13.) MVCC (D11) is the *visibility / uniqueness / snapshot-isolation*
+**model** — it answers "is key K live at snapshot T?" and is what uniqueness enforcement needs; it is
+**not** a physical delete encoding. Its physical realization is split by tier:
+
+* **Hot / local-WAL (mutable):** row-level MVCC — versioned rows + tombstones, resolved in memory / WAL.
+  Fast point updates, uniqueness checks, snapshot isolation.
+* **Cold / columnar-PAX on object store (immutable):** **deletion vectors / merge-on-read** — a compact
+  roaring-bitmap of deleted row positions per data object, applied at scan time (Iceberg-v3 Puffin
+  <<biblio-icebergdv>> / Delta Lake <<biblio-deltadv>>). You **cannot mutate an immutable object**, so
+  copy-on-write would rewrite whole files; a deletion vector marks rows dead in O(1) and is purged at
+  compaction. A CoW rewrite is the fallback only for read-heavy files.
+
+The **bridge:** a hot-tier MVCC tombstone (D11) **materializes as a deletion-vector entry** on flush to
+the cold tier; DV-marked rows are purged at compaction **behind the same oldest-active-reader watermark**
+D11 uses. So a deletion vector is *how D11's append-only tombstone + watermark-GC is realized on immutable
+storage* — a refinement, not a competitor.
+
+**Load-bearing caveat:** a deletion vector **encodes deletes but does not enforce uniqueness** — it cannot
+answer "is PK K currently live across all base files + their DVs?" That answer stays with the MVCC
+visibility model + the durable `ConditionalKeyStore` index (D3/D11). DV is a storage optimization *under*
+the uniqueness layer, never instead of it. Build split: MVCC visibility in **F1d** (hot); deletion
+vectors / merge-on-read in **F3v** (cold, parallel — not on the critical path).
+
 == Research bibliography
 
 Full-text briefs and section citations live in RFC-0002 §_Research calibration_. arXiv links:
@@ -276,6 +302,8 @@ Full-text briefs and section citations live in RFC-0002 §_Research calibration_
 * [[biblio-vecpolicy]] **Policy-aware Vector Search** — Fine-Grained Access Control. arXiv:2606.19803. https://arxiv.org/abs/2606.19803
 * [[biblio-pgvector]] **Filter-Agnostic Vector Search on a PostgreSQL Database** (SIGMOD 2026). arXiv:2603.23710. https://arxiv.org/abs/2603.23710
 * Time-series identity/storage calibrated against InfluxDB/IOx, Prometheus, TimescaleDB (systems, no single arXiv anchor — corpus-thin axis).
+* [[biblio-icebergdv]] **Apache Iceberg v3** — deletion vectors (Puffin blob, roaring bitmap; merge-on-read). https://iceberg.apache.org/spec/#deletion-vectors
+* [[biblio-deltadv]] **Delta Lake** — deletion vectors / merge-on-read. https://docs.delta.io/latest/delta-deletion-vectors.html
 
 == Consequences
 

--- a/docs/rfcs/0002-foundational-modality-consolidation.adoc
+++ b/docs/rfcs/0002-foundational-modality-consolidation.adoc
@@ -3,7 +3,7 @@
 :email: vjdsingh@icloud.com
 :date: 2026-07-24
 :status: Draft (P3 research-calibrated)
-:revremark: P2 — reconciled against a three-model adversarial review (Kimi, GLM-5.2, DeepSeek). P3 — calibrated against 10 research papers: reclaim is append-only MVCC; contract returns-holder-on-conflict + capability-typed; graph edges first-class; logical/physical metamodel split. P4 — per-modality calibration (§Modality calibration): shared record-store substrate is columnar/PAX (pgvector 55–85% row-heap tax); vector identity is a surrogate; TS is ordering; vector RLS must be pre-filter not post-filter.
+:revremark: P2 — reconciled against a three-model adversarial review (Kimi, GLM-5.2, DeepSeek). P3 — calibrated against 10 research papers: reclaim is append-only MVCC; contract returns-holder-on-conflict + capability-typed; graph edges first-class; logical/physical metamodel split. P4 — per-modality calibration (§Modality calibration): shared record-store substrate is columnar/PAX (pgvector 55–85% row-heap tax); vector identity is a surrogate; TS is ordering; vector RLS must be pre-filter not post-filter. P5 — delete representation is tier-split: MVCC visibility/uniqueness model + deletion vectors (merge-on-read) in the immutable cold tier.
 :toc: left
 :toclevels: 3
 
@@ -311,6 +311,15 @@ is a hard invariant decoupled from recall as QoS (<<biblio-vecpolicy>>). Graph p
 composable components but cautions "**interoperability, not unification**" and "a data lake ≠ integrated
 data" — so the catalog metamodel is an *interoperability substrate*, not a universal language.
 
+**Delete representation is tier-split (P5, ADR-072 D14).** MVCC is the *visibility / uniqueness* model
+everywhere; its *physical* delete encoding follows the tier: row-level MVCC in the hot/local-WAL tier, and
+**deletion vectors / merge-on-read** (roaring-bitmap per data object, Iceberg-v3 <<biblio-icebergdv>> /
+Delta Lake <<biblio-deltadv>>) in the immutable cold columnar tier — because an object store cannot mutate
+objects in place and copy-on-write would rewrite whole files. A hot-tier tombstone flushes to a DV entry,
+purged at compaction behind the same reader watermark. A deletion vector **encodes deletes but does not
+enforce uniqueness** — that stays with MVCC + the `ConditionalKeyStore` index. Build split: hot MVCC = F1d
+(critical path), cold deletion vectors = F3v (parallel).
+
 === Residual risk (honestly flagged)
 
 - **Time-series and vector identity: now calibrated (P4)** as surrogate/ordering (not uniqueness) — but no
@@ -338,6 +347,8 @@ data" — so the catalog metamodel is an *interoperability substrate*, not a uni
 - [[biblio-compass]] **Compass** — General Filtered Search across Vector and Structured Data. https://arxiv.org/abs/2510.27141
 - [[biblio-vecpolicy]] **Policy-aware Vector Search** — Fine-Grained Access Control. https://arxiv.org/abs/2606.19803
 - [[biblio-pgvector]] **Filter-Agnostic Vector Search on a PostgreSQL Database** (SIGMOD 2026). https://arxiv.org/abs/2603.23710
+- [[biblio-icebergdv]] **Apache Iceberg v3** — deletion vectors (Puffin, roaring bitmap; merge-on-read). https://iceberg.apache.org/spec/#deletion-vectors
+- [[biblio-deltadv]] **Delta Lake** — deletion vectors / merge-on-read. https://docs.delta.io/latest/delta-deletion-vectors.html
 
 == Migration Path
 


### PR DESCRIPTION
## What
P5 refinement of the foundational-consolidation design set. **Docs only — no code.**

Adds **ADR-072 D14**: the delete representation is **tier-split**.

- **MVCC (D11) is the visibility / uniqueness / snapshot-isolation *model*** everywhere — it answers "is key K live at snapshot T?" and is what uniqueness enforcement needs. It is **not** a physical delete encoding.
- **Physical delete follows the tier:**
  - hot / local-WAL (mutable) → row-level MVCC (versions + tombstones)
  - cold / columnar-PAX on object store (immutable) → **deletion vectors / merge-on-read** (roaring bitmap per data object, Iceberg-v3 / Delta Lake style) — an object store can't mutate in place, and copy-on-write rewrites whole files.
- **Bridge:** a hot-tier MVCC tombstone materializes as a DV entry on flush, purged at compaction **behind the same oldest-active-reader watermark** D11 uses. So a deletion vector is *how D11's append-only tombstone + watermark-GC is realized on immutable storage* — a refinement, not a competitor.
- **Caveat (load-bearing):** a deletion vector **encodes deletes but does not enforce uniqueness** — that stays with MVCC + the `ConditionalKeyStore` index.

## Plan impact
- New work package **F3v — Deletion vectors / merge-on-read (cold-tier delete)**: depends on F1d (MVCC model) + F3 (PAX substrate), feeds F4. **Parallel — not on the critical path** (which stays ~15 weeks).
- Build split: hot MVCC = **F1d** (critical); cold deletion vectors = **F3v** (parallel).
- Bibliography adds Iceberg-v3 + Delta Lake deletion-vector references.

## Guards
design-status-index, status-as-of, td-adr-unique, td-status-consistency, doc-authority, risk-coverage, perf-claims, no-commercial-docs — all green; all biblio cross-refs resolve.