### PR TITLE
test(cache): TD-CACHE-7 — lock the restart-warming object-store boundary

### DIFF
--- a/docs/10-quality/td/TD-CACHE-7-restart-warming-object-store-coverage.adoc
+++ b/docs/10-quality/td/TD-CACHE-7-restart-warming-object-store-coverage.adoc
@@ -1,0 +1,64 @@
+= TD-CACHE-7: restart warming had ZERO object-store test coverage — the boundary its economics depend on kept silently regressing
+:status: S1 shipped (2026-07-26) — round-trip guard + always-on URL well-formedness test
+:filed: 2026-07-26
+:priority: P1 (Spot-economics foundation; recurring silent-regression class)
+
+== Why this is foundational, from first principles
+
+The pricing thesis rests on serving from **Spot instances** (−70–90%) to
+undercut competitors. Spot instances are reaped constantly; the ONLY thing
+making a stateful serving tier survivable on Spot is **restart warming**
+(TD-CACHE-1 S1–S4): on eviction, persist a per-tenant `warm_cache.json` to
+object storage; on the replacement pod, replay it so the hot working set is
+not cold-started. Restart warming therefore lives-or-dies at the
+**object-storage write/read boundary**.
+
+That boundary had **no test**. The manifest write/read was exercised only on
+local `file://` (the #1187 verification bed), and the URL construction +
+factory resolution repeatedly broke on cloud schemes without anything
+catching it:
+
+* TD-FLUSH-6 / #1216 — `resolve_path` dropped the container from cloud URLs
+  (`Url::parse().path()` loses the host) → `not an azure path: /…`.
+* TD-CACHE-5 / #1218 — `manifest_url` used the collection-scoped
+  `manifests_subprefix()` → malformed `data/<tenant>///manifests/…`.
+* 2026-07-26 two-tenant Azurite bed — a stale binary reproduced BOTH,
+  surfacing that warming was silently a no-op on `azure://`.
+
+Each was fixed reactively; nothing prevented the next regression. Co-design
+mandate #3 ("treat the boundary as the contract") was violated exactly here.
+
+== S1 (shipped): lock the boundary
+
+`src/storage/engines/sst/warming.rs` tests:
+
+1. `manifest_url_is_well_formed_on_cloud_bases` (always-on unit): for
+   `azure://`, `s3://`, `adls://` bases (incl. a trailing-slash base),
+   asserts the built URL preserves the container, has no `//` run after the
+   scheme, never uses the legacy `…/manifests/…` prefix, and is the
+   tenant-scoped `…/warm_cache.json`. Permanent guard against the whole
+   malformation/strip class.
+2. `warm_manifest_round_trips_on_object_store` (`#[ignore]`, cloud-emulator
+   tier): emit → `factory.write(create_dirs)` → `factory.read` →
+   deserialize a `WarmManifest` against a real backend
+   (`PROXIMADB_WARM_TEST_BASE` + Azurite/MinIO/creds). Proves the actual
+   write/read boundary, not just URL construction. Wired into the cloud-
+   emulator CI tier so a container-strip regression fails there.
+
+Empirical result (2026-07-26, current develop + Azurite): round-trip
+PASSES — current develop's warming IS correct on object storage; the bed
+failure was a stale binary. S1 converts that from an unguarded accident into
+a pinned contract.
+
+== Open (S2)
+
+An end-to-end warm-restart on object storage (server SIGTERM → manifest on
+azure → replacement server → measured GET-avoidance on replay) — the #1187
+E2E, re-run on `azure://` instead of `file://`, to close the last gap
+between "the boundary round-trips" and "the feature delivers its GET
+savings on cloud".
+
+== Related
+
+TD-CACHE-1 (restart warming), TD-FLUSH-6 + TD-CACHE-5 (the reactive fixes
+this test locks), ADR-073 (Spot topology), `scripts/bench/two_tenant_bed.py`.

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -146,6 +146,7 @@ the emergency off) · *config-mirror* (env overrides a config field) ·
 | `PROXIMADB_NETWORK_SCOPE_MAP` | JSON file path for CIDR→client-locality scope map (result-egress) | default-empty (clients classify Unknown) | config-mirror; Co-design KOU | `src/metrics/consumption_metrics.rs`
 | `PROXIMADB_NOVA_MAX_ROW_GROUP_SIZE` | Forces smaller NOVA parquet row-group size (exercise row-group pruning) | 50,000 | test-only/opt-in; TD-040 | `src/storage/engines/nova/operations/flush.rs`
 | `PROXIMADB_OBJECT_STORE_LOCALITY` | Overrides derived object-store read-egress locality | derived locality (invalid ⇒ WARN + derived) | opt-in override; Co-design C3/KOU | `src/metrics/consumption_metrics.rs`
