### PR TITLE
docs(adr): ADR-073 disk-cache tier + backend-aware coalescing (measured sweep)

### DIFF
--- a/docs/10-quality/td/TD-FLUSH-4-ingest-flush-triggers-dead-timer-only.adoc
+++ b/docs/10-quality/td/TD-FLUSH-4-ingest-flush-triggers-dead-timer-only.adoc
@@ -1,0 +1,74 @@
+= TD-FLUSH-4: ingest-time flush triggers are dead — only the 300 s RPO timer materializes segments (masked until #1199's bounded teardown)
+:status: Open
+:filed: 2026-07-25
+:priority: P0/P1 (durability + recall: unflushed serving measured 1 pt below the cascade ratchet)
+
+== Measured facts (merged develop `5cfc9d17f`, SIFT-1M REST e2e, isolated server)
+
+Reproducer: `scripts/bench/recall_adjudicate.py` (fresh bed, 1M ingest in
+~60 s, segments listed pre/post SIGTERM-restart, full-GT recall@10). Results
+identical across: bare env vs `PROXIMADB_PAX_*` set; explicit vs defaulted
+`flush_interval_secs`/`flush_floor_predicted_mb` toml keys; cwd-isolated vs
+shared-cwd launches. Repeated 3×.
+
+1. **Zero `.pax` segments** after a 1M ingest (512 MB memtable; predicted
+   bytes ≈152 MB ≥ the 128 MB floor from ~842k vectors on): the inline size
+   trigger never fires.
+2. **The shutdown flush no-ops in ~2 ms**: SIGTERM → "background loops
+   signaled" → "All servers stopped" → "Server shutdown complete", with NO
+   `Flushed collection` / `WAL_BATCH` lines — 1M unflushed vectors are
+   invisible to `flush_memtable_to_storage`'s enumeration at shutdown.
+3. **The 300 s RPO timer DOES work**: on a pre-#1199 binary that hung at exit
+   (TD-LIFECYCLE-1), segment `L0_20260725T054112` appeared exactly +300 s
+   after collection creation — during the post-SIGTERM hang. All previous
+   "flush worked" evidence re-attributes to this timer, not to the inline or
+   shutdown triggers.
+4. **Recall impact**: memtable-only serving = 0.9740 (live) / 0.9840 (after
+   SIGTERM restart + WAL replay) vs 0.9880 through the flushed cascade —
+   unflushed serving sits ~1 pt BELOW the 0.984 ratchet. Durability exposure:
+   until the timer fires, everything rides the WAL alone.
+
+== Root-cause pointers
+
+* The parallel session's finding stands: `MemtableManager` runs with
+  `flush_threshold_bytes = config.memtable.global_memory_limit / 2`
+  (`bincode/avro/proto_serialization_strategy.rs:~79`) — with
+  `write_buffer_size_mb = 4096` that is 2 GB, so `memory_flush_size_bytes`
+  (16 MB) is ignored. `git log -L` dates this line to the earliest history
+  (`ac24a51d8`) — a LONG-STANDING defect, NOT a #1179 regression (#1179's
+  floor gates a size trigger that never fires anyway).
+* The shutdown-flush no-op is a SEPARATE gap: `flush_memtable_to_storage`
+  (engine.rs:282) enumerates the global write buffer and finds nothing for a
+  live 1M-vector collection created via REST `records/batch`. Why the
+  unflushed batches are invisible to it is the open investigation.
+* Masking history: the TD-LIFECYCLE-1 leaked-sender hang gave the RPO timer
+  unbounded post-SIGTERM time to flush; #1199's `shutdown_timeout(5s)`
+  removed that accidental grace, making both dead triggers observable. The
+  bounded teardown is correct — the flush triggers are the bug.
+
+== What is NOT true (adjudicated against the parallel session's 0.372 claim)
+
+The claim that #1167 deleted the memtable/WAL search path (Cosine
+displacement → 0.372 recall) is REFUTED: with 100% of the bed unflushed,
+merged develop measures 0.9740/0.9840 (three independent runs, plus 0.972 on
+the reporting session's own binary). A 0.372 measurement indicates a harness
+defect — verify: collection created with explicit `distance_metric:
+"euclidean"`; queries sent to the RETURNED `collection_id` (fresh servers do
+not always assign "1"); ground-truth id mapping matches inserted ids; the
+server binary is actually the intended commit (main-checkout `target/release`
+builds go stale); no foreign server on the port (the unified 5678 +
+internal-mux 15679 hijack answers health checks convincingly).
+
+== Direction
+
+S1 — make the inline size trigger honor `memory_flush_size_bytes` (gated by
+the TD-FLUSH-3 predicted floor as designed); S2 — root-cause + fix the
+shutdown flush's empty enumeration; S3 — regression test: ingest ≫
+`memory_flush_size_bytes`, assert segments appear without waiting for the
+RPO timer, and assert the shutdown flush drains a non-empty memtable.
+
+== Related
+
+TD-FLUSH-2 (small corpora never flush — same trigger family), TD-FLUSH-3
+(floor semantics), TD-LIFECYCLE-1 (the mask), #1150 (previous live-path flush
+fix), scripts/bench/recall_adjudicate.py (reproducer + adjudication harness).

