### PR TITLE
refactor(path): TD-CACHE-5 split DrResolvedPath by meaning

### DIFF
--- a/crates/foundation/proximadb-kernel/src/stable_id.rs
+++ b/crates/foundation/proximadb-kernel/src/stable_id.rs
@@ -96,9 +96,9 @@ impl ToPathSegment for u32 {
 ///
 /// This is a **pure value type** — it carries the typed IDs only. Full
 /// object-store path construction (`accounts/{base62}/…/`) lives in
-/// `DrPathBuilder` / `DrResolvedPath` (the SaaS mandate: every object-store
+/// `DrPathBuilder` / `DrCollectionPath` (the SaaS mandate: every object-store
 /// write is prefixed via DrPathBuilder, the single allowlisted path builder).
-/// DrResolvedPath consumes a `CollectionIdentity` via `build_from_identity`.
+/// DrCollectionPath consumes a `CollectionIdentity` via `build_from_identity`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CollectionIdentity {
     pub account_id: AccountId,
@@ -109,9 +109,9 @@ pub struct CollectionIdentity {
 impl CollectionIdentity {
     /// The three zero-padded base62 path segments, in path order
     /// `(account, namespace, collection)`. Composed into the full prefix by
-    /// `DrResolvedPath::typed_root_prefix` — kept here only so the encoding
+    /// `DrCollectionPath::typed_root_prefix` — kept here only so the encoding
     /// (segment width / zero-pad contract) is testable at the type layer
-    /// without a `DrResolvedPath`.
+    /// without a `DrCollectionPath`.
     pub fn path_segments(&self) -> (String, String, String) {
         (
             self.account_id.to_path_segment(),
@@ -163,7 +163,7 @@ mod tests {
 
     // ── CollectionIdentity segment-encoding tests ───────────────────────
     // (Full-path construction tests live in path_resolver.rs, where
-    // DrResolvedPath::typed_root_prefix composes the canonical prefix.)
+    // DrCollectionPath::typed_root_prefix composes the canonical prefix.)
     // (Per-scope minting tests live in the catalog crate's id_allocator.rs.)
 
     #[test]

--- a/docs/10-quality/td/TD-CACHE-5-warm-manifest-invalid-path.adoc
+++ b/docs/10-quality/td/TD-CACHE-5-warm-manifest-invalid-path.adoc
@@ -1,14 +1,14 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-CACHE-5: The restart warm-cache manifest is written to a structurally invalid path — TD-CACHE-1 S2 has never warmed anything on object storage
-:status: Open
+:status: Fixed (2026-07-26)
 :dim: D3
 :pillar: PERF
 
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open.** Root cause identified by code reading (2026-07-26); one call site, one-line class of fix, plus a type-level fix that closes the class.
+| Status | **Fixed (2026-07-26)** by the `DrResolvedPath` type split (Slice B / ADR-074 S1). `build_tenant_system` now returns a `DrTenantSystemPath` that **structurally lacks** the collection-scoped `manifests_subprefix()`; `warming.rs` uses the new `cache_subprefix()` (`<tenant_root>_cache/`, alongside `_metering/`/`_trace/`). The misuse can no longer compile — the class is closed, not just the one call site. `_cache` added to `RESERVED_SYSTEM_SEGMENTS`.
 | Priority | **P2** — silent, non-fatal, but TD-CACHE-1 S2 (the whole restart-warming slice, shipped 2026-07-24) is inert on any object-store backend that validates paths. The cold-herd it was built to defuse is undefused.
 | Component | `src/storage/engines/sst/warming.rs:44-49` (`manifest_url`); `src/storage/trait_components/path_resolver.rs:883-912` (`DrPathBuilder::build_tenant_system`).
 | Evidence | Azurite SIFT-1M bench log: `Read failed from az://{bucket}/data/default///manifests/warm_cache.json: Invalid path: not an azure path`. Reproduced by inspection — see mechanism below.

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -543,7 +543,7 @@ impl AxisManager {
     /// `index_persist_url`/`index_persist_dir` conventions in
     /// [`index_fs_and_path`](Self::index_fs_and_path), so the index path is
     /// authoritative-from-catalog (relocatable/tierable per projection). The boot
-    /// adapter computes this via `DrResolvedPath::resolve_index_location`
+    /// adapter computes this via `DrCollectionPath::resolve_index_location`
     /// (projection `location`, else the derived `indexes/<projection>/` default).
     ///
     /// `&self` + async because the location memo is interior-mutable (filled at

--- a/src/metrics/metering_writer.rs
+++ b/src/metrics/metering_writer.rs
@@ -5,7 +5,7 @@
 //!
 //! ADR-027 decided the differentiator: per-tenant billing meters are not just
 //! scraped from Prometheus (pull-only, ephemeral) but **persisted durably to the
-//! tenant's own object-store subtree** under [`DrResolvedPath::metering_subprefix`]
+//! tenant's own object-store subtree** under [`DrTenantSystemPath::metering_subprefix`]
 //! (`data/{tenant}/_metering/…`), where the control plane (AnvaiOps) reads them
 //! and applies its rate card. This module is the OSS-native half of that sink:
 //! it serializes the per-tenant resident-storage (KSU) snapshot the
@@ -86,7 +86,7 @@ impl MeteringRecord {
 /// `s3://bucket/prefix`). The returned URL is
 /// `{base}/data/{tenant}/_metering/storage/snapshot-{secs}.json` — the
 /// `data/{tenant}/_metering/` portion comes verbatim from
-/// [`DrResolvedPath::metering_subprefix`], so the metering sink stays under the
+/// [`DrTenantSystemPath::metering_subprefix`], so the metering sink stays under the
 /// same `DrPathBuilder` isolation prefix as the tenant's data. Returns `Err` if
 /// the tenant id fails path validation (fail-closed — never write to an
 /// unvalidated key).

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -2413,7 +2413,7 @@ impl CollectionService {
         // ADR-031: the collection ID is the stable object_id (u64) as a decimal
         // string — NOT a UUID. The monotonic allocator guarantees uniqueness by
         // construction (no retry loop needed). base62 is reserved for path
-        // segments only (DrResolvedPath), not the collection.id variable.
+        // segments only (DrCollectionPath), not the collection.id variable.
         Ok(generate_numeric_collection_id())
     }
 }
@@ -2430,7 +2430,7 @@ static COLLECTION_ID_ALLOCATOR: std::sync::OnceLock<proximadb_catalog::id_alloca
 /// the canonical identity, never stringified for keying/lookup). Its
 /// client-facing string form (the `collection.id` API field) is the **decimal**
 /// `object_id` — numeric, opaque, JSON-safe. The **base62** encoding is reserved
-/// strictly for object-store *path segments* (`DrResolvedPath`), where
+/// strictly for object-store *path segments* (`DrCollectionPath`), where
 /// zero-padded base62 gives lexicographic S3 LIST order; it is NOT used for the
 /// `collection.id` variable.
 fn generate_numeric_collection_id() -> String {

--- a/src/services/snapshot/branch_ref.rs
+++ b/src/services/snapshot/branch_ref.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::storage::trait_components::path_resolver::DrResolvedPath;
+use crate::storage::trait_components::path_resolver::DrCollectionPath;
 
 /// An immutable, object-store-persisted pointer to a point in a collection's
 /// (and its tables') history, forming the root of a copy-on-write branch.
@@ -79,7 +79,7 @@ impl BranchRef {
 
     /// Object-store key for this ref under a resolved collection path,
     /// `data/<tenant>/<ns>/<collection>/_branches/<branch_id>.json`.
-    pub fn object_key(&self, resolved: &DrResolvedPath) -> String {
+    pub fn object_key(&self, resolved: &DrCollectionPath) -> String {
         format!("{}{}.json", resolved.branches_subprefix(), self.branch_id)
     }
 }

--- a/src/storage/engines/sst/warming.rs
+++ b/src/storage/engines/sst/warming.rs
@@ -42,9 +42,14 @@ struct WarmManifest {
 /// fail-closed on an invalid tenant id (same recipe as
 /// `metrics::metering_writer::ksu_snapshot_object_url`).
 fn manifest_url(base_url: &str, tenant_id: &str) -> anyhow::Result<String> {
+    // TD-CACHE-5: build_tenant_system returns a DrTenantSystemPath, whose only
+    // subprefixes are the tenant-system ones (_metering/_trace/_cache). The warm
+    // manifest is a tenant-system object, so it lives under cache_subprefix()
+    // (<tenant_root>_cache/) — NOT the collection-scoped manifests_subprefix(),
+    // which previously rendered the malformed `data/default///manifests/…`.
     let resolved = DrPathBuilder::build_tenant_system(None, tenant_id)
         .map_err(|e| anyhow::anyhow!("invalid tenant id for warm manifest: {e}"))?;
-    let prefix = resolved.manifests_subprefix();
+    let prefix = resolved.cache_subprefix();
     let base = base_url.trim_end_matches('/');
     Ok(format!("{base}/{prefix}warm_cache.json"))
 }

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -293,7 +293,7 @@ impl CollectionPathResolver for CompositeResolver {
 /// See `docs/12-design/COLLECTION_DR_CRR_ENGINE_CONTRACT.adoc` "LLD: Physical
 /// Path Contract".
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DrResolvedPath {
+pub struct DrCollectionPath {
     /// Owning customer account — the billing/isolation boundary above
     /// `tenant_id`. `None` keeps the legacy flat `data/...` render.
     pub account_id: Option<String>,
@@ -310,7 +310,7 @@ pub struct DrResolvedPath {
     pub typed_identity: Option<CollectionIdentity>,
 }
 
-impl DrResolvedPath {
+impl DrCollectionPath {
     /// Root prefix. Account-rooted
     /// (`accounts/<account_id>/<tenant_id>/<namespace_id>/<collection_id>/`)
     /// when an account is set, else the legacy flat
@@ -419,19 +419,31 @@ impl DrResolvedPath {
     pub fn branches_subprefix(&self) -> String {
         format!("{}_branches/", self.root_prefix())
     }
+}
 
+/// A **per-tenant system path** — resolved *independent of any namespace or
+/// collection* (TD-CACHE-5 / ADR-074 S1 type split). Carries only the identity
+/// tiers the tenant-system subtrees render: `account_id` + `tenant_id` +
+/// `storage_pool_class`. The collection-scoped accessors (`root_prefix`,
+/// `segments_subprefix`, …) are deliberately ABSENT here — they require a
+/// namespace and collection, so the type system forbids the misuse that rendered
+/// the malformed `data/default///manifests/warm_cache.json` (a collection-scoped
+/// `manifests_subprefix()` called on a tenant-system path). Tenant-system
+/// objects hang off [`tenant_root`](Self::tenant_root) under reserved
+/// `_`-prefixed subtrees (`_metering/`, `_trace/`, `_cache/`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrTenantSystemPath {
+    pub account_id: Option<String>,
+    pub tenant_id: String,
+    pub storage_pool_class: StoragePoolClass,
+}
+
+impl DrTenantSystemPath {
     /// Per-**tenant** root prefix (account/legacy split) — `accounts/{account}/
     /// {tenant}/` or legacy `data/{tenant}/`. Stops *above* the namespace and
-    /// collection so per-tenant system subtrees (`_metering`, `_trace`) hang off
-    /// the tenant, not off a single collection. (TD-164)
-    ///
-    /// For an ADR-031 typed path the tenant tier is collapsed into the account,
-    /// so this returns the typed account root `accounts/{base62(account)}/`.
+    /// collection so per-tenant system subtrees (`_metering`, `_trace`, `_cache`)
+    /// hang off the tenant, not off a single collection. (TD-164)
     pub fn tenant_root(&self) -> String {
-        if let Some(id) = self.typed_identity {
-            let (acct, _, _) = id.path_segments();
-            return format!("accounts/{}/", acct);
-        }
         match &self.account_id {
             Some(account_id) => format!("accounts/{}/{}/", account_id, self.tenant_id),
             None => format!("data/{}/", self.tenant_id),
@@ -439,10 +451,9 @@ impl DrResolvedPath {
     }
 
     /// Per-tenant **metering** subtree `<tenant_root>_metering/` — the durable,
-    /// tenant-owned billing-meter sink (ADR-027 dual-sink; the differentiator;
-    /// written by TD-161's coalesced writer). The leading underscore keeps it
-    /// lexically separate from namespace/collection ids, which `validate_id`
-    /// reserves so a user object can never collide (structural isolation #3).
+    /// tenant-owned billing-meter sink (ADR-027 dual-sink; written by TD-161's
+    /// coalesced writer). The leading underscore is reserved by `validate_id`
+    /// so a user object can never collide (structural isolation).
     pub fn metering_subprefix(&self) -> String {
         format!("{}_metering/", self.tenant_root())
     }
@@ -451,6 +462,16 @@ impl DrResolvedPath {
     /// gateable perf class (ADR-027), written by TD-161's coalesced writer.
     pub fn trace_subprefix(&self) -> String {
         format!("{}_trace/", self.tenant_root())
+    }
+
+    /// Per-tenant **warm-cache** subtree `<tenant_root>_cache/` — the warm-restart
+    /// manifest is a tenant-system object, NOT collection-scoped (TD-CACHE-5). The
+    /// prior code rendered `data/default///manifests/warm_cache.json` by calling
+    /// the collection-scoped `manifests_subprefix()` on a tenant-system path; this
+    /// accessor is the tenant-system home for that object, alongside `_metering/`
+    /// and `_trace/`.
+    pub fn cache_subprefix(&self) -> String {
+        format!("{}_cache/", self.tenant_root())
     }
 }
 
@@ -596,7 +617,7 @@ pub enum PathResolverError {
 }
 
 /// Builder that turns a (namespace, collection_id) pair into a fully
-/// validated [`DrResolvedPath`].
+/// validated [`DrCollectionPath`].
 ///
 /// Pure construction — no I/O, no catalog calls. Callers fetch the
 /// owning `CatalogNamespace` themselves (cache, store, or test fixture)
@@ -606,13 +627,13 @@ pub struct DrPathBuilder;
 
 /// T2.3: Version-aware cache for `DrPathBuilder` results.
 ///
-/// Caches `DrResolvedPath` by `(tenant_id, namespace_id, collection_id, pool_class)`
+/// Caches `DrCollectionPath` by `(tenant_id, namespace_id, collection_id, pool_class)`
 /// with corpus version tracking for automatic invalidation on catalog changes.
 /// When the corpus version bumps, cached entries are considered stale and
 /// re-resolved on next access.
 pub struct DrPathCache {
     /// Cache entries: key → (version, path)
-    cache: DashMap<CacheKey, (u64, DrResolvedPath)>,
+    cache: DashMap<CacheKey, (u64, DrCollectionPath)>,
 }
 
 /// Cache key for path resolution results.
@@ -643,11 +664,11 @@ impl DrPathCache {
         collection_id: &str,
         pool_class: StoragePoolClass,
         resolve_fn: F,
-    ) -> Result<DrResolvedPath, PathResolverError>
+    ) -> Result<DrCollectionPath, PathResolverError>
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<R, PathResolverError>>,
-        R: std::borrow::Borrow<DrResolvedPath>,
+        R: std::borrow::Borrow<DrCollectionPath>,
     {
         let key = CacheKey {
             tenant_id: tenant_id.to_string(),
@@ -734,7 +755,7 @@ impl DrPathBuilder {
     pub fn build(
         namespace: &CatalogNamespace,
         collection_id: &str,
-    ) -> Result<DrResolvedPath, PathResolverError> {
+    ) -> Result<DrCollectionPath, PathResolverError> {
         let tenant_id =
             namespace
                 .tenant_id
@@ -762,7 +783,7 @@ impl DrPathBuilder {
             None => None,
         };
 
-        Ok(DrResolvedPath {
+        Ok(DrCollectionPath {
             account_id,
             tenant_id: tenant_id.to_string(),
             namespace_id: namespace_id.to_string(),
@@ -780,7 +801,7 @@ impl DrPathBuilder {
         namespace: &CatalogNamespace,
         collection_id: &str,
         destination_pool_class: StoragePoolClass,
-    ) -> Result<DrResolvedPath, PathResolverError> {
+    ) -> Result<DrCollectionPath, PathResolverError> {
         let resolved = Self::build(namespace, collection_id)?;
         if resolved.storage_pool_class != destination_pool_class {
             return Err(PathResolverError::PoolClassMismatch {
@@ -791,7 +812,7 @@ impl DrPathBuilder {
         Ok(resolved)
     }
 
-    /// Build a validated [`DrResolvedPath`] from already-resolved parts, rather
+    /// Build a validated [`DrCollectionPath`] from already-resolved parts, rather
     /// than from a `CatalogNamespace`.
     ///
     /// Use this when the authoritative `tenant_id` comes from the request/connection
@@ -805,7 +826,7 @@ impl DrPathBuilder {
         namespace_id: &str,
         collection_id: &str,
         storage_pool_class: StoragePoolClass,
-    ) -> Result<DrResolvedPath, PathResolverError> {
+    ) -> Result<DrCollectionPath, PathResolverError> {
         Self::build_from_parts_with_account(
             None,
             tenant_id,
@@ -827,7 +848,7 @@ impl DrPathBuilder {
         namespace_id: &str,
         collection_id: &str,
         storage_pool_class: StoragePoolClass,
-    ) -> Result<DrResolvedPath, PathResolverError> {
+    ) -> Result<DrCollectionPath, PathResolverError> {
         let account_id = match account_id {
             Some(account_id) => {
                 Self::validate_id("account_id", account_id)?;
@@ -838,7 +859,7 @@ impl DrPathBuilder {
         Self::validate_id("tenant_id", tenant_id)?;
         Self::validate_id("namespace_id", namespace_id)?;
         Self::validate_id("collection_id", collection_id)?;
-        Ok(DrResolvedPath {
+        Ok(DrCollectionPath {
             account_id,
             tenant_id: tenant_id.to_string(),
             namespace_id: namespace_id.to_string(),
@@ -848,14 +869,14 @@ impl DrPathBuilder {
         })
     }
 
-    /// Build a [`DrResolvedPath`] from an ADR-031 typed
+    /// Build a [`DrCollectionPath`] from an ADR-031 typed
     /// [`CollectionIdentity`] — the compact-numeric identity (account u32 /
     /// namespace u16 / collection u32) that retires UUID collection IDs.
     ///
     /// The string mirror fields (`account_id`/`namespace_id`/`collection_id`)
     /// are populated from the base62 segment encodings so that the **legacy**
-    /// [`root_prefix`](DrResolvedPath::root_prefix) still resolves a valid path,
-    /// and [`typed_root_prefix`](DrResolvedPath::typed_root_prefix) emits the
+    /// [`root_prefix`](DrCollectionPath::root_prefix) still resolves a valid path,
+    /// and [`typed_root_prefix`](DrCollectionPath::typed_root_prefix) emits the
     /// canonical zero-padded base62 prefix (no `tenant_id` — Phase 4 hierarchy
     /// collapse). `tenant_id` is left empty: the typed model has no tenant tier.
     ///
@@ -865,9 +886,9 @@ impl DrPathBuilder {
     pub fn build_from_identity(
         identity: CollectionIdentity,
         storage_pool_class: StoragePoolClass,
-    ) -> DrResolvedPath {
+    ) -> DrCollectionPath {
         let (acct_seg, ns_seg, coll_seg) = identity.path_segments();
-        DrResolvedPath {
+        DrCollectionPath {
             // String mirror populated from the base62 segments so legacy
             // root_prefix() stays valid for mixed reads.
             account_id: Some(acct_seg),
@@ -879,21 +900,23 @@ impl DrPathBuilder {
         }
     }
 
-    /// Resolve a **per-tenant system path** — the `_metering/` and `_trace/`
-    /// subtrees that hang off the tenant root, *independent of any namespace or
-    /// collection* (TD-161 / TD-164). Unlike [`build_from_parts`], it validates
-    /// only `account_id` + `tenant_id` (the only ids `tenant_root()` renders) and
-    /// leaves `namespace_id`/`collection_id` empty, so callers that hold just a
-    /// tenant — e.g. the storage-snapshot metering daemon, which keys off
-    /// `Collection.config.owner` — can build the durable sink path without
-    /// fabricating placeholder ids (which `validate_id` would reject for the
-    /// reserved `_`-prefixed system segments). Only `tenant_root()` /
-    /// `metering_subprefix()` / `trace_subprefix()` are meaningful on the result;
-    /// `root_prefix()` and the collection-scoped subprefixes are not.
+    /// Resolve a **per-tenant system path** — the `_metering/`, `_trace/`, and
+    /// `_cache/` subtrees that hang off the tenant root, *independent of any
+    /// namespace or collection* (TD-161 / TD-164 / TD-CACHE-5). Returns a
+    /// [`DrTenantSystemPath`], which validates only `account_id` + `tenant_id`
+    /// (the only ids `tenant_root()` renders) and structurally LACKS the
+    /// `namespace_id`/`collection_id` tiers — so callers that hold just a tenant
+    /// (e.g. the storage-snapshot metering daemon, keying off
+    /// `Collection.config.owner`) build the durable sink path without fabricating
+    /// placeholder ids, and the collection-scoped accessors (`root_prefix`,
+    /// `segments_subprefix`, …) cannot be called on the result. This is the class
+    /// fix for TD-CACHE-5: previously this returned a collection path with empty
+    /// namespace/collection, which let `warming.rs` compile a collection-scoped
+    /// `manifests_subprefix()` on it and render `data/default///manifests/…`.
     pub fn build_tenant_system(
         account_id: Option<&str>,
         tenant_id: &str,
-    ) -> Result<DrResolvedPath, PathResolverError> {
+    ) -> Result<DrTenantSystemPath, PathResolverError> {
         let account_id = match account_id {
             Some(account_id) => {
                 Self::validate_id("account_id", account_id)?;
@@ -902,13 +925,10 @@ impl DrPathBuilder {
             None => None,
         };
         Self::validate_id("tenant_id", tenant_id)?;
-        Ok(DrResolvedPath {
+        Ok(DrTenantSystemPath {
             account_id,
             tenant_id: tenant_id.to_string(),
-            namespace_id: String::new(),
-            collection_id: String::new(),
             storage_pool_class: StoragePoolClass::default(),
-            typed_identity: None,
         })
     }
 
@@ -979,7 +999,7 @@ impl DrPathBuilder {
 /// isolation model (Phase 5). The **operator** (control) plane lives under
 /// [`OPERATOR_ROOT`](Self::OPERATOR_ROOT) and holds the SaaS provider's
 /// registry of accounts; the **account** (data) plane lives under
-/// `accounts/{account_id}/…` (rendered by [`DrResolvedPath::root_prefix`]).
+/// `accounts/{account_id}/…` (rendered by [`DrCollectionPath::root_prefix`]).
 impl DrPathBuilder {
     /// Control-plane root prefix for the **operator** catalog — the SaaS
     /// provider's registry of all accounts (entitlements, storage bindings,
@@ -1000,6 +1020,10 @@ impl DrPathBuilder {
         "_metering",
         "_trace",
         "_manifests",
+        // TD-CACHE-5: per-tenant warm-cache subtree (`_cache/warm_cache.json`) —
+        // the warm-restart manifest is a tenant-system object, not
+        // collection-scoped; reserved so a user object can never shadow it.
+        "_cache",
         // TD-181 P3 (S2a): per-tenant system catalog subtree holding the
         // object_id-keyed metadata (`_syscat/objects/{oid}.json`) + index +
         // migration marker. Reserved before anything is written under it so a
@@ -1170,7 +1194,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // DrPathBuilder / DrResolvedPath
+    // DrPathBuilder / DrCollectionPath
     // ------------------------------------------------------------------
 
     fn dr_addressable_namespace() -> CatalogNamespace {
@@ -1219,18 +1243,21 @@ mod tests {
 
     #[test]
     fn per_tenant_metering_and_trace_subprefixes_hang_off_tenant_root() {
-        // TD-164: _metering / _trace are per-TENANT (above namespace/collection),
-        // unlike the per-collection data subprefixes (segments/, wal/, …).
-        let ns = dr_addressable_namespace();
-        let path = DrPathBuilder::build(&ns, "col_orders").unwrap();
+        // TD-164 / TD-CACHE-5: _metering / _trace / _cache are per-TENANT (above
+        // namespace/collection), so they live on DrTenantSystemPath; the per-
+        // collection data subprefixes (segments/, wal/, …) live on DrCollectionPath.
+        let sys = DrPathBuilder::build_tenant_system(None, "tnt_acme").unwrap();
+        assert_eq!(sys.tenant_root(), "data/tnt_acme/");
+        assert_eq!(sys.metering_subprefix(), "data/tnt_acme/_metering/");
+        assert_eq!(sys.trace_subprefix(), "data/tnt_acme/_trace/");
+        assert_eq!(sys.cache_subprefix(), "data/tnt_acme/_cache/");
+        // The tenant-system subprefixes never carry a collection id.
+        assert!(!sys.metering_subprefix().contains("col_orders"));
 
-        assert_eq!(path.tenant_root(), "data/tnt_acme/");
-        assert_eq!(path.metering_subprefix(), "data/tnt_acme/_metering/");
-        assert_eq!(path.trace_subprefix(), "data/tnt_acme/_trace/");
-        // Lexically separate from (and a strict prefix-parent of) the collection
-        // tree, never nested under a single collection.
-        assert!(path.root_prefix().starts_with(&path.tenant_root()));
-        assert!(!path.metering_subprefix().contains("col_orders"));
+        // The collection tree is a strict prefix-child of the tenant root.
+        let ns = dr_addressable_namespace();
+        let coll = DrPathBuilder::build(&ns, "col_orders").unwrap();
+        assert!(coll.root_prefix().starts_with(&sys.tenant_root()));
     }
 
     #[test]


### PR DESCRIPTION
## What
Class fix for **TD-CACHE-5** (Slice B of the namespace-isolation consensus). The warm-manifest misuse (`build_tenant_system(...).manifests_subprefix()` → `data/default///manifests/warm_cache.json`) compiled because one type carried **both** collection-scoped and tenant-system accessors, enforced only by doc comments. This makes the invariant structural: the type system forbids the call.

## Change
- **`DrResolvedPath` → `DrCollectionPath`** (collection-scoped): `root_prefix`, `wal/manifests/snapshots/segments/indexes/restore_checkpoints/branches` subprefixes, `index_prefix`, `resolve_index_location`, `typed_root_prefix`. Carries `namespace_id` + `collection_id` + `typed_identity`.
- **New `DrTenantSystemPath`** (tenant-scoped): `tenant_root`, `metering_subprefix`, `trace_subprefix`, **new `cache_subprefix`** (`<tenant_root>_cache/`). Carries only `account_id` + `tenant_id` + `storage_pool_class` — **structurally lacks** the collection-scoped accessors, so the misuse can no longer compile.
- `build_tenant_system` returns `DrTenantSystemPath` (no fabricated empty namespace/collection tiers).
- `warming.rs::manifest_url` → `cache_subprefix()` (warm manifest is a tenant-system object; `_cache/` alongside `_metering/`/`_trace/`).
- `_cache` added to `RESERVED_SYSTEM_SEGMENTS`.
- `metering_writer.rs` unchanged (metering still on the tenant-system type); `branch_ref.rs` `DrResolvedPath→DrCollectionPath`; doc refs updated; path_resolver test rewritten to assert each accessor on its own type.

## Properties
- **Zero behavior change** for existing paths (collection paths byte-identical; `metering`/`trace` unchanged).
- Blast radius: 1 real external code site (`branch_ref.rs`) + doc-comment renames; `manifests_subprefix`/`tenant_root`/`metering`/`trace` confirmed called only on the correct type post-split.
- `cargo check --lib` ✅ (×2, under contention); `cargo fmt --check` ✅; `make work-commit-check` ✅.
- This is orthogonal to the string→stable-ID axis (ADR-031 typed paths, env-gated) — the stable-ID form is the `typed_identity` layer, untouched here.

## Docs
TD-CACHE-5: `Open` → `Fixed` (closed by the type split, not just the one call site).

Slice A (TD-FLUSH-6, #1216) and Slice B are independent. Slice C (ADR-074 S1 namespace threading, stable-ID-aware) is next.