### PR TITLE
docs(adr): ADR-076 async compaction + admission control + training debounce (TD-COMPACT-6/7/8)

### DIFF
--- a/docs/10-quality/td/TD-COMPACT-6-async-compaction.adoc
+++ b/docs/10-quality/td/TD-COMPACT-6-async-compaction.adoc
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-6: Move compaction from inline-synchronous to async-background
+:status: Open
+:dim: D1
+:pillar: REL
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** Design decided in ADR-076 (Proposed). First slice — the highest-impact change (ingest throughput ~30×).
+| Priority | **P0** — the inline-blocking pathology gates ingest throughput on object storage (measured: 1 flush/35 s during training compaction).
+| Component | `src/storage/engines/sst/flush/mod.rs:747-781` (inline call); `src/storage/engines/sst/compaction.rs:589-902` (`schedule_compaction` + `worker_loop`, currently idle); `src/storage/engine.rs:208-213` (2 workers, hardcoded).
+| Evidence | 2026-07-26 verification: TD-COMPACT-5 training arm fires every ~35 s during ingest (5-7 cycles). Each cycle: N object-store GETs + PCA (~35 s CPU) + 1 PUT + N DELETEs. Flush blocks for the full duration.
+|===
+
+== Mechanism
+
+The production flush path calls `run_due_compaction` INLINE (`flush/mod.rs:756`,
+awaited). The existing `schedule_compaction` (`compaction.rs:589-628`) +
+`task_queue` + `worker_loop` (`compaction.rs:792-902`) + 2 daemon workers
+(`engine.rs:212`) provide the async machinery — built, tested, and idle.
+
+== Fix
+
+1. Replace the inline `run_due_compaction` call at `flush/mod.rs:747-781` with
+   `schedule_compaction` (enqueue the task; the background worker picks it up).
+2. The flush returns immediately after creating the L0 file (~1 s), without
+   awaiting compaction.
+3. The background worker runs `perform_compaction_enhanced` concurrently with
+   flushes. The atomic coordinator serializes the publish; the
+   `schedule_compaction` per-output dedup (`compaction.rs:596-610`) prevents
+   double-compaction.
+4. The inline path remains as a `#[cfg(test)]` synchronous option (tests can
+   await compaction deterministically).
+
+== Verification
+
+* Ingest throughput: ~1 flush/s (vs ~1 flush/35 s) during 1M SIFT ingest on
+  Azurite.
+* No compaction contention on the query path (idle-server queries ~1 ms during
+  ingest, not ~400 ms).
+* Compaction completes post-ingest (poll: L0 count drops, L1 appears).
+
+== Related
+
+link:ADR-076-async-compaction-admission-control.adoc[ADR-076],
+link:TD-COMPACT-5-training-compaction-trigger.adoc[TD-COMPACT-5],
+link:TD-COMPACT-7-l0-admission-control-watermarks.adoc[TD-COMPACT-7],
+link:TD-COMPACT-8-training-arm-debounce.adoc[TD-COMPACT-8].

