### PR TITLE
fix(metrics): P0 duplicate-IVF-metric panic on default search path (TD-METRICS-3) + corrected hot-tier economics (TD-CACHE-8)

### DIFF
--- a/docs/10-quality/td/TD-CACHE-8-hot-tier-value-diverse-queries.adoc
+++ b/docs/10-quality/td/TD-CACHE-8-hot-tier-value-diverse-queries.adoc
@@ -1,0 +1,55 @@
+= TD-CACHE-8: the hot-tier "0-GET" headline is a result-cache artifact — diverse queries get ~33% survivor-cache reduction, not ~free
+:status: Open (measured 2026-07-26)
+:filed: 2026-07-26
+:priority: P1 (corrects the flagship rate-card number)
+
+== The finding (diverse-query hot-tier bed)
+
+The "hot ≈ 0 GETs, 2,602 QPS, ~$0.01/M" claim was measured with IDENTICAL
+repeat queries, which the vector-search query-result cache (vector_hash-keyed,
+300 s freshness — legacy.rs:2285) short-circuits ABOVE the survivor cache.
+Real vector search never repeats a query (every RAG embedding is unique).
+
+Streaming 1,200 UNIQUE SIFT queries against a 200k trained collection
+(probe-armed, 256 MB survivor budget) — each MISSES the result cache and
+falls through to the survivor cache:
+
+|===
+| window | GETs/query | survivor hit%
+| 0–100 | 18.5 | 31%
+| 500–600 | 18.5 | 34%
+| 1100–1200 | 18.3 | 32%
+|===
+
+GETs/query stays FLAT at ~18 and survivor hit-rate PLATEAUS at ~33% — it does
+NOT converge toward 100% as more of the working set is seen. So under a
+realistic diverse workload the hot tier delivers ~33% GET reduction, not the
+~100% the headline implied.
+
+== Analysis (why 33%, not 100%)
+
+The whole SQ8 region for 200k×128d is ~25.6 MB, comfortably inside the 256 MB
+budget — so capacity is NOT the limit. The reuse gap is KEYING: the coalesced
+SQ8 survivor fetch's `(offset, len)` is QUERY-SPECIFIC (each query's survivor
+set → different coalesced byte ranges), so the cache rarely sees the same
+range twice. The fixed cell fetches DO reuse (~the 33% floor); the
+query-specific SQ8 ranges do not. This is the "tight survivor ranges need
+IVF/Hilbert locality" follow-up already flagged in segment_format.rs.
+
+== Direction
+
+* **Whole-region SQ8 caching for hot tenants**: cache the FIXED
+  `(sq8_off, sq8_len)` range (already the seam for the scattered-survivor
+  fallback, TD-CACHE-6) so a hot tenant's SQ8 region goes 100%-resident after
+  first exposure — turning ~18 GETs/query into ~probe-cells-only. Trades a
+  larger per-query decode (whole region) for near-zero GETs: the right trade
+  when the region fits the budget (the hot-tier case by definition).
+* **Reprice honestly meanwhile**: hot diverse-query traffic ≈ 18 GETs/query ≈
+  $0.7/M (Azure GET rate), not $0.01/M. Still an order below cold, still a
+  strong undercut, but the headline must not claim 0-GET for diverse loads.
+
+== Related
+
+TD-CACHE-6 (probe/Region-B seam — the caching mechanism), TD-CACHE-3
+(pinning economics rest on this reuse), the rate-card ledger claims
+(hot_repeat numbers were identical-query), scripts/bench/diverse_query_bed.py.

