### PR TITLE
fix(storage): TD-FLUSH-6 unblock object-store flush commit on a clean container

### DIFF
--- a/docs/10-quality/td/TD-FLUSH-6-atomic-flush-commit-fails-clean-container.adoc
+++ b/docs/10-quality/td/TD-FLUSH-6-atomic-flush-commit-fails-clean-container.adoc
@@ -1,14 +1,14 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-FLUSH-6: Atomic flush commit fails against a clean object-store container — ingest stalls at record_count 0 under permanent backpressure
-:status: Open
+:status: Fixed (2026-07-26)
 :dim: D1
 :pillar: REL
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open — UNDIAGNOSED.** Filed to stop the symptom being attributed to unrelated log noise (see "Ruled out"). The mechanism is not yet known; this TD scopes the diagnosis, it does not claim a cause.
+| Status | **Fixed (2026-07-26).** Root cause identified by capturing the full `anyhow` chain (candidate #1 of the diagnosis plan, not the suspected `move_atomic`): `FilesystemFactory::resolve_path` stripped the container off cloud URLs, so the staging-dir `list` was rejected as `not an azure path`. Fix + verification below.
 | Priority | **P0 for the object-store bench posture** — SIFT-1M ingest against Azurite cannot complete, so every object-store-backed measurement (recall, GETs/query, flush timing) is blocked.
 | Component | `src/storage/transaction_coordinator.rs:531` (`finalize_atomic_operation`), reached via `src/storage/engines/sst/flush/mod.rs:608` and `src/storage/engines/sst/flush/operations.rs:131`.
 | Evidence | SIFT-1M ingest, Azurite backend, mmap off, **clean container**: `record_count` stuck at 0, every write rejected with BACKPRESSURE, `auto-flush failed: Failed to commit atomic flush operation`. Reproduces on both current `develop` and an 8-day-old `feat/flush-triggers` binary that previously succeeded — same binary, different container state, different outcome ⇒ environmental/state-dependent, **not a code regression**.
@@ -37,7 +37,67 @@ user-visible failure is "ingest is dead"; the actionable failure is the commit.
 * **Not** disk capacity (161 GiB free), Azurite writability (probe upload
   succeeded), or env-gate configuration.
 
-== Diagnosis plan (in order)
+== Root cause (confirmed 2026-07-26)
+
+Capturing the full `anyhow` chain (the A1 fix below stops `transaction_coordinator`
+from flattening it) localized the failure to diagnosis candidate **#1 — `list`**, not
+the suspected `move_atomic`:
+
+....
+Failed to commit atomic flush operation:
+  Failed to list staging directory:
+    Invalid path: not an azure path: /1/data/__flush
+....
+
+`FilesystemFactory::resolve_path` (`src/storage/persistence/filesystem/mod.rs`)
+reduced cloud-scheme URLs to `Url::parse(url).path()` — which returns **only**
+`/1/data/__flush`, **dropping the host (the container `proximadb-bench`)**. But the
+cloud backends parse the **full** url themselves to recover container + blob
+(`AzureBlobFileSystem::parse` strips the `az://` scheme and `split_once('/')`s the
+container off). So every `FilesystemFactory` inherent op (`list`/`read`/`write`/
+`delete`/`move_atomic`) handed the backend a container-less path it rejected. The
+SST `.pax` *write* only succeeded because the SST engine **bypasses the factory**
+and calls the backend with full URLs; the transaction coordinator's staging-dir
+`list`/`move` was the one path that went through the factory and hit the bug. This
+also explains the clean-vs-warm split: a warm container's staging prefix already
+existed from prior runs, so the (equally broken) list was tolerated; a clean
+container has no such prefix, so the malformed-path list fails immediately.
+
+== Fix
+
+1. **`resolve_path`** (filesystem/mod.rs) now passes cloud-scheme urls through
+   **verbatim** (`file://` still reduces to a local path; `Url::parse` is kept
+   only as a fail-fast validity check). The cloud backend parses container+blob
+   from the full url, as it already does for the working SST write path.
+2. **Error-chain preservation** (transaction_coordinator.rs): the per-file move
+   `Err(e)` arm previously did `anyhow::anyhow!("…{e}")`, which consumed `e` via
+   `Display` and dropped its `.source()` — the reason every prior report lost the
+   proximate cause. It now does `anyhow::Error::from(e).context(...)`. The two
+   consumer logs (`auto_flush_driver.rs`, `flush/mod.rs`) print the full chain
+   with `{:#}` instead of the top message only.
+3. **Best-effort staging cleanup** (transaction_coordinator.rs): the trailing
+   `delete(&staging_url)` is housekeeping — every segment is already moved to the
+   final prefix when it runs. On object stores the staging "directory" is a
+   *prefix* with no blob of its own, so once the move loop drains it the delete
+   returns NotFound (404); that is the expected end state. It no longer fails the
+   commit (warn + continue); orphans are reaped by the staging `auto_cleanup` sweep.
+4. **Regression test**: `test_resolve_path_cloud_urls_pass_through_verbatim` locks
+   in the verbatim-passthrough for `az://`/`s3://`/`gs://` (the existing
+   `test_path_extraction` asserted the old broken `/key` strip and is corrected).
+
+== Verification (passed 2026-07-26, Azurite, clean container)
+
+* 1000-vector ingest → `.pax` lands at the **final** `1/data/L0_*.pax` prefix
+  (not stuck in `1/data/__flush/`); `auto-flush failed` count = 0; no BACKPRESSURE.
+* Search returns the ingested vectors ranked correctly (query with `base[0]` →
+  top hit `v0`), proving ingest→flush→search works end-to-end.
+
+NOTE: `record_count` from `/api/v2/collections/{id}` still reads 0 — that is a
+**separate** catalog-stat issue (`Table 'default.1' not found` / precision-resolver
+warnings), present in all prior runs and unrelated to the flush; it does not block
+ingest or search. Tracked under the namespace/identity work (ADR-074 / TD-NS-1).
+
+== Diagnosis plan (in order) — resolved (candidate #1)
 
 The commit path after the metadata lookup does three object-store operations,
 each with a plausible clean-container failure mode:

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -232,8 +232,12 @@ impl AutoFlushDriver {
                         dur,
                         0,
                     );
+                    // TD-FLUSH-6: `{:#}` prints the full anyhow source chain, not
+                    // just the outer "Failed to commit atomic flush operation"
+                    // wrapper — the proximate object-store cause lives 1-2 .context
+                    // layers down and was previously dropped.
                     tracing::warn!(
-                        "❌ ADR-069 auto-flush [{}] '{}' failed: {}",
+                        "❌ ADR-069 auto-flush [{}] '{}' failed: {:#}",
                         reason.as_str(),
                         collection_id,
                         e

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -598,7 +598,12 @@ impl SstEngine {
                 .finalize_atomic_operation(&atomic_op.operation_id)
                 .await
             {
-                tracing::warn!(%error, "failed to finalize recovery publication tracking");
+                // TD-FLUSH-6: print the full source chain (`{:#}`) so the inner
+                // object-store cause is visible, not just the outer wrapper.
+                tracing::warn!(
+                    "failed to finalize recovery publication tracking: {:#}",
+                    error
+                );
             }
         } else {
             tracing::debug!(operation_id = %atomic_op.operation_id, "Committing atomic operation");

--- a/src/storage/persistence/filesystem/mod.rs
+++ b/src/storage/persistence/filesystem/mod.rs
@@ -991,15 +991,25 @@ impl FilesystemFactory {
                 Ok(after_file.to_string())
             }
         } else {
-            // Case 3: Non-file schemes still need URL parsing (s3://, azure://, etc.)
-            let parsed_url = Url::parse(url)
+            // Case 3: Cloud schemes (s3://, az://, adls://, abfs://, gs://, ...).
+            // The cloud backends parse the FULL url themselves to recover the
+            // container/bucket + blob key — e.g. `AzureBlobFileSystem::parse`
+            // strips the `az://` scheme and split_once('/')s the container off
+            // the blob. Returning only `parsed_url.path()` here drops the host
+            // (the container), so the backend rejects it: TD-FLUSH-6 root cause
+            // was the staging-dir `list` failing with
+            // `Invalid path: not an azure path: /1/data/__flush` (container
+            // `proximadb-bench` stripped). Pass the url through verbatim and let
+            // the backend parse it; only `file://` (Case 2 above) and scheme-less
+            // paths (Case 1) are reduced to a local path. Url::parse is kept as
+            // a fail-fast validity check; its `.path()` is intentionally unused.
+            let _parsed = Url::parse(url)
                 .map_err(|e| FilesystemError::InvalidPath(format!("Invalid URL: {}", e)))?;
-            let path = parsed_url.path();
             trace!(
-                "🔍 [FILESYSTEM] resolve_path: Non-file scheme path: '{}'",
-                path
+                "🔍 [FILESYSTEM] resolve_path: cloud scheme — full url passed to backend: '{}'",
+                url
             );
-            Ok(path.to_string())
+            Ok(url.to_string())
         }
     }
 
@@ -1506,13 +1516,41 @@ mod inline_tests {
             "/tmp/test.txt"
         );
         assert_eq!(
-            FilesystemFactory::resolve_path("s3://bucket/key")
-                .expect("Failed to resolve path from s3:// URL"),
-            "/key"
-        );
-        assert_eq!(
             FilesystemFactory::resolve_path("/local/path").expect("Failed to resolve local path"),
             "/local/path"
+        );
+    }
+
+    /// TD-FLUSH-6 regression: cloud-scheme URLs must be passed through VERBATIM
+    /// to the backend. The cloud backends (`AzureBlobFileSystem::parse`,
+    /// `AwsS3FileSystem`, ...) recover the container/bucket + blob key from the
+    /// full url themselves; stripping to `Url::path()` here dropped the host
+    /// (container) and made `list`/`copy`/`delete` fail with
+    /// `Invalid path: not an azure path: /1/data/__flush` on a clean object
+    /// store, blocking flush. `file://` (above) and scheme-less paths are still
+    /// reduced to a local path.
+    #[tokio::test]
+    async fn test_resolve_path_cloud_urls_pass_through_verbatim() {
+        // exact shape that broke the SST flush staging-dir list on Azurite
+        assert_eq!(
+            FilesystemFactory::resolve_path("az://proximadb-bench/1/data/__flush")
+                .expect("az:// staging url must resolve"),
+            "az://proximadb-bench/1/data/__flush"
+        );
+        // s3 / gs likewise — backend parses container+blob from the full url
+        assert_eq!(
+            FilesystemFactory::resolve_path("s3://bucket/key").expect("s3:// url must resolve"),
+            "s3://bucket/key"
+        );
+        assert_eq!(
+            FilesystemFactory::resolve_path("gs://bucket/a/b/c.pax")
+                .expect("gs:// url must resolve"),
+            "gs://bucket/a/b/c.pax"
+        );
+        // malformed url is still rejected (Url::parse validity check retained)
+        assert!(
+            FilesystemFactory::resolve_path("az://[bad").is_err(),
+            "malformed cloud url must be rejected"
         );
     }
 

--- a/src/storage/transaction_coordinator.rs
+++ b/src/storage/transaction_coordinator.rs
@@ -604,13 +604,16 @@ impl UnifiedTransactionCoordinator {
                         // File existence verification removed - move_atomic already guarantees this
                     }
                     Err(e) => {
-                        error!("Failed to move file {}: {}", entry.name, e);
-                        return Err(anyhow::anyhow!(
-                            "Failed to move {} to {}: {}",
-                            staging_file_url,
-                            final_file_url,
-                            e
-                        ));
+                        // TD-FLUSH-6: preserve the full error chain. The prior
+                        // `anyhow::anyhow!("…{e}")` consumed `e` via Display and
+                        // dropped its `.source()`, hiding the real object-store
+                        // cause under the generic outer wrapper. `Error::from(e)
+                        // .context(..)` keeps the inner error traversable so it
+                        // surfaces in `{:#}` / Debug log output.
+                        error!("Failed to move file {}: {:#}", entry.name, e);
+                        return Err(anyhow::Error::from(e).context(format!(
+                            "Failed to move {staging_file_url} to {final_file_url}"
+                        )));
                     }
                 }
 