--- a/docs/10-quality/td/TD-COMPACT-7-l0-admission-control-watermarks.adoc
+++ b/docs/10-quality/td/TD-COMPACT-7-l0-admission-control-watermarks.adoc
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-7: L0 admission control watermarks (slowdown + stop triggers)
+:status: Open
+:dim: D1
+:pillar: REL
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** Design decided in ADR-076 (Proposed). Depends on TD-COMPACT-6 (async compaction — watermarks are only meaningful when compaction runs in the background).
+| Priority | **P1** — prevents compaction storms + unbounded L0 backlog once compaction is async.
+| Component | `src/storage/engines/sst/flush/mod.rs` (flush trigger); `src/storage/auto_flush_driver.rs` (the write gate); new fields on `SstConfig`.
+| Evidence | 2026-07-26: no admission control exists — writes proceed at full speed regardless of L0 backlog. The only backpressure is memtable-level (`BACKPRESSURE: collection over memtable threshold`). RocksDB/HBase/Cassandra all have L0 watermarks; ProximaDB does not.
+|===
+
+== Mechanism
+
+Add two L0-file-count watermarks to `SstConfig` (TOML-controllable under
+`[storage.sst_config]`):
+
+- `l0_slowdown_trigger` (default 8): when L0 file count ≥ this, delay each
+  write/flush by ~1 ms (gives the async compaction workers breathing room).
+- `l0_stop_trigger` (default 12): when L0 file count ≥ this, reject writes
+  with BACKPRESSURE (same mechanism as the existing memtable backpressure)
+  until compaction reduces L0 below the watermark.
+
+The watermarks are per-collection (each collection tracks its own L0 count).
+They are read at the auto-flush driver's flush-decision point
+(`auto_flush_driver.rs`), not at every individual write (amortized).
+
+== Fix
+
+1. Add `l0_slowdown_trigger: u32` + `l0_stop_trigger: u32` to `SstConfig`
+   with `#[serde(default)]`.
+2. Add an L0-count check in the flush path: before flushing, count L0 files;
+   if ≥ slowdown → sleep ~1 ms; if ≥ stop → return backpressure.
+3. The check is in the auto-flush driver (not the per-write hot path) to
+   amortize cost.
+
+== Verification
+
+* During a sustained ingest that outpaces compaction: writes slow down (not
+  crash/stall indefinitely); L0 count stays bounded (< stop_trigger).
+* After compaction catches up: writes resume full speed.
+
+== Related
+
+link:ADR-076-async-compaction-admission-control.adoc[ADR-076],
+link:TD-COMPACT-6-async-compaction.adoc[TD-COMPACT-6],
+link:TD-COMPACT-8-training-arm-debounce.adoc[TD-COMPACT-8].

--- a/docs/10-quality/td/TD-COMPACT-8-training-arm-debounce.adoc
+++ b/docs/10-quality/td/TD-COMPACT-8-training-arm-debounce.adoc
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-8: Training-arm debounce (wait for segment stability)
+:status: Open
+:dim: D1
+:pillar: PERF
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** Design decided in ADR-076 (Proposed). Independent of TD-COMPACT-6 (works with inline too — just fewer redundant cycles).
+| Priority | **P1** — the re-training loop wastes ~7× object-store I/O during ingest (each redundant cycle = N GETs + 1 PUT + N DELETEs).
+| Component | `src/storage/engines/sst/flush/mod.rs:881-906` (the TD-COMPACT-5 training arm inside `should_trigger_compaction`).
+| Evidence | 2026-07-26: the training arm fires on every flush whenever ANY untrained L0 ≥ 32 MB exists. During a 173 s ingest (flushes every ~35 s), it fires 5-7 times — re-training the SAME growing segment. Each PCA training cycle = ~35 s CPU + N object-store I/O. Post-ingest, ONE pass would suffice.
+|===
+
+== Mechanism
+
+Add a **stability guard** to the TD-COMPACT-5 training arm
+(`should_trigger_compaction` arm 2, `flush/mod.rs:881-906`): track the
+last-flush timestamp per collection (an `AtomicI64` epoch-seconds on the
+`Compaction` struct or the `SstEngine`). Only arm the training compaction if
+`now - last_flush_time >= training_debounce_secs` (default 120 s).
+
+This ensures the training arm fires ONCE after ingest settles (no new flushes
+for 120 s), not N times during active ingest. The count arm (threshold 5) is
+unaffected — it fires based on file count, not training status.
+
+== Fix
+
+1. Add `last_flush_epoch: AtomicI64` to track the most recent flush time per
+   collection (updated at `flush/mod.rs:209` when the L0 file is created).
+2. In `should_trigger_compaction` arm 2 (`flush/mod.rs:885`): add the guard
+   `if now - last_flush_epoch < training_debounce_secs { skip the training arm }`.
+3. `training_debounce_secs` configurable via `SstConfig` (default 120 s).
+4. The count arm (threshold 5) is NOT debounced — it fires whenever file count
+   ≥ 5, regardless of flush recency (count compaction is cheap — just merge,
+   no PCA training).
+
+== Verification
+
+* During a 173 s ingest: the training arm fires 0 times (debounced). The count
+  arm fires normally (at threshold 5).
+* After ingest settles (120 s no flush): the training arm fires ONCE, trains
+  PCA/IVF on the stable L0 segments.
+* Object-store I/O during ingest: reduced ~7× (1 training cycle vs 7).
+
+== Related
+
+link:ADR-076-async-compaction-admission-control.adoc[ADR-076],
+link:TD-COMPACT-5-training-compaction-trigger.adoc[TD-COMPACT-5],
+link:TD-COMPACT-6-async-compaction.adoc[TD-COMPACT-6],
+link:TD-COMPACT-7-l0-admission-control-watermarks.adoc[TD-COMPACT-7].