--- a/docs/10-quality/td/TD-METRICS-3-duplicate-ivf-metric-registration-panic.adoc
+++ b/docs/10-quality/td/TD-METRICS-3-duplicate-ivf-metric-registration-panic.adoc
@@ -1,0 +1,49 @@
+= TD-METRICS-3: duplicate IVF metric registration panics the search worker (reachable by default since #1210)
+:status: S1 shipped (2026-07-26)
+:filed: 2026-07-26
+:priority: P0 (production panic on the default search path)
+
+== The finding (diverse-query hot-tier bed, 2026-07-26)
+
+First probe-armed search on a trained collection panicked a tokio worker:
+
+  thread 'tokio-rt-worker' panicked at src/metrics/consumption_metrics.rs:28:
+  called `Result::unwrap()` on an `Err(Msg("empty help string"))`
+
+Two independent defects compounded:
+
+1. **Duplicate metric name.** Four IVF probe metrics are declared with the
+   SAME prometheus name in two modules with DIFFERENT types:
+   `src/storage/engines/sst/metrics.rs` (unlabeled `IntCounter`, the aggregate
+   operator surface) and `src/metrics/consumption_metrics.rs` (per-tenant
+   `CounterVec{tenant_id}`, the billing surface): `proximadb_ivf_cells_total`,
+   `…_cells_probed_total`, `…_probed_rows_total`, `…_fetch_rounds_total`.
+   Whichever `lazy_static` initializes second fails with "Duplicate metrics
+   collector registration attempted".
+2. **A fallback that cannot recover.** `registered_counter_vec`/`_gauge_vec`
+   handled that failure by building a vec with an EMPTY help string (`""`),
+   which prometheus ALSO rejects — so the `.unwrap()` panicked the worker
+   instead of degrading.
+
+**#1210 made it reachable by default.** The coarse probe flipped default-ON,
+so the sst IVF `IntCounter`s now initialize on every trained search, colliding
+with the consumption `CounterVec`s the billing observer touches — a normal
+search crashes the worker.
+
+== S1 (shipped)
+
+* No-panic fix (mandate #4): the fallback reuses the real (non-empty) help and
+  returns an unregistered-but-usable vec — never panics.
+* Collision fix: the sst/metrics.rs AGGREGATE prometheus strings carry an
+  `_agg_` infix (`proximadb_ivf_cells_agg_total`, …). In-process readers use
+  the Rust statics (`IVF_CELLS_TOTAL`), so they are unaffected; the per-tenant
+  billing `CounterVec` keeps the canonical `proximadb_ivf_*_total{tenant_id}`
+  name (sum over tenant = the aggregate).
+
+Regression guard: covered by re-running the diverse-query bed (searches no
+longer crash) + the always-green metrics init.
+
+== Related
+
+#1210 (probe default-ON — the trigger), TD-RDSTRAT-8 (the probe telemetry),
+TD-IOTRACE-2 (the per-tenant billing metrics), scripts/bench/diverse_query_bed.py.

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -688,3 +688,19 @@ hardware = "Local macOS arm64, Azurite 3.36 blob emulator on localhost:11000"
 date = "2026-07-26"
 version = "fix/warm-manifest-azure-path -> develop"
 
+[[claims]]
+id = "hot_tier_diverse_query_getcost"
+claim = "TD-CACHE-8: under REALISTIC diverse (never-repeated) query load — 1,200 unique SIFT queries, 200k trained collection, probe-armed, 256MB survivor budget — GETs/query stays FLAT at ~18 and survivor-cache hit-rate PLATEAUS at ~33%, NOT converging toward 0-GET. The prior 'hot ~0 GETs / 2,602 QPS' headline was a query-RESULT-cache (vector_hash-keyed) artifact of identical-query testing. Corrected hot economics: ~18 GETs/query ~= $0.7/M queries (Azure GET rate), an order below cold but NOT free. Root cause: query-specific coalesced SQ8 ranges do not reuse (cells do, ~33% floor); whole-region SQ8 caching is the lever (region fits budget). Also confirmed TD-METRICS-3 fix: 1,200 searches, zero panics."
+metric = "GETs/query + survivor hit% across a diverse (unique) query stream"
+status = "measured"
+asserted_in = [
+  "docs/10-quality/td/TD-CACHE-8-hot-tier-value-diverse-queries.adoc",
+  "docs/10-quality/td/TD-METRICS-3-duplicate-ivf-metric-registration-panic.adoc",
+]
+bench_source = "scripts/bench/diverse_query_bed.py"
+bench_command = "python3 scripts/bench/diverse_query_bed.py <bin> <cfg> <bed> 5879  # probe+train env set by harness"
+artifact = "docs/10-quality/td/TD-CACHE-8-hot-tier-value-diverse-queries.adoc"
+hardware = "Local macOS arm64 (10-core Apple Silicon, 64GB), release build"
+date = "2026-07-26"
+version = "fix/td-metrics-2-ivf-dup-panic -> develop"
+

--- a/scripts/bench/diverse_query_bed.py
+++ b/scripts/bench/diverse_query_bed.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Hot-tier value under REALISTIC (diverse) query load.
+
+The '0-GET hot' claim was measured with identical repeats, which the
+query-result cache (vector_hash-keyed) short-circuits above the survivor
+cache. Real vector search never repeats a query. This bed streams UNIQUE
+queries (every one misses the result cache -> falls through to the survivor
+cache) and measures whether GETs/query DECLINES across the stream as
+overlapping hot ranges become resident. Convergence toward low GETs = the
+hot tier delivers for diverse workloads; flat = the '0-GET' number was a
+result-cache artifact.
+
+Usage: diverse_query_bed.py <bin> <cfg> <datadir> <port>
+"""
+import json, os, signal, socket, subprocess, sys, time, urllib.request
+import numpy as np
+
+BIN, CFG, DATADIR, PORT = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+BASE = f"http://127.0.0.1:{PORT}"
+SIFT = "/Users/vijaysingh/sift1m/sift_base.fvecs"
+QUERY = "/Users/vijaysingh/sift1m/sift_query.fvecs"
+LOG = "/tmp/diverse_bed_server.log"
+N = 200_000
+STREAM = 1200
+
+ENV = dict(os.environ,
+           PROXIMADB_INTERNAL_MUX_PORT="25811",
+           PROXIMADB_PAX_WRITE_A0_TRAIN="1",
+           PROXIMADB_PAX_READ_COARSE_PROBE="1",
+           PROXIMADB_L0_COMPACTION_ENABLED="1",
+           PROXIMADB_SURVIVOR_CACHE_BUDGET_MB="256",
+           RUST_LOG="proximadb=warn")
+
+
+def read_fvecs(path, count):
+    with open(path, "rb") as f:
+        d = np.frombuffer(f.read(4), dtype="<i4")[0]
+        rec = 4 + 4 * d
+        f.seek(0)
+        raw = f.read(rec * count)
+    a = np.frombuffer(raw, dtype="<u1").reshape(-1, rec)
+    return a[:, 4:].copy().view("<f4").reshape(-1, d)
+
+
+def post(path, body, timeout=300, retries=4):
+    last = None
+    for a in range(retries):
+        req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code >= 500:
+                time.sleep(2 * (a + 1)); continue
+            raise
+    raise last
+
+
+def gets():
+    with urllib.request.urlopen(BASE + "/metrics/prometheus", timeout=30) as r:
+        txt = r.read().decode()
+    g = s = h = m = 0.0
+    for line in txt.splitlines():
+        if line.startswith("proximadb_object_store_gets_total") and " " in line:
+            g += float(line.rsplit(" ", 1)[1])
+        elif line.startswith("proximadb_survivor_cache_hits ") :
+            h = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("proximadb_survivor_cache_misses "):
+            m = float(line.rsplit(" ", 1)[1])
+    return g, h, m
+
+
+def main():
+    for _ in range(120):
+        with socket.socket() as sck:
+            try: sck.bind(("127.0.0.1", PORT)); break
+            except OSError: time.sleep(1)
+    else: sys.exit("port never freed")
+    lf = open(LOG, "wb")
+    p = subprocess.Popen([BIN, "-c", CFG, "-d", DATADIR, "-p", str(PORT)],
+                         stdout=lf, stderr=lf, env=ENV, cwd=DATADIR)
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(BASE + "/health", timeout=2); time.sleep(3)
+            if p.poll() is not None: sys.exit("foreign trap")
+            break
+        except Exception:
+            if p.poll() is not None: sys.exit(f"died, see {LOG}")
+            time.sleep(0.5)
+
+    base = read_fvecs(SIFT, N)
+    qs = read_fvecs(QUERY, 10_000)
+    cid = post("/api/v2/collections", {"name": "hot", "dimension": 128, "engine": "sst",
+               "enable_proxima_record": True, "distance_metric": "euclidean"}).get("collection_id")
+    print(f"collection -> {cid}", flush=True)
+    t0 = time.time()
+    for i in range(0, N, 1000):
+        b = base[i:i+1000]
+        post(f"/api/v2/collections/{cid}/records/batch",
+             {"records": [{"id": f"v{i+j}", "vector": b[j].tolist()} for j in range(len(b))]})
+    print(f"ingest {time.time()-t0:.0f}s; settle+train 60s", flush=True)
+    time.sleep(60)
+
+    # Stream UNIQUE queries; report GETs/query per 100-window + survivor hit-rate.
+    print(f"\nstreaming {STREAM} UNIQUE queries (each misses result cache):", flush=True)
+    print(f"{'window':>12} {'GETs/q':>8} {'surv_hit%':>9}")
+    g_prev, h_prev, m_prev = gets()
+    for w in range(0, STREAM, 100):
+        for q in qs[w:w+100]:
+            post(f"/api/v2/collections/{cid}/search", {"vector": q.tolist(), "top_k": 10})
+        g, h, m = gets()
+        dg, dh, dm = g - g_prev, h - h_prev, m - m_prev
+        hr = 100.0 * dh / max(dh + dm, 1)
+        print(f"{w:>5}-{w+100:<6} {dg/100:>8.1f} {hr:>8.1f}%", flush=True)
+        g_prev, h_prev, m_prev = g, h, m
+
+    p.send_signal(signal.SIGTERM)
+    try: p.wait(timeout=120)
+    except subprocess.TimeoutExpired: p.kill()
+    print("done", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metrics/consumption_metrics.rs
+++ b/src/metrics/consumption_metrics.rs
@@ -24,15 +24,21 @@ use tracing::error;
 // sanctioned panic site per vec type instead of repeating it at every metric.
 fn registered_counter_vec(name: &'static str, help: &'static str, labels: &[&str]) -> CounterVec {
     register_counter_vec!(Opts::new(name, help), labels).unwrap_or_else(|err| {
-        error!("failed to register {}: {}", name, err);
-        CounterVec::new(Opts::new(name, ""), labels).unwrap()
+        // No-panic mandate #4: registration can fail (e.g. a duplicate name).
+        // The fallback MUST NOT reuse an empty help — prometheus rejects that
+        // too, so the old `""` here panicked the tokio worker on the first
+        // search (an unregistered-but-usable vec is the correct degradation).
+        error!("failed to register {name} (using unregistered fallback): {err}");
+        CounterVec::new(Opts::new(name, help), labels)
+            .expect("counter descriptor with non-empty help is always valid")
     })
 }
 
 fn registered_gauge_vec(name: &'static str, help: &'static str, labels: &[&str]) -> GaugeVec {
     register_gauge_vec!(Opts::new(name, help), labels).unwrap_or_else(|err| {
-        error!("failed to register {}: {}", name, err);
-        GaugeVec::new(Opts::new(name, ""), labels).unwrap()
+        error!("failed to register {name} (using unregistered fallback): {err}");
+        GaugeVec::new(Opts::new(name, help), labels)
+            .expect("gauge descriptor with non-empty help is always valid")
     })
 }
 

--- a/src/storage/engines/sst/metrics.rs
+++ b/src/storage/engines/sst/metrics.rs
@@ -23,21 +23,27 @@ fn counter(name: &str, help: &str) -> IntCounter {
     })
 }
 
+// NOTE: unlabeled AGGREGATE operator surface. The per-tenant billing versions
+// in metrics/consumption_metrics.rs own the canonical
+// `proximadb_ivf_*_total{tenant_id}` names (sum over tenant = this aggregate);
+// these carry `_agg_` to avoid a duplicate-registration crash when both init
+// on a probe-armed search (default-ON since #1210). In-process readers use the
+// Rust statics below, unaffected by the prometheus name.
 lazy_static! {
     pub static ref IVF_CELLS_TOTAL: IntCounter = counter(
-        "proximadb_ivf_cells_total",
+        "proximadb_ivf_cells_agg_total",
         "Persisted coarse centroids seen by the TD-RDSTRAT-8 two-level IVF coarse probe",
     );
     pub static ref IVF_CELLS_PROBED: IntCounter = counter(
-        "proximadb_ivf_cells_probed_total",
+        "proximadb_ivf_cells_probed_agg_total",
         "Coarse centroids ranked in RAM by the nprobe-scoped TD-RDSTRAT-8 probe",
     );
     pub static ref IVF_PROBED_ROWS: IntCounter = counter(
-        "proximadb_ivf_probed_rows_total",
+        "proximadb_ivf_probed_rows_agg_total",
         "Rows ranged-read from the probed cells' Region-A extents (TD-RDSTRAT-8)",
     );
     pub static ref IVF_FETCH_ROUNDS: IntCounter = counter(
-        "proximadb_ivf_fetch_rounds_total",
+        "proximadb_ivf_fetch_rounds_agg_total",
         "Coalesced Region-A ranged-read runs issued by the TD-RDSTRAT-8 probe (the GET round-trip budget it pays)",
     );
     pub static ref IVF_WHOLE_REGION_FALLBACK: IntCounter = counter(


### PR DESCRIPTION
## P0: production panic on the default search path (TD-METRICS-3)

A probe-armed search panicked a tokio worker: `consumption_metrics.rs:28` unwrapped an `Err("empty help string")`. **#1210 made it reachable by default** — the probe flipped default-ON, so the `sst/metrics.rs` IVF `IntCounter`s now initialize on every trained search and **collide** with the per-tenant billing `CounterVec`s (same prometheus name, different type → duplicate registration), and the register **fallback reused an empty help** (also rejected by prometheus) → panic instead of degrading.

**Fix**: panic-free fallback (reuse the real help → unregistered-but-usable vec, no-panic mandate #4) + `_agg_` infix on the sst aggregate prometheus strings (in-process readers use the Rust statics, unaffected; per-tenant billing keeps the canonical `proximadb_ivf_*_total{tenant_id}` names). **Verified**: diverse-query bed re-run, 1,200 probe-armed searches, zero panics.

## Corrected hot-tier economics (TD-CACHE-8)

The same bed measured the flagship number honestly. Streaming **1,200 unique** queries (which the `vector_hash`-keyed result cache does *not* short-circuit): GETs/query stays **flat at ~18**, survivor hit-rate **plateaus at ~33%** — it does not converge to 0-GET. The prior "hot ≈ 0 GETs / 2,602 QPS" headline was a **result-cache artifact of identical-query testing**. Corrected: hot diverse ≈ 18 GETs/query ≈ **$0.7/M** (an order below cold, still a strong undercut, but not free). Root cause: query-specific coalesced SQ8 ranges don't reuse (cells do, ~33% floor); whole-region SQ8 caching is the lever (region fits budget). Filed with the fix hypothesis + rate-card correction.

Gates: work-commit-check, clippy 0, td-adr-unique (285), ledger validated (43 claims). Harness promoted to `scripts/bench/diverse_query_bed.py`.