### PR TITLE
feat(dml): F2 fenced composite-PK uniqueness in the insert path (ADR-072 D3/D5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,6 +824,10 @@ jobs:
           # Ledger modality gRPC service (S3, ADR-071) — the ProximaLedgerService + its port wiring
           # are behind the non-default `experimental-ledger` feature on the root crate.
           - { label: "experimental-ledger", pkg: proximadb,        args: "--features experimental-ledger" }
+          # F2 (ADR-072 D3/D5): the fenced ConditionalKeyStore in the relational insert
+          # path is behind the non-default `oltp-integrity` feature; check it compiles so
+          # cfg drift in that path is caught (the feature-gated test executes locally).
+          - { label: "oltp-integrity",       pkg: proximadb,        args: "--features oltp-integrity" }
           # Refactor/move coverage: these configurations catch cfg drift hidden
           # by the default build. Keep them in the same mandatory matrix rather
           # than relying on a PR being correctly labelled as mechanical.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6747,6 +6747,7 @@ dependencies = [
  "proximadb-cache",
  "proximadb-catalog",
  "proximadb-catalog-introspection",
+ "proximadb-cks-local",
  "proximadb-clustering-kernel",
  "proximadb-codec",
  "proximadb-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -396,6 +396,10 @@ proximadb-observability = { path = "crates/modalities/proximadb-observability" }
 proximadb-observability-engine = { path = "crates/modalities/proximadb-observability-engine" }
 # Optional: the experimental transactional Ledger modality (gated by `experimental-ledger`).
 proximadb-ledger = { path = "crates/modalities/proximadb-ledger", optional = true }
+# F2 (ADR-072 D3/D5): the generation-fenced local-WAL ConditionalKeyStore impl,
+# wired into the relational insert path for atomic composite-PK uniqueness under
+# the `oltp-integrity` feature. Optional → default builds are byte-for-byte unchanged.
+proximadb-cks-local = { path = "crates/storage/proximadb-cks-local", optional = true }
 proximadb-embedding = { path = "crates/modalities/proximadb-embedding" }
 proximadb-queue = { path = "crates/modalities/proximadb-queue" }
 proximadb-rank-core = { path = "crates/modalities/proximadb-rank-core" }
@@ -696,6 +700,10 @@ experimental-engines = ["proximadb-raptor-engine/experimental-engines"]
 # Experimental transactional Ledger modality (ADR-071 / TD-LEDGER-1): the durable atomic-CAS
 # KV + TTL-lease OLTP surface. Off by default; enables the durable backend + its gRPC service.
 experimental-ledger = ["dep:proximadb-ledger", "proximadb-ledger/durable"]
+# F2 (ADR-072 D3/D5): enable the fenced ConditionalKeyStore in the relational insert
+# path. Off by default → the existing check-then-act PK-uniqueness probe runs unchanged;
+# on, a LocalWalKeyStore is wired in and enforces composite-PK uniqueness atomically.
+oltp-integrity = ["dep:proximadb-cks-local"]
 # Experimental SIMD path; not enabled by default
 simd-experimental = ["proximadb-codec/simd-experimental"]
 # TD-160 / ADR-027 / ADR-030: gate the PERF-CLASS I/O-trace *emission* (the

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -819,6 +819,12 @@ pub struct DmlService {
     /// Optional tenant-scoped DML lock service. When absent, DML executes with
     /// the legacy local behavior.
     dml_lock_service: Option<Arc<DmlLockService>>,
+    /// F2 (ADR-072 D3/D5): when present, composite-PK uniqueness is enforced by a
+    /// fenced `put_if_absent` at write time instead of the check-then-act
+    /// `get_by_key` probe. `None` (the default) keeps the legacy probe path;
+    /// a store is wired only at the composition root under the `oltp-integrity`
+    /// feature, so default builds are behaviorally unchanged.
+    conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
 }
 
 /// ADR-025: `DmlService` is the authoritative post-snapshot delta source for the
@@ -994,7 +1000,20 @@ impl DmlService {
             record_store,
             table_write_executor,
             dml_lock_service: None,
+            conditional_key_store: None,
         }
+    }
+
+    /// F2 (ADR-072 D3/D5): wire a fenced `ConditionalKeyStore` so composite-PK
+    /// uniqueness is enforced atomically at write time rather than by the
+    /// check-then-act probe. Injected at the composition root under the
+    /// `oltp-integrity` feature; absent by default.
+    pub fn with_conditional_key_store(
+        mut self,
+        store: Arc<dyn proximadb_storage_ports::ConditionalKeyStore>,
+    ) -> Self {
+        self.conditional_key_store = Some(store);
+        self
     }
 
     /// T4.1: Get the canonical table-record store.
