### PR TITLE
docs(td): promote FC metamodel + policy model out of Draft (keys on ADR-075 stable ids, coord #1223)

### DIFF
--- a/docs/10-quality/td/TD-FOUNDATION-2-catalog-metamodel-abac-plane.adoc
+++ b/docs/10-quality/td/TD-FOUNDATION-2-catalog-metamodel-abac-plane.adoc
@@ -1,16 +1,17 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-FOUNDATION-2: Catalog metamodel + ABAC access-control plane (FC)
-:status: Draft — design-gate (pre-implementation)
+:status: Accepted (metamodel + policy model) — build; enforcement (FA) stays Draft/blocked in TD-FOUNDATION-3
 :date: 2026-07-25
 :authors: co-design session 2026-07-25
 :realizes: ADR-072 D12 (metamodel) — FC; the D6/D15 enforcement plane splits to TD-FOUNDATION-3
-:sits-on: ADR-074 (namespace isolation boundary), ADR-031 (stable object_id)
+:sits-on: ADR-074 (namespace isolation boundary), ADR-031 + ADR-075 (stable-ID-authoritative object_id)
 :tracks: FC = D12 metamodel + policy model. Enforcement (FA) → TD-FOUNDATION-3. Cross-tenant → deferred.
 
 [cols="1,3"]
 |===
-| Status | Draft — **scope re-cut after 3 red-team rounds** (see §0.1)
+| Status | **Accepted for build — metamodel + policy model** (2026-07-26). The D12 metamodel + policy model (§2, §3.1–§3.3) are promoted out of Draft and cleared to build — additive, feature-gated, inert, and survived three red-team rounds. The **enforcement** design (§3.4, §8) remains the design-of-record for **FA / TD-FOUNDATION-3**, which stays Draft/blocked. Scope re-cut: §0.1.
+| ID authority (coordinates with #1223) | **All metamodel id-references key on the ADR-075 stable numeric ids** — catalog `object_id: u64`, `tenant_stable_id: u64`, `NamespaceId: u16`, `CollectionId: u32` (Model A / `lib.rs` already uses these). `EntityRef` endpoints, `PolicyBinding.scope`, and the `owning_primary` `KeyRef` are stable ids, **never display strings** (strings are derived legacy-compat, resolved at the ADR-074 seam). FC does **not** touch Model B's (`internal::CatalogObject`) String-UUID `object_id` — reconciling that to `u64` is the parallel-model collapse (TF-1 roadmap), out of FC scope.
 | **Blocked-on** | **THREE adversarial red-team rounds have run (§6.1 log): round 1 broke all 5 §6 targets; round 2 broke all 5 fixes; round 3 broke the round-2 fixes AND proved the ABAC *enforcement* plane is a multi-package subsystem, not a wiring job (subject-blind cache tier above the seam; write-path disclosure; `Brokered` unbuildable against a stub graph executor; `resolve_effective_attributes`/`Reference` need an absent attribute-authority + federation subsystem; JWT signature verification is not live). DECISION (2026-07-26): SPLIT — this doc (FC) ships the D12 **metamodel + policy model** (additive, low-risk, survived the attacks); the **ABAC enforcement subsystem** (AuthorizedReadContext, 4 surfaces, S1–S10, preconditions) moves to a new track **TD-FOUNDATION-3 (FA)**; **cross-tenant `Reference`/`Brokered` are deferred** (blocked on a real graph executor + attribute federation). A separate security TD must verify/fix **unsigned-JWT decode** independently. No FC code until this doc promotes out of Draft; no FA code until TF-3's preconditions are met.**
 | Realizes | ADR-072 **D12** (family-parameterized identity, first-class edges, logical/physical split), **D6** (structural tenancy), **D15** (cost-based hybrid/filter planner, RLS-as-global-filter)
 | Sits on | **ADR-074** (namespace = isolation boundary; alias→`namespace_id`, authz-gated) — FC supplies the *authz gate* ADR-074 defers
@@ -85,7 +86,8 @@ So the work is **split into three tranches**:
   in a system namespace, the hierarchical resolver, `SubjectAttributes` shape).
   All **additive, feature-gated, inert** — data structures + a resolver, no
   enforcement. This tranche largely **survived** the red-teams.
-| Buildable now. Ships when this doc promotes out of Draft. §2, §3.1–§3.3.
+| **Accepted — building** (2026-07-26). Feature `fc-metamodel`. Keys on ADR-075
+  stable ids (see status header). §2, §3.1–§3.3.
 
 | **FA — TD-FOUNDATION-3 (new)**
 | The **ABAC enforcement subsystem**: the `AuthorizedReadContext` across all four


### PR DESCRIPTION
Promotes the **D12 metamodel + policy model** tranche of TD-FOUNDATION-2 out of Draft — **Accepted for build**. Additive, feature-gated (`fc-metamodel`), inert, and survived three red-team rounds. The **enforcement** design (§3.4/§8) stays the design-of-record for **FA / TD-FOUNDATION-3** (Draft/blocked).

## Coordination with #1223 (ADR-075 stable-ID-authoritative identity)
Every metamodel id-reference keys on the **stable numeric ids** — `object_id: u64`, `tenant_stable_id: u64`, `NamespaceId: u16`, `CollectionId: u32` (Model A / `lib.rs` already uses these). `EntityRef` endpoints, `PolicyBinding.scope`, and the `owning_primary` `KeyRef` are stable ids, **never display strings**. FC does **not** touch Model B's (`internal::CatalogObject`) String-UUID `object_id` — that reconciliation is the parallel-model collapse (TF-1 roadmap), out of scope.

Stacked on the scope-re-cut (#1222). Docs-only; guards pass.