### PR TITLE
test(graph): run graph_ldbc_pgwire_e2e on an 8 MB-stack runtime (fix flaky stack overflow)

### DIFF
--- a/tests/graph_ldbc_pgwire_e2e.rs
+++ b/tests/graph_ldbc_pgwire_e2e.rs
@@ -201,8 +201,22 @@ fn graph_queries() -> Vec<(&'static str, String)> {
     ]
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn graph_ldbc_pgwire_conformance() {
+// 8 MB stack: this LDBC/pgwire e2e evaluates a `WITH RECURSIVE` transitive-closure
+// CTE over the `knows` graph, whose bounded-but-deep recursion overflows the tokio
+// worker default 2 MB stack intermittently under CI load. Run on a larger-stack
+// runtime, matching the tpcds/tpch/duckdb pgwire e2e tests.
+#[test]
+fn graph_ldbc_pgwire_conformance() {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(graph_ldbc_pgwire_conformance_inner());
+}
+
+async fn graph_ldbc_pgwire_conformance_inner() {
     let server = PgServer::start().await.expect("server start");
     let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
         .await
@@ -348,8 +362,19 @@ async fn graph_ldbc_pgwire_conformance() {
 /// passes every existing graph test (the conformance suite never mutates after
 /// MATERIALIZE). The materialized-but-unmutated `gperson` dimension exercises the
 /// empty-delta fast path in the same query.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn graph_deletion_vector_reflects_edge_mutations() {
+// 8 MB stack (same rationale as `graph_ldbc_pgwire_conformance`).
+#[test]
+fn graph_deletion_vector_reflects_edge_mutations() {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(graph_deletion_vector_reflects_edge_mutations_inner());
+}
+
+async fn graph_deletion_vector_reflects_edge_mutations_inner() {
     let server = PgServer::start().await.expect("server start");
     let (client, conn) = tokio_postgres::connect(&server.conn_str(), tokio_postgres::NoTls)
         .await


### PR DESCRIPTION
## Problem
`graph_ldbc_pgwire_e2e` intermittently fails the **"Rust Integration Tests (graph)"** check on unrelated PRs with:

```
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `--test graph_ldbc_pgwire_e2e`
```

## Root cause
The test evaluates a `WITH RECURSIVE` transitive-closure CTE over the `knows` graph (`g10_recursive_reach`). Its **bounded-but-deep** recursion overflows the tokio worker default **2 MB stack** roughly half the time — a coin-flip by CI runner load (develop's recent runs passed; a rerun on another branch failed twice). It aborts the whole test binary.

## Fix (repo-idiomatic)
The rest of the pgwire e2e suite already runs on a larger-stack runtime precisely for this reason — `tpcds_pgwire_e2e`, `tpch`, `duckdb_route_pgwire_e2e`, and the `rel_*_e2e` tests use an **8–16 MB** stack. This graph test was the only one left on the bare `#[tokio::test]`. This PR converts both tests in the file to a manually-built multi-thread runtime with `.thread_stack_size(8 * 1024 * 1024)`, matching that pattern.

- No behavior change — the test bodies are moved verbatim into `_inner` fns and driven via `rt.block_on(...)`.
- Stops the flake recurring for **every** PR, not just the one that happened to hit it.

The authoritative validation is this PR's own "Rust Integration Tests (graph)" check running green with the 8 MB stack.