+| `PROXIMADB_WARM_TEST_BASE` | Cloud base URL for the warm-manifest round-trip test (falls back to `PROXIMADB_OBJECT_STORE_URL`) | none (test `#[ignore]` without it) | test-only; TD-CACHE-7 | `src/storage/engines/sst/warming.rs`
 | `PROXIMADB_OBJECT_STORE_URL` | Object-store base URL (s3/adls/gs) for restart-recovery integration tests | none (tests `#[ignore]` without it) | test-only; TD-OBJSTORE-5 | `apps/proximadb-server/tests/object_store_restart_recovery.rs`
 | `PROXIMADB_OLAP_DELTA_MERGE` | Engine-wide read-merge (delta-over-parquet) toggle; tables can re-opt-in | ON (falsy token `0/false/off/no` disables) | kill-switch; ADR-025 | `src/network/postgres/relational_pipeline.rs`
 | `PROXIMADB_OLAP_TABLE_CACHE` | Enables the table-OPEN cache | OFF (default-OFF-until-baked) | opt-in; TD-OLAP | `src/datafusion/engine_adapters/table_open_cache.rs`

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -674,3 +674,17 @@ hardware = "WSL2 Linux 5.15, 32 cores, 78 GB RAM, in-process memory:// object-st
 date = "2026-07-07"
 version = "v0.2"
 notes = "P-Trace (ADR-055 first phase; trace before you tune). 500-doc corpus, one PAX segment: point_get.bytes_read = filtered_scan.bytes_read = 329,111 B (get_ops=1, range_gets=0), write.bytes_written=329,111 (put_ops=1). A document read fetches the ENTIRE segment whether it wants 1 or 500 records — no block/zone-map pruning, no ranged reads. Wired the write-side put_pax hook (record_bytes_written at the object-store PUT in record_store.rs; shared with vectors); reads already record fetch_pax+bytes_read. range_gets is io-trace-feature-gated but legitimately 0 (whole-segment fetch path). Target for P-Pushdown: a filtered query reads strictly < 329,111 B with range_gets>0, results identical."
+
+[[claims]]
+id = "warm_manifest_object_store_roundtrip"
+claim = "TD-CACHE-7: restart-warming manifest write+read round-trips correctly on object storage (Azurite azure:// via the production FilesystemFactory path): manifest_url builds a well-formed cloud URL (container preserved, no // run, tenant-scoped _cache/ prefix, not the legacy manifests/), and factory.write(create_dirs)->read->deserialize succeeds. Empirically confirms current develop is CORRECT on cloud (the 2026-07-26 two-tenant bed failure was a stale binary), and locks the boundary that silently regressed 3x (TD-FLUSH-6 container-strip, TD-CACHE-5 malformed prefix, bed) with an always-on URL guard + a cloud-emulator-tier round-trip."
+metric = "well-formed cloud manifest URL + write/read/deserialize round-trip on object storage"
+status = "measured"
+asserted_in = ["docs/10-quality/td/TD-CACHE-7-restart-warming-object-store-coverage.adoc"]
+bench_source = "src/storage/engines/sst/warming.rs"
+bench_command = "PROXIMADB_AZURE_EMULATOR=1 AZURITE_BLOB_STORAGE_URL=http://127.0.0.1:11000 AZURE_STORAGE_ACCOUNT=devstoreaccount1 PROXIMADB_OBJECT_STORE_URL=azure://benchbucket/objtier cargo test -p proximadb --features azure --lib warm_manifest_round_trips_on_object_store -- --ignored"
+artifact = "docs/10-quality/td/TD-CACHE-7-restart-warming-object-store-coverage.adoc"
+hardware = "Local macOS arm64, Azurite 3.36 blob emulator on localhost:11000"
+date = "2026-07-26"
+version = "fix/warm-manifest-azure-path -> develop"
+

