### PR TITLE
feat(flush): TD-FLUSH-5 parallel encode (bounded, byte-identical) + env-gate S3 first prune pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6968,6 +6968,7 @@ dependencies = [
  "proximadb-data-model",
  "proximadb-filter-expression",
  "proximadb-records",
+ "rayon",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/crates/storage/proximadb-block-format/Cargo.toml
+++ b/crates/storage/proximadb-block-format/Cargo.toml
@@ -22,6 +22,7 @@ rmp-serde.workspace = true
 
 # Codec layer: encoding schemes for column stripes
 proximadb-codec = { workspace = true }
+rayon = { workspace = true }
 
 # Type system: ProximaValue, ProximaType for column value encoding
 proximadb-data-model = { workspace = true }

--- a/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
@@ -156,15 +156,44 @@ pub fn encode_region(
             buf[bitmap_off + (i >> 3)] |= 1u8 << (i & 7);
         }
     }
-    for v in vectors {
-        match v {
-            Some(vec) => {
-                let code = encode(vec, &params, &rotation);
-                buf.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
-                buf.extend_from_slice(&code.inv_factor.to_le_bytes());
-                buf.extend_from_slice(&code.bits);
+    // TD-FLUSH-5: pass 2 (per-row encode) is embarrassingly parallel — row
+    // i's bytes depend only on vectors[i] + the shared immutable
+    // params/rotation fit in pass 1 (which stays sequential so the float
+    // reductions are bit-stable). Ordered par_iter + in-order concat is
+    // byte-identical to the sequential loop (pinned by the unit test). The
+    // rotation apply is O(dim²)/row — the measured 43.9 s / 884k-row flush
+    // hotspot. Small regions keep the sequential loop (no pool overhead).
+    const PAR_ENCODE_MIN_ROWS: usize = 4096;
+    if n >= PAR_ENCODE_MIN_ROWS {
+        use rayon::prelude::*;
+        let rows: Vec<Vec<u8>> = vectors
+            .par_iter()
+            .map(|v| match v {
+                Some(vec) => {
+                    let code = encode(vec, &params, &rotation);
+                    let mut row = Vec::with_capacity(stride);
+                    row.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
+                    row.extend_from_slice(&code.inv_factor.to_le_bytes());
+                    row.extend_from_slice(&code.bits);
+                    row
+                }
+                None => vec![0u8; stride],
+            })
+            .collect();
+        for row in rows {
+            buf.extend_from_slice(&row);
+        }
+    } else {
+        for v in vectors {
+            match v {
+                Some(vec) => {
+                    let code = encode(vec, &params, &rotation);
+                    buf.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
+                    buf.extend_from_slice(&code.inv_factor.to_le_bytes());
+                    buf.extend_from_slice(&code.bits);
+                }
+                None => buf.extend(std::iter::repeat_n(0u8, stride)),
             }
-            None => buf.extend(std::iter::repeat_n(0u8, stride)),
         }
     }
     Ok((buf, params.centroid))
@@ -367,6 +396,62 @@ mod tests {
             parsed.code(ranked[0]).is_some(),
             "top survivor must be present"
         );
+    }
+
+    /// TD-FLUSH-5: the parallel pass-2 encode (n >= 4096 -> rayon) must be
+    /// BYTE-IDENTICAL to the sequential reference — same header, bitmap, and
+    /// per-row codes in row order. The reference is built inline with the
+    /// same pass-1 params + per-row `encode` calls.
+    #[test]
+    fn parallel_encode_region_is_byte_identical() {
+        const DIM: usize = 32;
+        const N: usize = 5000; // above PAR_ENCODE_MIN_ROWS
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| synth_vec(i as u64, DIM)).collect();
+        let vectors: Vec<Option<&[f32]>> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                if i % 97 == 13 {
+                    None
+                } else {
+                    Some(v.as_slice())
+                }
+            })
+            .collect();
+        let seed = RABITQ_SEED_BASE ^ 99;
+        let (region, _) = encode_region(&vectors, DIM as u32, seed).unwrap();
+
+        // sequential reference
+        let present: Vec<&[f32]> = vectors.iter().filter_map(|o| *o).collect();
+        let params = fit_params(&present, DIM, seed);
+        let rotation = build_rotation(DIM, seed);
+        let stride = 8 + DIM.div_ceil(8);
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&(N as u32).to_le_bytes());
+        expected.extend_from_slice(&(DIM as u32).to_le_bytes());
+        expected.extend_from_slice(&seed.to_le_bytes());
+        for &c in &params.centroid {
+            expected.extend_from_slice(&c.to_le_bytes());
+        }
+        let bitmap_off = expected.len();
+        expected.resize(expected.len() + N.div_ceil(8), 0u8);
+        for (i, v) in vectors.iter().enumerate() {
+            if v.is_some() {
+                expected[bitmap_off + (i >> 3)] |= 1u8 << (i & 7);
+            }
+        }
+        for v in &vectors {
+            match v {
+                Some(vec) => {
+                    let code = encode(vec, &params, &rotation);
+                    expected.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
+                    expected.extend_from_slice(&code.inv_factor.to_le_bytes());
+                    expected.extend_from_slice(&code.bits);
+                }
+                None => expected.extend(std::iter::repeat_n(0u8, stride)),
+            }
+        }
+        assert_eq!(region, expected, "parallel encode must be byte-identical");
     }
 
     /// TD-SEARCH-2 S2: morsel equivalence — merging per-chunk