--- a/docs/12-design/adr/ADR-076-async-compaction-admission-control.adoc
+++ b/docs/12-design/adr/ADR-076-async-compaction-admission-control.adoc
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-076: Async compaction + L0 admission control for streaming ingest on object storage
+:status: Proposed
+:date: 2026-07-26
+:authors: co-design session 2026-07-26
+
+[cols="1,3"]
+|===
+| Status | Proposed
+| Date | 2026-07-26
+| Deciders | Vijaykumar Singh
+| Relates to | ADR-027 (DrPath / storage layout — compaction writes under the path contract), ADR-036 (flat keys + per-object access tier — compaction I/O cost), ADR-052 (co-design cost spine — object-store round-trips dominate), TD-COMPACT-5 (training compaction trigger — the arm that fires per-flush), `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (the dominant cost term is I/O round-trips, not CPU)
+| Tracked by | TD-COMPACT-6 (async compaction), TD-COMPACT-7 (admission control watermarks), TD-COMPACT-8 (training-arm debounce)
+| Supersedes | —
+|===
+
+== Context
+
+ProximaDB's SST compaction is **inline synchronous**: every flush awaits the
+full compaction cycle (read all L0 → merge → train PCA/IVF → write new segment
+→ delete inputs) before continuing (`flush/mod.rs:747-781`). This is the
+opposite of every production LSM system:
+
+[cols="1,2,2,2"]
+|===
+| System | Compaction model | Admission control | Write blocking?
+| RocksDB | Async (separate compaction thread pool) | `slowdown_trigger` + `stop_trigger` L0 watermarks | No
+| HBase | Async (background compaction threads) | Compaction throttling + pressure mode | No
+| Cassandra | Async (`concurrent_compactors`) | IO throughput throttle + backpressure | No
+| Delta / Iceberg | Batch maintenance (OPTIMIZE / rewrite_data_files) | N/A (append-only, no flush) | No
+| **ProximaDB (today)** | **Inline synchronous** (blocks flush) | **None** | **Yes — full compaction duration**
+|===
+
+=== The measured pathology
+
+The 2026-07-26 verification (1M SIFT ingest, Azurite) showed the TD-COMPACT-5
+training arm firing **every ~35s during ingest** — 5-7 redundant cycles, each
+re-reading + re-training growing L0 segments. Each cycle: N object-store GETs
+(read inputs) + PCA training (~35s CPU) + 1 PUT (write output) + N DELETEs
+(remove inputs). On cloud (50 ms/GET), the 7 redundant cycles waste
+**7× the object-store I/O** of a single post-ingest training pass.
+
+The root cause is the intersection of three gaps:
+
+1. **Inline blocking**: flush awaits compaction → ingest throughput is gated by
+   compaction speed (~1 flush/35 s, not ~1 flush/1 s).
+2. **No admission control**: writes proceed at full speed regardless of L0
+   backlog → compaction falls behind → more untrained segments → more triggers.
+3. **No debounce**: the training arm (`should_trigger_compaction`, TD-COMPACT-5)
+   fires on every flush whenever ANY untrained L0 ≥ 32 MB exists — no
+   "recently-trained" or "segment-is-stable" guard. A segment that is still
+   growing (receiving new flushes) is re-trained on every cycle.
+
+== Decision
+
+Decouple the **write path** (flush → L0, fast, non-blocking) from the
+**maintenance path** (compaction → train → promote, scheduled, overlaps
+writes), gated by **L0 admission control watermarks**.
+
+=== D1 — Async compaction (background workers, not inline)
+
+Move `run_due_compaction` from inline-synchronous (blocking the flush at
+`flush/mod.rs:756`) to the **existing background compaction workers** (2
+daemon threads spawned at `engine.rs:212`, currently idle because the inline
+path bypasses them). Flush creates L0 files and returns immediately; compaction
+runs concurrently on the worker pool.
+
+The existing `schedule_compaction` + `task_queue` + `worker_loop`
+(`compaction.rs:589-902`) provide the machinery — they are built, tested, and
+idle. This decision wires them into the production path.
+
+=== D2 — L0 admission control (RocksDB-style watermarks)
+
+Add two L0-file-count watermarks to `SstConfig` (TOML-controllable):
+
+- **`l0_slowdown_trigger`** (default 8): when L0 file count ≥ this, delay each
+  write by a small amount (~1 ms) to give compaction breathing room.
+- **`l0_stop_trigger`** (default 12): when L0 file count ≥ this, **stall
+  writes** (reject with a BACKPRESSURE error, same as the existing memtable
+  backpressure) until compaction reduces L0 below the watermark.
+
+This is the proven RocksDB model: writes naturally slow down when compaction
+can't keep up, preventing unbounded L0 backlog + compaction storms.
+
+=== D3 — Training-arm debounce (wait for segment stability)
+
+The TD-COMPACT-5 training arm (`should_trigger_compaction` arm 2) should NOT
+fire on a segment that received new writes recently. Add a **stability guard**:
+track the last-flush timestamp per collection; only arm the training compaction
+if no new flush has arrived in the last `training_debounce_secs` (default 120 s).
+This ensures training happens ONCE after ingest settles, not N times during
+ingest.
+
+=== D4 — Separation of concerns (the boundary contract)
+
+Each surface has a single, well-integrated responsibility:
+
+[cols="2,4"]
+|===
+| Surface | Responsibility + boundary
+| **Flush** | Memtable → L0 `.pax` file (atomic, non-blocking). Never awaits compaction. Returns in ~1 s. Owns: L0 file creation, filename, WAL append.
+| **Compaction worker** | Reads L0 inputs → merge + dedup → train PCA/IVF → write L(n+1) output → delete L0 inputs. Runs on the background pool, concurrent with flushes. Owns: level promotion, segment training, input cleanup.
+| **Admission control** | Monitors L0 file count per collection. Throttles (slowdown) or stalls (stop) writes when the backlog exceeds watermarks. Owns: the write-rate ↔ compaction-rate feedback loop.
+| **Training debounce** | Guards the training arm: skip if the collection is actively receiving flushes. Owns: the "when to train" decision (post-ingest, not per-flush).
+|===
+
+The boundaries prevent the current pathology: flush never blocks on
+compaction; compaction never re-trains an actively-growing segment; admission
+control prevents backlog from outpacing compaction.
+
+== Consequences
+
+* **Ingest throughput**: ~30× faster (1 flush/1 s vs 1 flush/35 s) — flush
+  is no longer gated by compaction/training wall time.
+* **Object-store I/O**: ~7× less compaction I/O during ingest (1 training
+  pass post-ingest vs 7 redundant cycles during ingest). Each saved cycle =
+  N GETs + 1 PUT + N DELETEs avoided.
+* **Latency**: query latency during ingest drops (no compaction CPU contention
+  on the query path — compaction runs on separate worker threads).
+* **Complexity**: introduces background-thread coordination (the worker pool
+  already exists; the `schedule_compaction` + `worker_loop` are built). The
+  inline path remains as a test-only synchronous option.
+* **Correctness**: compaction is idempotent (read-merge-write-delete); running
+  it async doesn't change the output. The atomic coordinator serializes the
+  publish (`finalize_atomic_operation`), so concurrent flushes + compaction
+  don't corrupt. The segment-header `layout_version` is the mixed-read-safe
+  marker (v1 + v3 coexist).
+
+== Co-design cost analysis
+
+On object storage, each compaction cycle costs N GETs (read inputs) + 1 PUT
+(write output) + N DELETEs (remove inputs). The dominant cost term is the GET
+round-trips (50 ms each on cloud). The 7 redundant training cycles during
+ingest waste 7 × N × 50 ms of pure object-store I/O. The async + debounced
+model reduces this to 1 × N × 50 ms (one post-ingest pass) — a **7× I/O cost
+reduction** in the compaction path, the single largest waste in the current
+system during streaming ingest.
+
+The admission control watermarks prevent the L0 backlog from growing unbounded
+(which would increase the per-query GET count — each un-compacted L0 file adds
+footer + data GETs). By keeping L0 bounded, the watermarks protect query
+latency during heavy ingest.
+
+== Explicitly out of scope
+
+* **Compaction strategy tuning** (leveled vs tiered vs FIFO): unchanged — the
+  Cx L(n-1) → 1x Ln ratio and the `level_multiplier` stay as-is.
+* **Compaction priority / scheduling policy**: the existing FIFO queue +
+  `schedule_compaction` dedup suffice for the first cut. Priority-based
+  scheduling (e.g., compact the largest L0 first) is a follow-up.
+* **Per-collection compaction locks**: the atomic coordinator's operation-ID
+  serialization suffices; a per-collection mutex is a follow-up if contention
+  is observed.
+* **Iceberg/Delta-style scheduled-batch maintenance**: the async-background
+  model (D1) is the right first step; the scheduled-batch model (decouple
+  compaction from the engine entirely, run as a job) is a larger follow-up.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -379,6 +379,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Stable-ID-authoritative identity (amends ADR-031 + ADR-027)
 | Proposed (2026-07-26)
 | Establishes that **stable numeric ids** (account `u32`, tenant `u64`, namespace `u16`, collection `u32`, catalog `object_id: u64`) are the AUTHORITATIVE rename-safe identity across the catalog + path layer; display strings are a DERIVED legacy-compat form resolved at the identity seam and carried only so the legacy string path can read pre-migration data (mixed-read-safe; deprecated once ADR-031 typed paths go default-on). Amends ADR-031's "string remains authoritative" framing and ADR-027's string-keyed path contract: the DrPath authority is the stable id. Fixes the latent rename-safety defect (a path keyed on a mutable display string breaks on rename) and yields compact, `LIST`-ordered, name-opaque base62 paths. Migration (ordered): thread stable ids via the ADR-074 S1 seam (PR #1221) → fence the `u16` allocator (TD-NS-1 S4) → dual-read legacy data → flip `PROXIMADB_TYPED_PATHS` default-on → deprecate the string path. Motivated by the ADR-074 namespace design (2026-07-26 co-design).
+| link:ADR-076-async-compaction-admission-control.adoc[ADR-076]
+| Async compaction + L0 admission control for streaming ingest on object storage
+| Proposed (2026-07-26)
+| Decouples the write path (flush to L0, non-blocking) from the maintenance path (compaction to train + promote, background workers). Three gaps: (D1) move compaction from inline-synchronous (blocks flush ~35s) to existing idle background workers; ingest ~30x. (D2) RocksDB-style L0 admission watermarks (slowdown_trigger/stop_trigger). (D3) debounce the TD-COMPACT-5 training arm (120s post-flush; eliminates the 7x redundant re-training loop). Cross-system evidence: RocksDB/HBase/Cassandra all use async + watermarks; ProximaDB is the outlier (inline, no watermarks). Object-store co-design: each compaction cycle = N GETs + 1 PUT + N DELETEs; 7 redundant cycles = 7x wasted I/O. Tracked: TD-COMPACT-6/7/8.
 |===
 
 The index is complete and is enforced by `scripts/check_design_status_index.py`.


### PR DESCRIPTION
## What
Files the **compaction co-design** for cross-model review before implementation. ADR-076 (Proposed) + 3 TDs (Open). **Docs-only — no code changes.**

## The problem (measured 2026-07-26)
ProximaDB's SST compaction is **inline synchronous** — every flush blocks for the full compaction cycle (read L0 → merge → train PCA/IVF → write → delete). During 1M SIFT ingest on Azurite, the TD-COMPACT-5 training arm fired **every ~35s** (5-7 redundant cycles), each costing N object-store GETs + ~35s PCA CPU + 1 PUT + N DELETEs. The result: ingest throughput ~1 flush/35s (should be ~1/s), query latency ~400ms during ingest (should be ~1ms idle), and ~7× wasted object-store I/O.

## The design (ADR-076 — first principles + cross-system evidence)

Every production LSM system uses **async compaction + admission watermarks**. ProximaDB is the outlier:

| | RocksDB | HBase | Cassandra | Delta/Iceberg | **ProximaDB** |
|---|---|---|---|---|---|
| Compaction | Async | Async | Async | Batch maintenance | **Inline (blocks flush)** |
| Admission control | slowdown/stop triggers | throttling + pressure | IO throttle | N/A | **None** |
| Write blocking | No | No | No | No | **Yes** |

**Three decisions (each a boundary, not a micro-optimization):**
- **D1 — Async compaction** (TD-COMPACT-6): move compaction from inline-synchronous to the **existing idle background workers** (2 daemon threads at `engine.rs:212`, currently unused). Flush creates L0 and returns immediately (~1s); compaction runs concurrently. Ingest throughput ~30×.
- **D2 — L0 admission watermarks** (TD-COMPACT-7): RocksDB-style `l0_slowdown_trigger` (delay writes ~1ms) + `l0_stop_trigger` (stall writes) when L0 backlog exceeds thresholds. Prevents compaction storms.
- **D3 — Training-arm debounce** (TD-COMPACT-8): don't fire TD-COMPACT-5 on a segment that received new writes in the last 120s. Eliminates the 7× redundant re-training loop. One post-ingest pass instead of N during-ingest cycles.

**Object-store co-design**: each compaction cycle = N GETs + 1 PUT + N DELETEs. At 50ms/GET (cloud), 7 redundant cycles during ingest = pure waste. Async + debounce → 1 cycle → 7× less compaction I/O.

## Boundary contract (each surface well-integrated)
- **Flush**: memtable → L0 `.pax` (atomic, non-blocking, ~1s). Never awaits compaction.
- **Compaction worker**: reads L0 → merge + train → write L(n+1) → delete L0. Background, concurrent with flushes.
- **Admission control**: monitors L0 count; throttles/stalls writes when backlog exceeds watermarks.
- **Training debounce**: guards the training arm — waits for segment stability (120s no flush).

## Verification (guards)
`check_td_adr_unique` ✅ (76 ADRs, 288 TDs, 0 err) · `check_design_status_index` ✅.

## Requested review focus
1. Is **async compaction** (D1) the right first step vs the Iceberg/Delta scheduled-batch model? (The async-background model reuses existing infrastructure; the scheduled-batch is a larger refactor.)
2. Are the **watermark thresholds** (slowdown=8, stop=12) reasonable defaults? (RocksDB uses 20/36 for L0; we have fewer files per level.)
3. Is the **120s debounce** the right stability window? (Should it be configurable per workload?)
4. Does the **boundary contract** correctly separate flush / compaction / admission / training without overlap or gaps?