--- a/scripts/run_cloud_emulator_tests.sh
+++ b/scripts/run_cloud_emulator_tests.sh
@@ -118,6 +118,13 @@ if [ "$SCOPE" = "restart" ]; then
   CARGO_BUILD_JOBS=1 cargo test -p proximadb-server --features azure \
     --test object_store_restart_recovery \
     -- --ignored --nocapture --test-threads=1
+  # TD-CACHE-7: restart-warming manifest write/read round-trip on object storage
+  # — the boundary that repeatedly regressed with zero coverage (container-strip
+  # / malformed prefix). Reuses the exported PROXIMADB_OBJECT_STORE_URL.
+  echo "==> TD-CACHE-7: warm-manifest round-trip over Azurite (adls://)"
+  CARGO_BUILD_JOBS=1 cargo test -p proximadb --features azure --lib \
+    warm_manifest_round_trips_on_object_store \
+    -- --ignored --nocapture --test-threads=1
   # TD-OBJSTORE-5 S2: per-primitive contract tests against the PRODUCTION root
   # FileSystem backends (PUT->prefix-LIST, prefix-exists-false, multi-page LIST).
   # Azure + S3 strict; GCS best-effort (skips if the backend does not register).

--- a/src/storage/engines/sst/warming.rs
+++ b/src/storage/engines/sst/warming.rs
@@ -244,6 +244,91 @@ pub async fn boot_warm(factory: Arc<FilesystemFactory>, base_url: String, tenant
 mod tests {
     use super::*;
 
+    /// TD-CACHE-7: the warm-manifest URL for a CLOUD base must be well-formed —
+    /// container preserved, no `//` run, no legacy `…/manifests/…` malformation.
+    /// This is the always-on guard against the recurring container-strip /
+    /// double-slash class (TD-FLUSH-6, TD-CACHE-5) that repeatedly silently
+    /// disabled restart warming on object storage.
+    #[test]
+    fn manifest_url_is_well_formed_on_cloud_bases() {
+        for base in [
+            "azure://benchbucket/proximadb/collections",
+            "azure://benchbucket/proximadb/collections/", // trailing slash
+            "s3://mybucket/data",
+            "adls://container/root",
+        ] {
+            let url = manifest_url(base, "tenant-b").expect("manifest url");
+            let scheme_end = url.find("://").unwrap() + 3;
+            let after_scheme = &url[scheme_end..];
+            assert!(
+                !after_scheme.contains("//"),
+                "no `//` run after the scheme in {url}"
+            );
+            assert!(
+                !url.contains("/manifests/"),
+                "must NOT use the legacy collection-scoped manifests/ prefix: {url}"
+            );
+            // The container (first path segment after scheme) must survive.
+            let container = after_scheme.split('/').next().unwrap();
+            assert!(!container.is_empty(), "container present in {url}");
+            assert!(
+                url.ends_with("warm_cache.json") && url.contains("tenant-b"),
+                "tenant-scoped warm_cache.json: {url}"
+            );
+        }
+    }
+
+    /// TD-CACHE-7: full warm-manifest ROUND-TRIP through the FilesystemFactory
+    /// against a real object-store backend — the boundary that kept regressing
+    /// with ZERO coverage. Emit → write (create_dirs) → read → deserialize.
+    /// Gated on a cloud endpoint; run via the cloud-emulator tier or locally:
+    ///   PROXIMADB_AZURE_EMULATOR=1 AZURITE_BLOB_STORAGE_URL=http://127.0.0.1:11000 \
+    ///   AZURE_STORAGE_ACCOUNT=devstoreaccount1 \
+    ///   PROXIMADB_WARM_TEST_BASE=azure://benchbucket/warmtest \
+    ///   cargo test -p proximadb --features azure warm_manifest_round_trips -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires a cloud object-store endpoint (PROXIMADB_WARM_TEST_BASE + Azurite/MinIO/creds)"]
+    async fn warm_manifest_round_trips_on_object_store() {
+        // Accept the dedicated var, or slot into the shared cloud-emulator
+        // env (the runner exports PROXIMADB_OBJECT_STORE_URL for the whole tier).
+        let base = std::env::var("PROXIMADB_WARM_TEST_BASE")
+            .or_else(|_| {
+                std::env::var("PROXIMADB_OBJECT_STORE_URL").map(|b| format!("{b}/warm-manifest-rt"))
+            })
+            .expect("set PROXIMADB_WARM_TEST_BASE or PROXIMADB_OBJECT_STORE_URL");
+        let factory =
+            std::sync::Arc::new(FilesystemFactory::create_default().await.expect("factory"));
+        let url = manifest_url(&base, "tenant-a").expect("url");
+        let manifest = WarmManifest {
+            version: WARM_MANIFEST_VERSION,
+            created_unix: 1_700_000_000,
+            entries: vec![WarmKey {
+                k: 0,
+                p: "seg1.pax".to_string(),
+                o: 128,
+                l: 4096,
+            }],
+        };
+        let bytes = serde_json::to_vec(&manifest).unwrap();
+        let options = proximadb_storage_filesystem_types::FileOptions {
+            overwrite: true,
+            create_dirs: true,
+            ..Default::default()
+        };
+        factory
+            .write(&url, &bytes, Some(options))
+            .await
+            .unwrap_or_else(|e| panic!("write {url} failed (container-strip regression?): {e}"));
+        let read = factory
+            .read(&url)
+            .await
+            .unwrap_or_else(|e| panic!("read {url} failed: {e}"));
+        let got: WarmManifest = serde_json::from_slice(&read).expect("round-trip deserialize");
+        assert_eq!(got.entries.len(), 1);
+        assert_eq!(got.entries[0].p, "seg1.pax");
+        assert_eq!(got.entries[0].l, 4096);
+    }
+
     /// TD-CACHE-1 S4: notice parsers — Azure fires only on lifecycle-ending
     /// event types; GCP on the TRUE flag; malformed input never fires.
     #[test]


### PR DESCRIPTION
## Summary

**First-principles finding**: restart warming (TD-CACHE-1 S1–S4) is what makes serving on Spot instances viable — the economic foundation of the whole pricing story — and it lives-or-dies at the object-store write/read boundary. That boundary had **zero test coverage**: warming was verified only on local `file://`, and its cloud path silently broke **three times** (TD-FLUSH-6 container-strip, TD-CACHE-5 malformed prefix, the 2026-07-26 two-tenant bed), each fixed reactively with nothing preventing the next regression.

**Empirical result** (Azurite, current develop): the full manifest write→read round-trip **PASSES** — the bed failure was a **stale binary**, not a live bug. This PR converts that from an unguarded accident into a pinned contract:

- `manifest_url_is_well_formed_on_cloud_bases` (always-on unit): asserts container preserved, no `//` run, no legacy `/manifests/` prefix, tenant-scoped `warm_cache.json` — for `azure://`/`s3://`/`adls://` incl. trailing-slash bases. Permanent guard against the whole strip/malformation class.
- `warm_manifest_round_trips_on_object_store` (`#[ignore]`, cloud-emulator tier): emit → `factory.write(create_dirs)` → `read` → deserialize against a real backend; wired into `scripts/run_cloud_emulator_tests.sh` so a container-strip regression fails CI.

TD-CACHE-7 + ledger claim `warm_manifest_object_store_roundtrip`. Co-design mandate #3 (treat the boundary as the contract) now has a test at that seam. Gates: work-commit-check (incl. env-gate — the new test var is registered), ledger validated (42 claims), 3/3 warming unit tests, round-trip confirmed on Azurite.