### PR TITLE
feat(tenant): ADR-074 S1 identity-boundary seam (namespace threading, zero behavior change)

### DIFF
--- a/crates/storage/proximadb-storage-tenant/src/context.rs
+++ b/crates/storage/proximadb-storage-tenant/src/context.rs
@@ -19,6 +19,23 @@ pub struct StorageTenantContext {
     pub status: TenantStatus,
     pub domains: Arc<DashMap<String, DomainContext>>,
     pub resource_limits: ContextResourceLimits,
+    /// ADR-074 S1: identity tiers threaded from the ingress context
+    /// (`MiddlewareTenantContext`) via the `From<&MiddlewareTenantContext>`
+    /// bridge, so `DrPathBuilder` sources them from identity instead of
+    /// storage-layer constants. All `Option` + default `None` ⇒ zero behavior
+    /// change (paths byte-identical; single-tenant resolves namespace to
+    /// `ns_default`). Populated by the bridge; legacy `for_tenant_id` callers
+    /// leave them `None`.
+    pub account_id: Option<String>,
+    pub tenant_stable_id: Option<u64>,
+    pub namespace_id: Option<String>,
+    /// Stable numeric namespace id (ADR-031 `NamespaceId = u16`) — the
+    /// AUTHORITATIVE namespace identity (ADR-074: rename-safe). The string
+    /// `namespace_id` is a derived legacy-compat form carried so the legacy
+    /// string-resolved path can read existing data (mixed-read-safe,
+    /// deprecated once typed paths go default-on). Threaded but unused until
+    /// `PROXIMADB_TYPED_PATHS`.
+    pub namespace_stable_id: Option<u16>,
 }
 
 /// Tenant configuration
@@ -151,6 +168,10 @@ impl StorageTenantContext {
             status: TenantStatus::Active,
             domains: Arc::new(DashMap::new()),
             resource_limits: ContextResourceLimits::default(),
+            account_id: None,
+            tenant_stable_id: None,
+            namespace_id: None,
+            namespace_stable_id: None,
         }
     }
 
@@ -244,6 +265,10 @@ mod tests {
             status: TenantStatus::Active,
             domains: Arc::new(DashMap::new()),
             resource_limits: ContextResourceLimits::default(),
+            account_id: None,
+            tenant_stable_id: None,
+            namespace_id: None,
+            namespace_stable_id: None,
         };
 
         assert_eq!(context.tenant_id, "test_tenant");
@@ -262,6 +287,10 @@ mod tests {
             status: TenantStatus::Active,
             domains: Arc::new(DashMap::new()),
             resource_limits: ContextResourceLimits::default(),
+            account_id: None,
+            tenant_stable_id: None,
+            namespace_id: None,
+            namespace_stable_id: None,
         };
 
         let business_context = BusinessContext {

--- a/crates/storage/proximadb-storage-tenant/src/manager.rs
+++ b/crates/storage/proximadb-storage-tenant/src/manager.rs
@@ -53,6 +53,10 @@ impl TenantManager {
             status: TenantStatus::Active,
             domains: Arc::new(DashMap::new()),
             resource_limits: config.resource_limits.clone(),
+            account_id: None,
+            tenant_stable_id: None,
+            namespace_id: None,
+            namespace_stable_id: None,
         };
 
         // Initialize resource tracker - convert ResourceLimits from context to resources

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -82,6 +82,19 @@ pub struct MiddlewareTenantContext {
     /// optimization for catalog/storage keying, never a second source of
     /// truth (the string `tenant_id` remains authoritative).
     pub tenant_stable_id: Option<u64>,
+    /// ADR-074 S1: the resolved namespace id — the legacy string form of the
+    /// `data/{tenant}/{namespace_id}/...` path tier. `None` = single-tenant /
+    /// default (resolve via [`namespace_or_default`](Self::namespace_or_default)).
+    /// Threaded to `StorageTenantContext` via the `From` bridge; populated from
+    /// the alias→id resolution seam in S2/S3. NOTE: the stable numeric
+    /// [`namespace_stable_id`](Self::namespace_stable_id) is the AUTHORITATIVE
+    /// identity (rename-safe); this string is the derived legacy-compat form
+    /// carried so the legacy string-resolved path can read existing data
+    /// (mixed-read-safe, deprecated once typed paths go default-on).
+    pub namespace_id: Option<String>,
+    /// ADR-031 stable numeric namespace id (`NamespaceId = u16`). Threaded but
+    /// unused until `PROXIMADB_TYPED_PATHS`; `None` = legacy string-resolved path.
+    pub namespace_stable_id: Option<u16>,
 }
 
 impl MiddlewareTenantContext {
@@ -95,6 +108,8 @@ impl MiddlewareTenantContext {
             source,
             is_system_tenant,
             tenant_stable_id: None,
+            namespace_id: None,
+            namespace_stable_id: None,
         }
     }
 
@@ -121,9 +136,61 @@ impl MiddlewareTenantContext {
         )
     }
 
