### PR TITLE
feat(cks-local): F1d append-only MVCC reclaim + snapshot reads + watermark GC (ADR-072 D11)

### DIFF
--- a/crates/storage/proximadb-cks-local/src/lib.rs
+++ b/crates/storage/proximadb-cks-local/src/lib.rs
@@ -1,30 +1,38 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-//! # `proximadb-cks-local` — the generation-fenced local-WAL `ConditionalKeyStore`
+//! # `proximadb-cks-local` — the generation-fenced, MVCC local-WAL `ConditionalKeyStore`
 //!
-//! F1b (ADR-072 D5): the **hot, correctness-carrying default** implementation of
-//! [`ConditionalKeyStore`]. It generalizes the ledger's proven CAS core from
-//! `str → version` to `Identity → Oid`: an in-memory authoritative map fronted by
-//! an **append-only, CRC-framed WAL** so claimed keys survive restart, with
-//! torn-tail-tolerant replay (a crash mid-append is discarded, not recovered as a
-//! phantom claim).
+//! F1b + **F1d** (ADR-072 D5/D11): the hot, correctness-carrying default
+//! implementation of [`ConditionalKeyStore`], with an **append-only MVCC**
+//! reclaim model.
 //!
-//! Reclaim is **append-only** (D11/D14): [`ConditionalKeyStore::tombstone`] marks
-//! the live version deleted without reusing the slot; a later `put_if_absent` of
-//! the same key is a *new* claim. Physical WAL compaction / GC is the
-//! background-plane concern (F6), out of scope here.
+//! - **Versioned, not slot-reclaiming (D11/D14).** Each key keeps an
+//!   append-ordered version history (`Some(oid)` = a claim, `None` = a
+//!   tombstone). A PK update/delete + re-insert appends *new* versions; a slot is
+//!   never overwritten.
+//! - **Monotonic generation (ABA defense).** The store stamps every mutation with
+//!   a strictly increasing generation (≥ the caller's fence), so a reused key can
+//!   never masquerade as an older version.
+//! - **Snapshot reads.** [`LocalWalKeyStore::get_at`] resolves the version with
+//!   the greatest generation ≤ a snapshot — the MVCC visibility the record store
+//!   reads against.
+//! - **Reader-watermark GC.** [`LocalWalKeyStore::compact`] rewrites the WAL,
+//!   dropping versions no active reader can still observe (below the
+//!   oldest-active-reader watermark). Physical scheduling is the F6 background
+//!   plane; the mechanism lives here.
 //!