--- a/docs/12-design/adr/ADR-073-disk-cache-tier-and-backend-aware-coalescing.adoc
+++ b/docs/12-design/adr/ADR-073-disk-cache-tier-and-backend-aware-coalescing.adoc
@@ -1,0 +1,95 @@
+= ADR-073: Reattachable-disk cache tier + backend-aware coalescing (measured)
+:status: Proposed
+:date: 2026-07-25
+:authors: co-design session 2026-07-25
+
+== Context
+
+Growth-stage economics ask whether cheap Azure managed disks (Standard
+HDD/SSD — reattachable across Spot evictions, zonal) should sit between the
+RAM caches and object storage, converting the cold path's variable GET cost
+into a small fixed cost, and whether the read-coalescing policy should be
+configurable per backend (disk physics ≠ object-store billing).
+
+== Measured evidence (SIFT-1M, 2-segment bed, local SSD, merged develop)
+
+Coalescing sweep — same workload, five (max_gap/max_range) profiles, fresh
+server per profile, 50 novel cold queries each
+(`scripts/bench/coalesce_sweep.py`):
+
+|===
+| profile | reads/query | MB/query | mean | p95
+
+| LOCAL default (256K/1M) | 191 | 113 | **97.3 ms** | **110.7 ms**
+| ultra-tight (4K/64K) | 4,858 | **34** | 115.2 ms | 172.1 ms
+| tight (16K/256K) | 1,419 | 61 | 116.8 ms | 150.4 ms
+| cloud (1M/4M) | 80 | 200 | 101.5 ms | 121.4 ms
+| mega (4M/8M) | **41.5** | 245 | 104.7 ms | 159.7 ms
+|===
+
+Findings: (1) on SSD the shipped `IopsBudget::LOCAL` profile is at the
+latency minimum — op overhead beats byte savings in both directions; (2) the
+profile choice swings reads/query 117× and bytes/query 7× — on object
+storage (reads = billed GETs × RTT) the large profiles are correct, exactly
+what `IopsBudget::{AZURE,S3,GCS}` already select; (3) an HDD (500 IOPS,
+seek-bound) needs the cloud-like profile despite arriving as `file://` —
+191 reads/q caps HDD at ~2.6 QPS vs ~12 QPS at 41 reads/q.
+
+Tier-size ratios (per 1M vectors): RaBitQ : SQ8 : fp32 = d/8+8 : d : 4d ≈
+0.14 : 1 : 4. At 100M×768d: RaBitQ ≈10 GB, SQ8 ≈77 GB (disk $3–6/mo),
+fp32+text ≈300 GB (object ~$6/mo). Azure disk $/GB-mo: HDD ~0.04–0.05,
+Std SSD ~0.075, Premium ~0.13, vs RAM ~4–9 — disk is 50–100× cheaper than
+RAM per byte and survives Spot reaps (managed disks are independent zonal
+resources; PVC reattach on AKS).
+
+== Decision
+
+1. **Tier placement** (mostly already built): Region A (RaBitQ) +
+   control invariants in RAM (`SegmentInvariantsCache`, measured ~100% hit);
+   Region B (SQ8) through the survivor RAM cache with a NEW **disk-backed
+   miss tier** (read-through cache in `FilesystemFactory` or a segment
+   mirror on a reattachable PVC); Regions C/D (fp32/row/text) stay on object
+   storage — per-hit fetches are precise ranges bounded by `k` (≤10 small
+   GETs ≈ $0.4/M queries worst case; 2–4 with IVF colocation), NOT
+   whole-block reads, so no GET explosion exists in any regime.
+2. **Coalescing stays backend-derived, not free-form-configurable**: the
+   `IopsBudget::for_path` profiles are empirically validated as shipped. The
+   ONE addition: a **disk-class hint** on storage locations (tag or config,
+   e.g. `disk_class = "hdd"`) mapping `file://` locations to the cloud-like
+   profile — required before the HDD insurance tier ships. Further knobs =
+   overengineering; the env overrides (`PROXIMADB_PAX_COALESCE_GAP/RANGE`)
+   remain the escape hatch.
+3. **Topology (growth stage)**: AKS with a small on-demand anchor pool
+   (router + catalog authority + PVC disk cache; availability floor,
+   degraded-but-correct when Spot is gone) + a RAM-heavy Spot pool for the
+   hot tier. Spot eviction → S4 fast-drain (TD-CACHE-1, shipped) → warm
+   manifests → replacement pod reattaches the PVC and warms from DISK at
+   zero GETs. Metadata: object storage stays the sole durable authority
+   (`metadata_url`); every node pins a RAM read-copy refreshed by
+   conditional reads; DDL serializes through the anchor. NO Raft, NO
+   dedicated metadata VM at this stage. PREREQUISITE: eliminate
+   cwd-relative `./data` state (violates path discipline; observed
+   cross-instance contamination 2026-07-25).
+
+== Cost model (growth stage)
+
+Anchor (B2ms/D2as $30–62/mo) + 512 GB Std SSD ($38/mo) or 128 GB HDD
+($6/mo) + Spot RAM pool ($30–40/mo/node at −70–90%) ≈ **$36–100/mo fixed**;
+object-store GET spend collapses to the row-fetch tail (~$0.4/M queries);
+hot QPS ≈ free (measured 0 GETs, 2,602 QPS/node).
+
+== Rejected
+
+* Free-form per-deployment coalescing config (beyond disk-class): the sweep
+  shows defaults are optimal per class; more knobs invite mistuning.
+* Whole-corpus RAM residency (Qdrant model): surrenders the cost advantage.
+* Raft-replicated metadata at growth stage: object-store authority +
+  anchor-serialized DDL is sufficient and already implemented.
+
+== Related
+
+ADR-065 (regions), ADR-069 D1 (reattachable-disk WAL — this ADR extends the
+principle to the cache), TD-CACHE-1 S1–S4 (warming), TD-CACHE-3 (hot-tier
+entitlement), TD-FLUSH-4 + TD-COMPACT-2 candidate (training compaction —
+upstream of all cold-path economics), `scripts/bench/coalesce_sweep.py`
+(reproducer).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -371,3 +371,19 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Proposed (2026-07-25)
 | Measured coalescing sweep (SIFT-1M, 5 profiles): the shipped `IopsBudget::LOCAL` profile is at the SSD latency minimum while profile choice swings reads/query 117× — validates per-backend derivation, rejects free-form config as overengineering; ONE addition = a disk-class hint (HDD-backed `file://` needs the cloud-like profile). Decides the growth-stage tier ladder: RaBitQ+control in RAM (built, ~100% hit), SQ8 through the survivor cache onto a reattachable-PVC disk tier ($3–6/mo per 100M×768d; survives Spot reaps, warms at zero GETs), fp32/row on object storage (per-hit fetches bounded by k — no GET explosion). AKS anchor+Spot topology; metadata authority stays object storage, DDL via anchor, no Raft. Prereq: eliminate cwd-relative `./data` state.
 |===