@@ -618,13 +621,24 @@ impl UnifiedTransactionCoordinator {
             }
         }
 
-        // Clean up staging directory
+        // Clean up staging directory. Best-effort (TD-FLUSH-6): every staged
+        // segment has already been moved to the final prefix above — the move
+        // loop returns `Err` on the first failure, so reaching here means the
+        // commit is already durable. On object stores the staging "directory"
+        // is a *prefix* with no blob of its own, so once the move loop drains
+        // it the delete returns NotFound (404); that is the expected end state,
+        // not a failure. Never fail the commit on cleanup — orphaned staging
+        // objects are reaped by the staging config's `auto_cleanup` /
+        // `max_orphaned_age_hours` sweep.
         if metadata.operation_type != TransactionStageType::Custom("preserve_staging".to_string()) {
-            self.filesystem
-                .delete(&metadata.staging_url)
-                .await
-                .context("Failed to cleanup staging directory")?;
-            debug!("🧹 Cleaned up staging directory");
+            if let Err(e) = self.filesystem.delete(&metadata.staging_url).await {
+                warn!(
+                    staging_url = %metadata.staging_url,
+                    "staging cleanup failed (non-fatal — segments already committed to final prefix): {e:#}"
+                );
+            } else {
+                debug!("🧹 Cleaned up staging directory");
+            }
         }
 
         // Update status to completed


