### PR TITLE
feat(dml): F2b typed Identity key + disentangle uniqueness scoping vs access control (ADR-072 D9/D6-P7)

### DIFF
--- a/crates/storage/proximadb-storage-ports/src/conditional_key_store.rs
+++ b/crates/storage/proximadb-storage-ports/src/conditional_key_store.rs
@@ -13,14 +13,19 @@
 //! conflict **returns the current holder** (Cornus `LogOnce` returns the settled
 //! state).
 //!
-//! ## Tenancy is fail-closed by construction
+//! ## The key prefix is uniqueness *scoping*, not access control
 //!
-//! ADR-072 D3's signature named `tenant` + `keyspace` explicitly. They are
-//! **folded into the [`Identity`]'s leading prefix** by the F0 key codec
-//! (`proximadb_data_model::key_codec::encode_identity`, D9): a caller for tenant
-//! *A* literally cannot form tenant *B*'s key, so cross-tenant access is
-//! structurally impossible rather than checked. `get`/`tombstone` likewise key on
-//! the full `Identity`.
+//! The [`Identity`]'s leading tenant/keyspace prefix (from the F0 codec,
+//! `key_codec::encode_identity`, D9) exists so the same PK value in different
+//! tenants/tables is a **distinct uniqueness domain** — it *partitions the
+//! keyspace*, it does not authorize anyone. The prefix is *derived from* the
+//! caller's already-authenticated tenant, so uniqueness is scoped correctly; but
+//! the security boundary is the **authenticated subject + ABAC row-level filters
+//! applied at runtime** (ADR-072 D15/D6), governed by the catalog metamodel (D12)
+//! with subject↔permission bindings in a system namespace. Row-, field-, and
+//! attribute-level policies cannot live in a key — they are runtime filters,
+//! never this store's concern. `get`/`tombstone` likewise key on the full
+//! `Identity`.
 //!
 //! ## Two implementations, one contract (ADR-072 D5)
 //!

--- a/docs/12-design/adr/ADR-072-foundational-contract-consolidation.adoc
+++ b/docs/12-design/adr/ADR-072-foundational-contract-consolidation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed — P3 research-calibrated** (2026-07-24). Formalizes link:../../rfcs/0002-foundational-modality-consolidation.adoc[RFC-0002]; build plan in link:../../10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc[TD-FOUNDATION-1]. Additive + feature-gated; `default` behavior unchanged until each modality opts in. **P2: D3/D5 amended + D9/D10 added after a three-model adversarial review (Kimi, GLM-5.2, DeepSeek) reconciled against the code. P3: D11/D12 added + D3/D5/D1 refined after calibrating against 10 research papers. P4: D13 added — per-modality calibration (columnar/PAX substrate, per-modality identity, vector-RLS, graph-address WAL) from 5 vector/graph/field-report papers + TS systems. P5: D14 added — delete representation is tier-split (MVCC visibility model + deletion vectors in the immutable cold tier). P6: D15/D16/D17 added — production-systems calibration (LanceDB, Vespa, Weaviate): cost-based hybrid/filter planner, tiered compute placement, first-class background plane, + adaptive-encoding/deletion/tenant-lifecycle refinements. See _Design-gate revision (P3)/(P6)_ and _Research bibliography_.**
+| Status | **Proposed — P3 research-calibrated** (2026-07-24). Formalizes link:../../rfcs/0002-foundational-modality-consolidation.adoc[RFC-0002]; build plan in link:../../10-quality/td/TD-FOUNDATION-1-modality-consolidation.adoc[TD-FOUNDATION-1]. Additive + feature-gated; `default` behavior unchanged until each modality opts in. **P2: D3/D5 amended + D9/D10 added after a three-model adversarial review (Kimi, GLM-5.2, DeepSeek) reconciled against the code. P3: D11/D12 added + D3/D5/D1 refined after calibrating against 10 research papers. P4: D13 added — per-modality calibration (columnar/PAX substrate, per-modality identity, vector-RLS, graph-address WAL) from 5 vector/graph/field-report papers + TS systems. P5: D14 added — delete representation is tier-split (MVCC visibility model + deletion vectors in the immutable cold tier). P6: D15/D16/D17 added — production-systems calibration (LanceDB, Vespa, Weaviate): cost-based hybrid/filter planner, tiered compute placement, first-class background plane, + adaptive-encoding/deletion/tenant-lifecycle refinements. P7: D6 clarified — three planes disentangled (uniqueness-**scoping** key / order-preserving **storage-index** key / **ABAC-runtime-filter** access control), correcting any "fail-closed via the key prefix" phrasing. See _Design-gate revision (P3)/(P6)_ and _Research bibliography_.**
 | Decider | Vijaykumar Singh (2026-07-24)
 | Date | 2026-07-24
 | Relates to | link:ADR-039-olap-engine-boundary-swappable-physical-backend.adoc[ADR-039] (DataFusion swappable behind the read IR — the compute half of the storage⊥compute decoupling), link:ADR-069-wal-local-disk-tiered-flush.adoc[ADR-069] (local-disk WAL substrate), link:ADR-071-transactional-ledger-modality.adoc[ADR-071] (ledger dedicated WAL — the "divergent access ⇒ own impl behind the contract" precedent), link:ADR-052-analytics-execution-competitiveness-codesign.adoc[ADR-052] (co-design spine).