+    /// Set the resolved namespace (ADR-074 S1). `namespace_stable_id` is the
+    /// AUTHORITATIVE identity (rename-safe); `namespace_id` is the derived
+    /// string form carried for the legacy string-resolved path (mixed-read-safe;
+    /// deprecated when typed paths go default-on). Both are populated by the
+    /// alias→id resolution seam in S2/S3.
+    pub fn with_namespace(
+        mut self,
+        namespace_id: impl Into<String>,
+        namespace_stable_id: u16,
+    ) -> Self {
+        self.namespace_id = Some(namespace_id.into());
+        self.namespace_stable_id = Some(namespace_stable_id);
+        self
+    }
+
+    /// The namespace id, falling back to the reserved default-namespace id when
+    /// none was resolved (single-tenant / OSS). Use at I/O boundaries that render
+    /// the legacy string path `data/{tenant}/{namespace_id}/…`.
+    pub fn namespace_or_default(&self) -> &str {
+        self.namespace_id.as_deref().unwrap_or(
+            crate::storage::trait_components::path_resolver::DrPathBuilder::DEFAULT_NAMESPACE_ID,
+        )
+    }
+
     /// Check if this is a valid tenant (not empty)
     pub fn is_valid(&self) -> bool {
         !self.tenant_id.is_empty()
+    }
+}
+
+/// ADR-074 S1: the **single identity-boundary seam**. Converts the network-layer
+/// [`MiddlewareTenantContext`] into the storage-layer
+/// [`StorageTenantContext`], carrying ALL identity tiers (tenant, account,
+/// `tenant_stable_id`, `namespace_id`, `namespace_stable_id`) — replacing the
+/// ad-hoc `StorageTenantContext::for_tenant_id(string)` re-derivation scattered
+/// across ~18 protocol boundaries, which dropped account/stable/namespace on
+/// the floor. Protocol boundaries should call `StorageTenantContext::from(ctx)`
+/// (or `ctx.into()`) instead of `for_tenant_id`; S2/S3 populate the namespace
+/// fields from the alias→stable-id resolution seam.
+///
+/// NOTE on authority (ADR-074): the stable numeric ids (`tenant_stable_id`,
+/// `namespace_stable_id`) are the rename-safe source of truth; the string
+/// `tenant_id`/`namespace_id` are derived legacy-compat forms carried so the
+/// legacy string-resolved path can read existing data (mixed-read-safe). They
+/// are deprecated for new code once typed paths go default-on.
+///
+/// [`StorageTenantContext`]: crate::storage::tenant::context::StorageTenantContext
+impl From<&MiddlewareTenantContext> for crate::storage::tenant::context::StorageTenantContext {
+    fn from(ctx: &MiddlewareTenantContext) -> Self {
+        let mut s = Self::for_tenant_id(ctx.tenant_id.clone());
+        s.account_id = ctx.account_id.clone();
+        s.tenant_stable_id = ctx.tenant_stable_id;
+        s.namespace_id = ctx.namespace_id.clone();
+        s.namespace_stable_id = ctx.namespace_stable_id;
+        s
     }
 }
 

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -86,12 +86,9 @@ use proximadb_storage_common::object_store_bridge::ObjectStoreBridge;
 /// centralized so the gap is greppable and the eventual fix has one call site.
 pub(crate) const DEFAULT_TENANT_PLACEHOLDER: &str = "default_tenant";
 
