### PR TITLE
fix(network): derive internal REST port from unified_port (TD-NET-1 S2)

### DIFF
--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -967,9 +967,15 @@ impl MultiServer {
 
         // Internal addresses for REST and gRPC servers
         // These are only accessible via the TCP multiplexer
-        let internal_rest_addr: std::net::SocketAddr = "127.0.0.1:15678"
-            .parse()
-            .unwrap_or_else(|_| SocketAddr::from(([127, 0, 0, 1], 15678)));
+        // TD-NET-1 S2: the internal REST port is derived per-instance from
+        // `unified_port + 10000` (5678 → 15678 = historical constant; 5679 →
+        // 15679), mirroring the gRPC derivation below, so co-hosted instances
+        // with distinct unified ports never bind the same internal REST listener
+        // (the foreign-server hijack landmine surfaced by the recall
+        // adjudication — a second server's mux forwarded queries to the first
+        // server's internal REST at the shared 15678 port).
+        let internal_rest_port = self.config.unified_port.saturating_add(10000);
+        let internal_rest_addr = SocketAddr::from(([127, 0, 0, 1], internal_rest_port));
         // TD-NET-1 S1: the internal gRPC/Arrow-Flight upstream port is resolved
         // per-instance (config `[api] internal_mux_port` > env
         // `PROXIMADB_INTERNAL_MUX_PORT` > derived `unified_port + 10001`,


### PR DESCRIPTION
## What
The internal REST listener was **hardcoded at `127.0.0.1:15678`**, while the internal gRPC listener (TD-NET-1 S1) was already derived per-instance as `unified_port + 10001`. This asymmetry meant two co-hosted ProximaDB servers with distinct unified ports **both tried to bind the same internal REST port (15678)**. The second server's bind silently failed, and the TCP multiplexer forwarded HTTP/1.1 queries to whichever server held 15678 — **cross-instance query hijacking**.

## Evidence
This caused the recall adjudication false alarm (PR #1202): bench queries sent to a second server (port 5685) were actually processed by the first server (port 5678's internal REST at 15678), searching a different collection and producing **0.372 recall** — a harness artifact, not a code regression.

## Fix
Derive the internal REST port as `unified_port + 10000` (mirroring the gRPC `+ 10001` pattern from TD-NET-1 S1), so each co-hosted instance gets a distinct internal REST port:
- 5678 → 15678 (historical default, unchanged)
- 5685 → 15685 (no collision)

9 insertions, 3 deletions, 1 file (`src/network/multi_server.rs`). The default-deployment case (single server, unified_port=5678) is identical — no behavioral change. CI will verify clippy (skipped locally to avoid a cold compile).

## Related
- TD-NET-1 S1 (gRPC port derivation, already merged)
- PR #1202 (recall adjudication — flagged this as an "infrastructure landmine")