### PR TITLE
fix(security): guard the unwired signature-blind OIDC stubs (dead-code footgun)

### DIFF
--- a/src/auth/sso/oidc.rs
+++ b/src/auth/sso/oidc.rs
@@ -208,7 +208,15 @@ impl OIDCIntegration {
         })
     }
 
-    /// Simulate OIDC validation (placeholder)
+    /// ⚠️ **DEAD / UNWIRED placeholder — DO NOT WIRE INTO ANY INGRESS.**
+    ///
+    /// This *fabricates* an authenticated user from an ID token **without any
+    /// verification** (no signature, no JWKS, no issuer trust) — it does not even
+    /// decode the token. `OIDCIntegration` is not constructed in live code (only
+    /// referenced via `type_name` in a test), so this is unreachable today.
+    /// Wiring it would be an instant critical SSO-forgery vulnerability. The live,
+    /// verifying JWT path is `crate::network::auth::jwt`'s `JwtService`; a real
+    /// OIDC path must verify against the provider's JWKS before trusting a claim.
     async fn simulate_oidc_validation(&self, id_token: &str) -> Result<EnterpriseUserContext> {
         if id_token.is_empty() {
             return Err(anyhow!("Empty OIDC ID token"));

--- a/src/security/auth/oidc.rs
+++ b/src/security/auth/oidc.rs
@@ -78,10 +78,28 @@ struct JwtClaims {
 /// 2. Validating claims (issuer, audience, expiration)
 /// 3. Extracting user identity and roles from standard claims
 ///
-/// NOTE: Full cryptographic signature verification requires an RSA/EC
-/// library (e.g., `jsonwebtoken` crate).  This implementation validates
-/// claims and structure.  For production deployments, enable the
-/// `jsonwebtoken` feature for full signature verification.
+/// ⚠️ **DEAD / UNWIRED — DO NOT WIRE INTO ANY INGRESS.**
+///
+/// This provider decodes a JWT payload **without verifying its signature**
+/// ([`Self::decode_jwt_claims`]), so its `iss`/`aud`/`exp` checks run on
+/// attacker-controlled data. It is not constructed anywhere outside this file's
+/// tests and is retained only as a reference stub.
+///
+/// The **live** ingress JWT path is [`crate::network::auth::jwt`]'s
+/// `JwtService::verify_token`, which uses `jsonwebtoken::decode` + `Validation`
+/// (real signature/issuer/audience/exp verification). There is **no**
+/// `jsonwebtoken` cargo feature to "enable" — the crate is already a hard
+/// dependency; this code was simply never finished.
+///
+/// Wiring this type (or `sso::oidc`'s `simulate_oidc_validation`) into the
+/// `IdentityProvider` dispatch would be an instant critical SSO-forgery
+/// vulnerability. If it is ever revived, verify against the provider's JWKS
+/// (fetch `n`/`e` by `kid`, `jsonwebtoken::decode` + `Validation`, reject
+/// `alg:none` and HS/RSA key-confusion) first. Hence `#[deprecated]`: any live
+/// use trips `-D warnings` in CI.
+#[deprecated(
+    note = "unwired + signature-blind; use JwtService (network::auth::jwt). Wiring this is an SSO-forgery footgun — verify against JWKS first."
+)]
 pub struct OidcProvider {
     issuer: String,
     client_id: String,
@@ -92,6 +110,7 @@ pub struct OidcProvider {
     default_roles: Vec<String>,
 }
 
+#[allow(deprecated)]
 impl OidcProvider {
     pub fn new(issuer: String, client_id: String) -> Self {
         Self {
@@ -168,6 +187,7 @@ impl OidcProvider {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl IdentityProvider for OidcProvider {
     async fn authenticate(&self, credentials: &AuthCredentials) -> Result<UnifiedUserContext> {
         match credentials {
@@ -239,6 +259,7 @@ impl IdentityProvider for OidcProvider {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
Follow-up to the JWT verification (task #18). `OidcProvider::decode_jwt_claims` really does decode JWTs **without signature verification** — but it is **dead/unwired** (zero non-test callers), and the *live* ingress path (`network::auth::jwt` `JwtService`) verifies signatures correctly. **Not a live vulnerability** — a loaded footgun. This closes the trap without deleting (per the recommended doc-correction + guard):

- **Rewrote the misleading `OidcProvider` doc.** It told future devs to "enable the `jsonwebtoken` feature for full signature verification" — that feature **doesn't exist** (`jsonwebtoken` is already a hard dep); the code was just never finished. Now a DEAD/UNWIRED/DO-NOT-WIRE warning pointing at `JwtService`.
- **`#[deprecated]` on `OidcProvider`** — any future *live* wiring trips `-D warnings` in CI. Existing dead impls/tests carry `#[allow(deprecated)]`; confirmed no other uses.
- **Strengthened `sso::oidc::simulate_oidc_validation`'s understated `(placeholder)` doc** — it fabricates a user without even decoding the token (also dead; all callers are tests).

No behavior change (doc + attribute only). **clippy `-D warnings` clean** on the main crate lib; oidc + sso tests pass. Delete-or-JWKS-implement follow-up is task #21.