### PR TITLE
feat(storage-ports): F1a fenced ConditionalKeyStore contract (ADR-072 D3/D11/D14)

### DIFF
--- a/crates/storage/proximadb-storage-ports/Cargo.toml
+++ b/crates/storage/proximadb-storage-ports/Cargo.toml
@@ -46,5 +46,9 @@ proximadb-storage-filesystem-types.workspace = true
 # write-op model) — pure-data leaf types (downward dep, facade-free).
 proximadb-graph-model.workspace = true
 
+[dev-dependencies]
+# `#[tokio::test]` for the ConditionalKeyStore contract's in-memory reference test.
+tokio = { workspace = true, features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/crates/storage/proximadb-storage-ports/src/conditional_key_store.rs
+++ b/crates/storage/proximadb-storage-ports/src/conditional_key_store.rs
@@ -1,0 +1,245 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! # `ConditionalKeyStore` — the fenced atomic OLTP uniqueness primitive
+//!
+//! ADR-072 **D3** (the contract), **D11** (fenced, returns-holder-on-conflict,
+//! capability-typed, append-only reclaim) and **D14** (tombstone, not slot-reclaim).
+//!
+//! This is the storage-plane primitive that enforces composite-natural-key
+//! uniqueness. It is deliberately **not** a bare `put_if_absent`: the ledger's
+//! proven core returns a version, and a bare object-store `PutMode::Create`
+//! drops that token — without it a writer cannot tell "my own idempotent retry"
+//! from "a real conflict". So every write is fenced by a [`Generation`] and a
+//! conflict **returns the current holder** (Cornus `LogOnce` returns the settled
+//! state).
+//!
+//! ## Tenancy is fail-closed by construction
+//!
+//! ADR-072 D3's signature named `tenant` + `keyspace` explicitly. They are
+//! **folded into the [`Identity`]'s leading prefix** by the F0 key codec
+//! (`proximadb_data_model::key_codec::encode_identity`, D9): a caller for tenant
+//! *A* literally cannot form tenant *B*'s key, so cross-tenant access is
+//! structurally impossible rather than checked. `get`/`tombstone` likewise key on
+//! the full `Identity`.
+//!
+//! ## Two implementations, one contract (ADR-072 D5)
+//!
+//! - generation-fenced **local-WAL** CAS — the hot, correctness-carrying default;
+//! - object-store **successor-slot / batch-manifest** — the scale-to-zero escape
+//!   hatch.
+//!
+//! Each declares its [`AtomicScope`] so callers never assume uniform atomicity
+//! (ScalarDB's *Atomicity Unit*; D11).
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// A typed composite key: the opaque, order-preserving bytes produced by the F0
+/// codec (`proximadb_data_model::key_codec::encode_identity`, ADR-072 D9). The
+/// bytes embed the `tenant`/`keyspace` prefix, so equality and range order are
+/// tenant-scoped (see the module docs).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Identity(pub Vec<u8>);
+
+impl Identity {
+    /// Wrap already-encoded key bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    /// The encoded key bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// The object a key resolves to (the row's `oid`). For a composite **natural
+/// primary key** `oid` is the key's own encoding (`oid == primary_key_string`);
+/// for a **secondary `UNIQUE`** the key is the unique-value encoding and `oid`
+/// is the owning row's identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Oid(pub String);
+
+/// A monotonic fence token. Every mutation carries one; the store rejects a write
+/// carrying a stale generation, and reads use it to place a version on the MVCC
+/// timeline (ADR-072 D11). A generation never decreases for a given key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Generation(pub u64);
+
+/// The logical outcome of [`ConditionalKeyStore::put_if_absent`]. `Err` is
+/// reserved for I/O / transport failure — a **conflict is not an error**, it is
+/// an expected `Ok` outcome that carries the current holder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PutOutcome {
+    /// The key was absent (or a prior version was tombstoned) and is now claimed
+    /// for `oid` at `generation`.
+    Committed { generation: Generation },
+    /// The key is already live. `holder` is the current owner and `generation`
+    /// its version — enough for a loser to distinguish an idempotent retry
+    /// (`holder == my oid`) from a genuine uniqueness conflict (ADR-072 D11).
+    Conflict { holder: Oid, generation: Generation },
+}
+
+/// The atomic scope an implementation guarantees for a single call — a
+/// *capability* the caller can inspect, never a boolean `supports_cas`
+/// (ScalarDB's Atomicity Unit; ADR-072 D11). Callers must not assume atomicity
+/// wider than the declared scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomicScope {
+    /// Atomic per individual key (the generation-fenced local-WAL default).
+    PerKey,
+    /// Atomic per `(tenant, partition)` — a partition-lease-fenced impl.
+    PerPartition,
+    /// Atomic per committed batch manifest (the object-store escape hatch:
+    /// many keys become visible together on one successor-slot commit).
+    PerBatchManifest,
+}
+
+/// The fenced atomic uniqueness primitive. One contract, many implementations
+/// (ADR-072 D2/D5): each backend implements this behind the same surface.
+///
+/// Reclaim is **append-only** (ADR-072 D11/D14): [`Self::tombstone`] never reuses
+/// a durable slot — it records a delete at a generation, and physical
+/// reclamation is a background-plane concern (F6) gated by the oldest-active-reader
+/// watermark. A deletion **encodes** a delete; it does **not** enforce uniqueness
+/// — that is this store's job via `put_if_absent`.
+#[async_trait::async_trait]
+pub trait ConditionalKeyStore: Send + Sync {
+    /// The atomic scope this implementation guarantees (D11 capability typing).
+    fn atomic_scope(&self) -> AtomicScope;
+
+    /// Claim `key` for `oid`, fenced by `fence`, iff no live version exists.
+    /// Returns the logical [`PutOutcome`]; `Err` is reserved for I/O/transport
+    /// failure, never a conflict. Idempotent under retry: re-issuing the same
+    /// `(key, oid)` observes `Conflict { holder: oid, .. }`, which the caller
+    /// reads as success.
+    async fn put_if_absent(
+        &self,
+        key: &Identity,
+        oid: &Oid,
+        fence: Generation,
+    ) -> Result<PutOutcome>;
+
+    /// Resolve `key` to its current live holder, or `None` if absent/tombstoned.
+    /// Foreign-key existence checks (phase 2) ride this method.
+    async fn get(&self, key: &Identity) -> Result<Option<Oid>>;
+
+    /// Append-only tombstone at `fence` — mark the current live version of `key`
+    /// deleted **without reusing the slot** (ADR-072 D11/D14). A later
+    /// `put_if_absent` of the same `key` is a *new* version, not a slot reuse.
+    /// Physical reclamation happens off the request path (F6).
+    async fn tombstone(&self, key: &Identity, fence: Generation) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// A minimal in-memory reference implementation used to pin the contract's
+    /// semantics (append-only reclaim, return-holder-on-conflict). Not a
+    /// production store.
+    #[derive(Default)]
+    struct MemStore {
+        // key -> (oid, generation, live)
+        map: Mutex<HashMap<Identity, (Oid, Generation, bool)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ConditionalKeyStore for MemStore {
+        fn atomic_scope(&self) -> AtomicScope {
+            AtomicScope::PerKey
+        }
+
+        async fn put_if_absent(
+            &self,
+            key: &Identity,
+            oid: &Oid,
+            fence: Generation,
+        ) -> Result<PutOutcome> {
+            let mut m = self.map.lock().unwrap();
+            match m.get(key) {
+                Some((holder, g, true)) => Ok(PutOutcome::Conflict {
+                    holder: holder.clone(),
+                    generation: *g,
+                }),
+                // absent or a tombstoned prior version -> claim a new version
+                _ => {
+                    m.insert(key.clone(), (oid.clone(), fence, true));
+                    Ok(PutOutcome::Committed { generation: fence })
+                }
+            }
+        }
+
+        async fn get(&self, key: &Identity) -> Result<Option<Oid>> {
+            let m = self.map.lock().unwrap();
+            Ok(match m.get(key) {
+                Some((oid, _, true)) => Some(oid.clone()),
+                _ => None,
+            })
+        }
+
+        async fn tombstone(&self, key: &Identity, fence: Generation) -> Result<()> {
+            let mut m = self.map.lock().unwrap();
+            if let Some(entry) = m.get_mut(key) {
+                entry.1 = fence;
+                entry.2 = false; // append-only: mark not-live, slot retained
+            }
+            Ok(())
+        }
+    }
+
+    fn id(s: &str) -> Identity {
+        Identity::from_bytes(s.as_bytes().to_vec())
+    }
+
+    #[tokio::test]
+    async fn lifecycle_commit_conflict_tombstone_reinsert() {
+        let store = MemStore::default();
+        let k = id("acme/users/\x02pk");
+        let a = Oid("row-a".into());
+        let b = Oid("row-b".into());
+
+        // First insert claims the key.
+        assert_eq!(
+            store.put_if_absent(&k, &a, Generation(1)).await.unwrap(),
+            PutOutcome::Committed {
+                generation: Generation(1)
+            }
+        );
+
+        // A second, different writer conflicts and learns the holder.
+        assert_eq!(
+            store.put_if_absent(&k, &b, Generation(2)).await.unwrap(),
+            PutOutcome::Conflict {
+                holder: a.clone(),
+                generation: Generation(1)
+            }
+        );
+
+        // The original writer's retry sees its own oid as holder -> success.
+        match store.put_if_absent(&k, &a, Generation(3)).await.unwrap() {
+            PutOutcome::Conflict { holder, .. } => assert_eq!(holder, a),
+            other => panic!("expected conflict-with-self, got {other:?}"),
+        }
+
+        assert_eq!(store.get(&k).await.unwrap(), Some(a.clone()));
+
+        // Append-only delete, then re-insert is a NEW version (not a slot reuse).
+        store.tombstone(&k, Generation(4)).await.unwrap();
+        assert_eq!(store.get(&k).await.unwrap(), None);
+        assert_eq!(
+            store.put_if_absent(&k, &b, Generation(5)).await.unwrap(),
+            PutOutcome::Committed {
+                generation: Generation(5)
+            }
+        );
+        assert_eq!(store.get(&k).await.unwrap(), Some(b));
+    }
+
+    #[test]
+    fn scope_is_a_capability() {
+        assert_eq!(MemStore::default().atomic_scope(), AtomicScope::PerKey);
+    }
+}

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -21,6 +21,11 @@ use std::sync::Arc;
 
 pub mod capabilities;
 pub use capabilities::*;
+/// The fenced atomic OLTP uniqueness primitive (ADR-072 D3/D11/D14).
+pub mod conditional_key_store;
+pub use conditional_key_store::{
+    AtomicScope, ConditionalKeyStore, Generation, Identity, Oid, PutOutcome,
+};
 pub mod scan_strategy;
 pub use scan_strategy::{ScanCostEstimate, ScanIterator, ScanStatistics, ScanStrategy};
 pub mod path_resolver;


### PR DESCRIPTION
## What
**F1a** — the storage-plane contract that enforces composite-natural-key uniqueness, in the trait-only `proximadb-storage-ports` crate.

```rust
#[async_trait] pub trait ConditionalKeyStore: Send + Sync {
    fn atomic_scope(&self) -> AtomicScope;                                       // capability-typed (D11)
    async fn put_if_absent(&self, key: &Identity, oid: &Oid, fence: Generation) -> Result<PutOutcome>;
    async fn get(&self, key: &Identity) -> Result<Option<Oid>>;                 // FK phase 2
    async fn tombstone(&self, key: &Identity, fence: Generation) -> Result<()>; // append-only (D11/D14)
}
```

Design, traceable to the decisions:
- **Fenced, not a bare `put_if_absent`** — every write carries a `Generation`; a conflict returns `PutOutcome::Conflict { holder, generation }` so a loser distinguishes its own idempotent retry from a real conflict (Cornus `LogOnce`; D11). `Err` is I/O-only — **a conflict is an expected `Ok` outcome**.
- **Tenancy fail-closed by construction** — the F0 `Identity` already embeds the tenant/keyspace prefix, so a tenant-A caller *cannot form* tenant-B's key. This folds ADR-072 D3's explicit `tenant`/`keyspace` params into the key (documented in-module; a clean reconciliation with the spec sig).
- **`tombstone`, not `delete`** — append-only; a later `put_if_absent` of the same key is a *new version*, never a slot reuse (D11/D14). Physical reclamation is F6's job.
- **`AtomicScope::{PerKey, PerPartition, PerBatchManifest}`** declared per impl (ScalarDB Atomicity Unit) — maps to the two D5 impls (local-WAL default / object-store escape hatch).

## Safety
Trait-only, additive. F1b/F1c implement it; F2 wires it into the write path. No existing behavior changes.

## Tests
An in-memory reference impl exercises the full lifecycle: commit → conflict-with-holder → retry-sees-self → tombstone → **re-insert as a new version** → get (pins the append-only reclaim semantics). `cargo fmt` + `cargo clippy -D warnings` clean.

Depends conceptually on F0 (#1197) but keys on opaque `Identity` bytes, so it lands independently; F2 joins them.