@@ -3018,20 +3037,38 @@ impl DmlService {
                         key
                     ));
                 }
-                let existing = self
-                    .record_store
-                    .get_by_key(
-                        &table_schema,
-                        TableRecordGetRequest {
-                            table_id: table_id.name.clone(),
-                            key: key.clone(),
-                            include_vector: false,
-                            include_props: false,
-                        },
-                        None,
+                // F2 (ADR-072 D3): when a fenced ConditionalKeyStore is wired, claim
+                // the PK atomically (oid == primary_key_string, so the row is keyed by
+                // its own PK) — a live holder is a duplicate. Otherwise fall back to the
+                // legacy check-then-act `get_by_key` probe. The op-lock is still held for
+                // cascade ordering (D3). NB: the claim and the later `write_mutations`
+                // row write are not yet a single atomic apply — that is the D11
+                // append-only-MVCC follow-up; recovery treats a claimed-but-rowless key
+                // as dead.
+                let is_duplicate = if let Some(cks) = &self.conditional_key_store {
+                    use proximadb_storage_ports::{Generation, Identity, Oid, PutOutcome};
+                    let id = Identity::from_bytes(key.clone().into_bytes());
+                    matches!(
+                        cks.put_if_absent(&id, &Oid(key.clone()), Generation(0))
+                            .await?,
+                        PutOutcome::Conflict { .. }
                     )
-                    .await?;
-                if existing.is_some() {
+                } else {
+                    self.record_store
+                        .get_by_key(
+                            &table_schema,
+                            TableRecordGetRequest {
+                                table_id: table_id.name.clone(),
+                                key: key.clone(),
+                                include_vector: false,
+                                include_props: false,
+                            },
+                            None,
+                        )
+                        .await?
+                        .is_some()
+                };
+                if is_duplicate {
                     return Err(anyhow!(
                         "duplicate key value violates primary key '{}' on table '{}': '{}' already exists",
                         pk_column,

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -1456,6 +1456,88 @@ async fn insert_rejects_duplicate_primary_key() {
     .expect("distinct key insert");
 }
 
+/// F2 (ADR-072 D3/D5): with a fenced `ConditionalKeyStore` wired via
+/// `with_conditional_key_store`, a duplicate PK is rejected by the store's
+/// `put_if_absent` (a live holder) rather than the `get_by_key` probe.
+#[cfg(feature = "oltp-integrity")]
+#[tokio::test]
+async fn insert_rejects_duplicate_primary_key_via_fenced_store() {
+    use crate::services::record_store::DirectWalTableRecordStore;
+    use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+    use proximadb_cks_local::{LocalWalKeyStore, SyncPolicy};
+
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(CatalogManager::new());
+    manager
+        .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+        .await
+        .expect("native catalog");
+    let ddl = DdlService::new(manager.clone());
+    ddl.execute(DdlStatement::CreateNamespace {
+        namespace: vec!["default".to_string()],
+        if_not_exists: true,
+        properties: HashMap::new(),
+    })
+    .await
+    .expect("create namespace");
+    let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+    let ddl_stmt = parser
+        .parse_ddl("CREATE TABLE users (id TEXT NOT NULL, email TEXT NOT NULL, PRIMARY KEY (id));")
+        .expect("parse create")
+        .expect("ddl");
+    ddl.execute(ddl_stmt).await.expect("create table");
+
+    let wal_appender = Arc::new(
+        FramedTableWalAppender::open(temp_dir.path().join("pk.wal"))
+            .await
+            .expect("open WAL"),
+    );
+    let record_store = Arc::new(DirectWalTableRecordStore::new(
+        Arc::new(MemtableRecordStorage::new()),
+        wal_appender,
+    ));
+    let cks = Arc::new(
+        LocalWalKeyStore::open(temp_dir.path().join("cks.wal"), SyncPolicy::PerOp)
+            .expect("open cks"),
+    );
+    let dml = DmlService::with_record_store_and_table_write_executor(
+        manager.clone(),
+        record_store,
+        Arc::new(PlannedOnlyTableWriteExecutor::new()),
+    )
+    .with_conditional_key_store(cks);
+
+    let insert = |sql: &'static str| {
+        let p = &parser;
+        p.parse_dml(sql).expect("parse dml").expect("dml")
+    };
+
+    dml.execute(insert(
+        "INSERT INTO users (id, email) VALUES ('u1', 'a@x.com');",
+    ))
+    .await
+    .expect("first insert");
+
+    let err = dml
+        .execute(insert(
+            "INSERT INTO users (id, email) VALUES ('u1', 'b@x.com');",
+        ))
+        .await
+        .expect_err("duplicate PK must be rejected by the fenced store");
+    assert!(
+        err.to_string()
+            .contains("duplicate key value violates primary key"),
+        "unexpected error: {err}"
+    );
+
+    // A distinct key still inserts through the fenced path.
+    dml.execute(insert(
+        "INSERT INTO users (id, email) VALUES ('u3', 'e@x.com');",
+    ))
+    .await
+    .expect("distinct key insert");
+}
+
 #[tokio::test]
 async fn insert_rejects_duplicate_unique_constraint() {
     // TD-110: a non-PK UNIQUE column rejects a duplicate value against a


### PR DESCRIPTION
## What
**F2** — wires the `ConditionalKeyStore` (F1a/F1b) into the relational **INSERT** path, so composite-PK uniqueness is enforced by a **fenced, storage-level atomic write** instead of the check-then-act `get_by_key` probe. Behind the new **`oltp-integrity`** feature, **off by default**.

- **Cargo:** optional `proximadb-cks-local` dep + `oltp-integrity` feature (mirrors `experimental-ledger`).
- **`DmlService`:** `conditional_key_store: Option<Arc<dyn ConditionalKeyStore>>` (`None` by default) + a `with_conditional_key_store` builder (injected at the composition root under the feature).
- **`execute_insert`** (the TD-110 PK block): when a store is wired, claim the PK via a fenced `put_if_absent` (`oid == primary_key_string`, so the row is keyed by its own PK) — a live holder is the duplicate. Otherwise the existing `get_by_key` probe runs. **Op-lock retained** for cascade ordering (D3); within-batch dedup unchanged.

## Safety
Additive + feature-gated: the field defaults `None` and the fenced branch is `if let Some(store)`, so the **default build and every existing test are behaviorally identical**. Both feature states `cargo check`-clean.

## Known follow-up (documented in-code)
The `put_if_absent` claim and the later `write_mutations` row write are **not yet a single atomic apply** — that's the D11 append-only-MVCC follow-up (F1d's versioning + watermark GC are the machinery for it); recovery treats a claimed-but-rowless key as dead.

## Test
Feature-gated `insert_rejects_duplicate_primary_key_via_fenced_store`: wires a `LocalWalKeyStore`, asserts a duplicate INSERT is rejected via the fenced store while a distinct key still inserts.

Completes the F1→F2 arc: contract (F1a) + both impls (F1b/F1c/F1d) + first live use in the insert path.