-/// Well-known, rename-stable `namespace_id` for the embedded / single-tenant path
-/// (no catalog namespace with its own id). Single-tenant is a degenerate
-/// multi-tenant: it resolves the same canonical DrPath layout as any real
-/// namespace, just under this fixed id. Matches the record-store write path, which
-/// already addresses the default namespace as `ns_default`.
-pub(crate) const DEFAULT_NAMESPACE_ID: &str = "ns_default";
+// The single-tenant default namespace id now lives on the path contract
+// (DrPathBuilder, ADR-074 S1) — the local const duplicate was removed so the
+// default has ONE source.
 
 /// Resolve the tenant-isolated object prefix (no trailing `/`) for a warehouse
 /// snapshot: the single canonical **DrPath** layout
@@ -101,7 +98,7 @@ pub(crate) const DEFAULT_NAMESPACE_ID: &str = "ns_default";
 ///
 /// There is exactly one layout. Every namespace carries a `namespace_id` — real
 /// namespaces get one at create (`NativeCatalog`), and the embedded / single-tenant
-/// path uses the well-known [`DEFAULT_NAMESPACE_ID`] (`ns_default`), the same id the
+/// path uses the well-known [`DrPathBuilder::DEFAULT_NAMESPACE_ID`] (`ns_default`), the same id the
 /// record-store write path already uses. The caller resolves `namespace_id`
 /// (real-or-`ns_default`) and passes it here, so single-tenant is just a degenerate
 /// multi-tenant — no legacy `data/{tenant}/{ns.join}/{table}` fork, no special case.
@@ -1189,7 +1186,7 @@ impl DmlService {
         };
 
         if namespace.is_empty() {
-            DEFAULT_NAMESPACE_ID.to_string()
+            DrPathBuilder::DEFAULT_NAMESPACE_ID.to_string()
         } else {
             namespace.join(".")
         }