### PR DESCRIPTION
## What

Unblocks ingest→flush→search on a clean object-store container (Azurite). Slice A of the namespace-isolation consensus (ADR-074 / TD-NS-1); TD-FLUSH-6 is independent of the namespace work — it is the P0 bench unblock.

## Root cause (confirmed via the full, no-longer-flattened `anyhow` chain)

`FilesystemFactory::resolve_path` reduced cloud URLs to `Url::parse(url).path()`, which **drops the host (the container)**. Cloud backends parse the **full** url to recover container+blob (`AzureBlobFileSystem::parse`), so every factory inherent op (`list`/`read`/`write`/`delete`/`move_atomic`) handed the backend a container-less path it rejected as `not an azure path`. The SST `.pax` write only worked because it **bypasses the factory**; the transaction coordinator's staging-dir `list`/`move` was the one path through the factory → flush could not commit → permanent backpressure → ingest dead. (Also explains the clean-vs-warm split: a warm container's staging prefix pre-existed, so the equally-broken list was tolerated.)

## Fix
- `resolve_path`: pass cloud URLs through **verbatim** (`file://` still reduces to a local path; `Url::parse` kept only as a validity check).
- `transaction_coordinator`: preserve the error chain (`anyhow::anyhow!("…{e}")` → `Error::from(e).context(..)`) so the proximate cause is visible; make the trailing staging-dir cleanup **best-effort** (housekeeping — segments already moved; on object stores the staging "dir" is an empty prefix whose delete 404s, which must not fail the commit).
- `auto_flush_driver` / `flush(mod)`: log the full chain with `{:#}`.
- Regression test `test_resolve_path_cloud_urls_pass_through_verbatim`; corrected `test_path_extraction`, which had locked in the broken `/key` strip.

## Verification (local, Azurite, clean container)
- 1000-vec ingest → `.pax` lands at the **final** `1/data/L0_*.pax` prefix; `auto-flush failed` = 0; no BACKPRESSURE.
- Search returns the ingested vectors ranked correctly (query with `base[0]` → top hit `v0`).
- `cargo fmt --check` ✅ · `cargo clippy --lib --bins -- -D warnings` ✅ · `make work-commit-check` ✅ (panic-policy within delta, env-gates 224).

## Scope / notes
- `record_count` from the collections API still reads 0 — a **separate** catalog-stat issue (`Table 'default.1' not found`), present in all prior runs, unrelated to the flush and not blocking ingest/search. Tracked under ADR-074 / TD-NS-1.
- TD-FLUSH-6 doc refined: `Open/UNDIAGNOSED` → `Fixed` (root cause + fix + verification).
- No rebase: develop moved 1 commit (#1210 coarse-probe) with zero overlap on these files; expecting a clean merge.