@@ -92,6 +92,16 @@ One contract, two placements.)_
 **D6 — Tenancy in every contract signature; enterprise security is structural.** `TenantContext`
 (fail-closed), `DrPathBuilder` per-tenant paths, and `ObjectAccessTier` are foundation facilities every
 modality inherits at the contract boundary — never re-implemented per silo. Neutral units only.
+_(Clarified P7 — three distinct planes, do not conflate: (1) the **uniqueness key** (`Identity`, D9) —
+its tenant/keyspace prefix is uniqueness **scoping** (so a PK does not collide across containers), *not*
+an access-control boundary; (2) the **storage/index key** — where the *order-preserving* typed encoding
+earns its keep (range scans on index-organized rows); the uniqueness store **reuses** the same
+`Identity`, but order-preservation is incidental to uniqueness. (3) **Access control (RLS)** — enforced
+at **runtime by ABAC filters** (D15), always-ANDed into the scan, over the catalog metamodel's
+container hierarchy (namespace/db → collection/table → column/field, D12), resolved against the
+authenticated subject's attributes, with subject↔permission bindings in a **system namespace**. A key
+never authorizes; row-/field-/attribute-level policy cannot live in a key. Supersedes any earlier
+"tenant isolation is fail-closed *by construction via the key prefix*" phrasing.)_
 
 **D7 — Compile-time modality composition.** Every modality + its contract impls are `#[cfg]`-gated
 features, so a deployment links only what it runs (lean profiles) — per the modality-composition

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -3047,7 +3047,28 @@ impl DmlService {
                 // as dead.
                 let is_duplicate = if let Some(cks) = &self.conditional_key_store {
                     use proximadb_storage_ports::{Generation, Identity, Oid, PutOutcome};
-                    let id = Identity::from_bytes(key.clone().into_bytes());
+                    // Key on the F0 typed, order-preserving codec (length-delimited,
+                    // NULL-explicit, no separator collision) built from the row's typed
+                    // PK value and its tenant/keyspace scope — not the legacy oid string
+                    // (ADR-072 D9). Single-column PK matches this block's scope; the oid
+                    // it maps to stays the row's PK-string identity.
+                    let pk_value = match record.props.get(&pk_column) {
+                        Some(ProximaTreeNode::Value(v)) => v.clone(),
+                        _ => {
+                            return Err(anyhow!(
+                                "primary key column '{}' missing from record for '{}' on table '{}'",
+                                pk_column,
+                                key,
+                                table_schema.name
+                            ));
+                        }
+                    };
+                    let id =
+                        Identity::from_bytes(proximadb_data_model::key_codec::encode_identity(
+                            &record.tenant_id,
+                            &table_schema.name,
+                            std::slice::from_ref(&pk_value),
+                        )?);
                     matches!(
                         cks.put_if_absent(&id, &Oid(key.clone()), Generation(0))
                             .await?,


### PR DESCRIPTION
## Context
A design-review catch: the earlier framing **conflated the per-row uniqueness key with access control** ("tenancy is fail-closed *by construction via the key prefix*"). This PR corrects that and, per the accompanying decision, makes the insert path use the real typed F0 codec.

## Two coupled changes

**Code — typed key (F0/D9):** `execute_insert` builds the `ConditionalKeyStore` key from the F0 typed, order-preserving codec — `encode_identity(tenant, keyspace, [pk_value])` using the row's **typed** primary-key value — instead of the interim oid string. The record store is index-organized by PK, so the order-preserving key is already needed for range scans; the uniqueness store **reuses that one `Identity`** (DRY). The oid it maps to stays the row's PK-string identity.

**Framing — the actual fix (disentangle three planes):**
1. **Uniqueness-scoping key** — the `Identity`'s tenant/keyspace prefix *partitions the keyspace* so a PK can't collide across containers. It is **not** an access-control boundary.
2. **Storage/index key** — where the *order-preserving* typed encoding earns its keep (range scans on index-organized rows); the uniqueness store reuses it, order-preservation incidental to uniqueness.
3. **Access control (RLS)** — enforced at **runtime by ABAC filters (D15)**, always-ANDed into the scan, over the catalog metamodel hierarchy (namespace/db → collection/table → column/field, **D12**), resolved against the authenticated subject's attributes, with subject↔permission bindings in a **system namespace**. **A key never authorizes.**

Corrected in the `ConditionalKeyStore` module doc and **ADR-072 D6 (P7 clarification)**.

## Safety
Additive + feature-gated: the enforcement branch is always-compiled, active only when a store is wired (`oltp-integrity`, off by default). **feature-off compiles clean**; the feature-gated test `insert_rejects_duplicate_primary_key_via_fenced_store` **passes** with the typed key. Doc guards green.