### PR TITLE
docs(td): TD-FLUSH-4 ingest flush triggers dead (adjudicated evidence) + bench harness env-driven concurrency

### DIFF
--- a/docs/10-quality/td/TD-FLUSH-4-ingest-flush-triggers-dead-timer-only.adoc
+++ b/docs/10-quality/td/TD-FLUSH-4-ingest-flush-triggers-dead-timer-only.adoc
@@ -1,0 +1,74 @@
+= TD-FLUSH-4: ingest-time flush triggers are dead — only the 300 s RPO timer materializes segments (masked until #1199's bounded teardown)
+:status: Open
+:filed: 2026-07-25
+:priority: P0/P1 (durability + recall: unflushed serving measured 1 pt below the cascade ratchet)
+
+== Measured facts (merged develop `5cfc9d17f`, SIFT-1M REST e2e, isolated server)
+
+Reproducer: `scripts/bench/recall_adjudicate.py` (fresh bed, 1M ingest in
+~60 s, segments listed pre/post SIGTERM-restart, full-GT recall@10). Results
+identical across: bare env vs `PROXIMADB_PAX_*` set; explicit vs defaulted
+`flush_interval_secs`/`flush_floor_predicted_mb` toml keys; cwd-isolated vs
+shared-cwd launches. Repeated 3×.
+
+1. **Zero `.pax` segments** after a 1M ingest (512 MB memtable; predicted
+   bytes ≈152 MB ≥ the 128 MB floor from ~842k vectors on): the inline size
+   trigger never fires.
+2. **The shutdown flush no-ops in ~2 ms**: SIGTERM → "background loops
+   signaled" → "All servers stopped" → "Server shutdown complete", with NO
+   `Flushed collection` / `WAL_BATCH` lines — 1M unflushed vectors are
+   invisible to `flush_memtable_to_storage`'s enumeration at shutdown.
+3. **The 300 s RPO timer DOES work**: on a pre-#1199 binary that hung at exit
+   (TD-LIFECYCLE-1), segment `L0_20260725T054112` appeared exactly +300 s
+   after collection creation — during the post-SIGTERM hang. All previous
+   "flush worked" evidence re-attributes to this timer, not to the inline or
+   shutdown triggers.
+4. **Recall impact**: memtable-only serving = 0.9740 (live) / 0.9840 (after
+   SIGTERM restart + WAL replay) vs 0.9880 through the flushed cascade —
+   unflushed serving sits ~1 pt BELOW the 0.984 ratchet. Durability exposure:
+   until the timer fires, everything rides the WAL alone.
+
+== Root-cause pointers
+
+* The parallel session's finding stands: `MemtableManager` runs with
+  `flush_threshold_bytes = config.memtable.global_memory_limit / 2`
+  (`bincode/avro/proto_serialization_strategy.rs:~79`) — with
+  `write_buffer_size_mb = 4096` that is 2 GB, so `memory_flush_size_bytes`
+  (16 MB) is ignored. `git log -L` dates this line to the earliest history
+  (`ac24a51d8`) — a LONG-STANDING defect, NOT a #1179 regression (#1179's
+  floor gates a size trigger that never fires anyway).
+* The shutdown-flush no-op is a SEPARATE gap: `flush_memtable_to_storage`
+  (engine.rs:282) enumerates the global write buffer and finds nothing for a
+  live 1M-vector collection created via REST `records/batch`. Why the
+  unflushed batches are invisible to it is the open investigation.
+* Masking history: the TD-LIFECYCLE-1 leaked-sender hang gave the RPO timer
+  unbounded post-SIGTERM time to flush; #1199's `shutdown_timeout(5s)`
+  removed that accidental grace, making both dead triggers observable. The
+  bounded teardown is correct — the flush triggers are the bug.
+
+== What is NOT true (adjudicated against the parallel session's 0.372 claim)
+
+The claim that #1167 deleted the memtable/WAL search path (Cosine
+displacement → 0.372 recall) is REFUTED: with 100% of the bed unflushed,
+merged develop measures 0.9740/0.9840 (three independent runs, plus 0.972 on
+the reporting session's own binary). A 0.372 measurement indicates a harness
+defect — verify: collection created with explicit `distance_metric:
+"euclidean"`; queries sent to the RETURNED `collection_id` (fresh servers do
+not always assign "1"); ground-truth id mapping matches inserted ids; the
+server binary is actually the intended commit (main-checkout `target/release`
+builds go stale); no foreign server on the port (the unified 5678 +
+internal-mux 15679 hijack answers health checks convincingly).
+
+== Direction
+
+S1 — make the inline size trigger honor `memory_flush_size_bytes` (gated by
+the TD-FLUSH-3 predicted floor as designed); S2 — root-cause + fix the
+shutdown flush's empty enumeration; S3 — regression test: ingest ≫
+`memory_flush_size_bytes`, assert segments appear without waiting for the
+RPO timer, and assert the shutdown flush drains a non-empty memtable.
+
+== Related
+
+TD-FLUSH-2 (small corpora never flush — same trigger family), TD-FLUSH-3
+(floor semantics), TD-LIFECYCLE-1 (the mask), #1150 (previous live-path flush
+fix), scripts/bench/recall_adjudicate.py (reproducer + adjudication harness).