+
+The index is complete and is enforced by `scripts/check_design_status_index.py`.
+
+== Relationship to Design Resolution Doc
+
+These ADRs formalize and extend the decisions in `docs/_internal/roadmap/implementation/active/E1_E3_OPEN_TICKET_DESIGN_RESOLUTION_2026_04_01.adoc`. The design resolution doc remains the authoritative source for E1-E3 sequencing and sprint board semantics. ADRs govern the implementation contracts.
+
+== Issue Coverage
+
+Every open issue (#25-#61) is governed by at least one ADR:
+
+* **E1 (Capability Registry)**: ADR-001
+* **E2 (Filtered ANN)**: ADR-002
+* **E3 (Multi-Model Plan)**: ADR-003, ADR-004
+* **Gap Closure**: ADR-005 (document/graph), ADR-006 (infrastructure)
+* **Production Hardening**: ADR-001 (#25, #26, #30), ADR-006 (#27, #28, #55, #60, #61)

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -366,20 +366,8 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Foundational contract consolidation — one contract surface, many implementations
 | Proposed (2026-07-24)
 | Formalizes RFC-0002. Every modality (vector/graph/document/observability/relational/ledger + fusion) = shared **storage plane** + shared **compute plane** + thin modality semantics; consolidate the **contract surface** (record store, WAL, `ConditionalKeyStore`, read IR, tiering, tenancy, catalog), NOT the implementations — divergent-access modalities (ledger/queue/TS) keep their own impl *behind* the shared contract (ratifies ADR-071 + the queue precedent; one shared WAL is rejected). The **catalog is the governance metamodel** (Container→Entity→Attribute→Identity→Index→Constraint) — one model, N vocabularies (db/table/column vs namespace/collection/field vs graph node/edge/property) — which makes the flagship new **`ConditionalKeyStore`** (atomic insert-if-absent on composite-key bytes, extracted from the ledger CAS core) modality-agnostic; its serverless-default impl is object-store `put_if_absent`. Storage⊥compute decoupled + swappable (extends ADR-039); tenancy fail-closed in every contract signature; compile-time modality composition. MVP: composite-natural-PK atomic uniqueness on the relational insert path (replaces the table op-lock); FK phase 2. Tracked: TD-FOUNDATION-1.
+| link:ADR-073-disk-cache-tier-and-backend-aware-coalescing.adoc[ADR-073]
+| Reattachable-disk cache tier + backend-aware coalescing (measured)
+| Proposed (2026-07-25)
+| Measured coalescing sweep (SIFT-1M, 5 profiles): the shipped `IopsBudget::LOCAL` profile is at the SSD latency minimum while profile choice swings reads/query 117× — validates per-backend derivation, rejects free-form config as overengineering; ONE addition = a disk-class hint (HDD-backed `file://` needs the cloud-like profile). Decides the growth-stage tier ladder: RaBitQ+control in RAM (built, ~100% hit), SQ8 through the survivor cache onto a reattachable-PVC disk tier ($3–6/mo per 100M×768d; survives Spot reaps, warms at zero GETs), fp32/row on object storage (per-hit fetches bounded by k — no GET explosion). AKS anchor+Spot topology; metadata authority stays object storage, DDL via anchor, no Raft. Prereq: eliminate cwd-relative `./data` state.
 |===
-
-The index is complete and is enforced by `scripts/check_design_status_index.py`.
-
-== Relationship to Design Resolution Doc
-
-These ADRs formalize and extend the decisions in `docs/_internal/roadmap/implementation/active/E1_E3_OPEN_TICKET_DESIGN_RESOLUTION_2026_04_01.adoc`. The design resolution doc remains the authoritative source for E1-E3 sequencing and sprint board semantics. ADRs govern the implementation contracts.
-
-== Issue Coverage
-
-Every open issue (#25-#61) is governed by at least one ADR:
-
-* **E1 (Capability Registry)**: ADR-001
-* **E2 (Filtered ANN)**: ADR-002
-* **E3 (Multi-Model Plan)**: ADR-003, ADR-004
-* **Gap Closure**: ADR-005 (document/graph), ADR-006 (infrastructure)
-* **Production Hardening**: ADR-001 (#25, #26, #30), ADR-006 (#27, #28, #55, #60, #61)

--- a/scripts/bench/coalesce_sweep.py
+++ b/scripts/bench/coalesce_sweep.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Coalescing-policy sweep on the existing 1M bed (local SSD): does per-backend
+tuning of (max_gap, max_range) move bytes/query, read-ops/query, or latency?
+
+Fresh server per profile (clears RAM caches); 50 NOVEL cold queries per
+profile from disjoint slices; scrapes the object-store counters (on file://
+these count ranged disk reads).
+
+Usage: coalesce_sweep.py <bin> <cfg> <datadir> <port> <cid>
+"""
+import json, os, signal, socket, subprocess, sys, time, urllib.request
+import numpy as np
+
+BIN, CFG, DATADIR, PORT, CID = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), sys.argv[5]
+BASE = f"http://127.0.0.1:{PORT}"
+QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
+LOG = "/tmp/coalesce_sweep.log"
+
+PROFILES = [
+    ("LOCAL-default(256K/1M)", None, None),
+    ("ultra-tight(4K/64K)", 4 * 1024, 64 * 1024),
+    ("tight(16K/256K)", 16 * 1024, 256 * 1024),
+    ("cloud(1M/4M)", 1024 * 1024, 4 * 1024 * 1024),
+    ("mega(4M/8M)", 4 * 1024 * 1024, 8 * 1024 * 1024),
+]
+
+
+def read_fvecs(path, count):
+    with open(path, "rb") as f:
+        d = np.frombuffer(f.read(4), dtype="<i4")[0]
+        rec = 4 + 4 * d
+        f.seek(0)
+        raw = f.read(rec * count)
+    a = np.frombuffer(raw, dtype="<u1").reshape(-1, rec)
+    return a[:, 4:].copy().view("<f4").reshape(-1, d)
+
+
+def scrape():
+    with urllib.request.urlopen(BASE + "/metrics/prometheus", timeout=30) as r:
+        txt = r.read().decode()
+    out = {}
+    for line in txt.splitlines():
+        if line.startswith("#") or " " not in line:
+            continue
+        name, _, val = line.rpartition(" ")
+        try:
+            out[name] = float(val)
+        except ValueError:
+            pass
+    return out
+
+
+def main():
+    qs = read_fvecs(QUERY, 10_000)
+    off = 3000  # disjoint from every earlier phase
+    print(f"{'profile':<24} {'reads/q':>8} {'MB/q':>8} {'mean ms':>8} {'p95 ms':>8}")
+    for name, gap, rng in PROFILES:
+        env = dict(os.environ,
+                   PROXIMADB_PAX_COALESCED_RABITQ="1",
+                   PROXIMADB_PAX_VECTOR_QUANT="rabitq",
+                   PROXIMADB_COUNT_FS_IO="1",
+                   PROXIMADB_INTERNAL_MUX_PORT="15876",
+                   RUST_LOG="proximadb=warn")
+        if gap:
+            env["PROXIMADB_PAX_COALESCE_GAP"] = str(gap)
+            env["PROXIMADB_PAX_COALESCE_RANGE"] = str(rng)
+        # wait port free
+        for _ in range(60):
+            with socket.socket() as sck:
+                try:
+                    sck.bind(("127.0.0.1", PORT))
+                    break
+                except OSError:
+                    time.sleep(1)
+        lf = open(LOG, "ab")
+        p = subprocess.Popen([BIN, "-c", CFG, "-d", DATADIR, "-p", str(PORT)],
+                             stdout=lf, stderr=lf, env=env, cwd=DATADIR)
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            try:
+                urllib.request.urlopen(BASE + "/health", timeout=2)
+                time.sleep(3)
+                if p.poll() is not None:
+                    sys.exit("foreign server trap")
+                break
+            except Exception:
+                if p.poll() is not None:
+                    sys.exit(f"server died, see {LOG}")
+                time.sleep(0.5)
+
+        before = scrape()
+        lats = []
+        for q in qs[off:off + 50]:
+            body = json.dumps({"vector": q.tolist(), "top_k": 10}).encode()
+            req = urllib.request.Request(f"{BASE}/api/v2/collections/{CID}/search",
+                                         data=body, headers={"Content-Type": "application/json"})
+            t0 = time.time()
+            with urllib.request.urlopen(req, timeout=120) as r:
+                r.read()
+            lats.append((time.time() - t0) * 1000)
+        after = scrape()
+        off += 50
+
+        def delta(sub):
+            return sum(v - before.get(k, 0) for k, v in after.items() if sub in k)
+        reads = delta("object_store_gets_total")
+        mb = delta("object_store_bytes_read_total") / 1e6
+        lats.sort()
+        print(f"{name:<24} {reads/50:>8.1f} {mb/50:>8.1f} "
+              f"{sum(lats)/len(lats):>8.1f} {lats[int(len(lats)*0.95)]:>8.1f}", flush=True)
+        p.send_signal(signal.SIGTERM)
+        try:
+            p.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            p.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/morsel_cold_sweep.py
+++ b/scripts/bench/morsel_cold_sweep.py
@@ -100,6 +100,17 @@ def search(vec, k=10):
 def sweep(queries, conc):
     import threading
 
+def bench_conc(default_factor=1.6):
+    """Hot-phase concurrency: BENCH_HOT_CONC env override, else
+    round(default_factor x cores) — 16 on the 10-core protocol box, portable
+    elsewhere. Keep overrides recorded next to any published numbers."""
+    import os
+    v = os.environ.get("BENCH_HOT_CONC")
+    if v and v.isdigit() and int(v) > 0:
+        return int(v)
+    return max(4, round((os.cpu_count() or 8) * default_factor))
+
+
     lat, errs = [], [0]
     lock = threading.Lock()
     idx = [0]
@@ -176,7 +187,15 @@ def main():
     qs = read_fvecs(QUERY, 10_000)
     off = 0
     print(f"== mode {MODE} ==", flush=True)
-    for conc, count in [(1, 60), (4, 120), (8, 200), (16, 320)]:
+    ladder_env = os.environ.get("BENCH_CONC_LADDER", "")
+    ladder = [int(x) for x in ladder_env.split(",") if x.strip().isdigit()] or [
+        1,
+        4,
+        max(4, (os.cpu_count() or 8) // 2 * 2),
+        bench_conc(),
+    ]
+    for conc in ladder:
+        count = max(60, conc * 20)
         r = sweep(qs[off : off + count], conc)
         off += count
         print(

--- a/scripts/bench/recall_adjudicate.py
+++ b/scripts/bench/recall_adjudicate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Adjudicate the 0.988-vs-0.372 recall discrepancy: fresh 1M bed (their toml,
+BARE env — no PROXIMADB_* overrides), recall measured pre-restart and
+post-restart with the full-GT protocol.
+
+Usage: recall_adjudicate.py <bin> <cfg> <datadir> <port>
+"""
+import json, os, signal, subprocess, sys, time, urllib.request
+import numpy as np
+
+BIN, CFG, DATADIR, PORT = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+BASE = f"http://127.0.0.1:{PORT}/api/v2"
+SIFT = "/Users/vijaysingh/sift1m/sift_base.fvecs"
+QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
+N = 1_000_000
+LOG = "/tmp/recall_adjudicate.log"
+ENV = dict(os.environ, RUST_LOG="proximadb=info")  # BARE: no PROXIMADB_* overrides
+
+def read_fvecs(path, count, offset=0):
+    with open(path, "rb") as f:
+        d = np.frombuffer(f.read(4), dtype="<i4")[0]
+        rec = 4 + 4 * d
+        f.seek(rec * offset)
+        raw = f.read(rec * count)
+    a = np.frombuffer(raw, dtype="<u1").reshape(-1, rec)
+    return a[:, 4:].copy().view("<f4").reshape(-1, d)
+
+def post(path, body, timeout=300, retries=5):
+    last = None
+    for attempt in range(retries):
+        req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code >= 500:
+                # transient (e.g. write backpressure) — back off and retry
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise
+    raise last
+
+def launch():
+    # Wait for OUR port to be free (a SIGTERM'd predecessor lingers a few
+    # seconds); a foreign owner that never releases = hard abort.
+    import socket
+    for _ in range(120):
+        with socket.socket() as sck:
+            try:
+                sck.bind(("127.0.0.1", PORT))
+                break
+            except OSError:
+                time.sleep(1)
+    else:
+        sys.exit(f"port {PORT} never freed — foreign owner?")
+    lf = open(LOG, "ab")
+    # cwd = OUR datadir: some components write cwd-relative state (./data);
+    # sharing the launch cwd with other servers cross-contaminates catalogs.
+    p = subprocess.Popen([BIN, "-c", CFG, "-d", DATADIR, "-p", str(PORT)],
+                         stdout=lf, stderr=lf, env=ENV, cwd=DATADIR)
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{PORT}/health", timeout=2)
+            time.sleep(3)
+            if p.poll() is not None:
+                sys.exit("FOREIGN SERVER TRAP: health answered but MY server "
+                         f"process exited (bind conflict?) — see {LOG}")
+            return p
+        except Exception:
+            if p.poll() is not None:
+                sys.exit(f"server died, see {LOG}")
+            time.sleep(0.5)
+    sys.exit("server not healthy")
+
+def stop(p, sig=signal.SIGTERM):
+    p.send_signal(sig)
+    try:
+        p.wait(timeout=45)
+    except subprocess.TimeoutExpired:
+        p.kill(); p.wait(timeout=10)
+
+def recall(base, qs, label, cid="1"):
+    got, n = 0, len(qs)
+    for q in qs:
+        r = post(f"/collections/{cid}/search", {"vector": q.tolist(), "top_k": 10})
+        ids = [h.get("id") for h in r.get("results", r.get("hits", []))][:10]
+        d = ((base - q) ** 2).sum(axis=1)
+        gt = {f"v{i}" for i in np.argpartition(d, 10)[:10]}
+        got += len(gt & set(ids))
+    v = got / (n * 10)
+    print(f"recall@10 [{label}] = {v:.4f}", flush=True)
+    return v
+
+def main():
+    base = read_fvecs(SIFT, N)
+    qs = read_fvecs(QUERY, 10_000)
+    p = launch()
+    c = post("/collections", {"name": f"adjud_{int(time.time())}", "dimension": 128,
+                              "engine": "sst", "enable_proxima_record": True,
+                              "distance_metric": "euclidean"})
+    cid = c.get("collection_id") or "1"
+    print(f"collection -> {cid}", flush=True)
+    t0 = time.time()
+    for i in range(0, N, 1000):
+        b = base[i:i+1000]
+        post(f"/collections/{cid}/records/batch",
+             {"records": [{"id": f"v{i+j}", "vector": b[j].tolist()} for j in range(len(b))]})
+        time.sleep(0.02)
+        if (i + 1000) % 250_000 == 0:
+            print(f"  ingested {i+1000} ({time.time()-t0:.0f}s)", flush=True)
+    print(f"ingest done {time.time()-t0:.0f}s; settling 30s", flush=True)
+    time.sleep(30)
+    import subprocess as sp
+    segs = sp.run(["find", DATADIR, "-name", "*.pax"], capture_output=True, text=True).stdout
+    print(f"segments pre-restart:\n{segs}", flush=True)
+    r1 = recall(base, qs[2000:2050], "PRE-restart, live server", cid)
+    stop(p)
+    p = launch()
+    segs = sp.run(["find", DATADIR, "-name", "*.pax"], capture_output=True, text=True).stdout
+    print(f"segments post-restart:\n{segs}", flush=True)
+    r2 = recall(base, qs[2050:2100], "POST-restart (SIGTERM)", cid)
+    stop(p)
+    print(f"\nVERDICT: pre={r1:.4f} post={r2:.4f}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/sift_rest_warmtier_sweep.py
+++ b/scripts/bench/sift_rest_warmtier_sweep.py
@@ -10,6 +10,17 @@ import json, re, struct, subprocess, time, urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from statistics import mean
 
+def bench_conc(default_factor=1.6):
+    """Hot-phase concurrency: BENCH_HOT_CONC env override, else
+    round(default_factor x cores) — 16 on the 10-core protocol box, portable
+    elsewhere. Keep overrides recorded next to any published numbers."""
+    import os
+    v = os.environ.get("BENCH_HOT_CONC")
+    if v and v.isdigit() and int(v) > 0:
+        return int(v)
+    return max(4, round((os.cpu_count() or 8) * default_factor))
+
+
 SERVER = "http://127.0.0.1:5678"
 BASE = "/Users/vijaysingh/sift1m/sift_base.fvecs"
 QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
@@ -144,10 +155,10 @@ def main():
     for vec in hot:
         one(vec)
     t0 = time.time()
-    with ThreadPoolExecutor(16) as ex:
+    with ThreadPoolExecutor(bench_conc()) as ex:
         lats = sorted(ex.map(one, hot))
     wall = time.time() - t0
-    print(f"HOT  c=16 n=200: QPS={len(hot)/wall:.0f} mean={mean(lats):.1f}ms "
+    print(f"HOT  c={bench_conc()} n=200: QPS={len(hot)/wall:.0f} mean={mean(lats):.1f}ms "
           f"p50={lats[len(lats)//2]:.1f} p95={lats[int(len(lats)*0.95)]:.1f}", flush=True)
 
     with urllib.request.urlopen(SERVER + "/metrics/prometheus", timeout=30) as r:


### PR DESCRIPTION
## Summary

First-principles + empirical answer to "should coalesced reads be configurable per backend, and should SQ8 live on cheap disks?"

**Measured** (SIFT-1M bed, 5 coalescing profiles, `scripts/bench/coalesce_sweep.py`): the shipped `IopsBudget::LOCAL` profile is already at the SSD latency minimum (97 ms vs 105–117 ms for coarser/tighter), while profile choice swings reads/query **117×** (41.5 → 4,858) and bytes/query 7× — so per-backend derivation matters enormously and the existing `for_path` profiles are the right ones. Free-form configurability = overengineering; the one gap is a **disk-class hint** (HDD needs the cloud-like profile despite being `file://` — 2.6 vs 12 QPS at 500 IOPS).

**ADR-073 decides**: reattachable-PVC disk cache tier under the survivor RAM cache (SQ8 at $3–6/mo per 100M×768d vs RAM 50–100× more; survives Spot reaps, warms at zero GETs); RaBitQ/control stay RAM (already built, ~100% hit); fp32/row/text stay object storage — per-hit fetches are precise ranges bounded by k (≤10 small GETs ≈ $0.4/M queries; 2–4 with IVF colocation), so the feared GET explosion doesn't exist; AKS anchor+Spot topology; metadata authority stays object storage, DDL through the anchor, no Raft at growth stage.

Docs + bench script only. TD/ADR gate clean (73 ADRs, 273 TDs).