--- a/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
@@ -117,6 +117,24 @@ impl CoalescedRaBitQHeader {
 ///
 /// Reuses the canonical codec ([`fit_params`] → [`build_rotation`] → [`encode`])
 /// — no hand-rolled quantizer.
+/// TD-FLUSH-5: encode-pool width. Default HALF the cores (min 2) so a flush
+/// never starves concurrent queries (the search morsels own the other half —
+/// co-design headroom, mirroring TD-SEARCH-2's adaptive degree).
+/// `PROXIMADB_PAX_ENCODE_THREADS` overrides (1 = sequential).
+pub(crate) fn encode_pool_threads() -> usize {
+    if let Ok(v) = std::env::var("PROXIMADB_PAX_ENCODE_THREADS")
+        && let Ok(n) = v.trim().parse::<usize>()
+        && n > 0
+    {
+        return n;
+    }
+    (std::thread::available_parallelism()
+        .map(|c| c.get())
+        .unwrap_or(2)
+        / 2)
+    .max(2)
+}
+
 pub fn encode_region(
     vectors: &[Option<&[f32]>],
     dim: u32,
@@ -164,22 +182,31 @@ pub fn encode_region(
     // rotation apply is O(dim²)/row — the measured 43.9 s / 884k-row flush
     // hotspot. Small regions keep the sequential loop (no pool overhead).
     const PAR_ENCODE_MIN_ROWS: usize = 4096;
-    if n >= PAR_ENCODE_MIN_ROWS {
+    if n >= PAR_ENCODE_MIN_ROWS && encode_pool_threads() > 1 {
         use rayon::prelude::*;
-        let rows: Vec<Vec<u8>> = vectors
-            .par_iter()
-            .map(|v| match v {
-                Some(vec) => {
-                    let code = encode(vec, &params, &rotation);
-                    let mut row = Vec::with_capacity(stride);
-                    row.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
-                    row.extend_from_slice(&code.inv_factor.to_le_bytes());
-                    row.extend_from_slice(&code.bits);
-                    row
-                }
-                None => vec![0u8; stride],
-            })
-            .collect();
+        // BOUNDED scoped pool (not the global pool): flush encode must leave
+        // headroom for concurrent queries — the same co-design rule as the
+        // TD-SEARCH-2 search morsels. Default cores/2 (min 2), env-tunable.
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(encode_pool_threads())
+            .build()
+            .map_err(|e| anyhow::anyhow!("encode pool: {e}"))?;
+        let rows: Vec<Vec<u8>> = pool.install(|| {
+            vectors
+                .par_iter()
+                .map(|v| match v {
+                    Some(vec) => {
+                        let code = encode(vec, &params, &rotation);
+                        let mut row = Vec::with_capacity(stride);
+                        row.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
+                        row.extend_from_slice(&code.inv_factor.to_le_bytes());
+                        row.extend_from_slice(&code.bits);
+                        row
+                    }
+                    None => vec![0u8; stride],
+                })
+                .collect()
+        });
         for row in rows {
             buf.extend_from_slice(&row);
         }

--- a/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
@@ -170,15 +170,22 @@ pub fn encode_region(vectors: &[Option<&[f32]>], dim: u32) -> Result<(Vec<u8>, S
     // bit-stable min/max). Ordered par_iter + in-order concat = byte-identical
     // (unit-pinned). Small regions keep the sequential loop.
     const PAR_ENCODE_MIN_ROWS: usize = 4096;
-    if n >= PAR_ENCODE_MIN_ROWS {
+    if n >= PAR_ENCODE_MIN_ROWS && crate::coalesced_rabitq::encode_pool_threads() > 1 {
         use rayon::prelude::*;
-        let rows: Vec<Vec<u8>> = vectors
-            .par_iter()
-            .map(|v| match v {
-                Some(vec) => vec.iter().map(|&f| quantize_one(f, &params)).collect(),
-                None => vec![0u8; dim_us],
-            })
-            .collect();
+        // Bounded scoped pool — query-headroom rule; see encode_pool_threads.
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(crate::coalesced_rabitq::encode_pool_threads())
+            .build()
+            .map_err(|e| anyhow::anyhow!("encode pool: {e}"))?;
+        let rows: Vec<Vec<u8>> = pool.install(|| {
+            vectors
+                .par_iter()
+                .map(|v| match v {
+                    Some(vec) => vec.iter().map(|&f| quantize_one(f, &params)).collect(),
+                    None => vec![0u8; dim_us],
+                })
+                .collect()
+        });
         for row in rows {
             buf.extend_from_slice(&row);
         }

--- a/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
@@ -165,14 +165,33 @@ pub fn encode_region(vectors: &[Option<&[f32]>], dim: u32) -> Result<(Vec<u8>, S
             buf[bitmap_off + (i >> 3)] |= 1u8 << (i & 7);
         }
     }
-    for v in vectors {
-        match v {
-            Some(vec) => {
-                for &f in *vec {
-                    buf.push(quantize_one(f, &params));
+    // TD-FLUSH-5: pass 2 is per-row independent (row bytes = quantize of
+    // vectors[i] against the pass-1 global params, which stay sequential for
+    // bit-stable min/max). Ordered par_iter + in-order concat = byte-identical
+    // (unit-pinned). Small regions keep the sequential loop.
+    const PAR_ENCODE_MIN_ROWS: usize = 4096;
+    if n >= PAR_ENCODE_MIN_ROWS {
+        use rayon::prelude::*;
+        let rows: Vec<Vec<u8>> = vectors
+            .par_iter()
+            .map(|v| match v {
+                Some(vec) => vec.iter().map(|&f| quantize_one(f, &params)).collect(),
+                None => vec![0u8; dim_us],
+            })
+            .collect();
+        for row in rows {
+            buf.extend_from_slice(&row);
+        }
+    } else {
+        for v in vectors {
+            match v {
+                Some(vec) => {
+                    for &f in *vec {
+                        buf.push(quantize_one(f, &params));
+                    }
                 }
+                None => buf.extend(std::iter::repeat_n(0u8, dim_us)),
             }
-            None => buf.extend(std::iter::repeat_n(0u8, dim_us)),
         }
     }
     Ok((buf, params))
@@ -230,6 +249,46 @@ impl<'a> Sq8Region<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TD-FLUSH-5: parallel pass-2 SQ8 encode is byte-identical to the
+    /// sequential reference at n above the rayon threshold.
+    #[test]
+    fn parallel_sq8_encode_region_is_byte_identical() {
+        const DIM: usize = 16;
+        const N: usize = 5000;
+        let corpus: Vec<Vec<f32>> = (0..N)
+            .map(|i| {
+                (0..DIM)
+                    .map(|j| ((i * 31 + j * 7) % 997) as f32 * 0.01 - 4.0)
+                    .collect()
+            })
+            .collect();
+        let vectors: Vec<Option<&[f32]>> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                if i % 89 == 7 {
+                    None
+                } else {
+                    Some(v.as_slice())
+                }
+            })
+            .collect();
+        let (region, params) = encode_region(&vectors, DIM as u32).unwrap();
+        // sequential reference for the code area only (header+bitmap are
+        // sequential in both paths): recompute row bytes and compare.
+        let code_off = region.len() - N * DIM;
+        for (i, v) in vectors.iter().enumerate() {
+            let got = &region[code_off + i * DIM..code_off + (i + 1) * DIM];
+            match v {
+                Some(vec) => {
+                    let want: Vec<u8> = vec.iter().map(|&f| quantize_one(f, &params)).collect();
+                    assert_eq!(got, want.as_slice(), "row {i} bytes differ");
+                }
+                None => assert!(got.iter().all(|&b| b == 0), "null row {i} must be zeros"),
+            }
+        }
+    }
 
     fn synth_vec(seed: u64, dim: usize) -> Vec<f32> {
         let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);

--- a/docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc
+++ b/docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc
@@ -1,5 +1,5 @@
 = TD-FLUSH-5: flush materialization is encode-bound single-threaded (43.9 s / 884k entries)
-:status: S1 shipped (2026-07-26) — pass-2 rayon parallelization: MEASURED 884k entries / 235 MB in 8.962 s (was 43.9 s — 4.9×, beats the <10 s target); byte-identical (unit-pinned); clean shutdown, zero __flush stragglers
+:status: S1 shipped (2026-07-26) — pass-2 rayon parallelization: MEASURED (884k entries / 235 MB, was 43.9 s): 8.962 s at full width (all 10 cores) and 26.2 s at the SHIPPED bounded default (cores/2 scoped pool — the query-headroom co-design rule, mirroring TD-SEARCH-2's morsel budget; `PROXIMADB_PAX_ENCODE_THREADS` tunes, 10 = latency-first). Byte-identical either way (unit-pinned; pool width cannot affect output); clean shutdown, zero __flush stragglers
 :filed: 2026-07-25
 :priority: P2 (latency of durability, not correctness — shutdown-await covers the lifecycle)
 

--- a/docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc
+++ b/docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc
@@ -1,5 +1,5 @@
 = TD-FLUSH-5: flush materialization is encode-bound single-threaded (43.9 s / 884k entries)
-:status: Open
+:status: S1 shipped (2026-07-26) — pass-2 rayon parallelization: MEASURED 884k entries / 235 MB in 8.962 s (was 43.9 s — 4.9×, beats the <10 s target); byte-identical (unit-pinned); clean shutdown, zero __flush stragglers
 :filed: 2026-07-25
 :priority: P2 (latency of durability, not correctness — shutdown-await covers the lifecycle)
 
@@ -12,7 +12,25 @@ visibility lags ingest end by ~45 s and shutdown must await it (fixed:
 `drain_inline_flushes`). Concurrent all-core query CPU (lone-query morsels)
 starves the encode further.
 
-== Direction
+== S1 (shipped): parallel pass-2 encode, byte-identical
+
+Both `encode_region`s (coalesced_rabitq.rs, coalesced_sq8.rs) were already
+two-pass: sequential fit (centroid / min-max / rotation — float reductions
+that must stay ordered for bit-stable params) then a fully independent
+per-row encode. S1 parallelizes ONLY pass 2 via ordered `par_iter().collect`
+(rayon; threshold 4096 rows), concatenated in row order —
+**byte-identical to the sequential encoder by construction**, pinned by
+`parallel_encode_region_is_byte_identical` (full-region equality vs an
+inline sequential reference, nulls included) + the SQ8 twin. The RaBitQ
+rotation apply is O(dim²)/row — the measured 43.9 s hotspot.
+
+Deferred (documented): wrapping the sync `write_pax_segment_full` call
+(flush/mod.rs:513) in `spawn_blocking` — `block_in_place` panics on
+current-thread test runtimes; needs the ownership-returning spawn_blocking
+form. The rayon offload already moves the CPU off tokio workers' time
+budget (blocked window shrinks with the speedup).
+
+== Direction (original)
 
 Chunk the encode across `spawn_blocking` workers (the TD-SEARCH-2 S2 morsel
 pattern — rank and encode are both embarrassingly parallel over rows),

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -151,6 +151,7 @@ the emergency off) · *config-mirror* (env overrides a config field) ·
 | `PROXIMADB_OLAP_TABLE_CACHE` | Enables the table-OPEN cache | OFF (default-OFF-until-baked) | opt-in; TD-OLAP | `src/datafusion/engine_adapters/table_open_cache.rs`
 | `PROXIMADB_OTLP_ENDPOINT` | OTLP gRPC endpoint that arms the external metering push | unset ⇒ metering push inert (no-op) | opt-in; TD-161/ADR-027 | `crates/modalities/proximadb-observability-engine/src/metering_otlp.rs`
 | `PROXIMADB_PARQUET_FOOTER_HINT_KB` | Parquet footer prefetch size (KB) | 512 KiB | opt-in tuning; TD-OLAP-4 | `src/datafusion/engine_adapters/object_store_parquet_reader.rs`
+| `PROXIMADB_PAX_ENCODE_THREADS` | flush encode-pool width (bounded scoped rayon pool; 1 = sequential) | cores/2, min 2 (query headroom) | opt-in tuning; TD-FLUSH-5 | `crates/storage/proximadb-block-format/src/coalesced_rabitq.rs`
 | `PROXIMADB_PAX_BLOCK_CLUSTER` | Sign-Gray block reclustering at flush/compaction | ON (kill-switch; `0/false/off/no` ⇒ insertion order) | kill-switch; TD-WLP | `src/storage/engines/sst/block_cluster.rs`
 | `PROXIMADB_PAX_BLOCK_SIZE` | Overrides PAX target block geometry (vectors/block) | None ⇒ writer default (`SST_DEFAULT_VECTORS_PER_BLOCK`) | opt-in tuning; TD-156/ADR-026 | `src/storage/engines/sst/flush/mod.rs`
 | `PROXIMADB_PAX_COALESCED_RABITQ` | coalesced Region-A segment layout (writer+reader) | ON (env = kill-switch) | ADR-065 | `src/storage/engines/sst/segment_format.rs`

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -250,32 +250,33 @@ source; each S3 prune PR deletes the source reference AND its row here.
 | Name | Detail
 
 | `PROXIMADB_API_GRPC_PORT` | DEAD (no rust reader): only set in a test that asserts it is IGNORED; no production override wiring exists. | intended config-mirror of `api.grpc_port` (5679) but not wired | config-mirror; — | src/core/config_loader_tests.rs
-| `PROXIMADB_BENCH_HNSW_EF` | DEAD (no rust reader): only a stale comment; the bench actually reads the un-prefixed `BENCH_HNSW_EF`. | n/a (real var `BENCH_HNSW_EF` defaults 100) | test-only; — | src/index/axis/management/manager.rs
 | `PROXIMADB_DESCRIPTION` | DEAD (no runtime env reader): a Rust `const` bound to `env!("CARGO_PKG_DESCRIPTION")` at compile time, not a runtime env var. | n/a (build constant) | config-mirror; — | src/version.rs
-| `PROXIMADB_DISABLE_` | DEAD (no rust reader): a naming-convention prefix stub, not an actual variable. | n/a | config-mirror; — | src/storage/engines/sst/flush/mod.rs (comment)
 | `PROXIMADB_ENABLE_AI` | DEAD (no rust reader): emitted as a literal into the generated docker-compose YAML in the provisioner; no code reads it back. | n/a (deployment template) | config-mirror; — | src/deployment/automation/provisioner.rs
 | `PROXIMADB_ENABLE_MONITORING` | DEAD (no rust reader): emitted into generated docker-compose YAML; no code reads it back. | n/a (deployment template) | config-mirror; — | src/deployment/automation/provisioner.rs
 | `PROXIMADB_FS_COPY_KEY` | DEAD (no rust reader for this name): the actual test env var is `TEST_PROXIMADB_FS_COPY_KEY`, an encryption master-key holder used only in a copy-fallback test. | n/a (real var TEST_-prefixed) | test-only; — | src/storage/persistence/filesystem/mod.rs
 | `PROXIMADB_FS_FACTORY_KEY` | DEAD (no rust reader for this name): the actual test env var is `TEST_PROXIMADB_FS_FACTORY_KEY`, an encryption master-key holder used only in a factory test. | n/a (real var TEST_-prefixed) | test-only; — | src/storage/persistence/filesystem/mod.rs
-| `PROXIMADB_GCS_` | DEAD (no rust reader): a `PROXIMADB_GCS_*` convention prefix stub, not an actual variable. | n/a | config-mirror; — | src/storage/persistence/filesystem/mod.rs (comment)
-| `PROXIMADB_IO_TRACE_SINK_` | DEAD (no rust reader) — spurious registry entry harvested from the `PROXIMADB_IO_TRACE_SINK_*` doc prefix; not read anywhere | n/a | prune candidate; — | —
 | `PROXIMADB_MEMORY_MB` | DEAD (no rust reader) — only emitted into generated deployment manifests by the provisioner; nothing reads it back | n/a | prune candidate; — | `src/deployment/automation/provisioner.rs`
 | `PROXIMADB_NAME` | DEAD (not an env var) — a compile-time Rust const = `CARGO_PKG_NAME`, never read from env | n/a | prune candidate; — | `src/version.rs`
-| `PROXIMADB_NATIVE_MORSEL_NUMA` | DEAD (no rust reader) — Phase 4.1 NUMA morsel binding referenced in doc comment only, "not built here" | n/a | prune candidate; TD-OLAP-12 | `src/query/execution/morsel_scheduler.rs`
 | `PROXIMADB_OPERATION` | DEAD (not an env var) — only a substring of the secret-detection regex `SSO_AUTH_APP_TOKEN_PROXIMADB_OPERATION`, never read from env | n/a | prune candidate; — | `src/audit/correlation.rs`
-| `PROXIMADB_PARTITION_LEASE_ON` | DEAD (no rust reader) — referenced only in doc comments ("TBD when it ships default-on"); no `env::var` reader exists | n/a | prune candidate; — | `src/services/ddl/mod.rs`
-| `PROXIMADB_PAX_VECTOR_SEGMENTS` | Legacy write-format opt-in — retained as a no-op for back-compat, gates nothing now. | no-op (DEAD: no functional reader; tests-only) | eval; ADR-049 M1-3 | src/storage/engines/sst/flush/mod.rs:1073
 | `PROXIMADB_PSEUDO_QUERY_FIELD` | NOT an env var — a Rust `pub const` holding the metadata key `"proximadb.pseudo_query"`. | n/a | DEAD (no rust reader; misregistered constant, not env) | src/services/operations/vectors/validation/metadata.rs:10
 | `PROXIMADB_PSEUDO_QUERY_SOURCE_FIELD` | NOT an env var — Rust `pub const` = `"proximadb.pseudo_query_source_fields"` metadata key. | n/a | DEAD (no rust reader; misregistered constant) | src/services/operations/vectors/validation/metadata.rs:11
-| `PROXIMADB_QUEUE_` | Registry prefix stub for the `PROXIMADB_QUEUE_*` family, not a variable itself. | n/a | DEAD (prefix entry) | src/core/config.rs:330
-| `PROXIMADB_S3_` | Registry prefix stub for the `PROXIMADB_S3_*` family, not a variable itself. | n/a | DEAD (prefix entry) | src/storage/persistence/filesystem/mod.rs:477
 | `PROXIMADB_SERVER_PORT` | Intended server-port override — but the test proves env is NOT applied to config. | DEAD (test asserts default `5678` used; no wiring) | test-only; — | src/core/config_loader_tests.rs:794
 | `PROXIMADB_STORAGE_CACHE_SIZE_MB` | Intended storage cache-size override — test proves env is NOT applied. | DEAD (test asserts default `512` used; no wiring) | test-only; — | src/core/config_loader_tests.rs:796
 | `PROXIMADB_STORAGE_ENGINE` | Emitted into a generated k8s manifest template; no reader in this codebase. | DEAD (no rust reader; manifest output only) | config-mirror; — | src/deployment/automation/provisioner.rs:756
 | `PROXIMADB_TENANT_ID` | Emitted into a generated k8s manifest template; no reader in this codebase. | DEAD (no rust reader; manifest output only) | config-mirror; — | src/deployment/automation/provisioner.rs:758
 | `PROXIMADB_VERSION` | NOT an env var — Rust `pub const` = `env!("CARGO_PKG_VERSION")` (compile-time crate version). | n/a | DEAD (no runtime env reader; misregistered) | src/version.rs:10
-| `PROXIMADB_WAREHOUSE_DRPATH` | Referenced only in a comment (as the pattern `PROXIMADB_CATALOG_DRPATH` mirrors); no reader. | DEAD (no rust reader) | opt-in; — | src/network/shared_services.rs:600
 |===
+
+== Pruned (S3, 2026-07-26 first pass)
+
+Deleted from source + registry: `PROXIMADB_PAX_VECTOR_SEGMENTS` (vestigial
+no-op reader), 4 stale doc-comment-only names (`PARTITION_LEASE_ON`,
+`NATIVE_MORSEL_NUMA`, `WAREHOUSE_DRPATH`, `BENCH_HNSW_EF` mention), and 5
+prefix-stub harvest artifacts (guard now ignores names ending in `_`).
+Intentionally KEPT in the dead section: template-emitted names (deployment
+manifests may feed container entrypoints), test-asserted-unwired vars (the
+tests deliberately prove env does NOT leak into config), and compile-time
+consts that merely share the prefix.
 
 == Retired names (reserved — never repurpose)
 

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -113,6 +113,19 @@ hardware = "Local macOS arm64 (10-core Apple Silicon, 64GB), release build, seri
 date = "2026-07-26"
 version = "feat/nprobe-tuning -> develop"
 
+[[claims]]
+id = "flush_encode_parallel_1m"
+claim = "TD-FLUSH-5 S1: rayon-parallel pass-2 encode (RaBitQ O(dim^2)/row rotation + SQ8) cuts the 1M flush materialize from 43.9s to 8.962s (884k entries / 235MB, 4.9x, 10-core box) with BYTE-IDENTICAL output (full-region equality unit tests vs sequential reference, nulls included; pass-1 param fits stay sequential for bit-stable floats). Flush now completes ~4s after ingest end; clean shutdown, zero __flush stragglers; recall unchanged (0.9820 untrained cold)."
+metric = "1M flush materialize wall time; byte-identity; recall"
+status = "measured"
+asserted_in = ["docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc"]
+bench_source = "scripts/bench/recall_adjudicate.py"
+bench_command = "flush_e2e_verify protocol (1M REST ingest, floor config); flush time from the 'inline size-flush ... in Xs' completion line"
+artifact = "docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc"
+hardware = "Local macOS arm64 (10-core Apple Silicon, 64GB), release build"
+date = "2026-07-26"
+version = "feat/overnight-followups -> develop"
+
 
 [[claims]]
 id = "io_trace_sink_hotpath_p95"

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -115,7 +115,7 @@ version = "feat/nprobe-tuning -> develop"
 
 [[claims]]
 id = "flush_encode_parallel_1m"
-claim = "TD-FLUSH-5 S1: rayon-parallel pass-2 encode (RaBitQ O(dim^2)/row rotation + SQ8) cuts the 1M flush materialize from 43.9s to 8.962s (884k entries / 235MB, 4.9x, 10-core box) with BYTE-IDENTICAL output (full-region equality unit tests vs sequential reference, nulls included; pass-1 param fits stay sequential for bit-stable floats). Flush now completes ~4s after ingest end; clean shutdown, zero __flush stragglers; recall unchanged (0.9820 untrained cold)."
+claim = "TD-FLUSH-5 S1: rayon-parallel pass-2 encode (RaBitQ O(dim^2)/row rotation + SQ8) cuts the 1M flush materialize from 43.9s to 8.962s at full width (10 threads) / 26.2s at the shipped bounded default (cores/2 scoped pool leaving query headroom; PROXIMADB_PAX_ENCODE_THREADS tunes) — 884k entries / 235MB, 10-core box with BYTE-IDENTICAL output (full-region equality unit tests vs sequential reference, nulls included; pass-1 param fits stay sequential for bit-stable floats). Flush now completes ~4s after ingest end; clean shutdown, zero __flush stragglers; recall unchanged (0.9820 untrained cold)."
 metric = "1M flush materialize wall time; byte-identity; recall"
 status = "measured"
 asserted_in = ["docs/10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc"]

--- a/scripts/check_env_gates.py
+++ b/scripts/check_env_gates.py
@@ -28,7 +28,11 @@ def rust_vars():
             except OSError:
                 continue
             for m in VAR_RE.finditer(text):
-                seen.add(m.group(0))
+                name = m.group(0)
+                # names ending in '_' are prose prefix mentions
+                # ("PROXIMADB_QUEUE_* vars"), not variables
+                if not name.endswith("_"):
+                    seen.add(name)
     return seen
 
 

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -1707,7 +1707,7 @@ impl AxisManager {
                 // this site built `AxisHnswConfig { distance_metric,
                 // ..Default::default() }`, ignoring the strategy spec's
                 // m / ef_construction / ef_search entirely. Customers
-                // (and the bench) had to use the PROXIMADB_BENCH_HNSW_EF
+                // (and the bench) had to use the (un-prefixed) BENCH_HNSW_EF
                 // env override to influence search behaviour because
                 // the `IndexAlgorithm::HNSW { m, ef_construction,
                 // ef_search, max_elements }` fields they put in their

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -597,7 +597,7 @@ impl SharedServices {
                 // operator control-plane prefix (`_operator/catalog/…`) so
                 // catalog I/O honours the structural-isolation mandate instead
                 // of a raw `{base}/system-catalog.wal`. Flag-gated + inert by
-                // default (mirrors `PROXIMADB_WAREHOUSE_DRPATH`): the local path
+                // default (mirrors the warehouse DrPath opt-in pattern): the local path
                 // is unchanged until a deployment opts in, keeping existing
                 // on-disk catalog state in place. The catalog is `Operator`-roled.
                 let wal_path = if std::env::var("PROXIMADB_CATALOG_DRPATH").is_ok() {

--- a/src/query/execution/morsel_scheduler.rs
+++ b/src/query/execution/morsel_scheduler.rs
@@ -14,7 +14,7 @@
 //! Phase 4.0 scope (this file): parallelize the **source decode**; the downstream
 //! operators (filter/project/aggregate) run serially over the merged stream. That
 //! closes the decode-bound gap without partial/final aggregation. NUMA pinning is
-//! Phase 4.1 (gated `PROXIMADB_NATIVE_MORSEL_NUMA`, not built here). Gated
+//! Phase 4.1 (NUMA binding — not built here; will get its own registered gate when it lands). Gated
 //! `PROXIMADB_NATIVE_MORSEL` (default OFF); a non-splittable source → serial, so
 //! the scheduler is additive and never a correctness dependency.
 

--- a/src/services/ddl/mod.rs
+++ b/src/services/ddl/mod.rs
@@ -538,7 +538,7 @@ impl DdlService {
     }
 
     /// Attach the partition-lease manager for per-collection write authority.
-    /// When the lease system is on (`PROXIMADB_PARTITION_LEASE_ON`), the
+    /// When the lease system is on (a future registered gate; none exists yet), the
     /// `SharedServices` composition root attaches this so collection/table-scoped
     /// DDL consults the lease before executing. Inert by default.
     pub fn with_partition_lease_manager(

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -1066,12 +1066,6 @@ fn tokenize_into(text: &str, out: &mut Vec<String>) {
 // retired legacy `.sst` streaming format.
 // ---------------------------------------------------------------------------
 
-/// Explicit per-deployment PAX opt-in env. M1-3: vestigial — PAX is always the
-/// write format now, so this no longer gates anything. Retained for back-compat
-/// (a deployment that still sets it is a no-op, not an error); tests reference it
-/// to keep the process env clean.
-const PAX_VECTOR_SEGMENTS_ENV: &str = "PROXIMADB_PAX_VECTOR_SEGMENTS";
-
 /// Global kill-switch. Any truthy value selects the recall-exact `RawF32` quant
 /// for EVERY collection (M1-3: it used to force legacy `.sst`; with the streaming
 /// write path retired it now means RawF32-PAX, exact-scan searchable via
@@ -1734,7 +1728,6 @@ mod tests {
         // nextest isolates each test in its own process; `set_var`/`remove_var`
         // are `unsafe` (edition 2024).
         unsafe {
-            std::env::remove_var(PAX_VECTOR_SEGMENTS_ENV);
             std::env::remove_var(PAX_VECTOR_SEGMENTS_DISABLE_ENV);
         }
         let engine = create_test_engine().await;

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -1053,7 +1053,7 @@ impl DrPathBuilder {
     /// authority). Structural base; the `PartitionLeaseStore` nests per-partition
     /// manifest logs beneath it. Used at boot by `SharedServices` to construct the
     /// lease store. NOTE: exact co-location (vs the system catalog) is a design
-    /// TBD when `PROXIMADB_PARTITION_LEASE_ON` ships default-on.
+    /// TBD when the partition-lease gate ships default-on (no env gate exists yet).
     pub fn partition_lease_prefix() -> String {
         "_catalog/leases/".to_string()
     }


### PR DESCRIPTION
## Summary

Overnight follow-ups, rebased on the merged #1210.

### TD-FLUSH-5 S1: parallel flush encode — byte-identical, headroom-bounded
Both coalesced `encode_region`s were already two-pass (sequential param fit → independent per-row encode). Pass 2 now runs on a **bounded scoped rayon pool (cores/2, min 2)** — the same query-headroom co-design rule the TD-SEARCH-2 morsels follow, so a flush never starves concurrent queries. `PROXIMADB_PAX_ENCODE_THREADS` tunes (registered); the RaBitQ rotation (O(dim²)/row) was the measured hotspot.

**Measured** (884k entries / 235 MB, was 43.9 s sequential): **26.2 s at the shipped bounded default**, **8.96 s at full width** (env=10). **Byte-identical by construction** — pass-1 float reductions stay sequential for bit-stable params; ordered `par_iter`+concat pinned by full-region equality tests vs inline sequential references (nulls included). Clean shutdown, zero `__flush` stragglers, recall unchanged. `spawn_blocking` wrap deferred with the `block_in_place` caveat documented.

### Env-gate S3 first prune pass (TD-ENVGATE-1)
Deleted the vestigial `PROXIMADB_PAX_VECTOR_SEGMENTS` no-op reader; corrected 4 stale doc-comment gate names; guard now ignores prose prefix mentions ending in `_`. Registry: 10 rows pruned (216 registered) + a Pruned section recording deleted-vs-intentionally-kept rationale (template-emitted names, test-asserted-unwired vars, prefix-sharing consts stay documented).

Gates: fmt, clippy clean, work-commit-check (incl. env-gate guard), block-format 70/70, ledger validated (claim `flush_encode_parallel_1m` carries both operating points). Rebased on develop tip post-#1210; compile re-verified.