--- a/scripts/bench/morsel_cold_sweep.py
+++ b/scripts/bench/morsel_cold_sweep.py
@@ -100,6 +100,17 @@ def search(vec, k=10):
 def sweep(queries, conc):
     import threading
 
+def bench_conc(default_factor=1.6):
+    """Hot-phase concurrency: BENCH_HOT_CONC env override, else
+    round(default_factor x cores) — 16 on the 10-core protocol box, portable
+    elsewhere. Keep overrides recorded next to any published numbers."""
+    import os
+    v = os.environ.get("BENCH_HOT_CONC")
+    if v and v.isdigit() and int(v) > 0:
+        return int(v)
+    return max(4, round((os.cpu_count() or 8) * default_factor))
+
+
     lat, errs = [], [0]
     lock = threading.Lock()
     idx = [0]
@@ -176,7 +187,15 @@ def main():
     qs = read_fvecs(QUERY, 10_000)
     off = 0
     print(f"== mode {MODE} ==", flush=True)
-    for conc, count in [(1, 60), (4, 120), (8, 200), (16, 320)]:
+    ladder_env = os.environ.get("BENCH_CONC_LADDER", "")
+    ladder = [int(x) for x in ladder_env.split(",") if x.strip().isdigit()] or [
+        1,
+        4,
+        max(4, (os.cpu_count() or 8) // 2 * 2),
+        bench_conc(),
+    ]
+    for conc in ladder:
+        count = max(60, conc * 20)
         r = sweep(qs[off : off + count], conc)
         off += count
         print(

--- a/scripts/bench/recall_adjudicate.py
+++ b/scripts/bench/recall_adjudicate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Adjudicate the 0.988-vs-0.372 recall discrepancy: fresh 1M bed (their toml,
+BARE env — no PROXIMADB_* overrides), recall measured pre-restart and
+post-restart with the full-GT protocol.
+
+Usage: recall_adjudicate.py <bin> <cfg> <datadir> <port>
+"""
+import json, os, signal, subprocess, sys, time, urllib.request
+import numpy as np
+
+BIN, CFG, DATADIR, PORT = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+BASE = f"http://127.0.0.1:{PORT}/api/v2"
+SIFT = "/Users/vijaysingh/sift1m/sift_base.fvecs"
+QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
+N = 1_000_000
+LOG = "/tmp/recall_adjudicate.log"
+ENV = dict(os.environ, RUST_LOG="proximadb=info")  # BARE: no PROXIMADB_* overrides
+
+def read_fvecs(path, count, offset=0):
+    with open(path, "rb") as f:
+        d = np.frombuffer(f.read(4), dtype="<i4")[0]
+        rec = 4 + 4 * d
+        f.seek(rec * offset)
+        raw = f.read(rec * count)
+    a = np.frombuffer(raw, dtype="<u1").reshape(-1, rec)
+    return a[:, 4:].copy().view("<f4").reshape(-1, d)
+
+def post(path, body, timeout=300, retries=5):
+    last = None
+    for attempt in range(retries):
+        req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code >= 500:
+                # transient (e.g. write backpressure) — back off and retry
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+    raise last
+
+def launch():
+    # Wait for OUR port to be free (a SIGTERM'd predecessor lingers a few
+    # seconds); a foreign owner that never releases = hard abort.
+    import socket
+    for _ in range(120):
+        with socket.socket() as sck:
+            try:
+                sck.bind(("127.0.0.1", PORT))
+                break
+            except OSError:
+                time.sleep(1)
+    else:
+        sys.exit(f"port {PORT} never freed — foreign owner?")
+    lf = open(LOG, "ab")
+    # cwd = OUR datadir: some components write cwd-relative state (./data);
+    # sharing the launch cwd with other servers cross-contaminates catalogs.
+    p = subprocess.Popen([BIN, "-c", CFG, "-d", DATADIR, "-p", str(PORT)],
+                         stdout=lf, stderr=lf, env=ENV, cwd=DATADIR)
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{PORT}/health", timeout=2)
+            time.sleep(3)
+            if p.poll() is not None:
+                sys.exit("FOREIGN SERVER TRAP: health answered but MY server "
+                         f"process exited (bind conflict?) — see {LOG}")
+            return p
+        except Exception:
+            if p.poll() is not None:
+                sys.exit(f"server died, see {LOG}")
+            time.sleep(0.5)
+    sys.exit("server not healthy")
+
+def stop(p, sig=signal.SIGTERM):
+    p.send_signal(sig)
+    try:
+        p.wait(timeout=45)
+    except subprocess.TimeoutExpired:
+        p.kill(); p.wait(timeout=10)
+
+def recall(base, qs, label, cid="1"):
+    got, n = 0, len(qs)
+    for q in qs:
+        r = post(f"/collections/{cid}/search", {"vector": q.tolist(), "top_k": 10})
+        ids = [h.get("id") for h in r.get("results", r.get("hits", []))][:10]
+        d = ((base - q) ** 2).sum(axis=1)
+        gt = {f"v{i}" for i in np.argpartition(d, 10)[:10]}
+        got += len(gt & set(ids))
+    v = got / (n * 10)
+    print(f"recall@10 [{label}] = {v:.4f}", flush=True)
+    return v
+
+def main():
+    base = read_fvecs(SIFT, N)
+    qs = read_fvecs(QUERY, 10_000)
+    p = launch()
+    c = post("/collections", {"name": f"adjud_{int(time.time())}", "dimension": 128,
+                              "engine": "sst", "enable_proxima_record": True,
+                              "distance_metric": "euclidean"})
+    cid = c.get("collection_id") or "1"
+    print(f"collection -> {cid}", flush=True)
+    t0 = time.time()
+    for i in range(0, N, 1000):
+        b = base[i:i+1000]
+        post(f"/collections/{cid}/records/batch",
+             {"records": [{"id": f"v{i+j}", "vector": b[j].tolist()} for j in range(len(b))]})
+        time.sleep(0.02)
+        if (i + 1000) % 250_000 == 0:
+            print(f"  ingested {i+1000} ({time.time()-t0:.0f}s)", flush=True)
+    print(f"ingest done {time.time()-t0:.0f}s; settling 30s", flush=True)
+    time.sleep(30)
+    import subprocess as sp
+    segs = sp.run(["find", DATADIR, "-name", "*.pax"], capture_output=True, text=True).stdout
+    print(f"segments pre-restart:\n{segs}", flush=True)
+    r1 = recall(base, qs[2000:2050], "PRE-restart, live server", cid)
+    stop(p)
+    p = launch()
+    segs = sp.run(["find", DATADIR, "-name", "*.pax"], capture_output=True, text=True).stdout
+    print(f"segments post-restart:\n{segs}", flush=True)
+    r2 = recall(base, qs[2050:2100], "POST-restart (SIGTERM)", cid)
+    stop(p)
+    print(f"\nVERDICT: pre={r1:.4f} post={r2:.4f}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/sift_rest_warmtier_sweep.py
+++ b/scripts/bench/sift_rest_warmtier_sweep.py
@@ -10,6 +10,17 @@ import json, re, struct, subprocess, time, urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from statistics import mean
 
+def bench_conc(default_factor=1.6):
+    """Hot-phase concurrency: BENCH_HOT_CONC env override, else
+    round(default_factor x cores) — 16 on the 10-core protocol box, portable
+    elsewhere. Keep overrides recorded next to any published numbers."""
+    import os
+    v = os.environ.get("BENCH_HOT_CONC")
+    if v and v.isdigit() and int(v) > 0:
+        return int(v)
+    return max(4, round((os.cpu_count() or 8) * default_factor))
+
+
 SERVER = "http://127.0.0.1:5678"
 BASE = "/Users/vijaysingh/sift1m/sift_base.fvecs"
 QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
@@ -144,10 +155,10 @@ def main():
     for vec in hot:
         one(vec)
     t0 = time.time()
-    with ThreadPoolExecutor(16) as ex:
+    with ThreadPoolExecutor(bench_conc()) as ex:
         lats = sorted(ex.map(one, hot))
     wall = time.time() - t0
-    print(f"HOT  c=16 n=200: QPS={len(hot)/wall:.0f} mean={mean(lats):.1f}ms "
+    print(f"HOT  c={bench_conc()} n=200: QPS={len(hot)/wall:.0f} mean={mean(lats):.1f}ms "
           f"p50={lats[len(lats)//2]:.1f} p95={lats[int(len(lats)*0.95)]:.1f}", flush=True)
 
     with urllib.request.urlopen(SERVER + "/metrics/prometheus", timeout=30) as r:


### PR DESCRIPTION
## Summary

Files **TD-FLUSH-4** with the adjudicated evidence from the cross-session SIFT-1M recall-discrepancy investigation, and promotes the adjudication harness.

**Measured on merged develop (`5cfc9d17f`), isolated server, 3× reproduced:** a 1M REST ingest produces **zero segments** — the inline size trigger never fires (`flush_threshold_bytes = global_memory_limit/2` = 2GB ignores `memory_flush_size_bytes` = 16MB; `git log -L` dates the defect to the earliest history — **not** a #1179 regression), the shutdown flush no-ops in ~2ms (1M unflushed vectors invisible to its enumeration), and only the 300s RPO timer materializes segments (timestamp-matched at exactly +300s). Previously masked by the TD-LIFECYCLE-1 exit hang; #1199's bounded teardown made it observable.

**Recall adjudication:** memtable-only serving measures **0.9740 live / 0.9840 post-restart** (vs 0.9880 cascade) — refuting the parallel session's theory that memtable search was broken (their 0.372 is a harness artifact; verification checklist in the TD), while confirming their no-flush observation. Note: unflushed serving sits ~1pt below the 0.984 recall ratchet — a durability *and* quality exposure until fixed.

Also: bench harnesses now take `BENCH_HOT_CONC`/`BENCH_CONC_LADDER` env with a cores-derived default (1.6×cores = 16 on the protocol box) instead of hardcoded c=16.

Docs + python only; no Rust changes. TD gate clean (273 ids).