@@ -1571,7 +1568,7 @@ impl DmlService {
             ns_meta
                 .as_ref()
                 .and_then(|n| n.namespace_id.as_deref())
-                .unwrap_or(DEFAULT_NAMESPACE_ID),
+                .unwrap_or(DrPathBuilder::DEFAULT_NAMESPACE_ID),
             ns_meta.as_ref().and_then(|n| n.tenant_id.as_deref()),
             ns_meta
                 .as_ref()
@@ -2405,7 +2402,7 @@ impl DmlService {
             ns_meta
                 .as_ref()
                 .and_then(|n| n.namespace_id.as_deref())
-                .unwrap_or(DEFAULT_NAMESPACE_ID),
+                .unwrap_or(DrPathBuilder::DEFAULT_NAMESPACE_ID),
             ns_meta.as_ref().and_then(|n| n.tenant_id.as_deref()),
             ns_meta
                 .as_ref()

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -190,7 +190,7 @@ fn resolve_materialize_prefix_drpath_and_cross_tenant() {
     // Embedded / single-tenant uses the well-known ns_default — same layout, no
     // legacy fork (single-tenant is a degenerate multi-tenant).
     assert_eq!(
-        resolve(DEFAULT_NAMESPACE_ID, None).unwrap(),
+        resolve(DrPathBuilder::DEFAULT_NAMESPACE_ID, None).unwrap(),
         "data/tnt_acme/ns_default/orders"
     );
     // Cross-tenant (namespace owned by another tenant) → refused.

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -300,9 +300,20 @@ pub(crate) fn object_store_write_base_path(
     let tenant_id = tenant_context
         .map(|tc| tc.tenant_id.as_str())
         .unwrap_or("default_tenant");
+    // ADR-074 S1 (C.2): source the namespace id from the identity context
+    // (threaded via the `From<&MiddlewareTenantContext>` bridge), not a hardcoded
+    // storage-layer constant. `None` (single-tenant / not yet threaded) falls
+    // back to the path contract's DEFAULT_NAMESPACE_ID — byte-identical to the
+    // prior "ns_default", so paths are unchanged (mixed-read-safe).
+    let namespace_id = tenant_context
+        .and_then(|tc| tc.namespace_id.clone())
+        .unwrap_or_else(|| {
+            crate::storage::trait_components::path_resolver::DrPathBuilder::DEFAULT_NAMESPACE_ID
+                .to_string()
+        });
     let mock_namespace = proximadb_catalog::CatalogNamespace::new(vec!["default".into()])
         .with_tenant(tenant_id)
-        .with_namespace_id("ns_default");
+        .with_namespace_id(namespace_id);
 
     let dr_path = crate::storage::trait_components::path_resolver::DrPathBuilder::build(
         &mock_namespace,

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -1014,6 +1014,15 @@ impl DrPathBuilder {
     /// `None` account keeps the legacy flat `data/…` render instead.
     pub const DEFAULT_ACCOUNT_ID: &'static str = "default";
 
+    /// Default `namespace_id` for single-tenant / OSS deployments that have
+    /// not provisioned an explicit namespace (ADR-074 S1). The canonical,
+    /// rename-stable id mirroring [`DEFAULT_ACCOUNT_ID`]; resolved at the
+    /// identity boundary via
+    /// [`MiddlewareTenantContext::namespace_or_default`](crate::network::middleware::tenant::MiddlewareTenantContext::namespace_or_default).
+    /// Paths stay byte-identical to the prior storage-layer constant
+    /// (`DEFAULT_NAMESPACE_ID = "ns_default"` in `services/dml`).
+    pub const DEFAULT_NAMESPACE_ID: &'static str = "ns_default";
+
     /// Reserved subpath under [`OPERATOR_ROOT`](Self::OPERATOR_ROOT) that holds
     /// the deployment's system catalog (WAL + snapshot). Single canonical
     /// constant so boot and any tooling agree on the location.


### PR DESCRIPTION
**ADR-074 S1 — thread `namespace_id` (and the stable ids) through the identity seam.** Now complete: the seam (C.1) + namespace sourced from identity instead of a storage-layer constant (C.2). **Zero behavior change** (all new fields `Option`/`None`; unset ⇒ `ns_default`; paths byte-identical).

## C.1 — the seam
- **`StorageTenantContext`**: add `account_id`, `tenant_stable_id`, `namespace_id`, `namespace_stable_id` (all `Option`/`None`). `for_tenant_id` + the 3 literal constructions default them.
- **`MiddlewareTenantContext`**: add `namespace_id` + `namespace_stable_id`; `with_namespace` builder; `namespace_or_default()`; new `DrPathBuilder::DEFAULT_NAMESPACE_ID` (mirrors `DEFAULT_ACCOUNT_ID`).
- **`From<&MiddlewareTenantContext> for StorageTenantContext`**: the **one** bridge carrying all identity tiers, replacing the ~18 ad-hoc `for_tenant_id(string)` re-derivations.

## C.2 — namespace from identity (not a storage-layer constant)
- `record_store::object_store_write_base_path`: source `namespace_id` from `tenant_context.namespace_id` (the bridge), falling back to `DrPathBuilder::DEFAULT_NAMESPACE_ID` — byte-identical to the prior hardcoded `"ns_default"` (mixed-read-safe). **Removes the R3 violation** (a default namespace chosen inside the storage layer).
- `dml`: remove the duplicate `DEFAULT_NAMESPACE_ID` const — now ONE source on the path contract (`DrPathBuilder`); readers + test updated.

## Stable-ID-authoritative (governing decision)
The stable numeric ids (`namespace_stable_id: u16`, `tenant_stable_id: u64`) are the **authoritative, rename-safe** source of truth; strings are derived legacy-compat (mixed-read-safe; deprecated once typed paths go default-on). Formalized in **ADR-075** (#1223, merged).

## Verification
- `cargo check --lib` ✅ (×2) · `cargo fmt --check` ✅ · `make work-commit-check` ✅ (env-gates 217).

## Out of scope (follow-ons)
- **~18 `for_tenant_id` sites → bridge** (so `namespace_id` populates end-to-end) + remove the `record_store` `.expect` (needs the `object_store_write_base_path` return-type change — ObjectPath callers).
- **alias→stable-id authz resolution** = ADR-074 S2/S3.
- **`record_count:0`** is a separate name-vs-id defect → #1224.