-//! Frame layout matches the ledger WAL: `[len u32-le][crc32 u32-le][payload]`.
-//! Payload: `op u8 | generation u64-le | key_len u32-le | key | oid_len u32-le | oid`.
+//! Durable via a CRC-framed, torn-tail-tolerant WAL (ledger framing):
+//! `[len u32-le][crc32 u32-le][payload]`,
+//! payload = `op u8 | generation u64-le | key_len u32-le | key | oid_len u32-le | oid`.
 
 use anyhow::{Context, Result};
 use proximadb_storage_ports::{
     AtomicScope, ConditionalKeyStore, Generation, Identity, Oid, PutOutcome,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 /// WAL fsync policy (mirrors the ledger's lever).
@@ -39,8 +47,8 @@ pub enum SyncPolicy {
 const OP_PUT: u8 = 0;
 const OP_TOMBSTONE: u8 = 1;
 
-/// IEEE CRC-32 (reflected, poly `0xEDB88320`). Inline so the crate needs no
-/// checksum dependency; identical to the ledger WAL's framing.
+/// IEEE CRC-32 (reflected, poly `0xEDB88320`). Inline (no dependency); identical
+/// to the ledger WAL's framing.
 fn crc32(data: &[u8]) -> u32 {
     let mut crc = 0xFFFF_FFFFu32;
     for &byte in data {
@@ -53,20 +61,26 @@ fn crc32(data: &[u8]) -> u32 {
     !crc
 }
 
+/// One version of a key. `oid = None` is a tombstone.
 #[derive(Clone)]
-struct Entry {
-    oid: Oid,
+struct Version {
     generation: Generation,
-    live: bool,
+    oid: Option<Oid>,
 }
 
 struct Inner {
-    map: HashMap<Identity, Entry>,
+    /// Per key, versions in ascending generation order (the WAL append order).
+    map: HashMap<Identity, Vec<Version>>,
+    /// Monotonic generation clock; the next stamp is `> clock` and `>= fence`.
+    clock: u64,
+    /// Active reader snapshots -> refcount (the GC watermark source).
+    readers: BTreeMap<u64, usize>,
     log: BufWriter<File>,
     sync: SyncPolicy,
+    path: PathBuf,
 }
 
-/// A durable, generation-fenced [`ConditionalKeyStore`] backed by a local WAL.
+/// A durable, generation-fenced, MVCC [`ConditionalKeyStore`] backed by a local WAL.
 pub struct LocalWalKeyStore {
     inner: Mutex<Inner>,
 }
@@ -74,19 +88,18 @@ pub struct LocalWalKeyStore {
 impl LocalWalKeyStore {
     /// Open (or create) the store at `path`, replaying any existing WAL.
     pub fn open(path: impl AsRef<Path>, sync: SyncPolicy) -> Result<Self> {
-        let path = path.as_ref();
-        let map = replay(path).with_context(|| format!("replaying WAL at {}", path.display()))?;
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .read(true)
-            .open(path)
-            .with_context(|| format!("opening WAL at {}", path.display()))?;
+        let path = path.as_ref().to_path_buf();
+        let (map, clock) =
+            replay(&path).with_context(|| format!("replaying WAL at {}", path.display()))?;
+        let log = open_append(&path)?;
         Ok(Self {
             inner: Mutex::new(Inner {
                 map,
-                log: BufWriter::new(file),
+                clock,
+                readers: BTreeMap::new(),
+                log: BufWriter::new(log),
                 sync,
+                path,
             }),
         })
     }
@@ -98,22 +111,94 @@ impl LocalWalKeyStore {
         g.log.get_ref().sync_all()?;
         Ok(())
     }
+
+    /// The current snapshot generation (the latest committed generation).
+    pub fn snapshot(&self) -> Generation {
+        Generation(self.inner.lock().unwrap().clock)
+    }
+
+    /// Begin a read at the current snapshot; the returned guard pins the GC
+    /// watermark until dropped, so [`Self::compact`] cannot reclaim versions this
+    /// reader can still observe.
+    pub fn begin_read(&self) -> ReadGuard<'_> {
+        let mut g = self.inner.lock().unwrap();
+        let snap = g.clock;
+        *g.readers.entry(snap).or_insert(0) += 1;
+        ReadGuard {
+            store: self,
+            snapshot: Generation(snap),
+        }
+    }
+
+    /// Resolve `key` at `snapshot`: the version with the greatest generation
+    /// `<= snapshot`, mapped to its holder (`None` if that version is a tombstone
+    /// or the key did not exist yet).
+    pub fn get_at(&self, key: &Identity, snapshot: Generation) -> Option<Oid> {
+        let g = self.inner.lock().unwrap();
+        resolve_at(g.map.get(key)?, snapshot).cloned()
+    }
+
+    /// Compact the WAL: drop every version no active reader can still observe
+    /// (strictly below the oldest-active-reader watermark, except the single
+    /// latest version at-or-below it that a watermark read must resolve), then
+    /// rewrite the log. Bounds WAL growth without losing visible state.
+    pub fn compact(&self) -> Result<()> {
+        let mut g = self.inner.lock().unwrap();
+        let watermark = g.oldest_active();
+
+        let mut kept: HashMap<Identity, Vec<Version>> = HashMap::new();
+        for (id, versions) in &g.map {
+            let pruned = prune(versions, watermark);
+            if !pruned.is_empty() {
+                kept.insert(id.clone(), pruned);
+            }
+        }
+
+        // Rewrite to a temp file, fsync, then atomically rename over the log.
+        let tmp = g.path.with_extension("wal.compact");
+        {
+            let mut w = BufWriter::new(
+                OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&tmp)?,
+            );
+            for (id, versions) in &kept {
+                for v in versions {
+                    let (op, oid): (u8, &[u8]) = match &v.oid {
+                        Some(o) => (OP_PUT, o.0.as_bytes()),
+                        None => (OP_TOMBSTONE, &[]),
+                    };
+                    write_frame(&mut w, op, v.generation, id.as_bytes(), oid)?;
+                }
+            }
+            w.flush()?;
+            w.get_ref().sync_all()?;
+        }
+        std::fs::rename(&tmp, &g.path)?;
+
+        g.map = kept;
+        g.log = BufWriter::new(open_append(&g.path)?);
+        Ok(())
+    }
 }
 
 impl Inner {
-    fn append(&mut self, op: u8, generation: Generation, key: &[u8], oid: &[u8]) -> io::Result<()> {
-        let mut payload = Vec::with_capacity(1 + 8 + 4 + key.len() + 4 + oid.len());
-        payload.push(op);
-        payload.extend_from_slice(&generation.0.to_le_bytes());
-        payload.extend_from_slice(&(key.len() as u32).to_le_bytes());
-        payload.extend_from_slice(key);
-        payload.extend_from_slice(&(oid.len() as u32).to_le_bytes());
-        payload.extend_from_slice(oid);
+    /// The GC watermark: the oldest active reader snapshot, or the current clock
+    /// when no reads are in flight (everything superseded is then reclaimable).
+    fn oldest_active(&self) -> Generation {
+        Generation(self.readers.keys().next().copied().unwrap_or(self.clock))
+    }
 
-        let len = u32::try_from(payload.len()).map_err(io::Error::other)?;
-        self.log.write_all(&len.to_le_bytes())?;
-        self.log.write_all(&crc32(&payload).to_le_bytes())?;
-        self.log.write_all(&payload)?;
+    /// Stamp the next monotonic generation, respecting the caller's fence.
+    fn tick(&mut self, fence: Generation) -> Generation {
+        self.clock = (self.clock + 1).max(fence.0);
+        Generation(self.clock)
+    }
+
+    fn append(&mut self, op: u8, stamp: Generation, key: &[u8], oid: &[u8]) -> io::Result<()> {
+        write_frame(&mut self.log, op, stamp, key, oid)?;
         if self.sync == SyncPolicy::PerOp {
             self.log.flush()?;
             self.log.get_ref().sync_all()?;
@@ -122,13 +207,98 @@ impl Inner {
     }
 }
 
-/// Rebuild the in-memory map from the WAL, stopping at the first torn/short/bad-CRC
-/// frame (an un-acked write is discarded, never recovered as a live claim).
-fn replay(path: &Path) -> Result<HashMap<Identity, Entry>> {
-    let mut map = HashMap::new();
+/// A live read reservation; pins the GC watermark until dropped.
+pub struct ReadGuard<'a> {
+    store: &'a LocalWalKeyStore,
+    snapshot: Generation,
+}
+
+impl ReadGuard<'_> {
+    /// The snapshot this read is pinned at.
+    pub fn snapshot(&self) -> Generation {
+        self.snapshot
+    }
+}
+
+impl Drop for ReadGuard<'_> {
+    fn drop(&mut self) {
+        let mut g = self.store.inner.lock().unwrap();
+        if let Some(n) = g.readers.get_mut(&self.snapshot.0) {
+            *n -= 1;
+            if *n == 0 {
+                g.readers.remove(&self.snapshot.0);
+            }
+        }
+    }
+}
+
+fn latest(versions: &[Version]) -> Option<&Version> {
+    versions.last()
+}
+
+fn resolve_at(versions: &[Version], snapshot: Generation) -> Option<&Oid> {
+    versions
+        .iter()
+        .rev()
+        .find(|v| v.generation <= snapshot)
+        .and_then(|v| v.oid.as_ref())
+}
+
+/// Keep every version `>= watermark`, plus the single latest version strictly
+/// below it (what a read at the watermark must still resolve). Drop the rest. If
+/// the sole survivor is a tombstone, the key is fully dead -> drop it.
+fn prune(versions: &[Version], watermark: Generation) -> Vec<Version> {
+    let split = versions.partition_point(|v| v.generation < watermark);
+    let mut out = Vec::new();
+    if split > 0 {
+        out.push(versions[split - 1].clone());
+    }
+    out.extend_from_slice(&versions[split..]);
+    if out.len() == 1 && out[0].oid.is_none() {
+        return Vec::new();
+    }
+    out
+}
+
+fn write_frame(
+    w: &mut impl Write,
+    op: u8,
+    stamp: Generation,
+    key: &[u8],
+    oid: &[u8],
+) -> io::Result<()> {
+    let mut payload = Vec::with_capacity(1 + 8 + 4 + key.len() + 4 + oid.len());
+    payload.push(op);
+    payload.extend_from_slice(&stamp.0.to_le_bytes());
+    payload.extend_from_slice(&(key.len() as u32).to_le_bytes());
+    payload.extend_from_slice(key);
+    payload.extend_from_slice(&(oid.len() as u32).to_le_bytes());
+    payload.extend_from_slice(oid);
+
+    let len = u32::try_from(payload.len()).map_err(io::Error::other)?;
+    w.write_all(&len.to_le_bytes())?;
+    w.write_all(&crc32(&payload).to_le_bytes())?;
+    w.write_all(&payload)?;
+    Ok(())
+}
+
+fn open_append(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .read(true)
+        .open(path)
+        .with_context(|| format!("opening WAL at {}", path.display()))
+}
+
+/// Rebuild version histories from the WAL, stopping at the first torn/short/bad-CRC
+/// frame. Returns the map and the max generation seen (the clock).
+fn replay(path: &Path) -> Result<(HashMap<Identity, Vec<Version>>, u64)> {
+    let mut map: HashMap<Identity, Vec<Version>> = HashMap::new();
+    let mut clock = 0u64;
     let mut file = match File::open(path) {
         Ok(f) => f,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(map),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok((map, clock)),
         Err(e) => return Err(e.into()),
     };
     let mut buf = Vec::new();
@@ -139,44 +309,33 @@ fn replay(path: &Path) -> Result<HashMap<Identity, Entry>> {
         let len = u32::from_le_bytes(buf[pos..pos + 4].try_into().unwrap()) as usize;
         let crc = u32::from_le_bytes(buf[pos + 4..pos + 8].try_into().unwrap());
         let start = pos + 8;
-        if start + len > buf.len() {
-            break; // torn tail
+        if start + len > buf.len() || crc32(&buf[start..start + len]) != crc {
+            break; // torn tail or corrupt frame
         }
-        let payload = &buf[start..start + len];
-        if crc32(payload) != crc {
-            break; // corrupt frame
-        }
-        match decode(payload) {
-            Some((op, generation, key, oid)) => {
-                let id = Identity::from_bytes(key);
-                match op {
-                    OP_PUT => match String::from_utf8(oid) {
-                        Ok(s) => {
-                            map.insert(
-                                id,
-                                Entry {
-                                    oid: Oid(s),
-                                    generation,
-                                    live: true,
-                                },
-                            );
-                        }
-                        Err(_) => break, // non-UTF-8 oid -> treat as corrupt
-                    },
-                    OP_TOMBSTONE => {
-                        if let Some(e) = map.get_mut(&id) {
-                            e.generation = generation;
-                            e.live = false;
-                        }
-                    }
-                    _ => break, // unknown op -> stop
-                }
-            }
-            None => break, // undecodable -> torn/corrupt
-        }
+        let Some((op, stamp, key, oid)) = decode(&buf[start..start + len]) else {
+            break;
+        };
+        let version = match op {
+            OP_PUT => match String::from_utf8(oid) {
+                Ok(s) => Version {
+                    generation: stamp,
+                    oid: Some(Oid(s)),
+                },
+                Err(_) => break, // non-UTF-8 oid -> corrupt
+            },
+            OP_TOMBSTONE => Version {
+                generation: stamp,
+                oid: None,
+            },
+            _ => break, // unknown op
+        };
+        clock = clock.max(stamp.0);
+        map.entry(Identity::from_bytes(key))
+            .or_default()
+            .push(version);
         pos = start + len;
     }
-    Ok(map)
+    Ok((map, clock))
 }
 
 fn decode(p: &[u8]) -> Option<(u8, Generation, Vec<u8>, Vec<u8>)> {
@@ -184,7 +343,7 @@ fn decode(p: &[u8]) -> Option<(u8, Generation, Vec<u8>, Vec<u8>)> {
     let op = *p.get(i)?;
     i += 1;
     let gen_bytes: [u8; 8] = p.get(i..i + 8)?.try_into().ok()?;
-    let generation = Generation(u64::from_le_bytes(gen_bytes));
+    let stamp = Generation(u64::from_le_bytes(gen_bytes));
     i += 8;
     let key_len = u32::from_le_bytes(p.get(i..i + 4)?.try_into().ok()?) as usize;
     i += 4;
@@ -195,9 +354,9 @@ fn decode(p: &[u8]) -> Option<(u8, Generation, Vec<u8>, Vec<u8>)> {
     let oid = p.get(i..i + oid_len)?.to_vec();
     i += oid_len;
     if i != p.len() {
-        return None; // trailing bytes -> reject
+        return None;
     }
-    Some((op, generation, key, oid))
+    Some((op, stamp, key, oid))
 }
 
 #[async_trait::async_trait]
@@ -214,38 +373,46 @@ impl ConditionalKeyStore for LocalWalKeyStore {
     ) -> Result<PutOutcome> {
         // Blocking WAL I/O under a std mutex; no `.await` is held across the lock.
         let mut g = self.inner.lock().unwrap();
-        if let Some(e) = g.map.get(key).filter(|e| e.live) {
+        if let Some(v) = g.map.get(key).and_then(|vs| latest(vs))
+            && let Some(holder) = &v.oid
+        {
             return Ok(PutOutcome::Conflict {
-                holder: e.oid.clone(),
-                generation: e.generation,
+                holder: holder.clone(),
+                generation: v.generation,
             });
         }
-        g.append(OP_PUT, fence, key.as_bytes(), oid.0.as_bytes())?;
-        g.map.insert(
-            key.clone(),
-            Entry {
-                oid: oid.clone(),
-                generation: fence,
-                live: true,
-            },
-        );
-        Ok(PutOutcome::Committed { generation: fence })
+        let stamp = g.tick(fence);
+        g.append(OP_PUT, stamp, key.as_bytes(), oid.0.as_bytes())?;
+        g.map.entry(key.clone()).or_default().push(Version {
+            generation: stamp,
+            oid: Some(oid.clone()),
+        });
+        Ok(PutOutcome::Committed { generation: stamp })
     }
 
     async fn get(&self, key: &Identity) -> Result<Option<Oid>> {
         let g = self.inner.lock().unwrap();
-        Ok(g.map.get(key).filter(|e| e.live).map(|e| e.oid.clone()))
+        Ok(g.map
+            .get(key)
+            .and_then(|vs| latest(vs))
+            .and_then(|v| v.oid.clone()))
     }
 
     async fn tombstone(&self, key: &Identity, fence: Generation) -> Result<()> {
         let mut g = self.inner.lock().unwrap();
-        let present = g.map.get(key).map(|e| e.live).unwrap_or(false);
-        if present {
-            g.append(OP_TOMBSTONE, fence, key.as_bytes(), &[])?;
-            if let Some(e) = g.map.get_mut(key) {
-                e.generation = fence;
-                e.live = false;
-            }
+        let live = g
+            .map
+            .get(key)
+            .and_then(|vs| latest(vs))
+            .map(|v| v.oid.is_some())
+            .unwrap_or(false);
+        if live {
+            let stamp = g.tick(fence);
+            g.append(OP_TOMBSTONE, stamp, key.as_bytes(), &[])?;
+            g.map.entry(key.clone()).or_default().push(Version {
+                generation: stamp,
+                oid: None,
+            });
         }
         Ok(())
     }
@@ -258,8 +425,7 @@ mod tests {
     fn id(s: &str) -> Identity {
         Identity::from_bytes(s.as_bytes().to_vec())
     }
-    fn tmp() -> std::path::PathBuf {
-        // A unique-enough path without Date/rand: process id + a static counter.
+    fn tmp() -> PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
         static N: AtomicU64 = AtomicU64::new(0);
         let n = N.fetch_add(1, Ordering::Relaxed);
@@ -267,70 +433,88 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lifecycle_and_durability() {
+    async fn mvcc_snapshot_resolution_and_monotonic_generations() {
         let path = tmp();
-        let a = Oid("row-a".into());
-        let b = Oid("row-b".into());
+        let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
+        let a = Oid("a".into());
+        let b = Oid("b".into());
+
+        // put(a), tombstone, put(b) -> strictly increasing generations.
+        let g1 = match s.put_if_absent(&id("k"), &a, Generation(0)).await.unwrap() {
+            PutOutcome::Committed { generation } => generation,
+            other => panic!("{other:?}"),
+        };
+        s.tombstone(&id("k"), Generation(0)).await.unwrap();
+        let g3 = match s.put_if_absent(&id("k"), &b, Generation(0)).await.unwrap() {
+            PutOutcome::Committed { generation } => generation,
+            other => panic!("{other:?}"),
+        };
+        assert!(g1 < g3, "generations must be monotonic: {g1:?} < {g3:?}");
+
+        // Snapshot reads see the version visible at that generation.
+        assert_eq!(s.get_at(&id("k"), g1), Some(a.clone())); // at g1, 'a' is live
+        assert_eq!(s.get_at(&id("k"), Generation(g3.0 - 1)), None); // after tombstone, before g3
+        assert_eq!(s.get_at(&id("k"), g3), Some(b.clone())); // at g3, 'b' is live
+        assert_eq!(s.get(&id("k")).await.unwrap(), Some(b)); // current
+
+        // A higher fence jumps the clock (fence is respected).
+        match s
+            .put_if_absent(&id("k2"), &a, Generation(1000))
+            .await
+            .unwrap()
         {
-            let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
-            assert_eq!(
-                s.put_if_absent(&id("k1"), &a, Generation(1)).await.unwrap(),
-                PutOutcome::Committed {
-                    generation: Generation(1)
-                }
-            );
-            // Conflict returns the holder.
-            assert_eq!(
-                s.put_if_absent(&id("k1"), &b, Generation(2)).await.unwrap(),
-                PutOutcome::Conflict {
-                    holder: a.clone(),
-                    generation: Generation(1)
-                }
-            );
-            s.tombstone(&id("k1"), Generation(3)).await.unwrap();
-            assert_eq!(s.get(&id("k1")).await.unwrap(), None);
-            // Re-insert after tombstone is a new claim (append-only reclaim).
-            assert_eq!(
-                s.put_if_absent(&id("k1"), &b, Generation(4)).await.unwrap(),
-                PutOutcome::Committed {
-                    generation: Generation(4)
-                }
-            );
-        }
-        // Reopen: the WAL-rebuilt state must survive restart.
-        {
-            let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
-            assert_eq!(s.get(&id("k1")).await.unwrap(), Some(b));
-            // The claimed key still conflicts after restart.
-            match s.put_if_absent(&id("k1"), &a, Generation(9)).await.unwrap() {
-                PutOutcome::Conflict { holder, .. } => assert_eq!(holder, Oid("row-b".into())),
-                other => panic!("expected conflict after restart, got {other:?}"),
-            }
+            PutOutcome::Committed { generation } => assert!(generation.0 >= 1000),
+            other => panic!("{other:?}"),
         }
         let _ = std::fs::remove_file(&path);
     }
 
     #[tokio::test]
-    async fn torn_tail_is_discarded() {
+    async fn compaction_bounds_history_but_preserves_visible_state_and_survives_restart() {
         let path = tmp();
         {
             let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
-            s.put_if_absent(&id("good"), &Oid("v".into()), Generation(1))
+            let a = Oid("a".into());
+            let b = Oid("b".into());
+            // Churn a key through several versions with no active readers.
+            s.put_if_absent(&id("k"), &a, Generation(0)).await.unwrap();
+            s.tombstone(&id("k"), Generation(0)).await.unwrap();
+            s.put_if_absent(&id("k"), &b, Generation(0)).await.unwrap();
+            // A separate key that ends dead should be reclaimed entirely.
+            s.put_if_absent(&id("dead"), &a, Generation(0))
                 .await
                 .unwrap();
-            s.flush().unwrap();
+            s.tombstone(&id("dead"), Generation(0)).await.unwrap();
+
+            s.compact().unwrap(); // watermark = current clock (no readers)
+
+            assert_eq!(s.get(&id("k")).await.unwrap(), Some(b));
+            assert_eq!(s.get(&id("dead")).await.unwrap(), None);
         }
-        // Corrupt the tail by appending a bogus (short) frame header.
+        // Compacted WAL replays to the same visible state.
         {
-            use std::io::Write as _;
-            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
-            f.write_all(&999u32.to_le_bytes()).unwrap(); // claims 999 bytes that aren't there
-            f.write_all(&0u32.to_le_bytes()).unwrap();
-            f.flush().unwrap();
+            let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
+            assert_eq!(s.get(&id("k")).await.unwrap(), Some(Oid("b".into())));
+            assert_eq!(s.get(&id("dead")).await.unwrap(), None);
         }
-        // Replay stops at the torn frame; the good record survives.
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn active_reader_pins_the_watermark() {
+        let path = tmp();
         let s = LocalWalKeyStore::open(&path, SyncPolicy::PerOp).unwrap();
-        assert_eq!(s.get(&id("good")).await.unwrap(), Some(Oid("v".into())));
+        let a = Oid("a".into());
+        let b = Oid("b".into());
+        s.put_if_absent(&id("k"), &a, Generation(0)).await.unwrap();
+        let snap = s.snapshot();
+        let reader = s.begin_read(); // pins `snap`
+        s.tombstone(&id("k"), Generation(0)).await.unwrap();
+        s.put_if_absent(&id("k"), &b, Generation(0)).await.unwrap();
+
+        s.compact().unwrap(); // must NOT drop the version visible at `snap`
+        assert_eq!(s.get_at(&id("k"), snap), Some(a)); // reader still sees 'a'
+        drop(reader);
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## What
**F1d** — reworks `LocalWalKeyStore` (F1b) from single-version to an **append-only MVCC** key store.

- **Version history per key** (`Some(oid)` = claim, `None` = tombstone), in WAL append (= generation) order. A PK update/delete + re-insert appends *new* versions; a slot is never overwritten (D11/D14).
- **Monotonic generation clock** (`≥` caller fence) → **ABA defense**: a reused key can never masquerade as an older version.
- **`get_at(snapshot)`** — resolve the version with the greatest generation `≤ snapshot` (the MVCC visibility the record store reads against).
- **`begin_read()`** pins a reader watermark; **`compact()`** rewrites the WAL dropping every version no active reader can still observe (atomic temp-file + rename), bounding WAL growth without losing visible state. Physical scheduling is the F6 plane.

## Tests
MVCC snapshot resolution + monotonic generations; compaction bounds history but preserves visible state + **survives restart**; **active-reader-pins-the-watermark** (compaction must not drop a version a live reader can still see). `cargo fmt` + `cargo clippy -D warnings` clean.

Builds on F1b (merged). Completes the local-WAL default: fenced contract (F1a) + durable MVCC impl.