### PR TITLE
feat(dml): F5 — FK existence rides the fenced ConditionalKeyStore (ADR-072, critical path)

### DIFF
--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -4879,20 +4879,43 @@ impl DmlService {
                 // Encode with the same encoder that built the parent oids so the
                 // point lookup matches exactly (single- or multi-column).
                 let key = encode_primary_key_tuple(&values)?;
-                let referenced_exists = self
-                    .record_store
-                    .get_by_key(
-                        &parent_schema,
-                        TableRecordGetRequest {
-                            table_id: parent_table_id.name.clone(),
-                            key: key.clone(),
-                            include_vector: false,
-                            include_props: false,
-                        },
-                        tenant_context,
-                    )
-                    .await?
-                    .is_some();
+                // F5 (ADR-072): when the fenced ConditionalKeyStore is wired,
+                // resolve FK existence against the SAME store that fences the
+                // parent's PK uniqueness (its `get` was designed for exactly this
+                // — "foreign-key existence checks (phase 2) ride this method"),
+                // instead of a check-then-act probe on the record store. This
+                // makes the child-insert see the authoritative uniqueness index
+                // and closes the TOCTOU with a concurrent parent delete. Only the
+                // single-column case is CKS-fenced today (F2 registers one PK
+                // value), so multi-column FKs keep the record-store probe.
+                let referenced_exists = if let Some(cks) = self
+                    .conditional_key_store
+                    .as_ref()
+                    .filter(|_| values.len() == 1)
+                {
+                    let id = proximadb_storage_ports::Identity::from_bytes(
+                        proximadb_data_model::key_codec::encode_identity(
+                            &record.tenant_id,
+                            &parent_schema.name,
+                            &values,
+                        )?,
+                    );
+                    cks.get(&id).await?.is_some()
+                } else {
+                    self.record_store
+                        .get_by_key(
+                            &parent_schema,
+                            TableRecordGetRequest {
+                                table_id: parent_table_id.name.clone(),
+                                key: key.clone(),
+                                include_vector: false,
+                                include_props: false,
+                            },
+                            tenant_context,
+                        )
+                        .await?
+                        .is_some()
+                };
                 if !referenced_exists {
                     return Err(anyhow!(
                         "FOREIGN KEY ({}) on table '{}' violates reference: '{}' is not present in {}({})",

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -1830,6 +1830,90 @@ async fn update_rejects_duplicate_unique_value() {
         .expect("UPDATE to a free unique value must be allowed");
 }
 
+/// F5 (ADR-072): with the fenced `ConditionalKeyStore` wired, a FOREIGN KEY
+/// existence check resolves against the SAME store that fences the parent's PK
+/// uniqueness (its `get` — "foreign-key existence checks (phase 2) ride this
+/// method"), not the record-store probe. A child whose FK matches a live parent
+/// PK inserts; a child referencing an absent parent is rejected by the store.
+#[cfg(feature = "oltp-integrity")]
+#[tokio::test]
+async fn insert_enforces_foreign_key_via_fenced_store() {
+    use crate::services::record_store::DirectWalTableRecordStore;
+    use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+    use proximadb_cks_local::{LocalWalKeyStore, SyncPolicy};
+
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(CatalogManager::new());
+    manager
+        .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+        .await
+        .expect("native catalog");
+    let ddl = DdlService::new(manager.clone());
+    ddl.execute(DdlStatement::CreateNamespace {
+        namespace: vec!["default".to_string()],
+        if_not_exists: true,
+        properties: HashMap::new(),
+    })
+    .await
+    .expect("create namespace");
+    let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+    for create in [
+        "CREATE TABLE customers (id TEXT NOT NULL, name TEXT, PRIMARY KEY (id));",
+        "CREATE TABLE orders (id TEXT NOT NULL, customer_id TEXT, PRIMARY KEY (id), FOREIGN KEY (customer_id) REFERENCES customers (id));",
+    ] {
+        let stmt = parser
+            .parse_ddl(create)
+            .expect("parse create")
+            .expect("ddl");
+        ddl.execute(stmt).await.expect("create table");
+    }
+
+    let wal_appender = Arc::new(
+        FramedTableWalAppender::open(temp_dir.path().join("fk.wal"))
+            .await
+            .expect("open WAL"),
+    );
+    let record_store = Arc::new(DirectWalTableRecordStore::new(
+        Arc::new(MemtableRecordStorage::new()),
+        wal_appender,
+    ));
+    let cks = Arc::new(
+        LocalWalKeyStore::open(temp_dir.path().join("cks.wal"), SyncPolicy::PerOp)
+            .expect("open cks"),
+    );
+    let dml = DmlService::with_record_store_and_table_write_executor(
+        manager.clone(),
+        record_store,
+        Arc::new(PlannedOnlyTableWriteExecutor::new()),
+    )
+    .with_conditional_key_store(cks);
+    let run = |sql: &'static str| parser.parse_dml(sql).expect("parse dml").expect("dml");
+
+    // Parent PK 'c1' is registered in the fenced store by execute_insert.
+    dml.execute(run(
+        "INSERT INTO customers (id, name) VALUES ('c1', 'Alice');",
+    ))
+    .await
+    .expect("insert parent customer");
+    // Child FK resolves via the CKS `get` → parent present → allowed.
+    dml.execute(run(
+        "INSERT INTO orders (id, customer_id) VALUES ('o1', 'c1');",
+    ))
+    .await
+    .expect("child referencing a live parent must insert (via the fenced store)");
+    // Child FK to an absent parent → CKS `get` returns None → rejected.
+    let err = dml
+        .execute(run(
+            "INSERT INTO orders (id, customer_id) VALUES ('o2', 'c99');",
+        ))
+        .await
+        .expect_err("FK to a missing parent must be rejected via the fenced store");
+    assert!(
+        err.to_string().contains("FOREIGN KEY"),
+        "unexpected error: {err}"
+    );
+}
+
 #[tokio::test]
 async fn insert_enforces_foreign_key_reference() {
     // TD-110: a FOREIGN KEY referencing the parent PK is enforced on INSERT —


### PR DESCRIPTION
**First F5 (FK referential-integrity + HTAP) slice — the OLTP critical path resumes.**

FK enforcement + TD-110 delete referential actions already exist; the gap was that FK existence used a **check-then-act probe** on `record_store.get_by_key` (`dml/mod.rs`) — the same pattern F2 replaced for PK uniqueness.

When the fenced `ConditionalKeyStore` is wired (`oltp-integrity`), `enforce_foreign_keys` now resolves parent-row existence via `cks.get(encode_identity(tenant, parent_table, fk_values))` — **the same store that fences the parent's PK** (its `get` was designed for exactly this: *"foreign-key existence checks (phase 2) ride this method"*). The child insert sees the authoritative uniqueness index, **closing the TOCTOU with a concurrent parent delete**.

- Mirrors F2b; **feature-inert by default** (store is `None` → record-store probe unchanged).
- Guarded to single-column PKs (F2's current fencing scope); multi-column FKs keep the probe.

**Tests:** new `insert_enforces_foreign_key_via_fenced_store` (live parent → child inserts; absent parent → rejected by `cks.get`→None) passes, **and** the existing TD-110 record-store FK test still passes; feature-off compiles clean.

Next F5 slices: UPDATE-path FK re-check on the same primitive, then the HTAP sub-item (through a brief design note first).