### PR TITLE
feat(dml): F5 slice 2 — DELETE tombstones the fenced CKS entry (closes slice-1 gap)

### DIFF
--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -3425,6 +3425,35 @@ impl DmlService {
             .iter()
             .map(|id| Self::build_delete_tombstone_record(id, &table_schema, now_ns))
             .collect::<Result<Vec<_>>>()?;
+        // F5: capture the fenced-store PK identities from these tombstone records
+        // (same insert-path builder → matching tenant_id + typed PK), applied
+        // after the record store confirms the delete. Single-column PKs only.
+        let cks_tombstone_ids: Vec<proximadb_storage_ports::Identity> =
+            if self.conditional_key_store.is_some() {
+                let pk_cols = Self::primary_key_columns(&table_schema);
+                if pk_cols.len() == 1 {
+                    tombstones
+                        .iter()
+                        .filter_map(|rec| {
+                            let pk_value = match rec.props.get(&pk_cols[0]) {
+                                Some(ProximaTreeNode::Value(v)) => v.clone(),
+                                _ => return None,
+                            };
+                            proximadb_data_model::key_codec::encode_identity(
+                                &rec.tenant_id,
+                                &table_schema.name,
+                                std::slice::from_ref(&pk_value),
+                            )
+                            .ok()
+                            .map(proximadb_storage_ports::Identity::from_bytes)
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
         let deleted_count = ids_to_delete.len();
         let mutations = tombstones
             .into_iter()
@@ -3443,6 +3472,22 @@ impl DmlService {
                     .cloned()
                     .unwrap_or_else(|| "unknown error".to_string())
             ));
+        }
+
+        // F5 (ADR-072): keep the fenced ConditionalKeyStore consistent with the
+        // delete — tombstone each removed row's PK Identity so FK existence
+        // (`cks.get`, the insert-path slice) and PK re-insert (`put_if_absent`)
+        // reflect the deletion. Without it a deleted parent stays "live": a child
+        // FK to it would wrongly succeed, and re-inserting the same PK would
+        // wrongly conflict. The identities are derived from the SAME tombstone
+        // records above (which go through the insert-path record builder), so the
+        // `tenant_id` + typed PK match the CKS registration exactly. Single-column
+        // PKs only (F2's fencing scope).
+        if let Some(cks) = &self.conditional_key_store {
+            for id in &cks_tombstone_ids {
+                cks.tombstone(id, proximadb_storage_ports::Generation(0))
+                    .await?;
+            }
         }
 
         info!(

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -1914,6 +1914,85 @@ async fn insert_enforces_foreign_key_via_fenced_store() {
     );
 }
 
+/// F5 (ADR-072): a DELETE tombstones the row's PK in the fenced
+/// `ConditionalKeyStore`, so the same PK re-inserts afterward. Without the
+/// tombstone, `put_if_absent` would see the lingering holder and wrongly reject —
+/// so this also proves the delete-side `Identity` matches the insert-side
+/// registration exactly (same tenant placeholder + keyspace + typed value).
+#[cfg(feature = "oltp-integrity")]
+#[tokio::test]
+async fn delete_tombstones_pk_in_fenced_store_allowing_reinsert() {
+    use crate::services::record_store::DirectWalTableRecordStore;
+    use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
+    use proximadb_cks_local::{LocalWalKeyStore, SyncPolicy};
+
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(CatalogManager::new());
+    manager
+        .create_native_catalog("native", temp_dir.path().to_string_lossy().as_ref())
+        .await
+        .expect("native catalog");
+    let ddl = DdlService::new(manager.clone());
+    ddl.execute(DdlStatement::CreateNamespace {
+        namespace: vec!["default".to_string()],
+        if_not_exists: true,
+        properties: HashMap::new(),
+    })
+    .await
+    .expect("create namespace");
+    let parser = crate::query::sql_frontend::SqlFrontendParser::new();
+    let ddl_stmt = parser
+        .parse_ddl("CREATE TABLE users (id TEXT NOT NULL, email TEXT NOT NULL, PRIMARY KEY (id));")
+        .expect("parse create")
+        .expect("ddl");
+    ddl.execute(ddl_stmt).await.expect("create table");
+
+    let wal_appender = Arc::new(
+        FramedTableWalAppender::open(temp_dir.path().join("del.wal"))
+            .await
+            .expect("open WAL"),
+    );
+    let record_store = Arc::new(DirectWalTableRecordStore::new(
+        Arc::new(MemtableRecordStorage::new()),
+        wal_appender,
+    ));
+    let cks = Arc::new(
+        LocalWalKeyStore::open(temp_dir.path().join("cks.wal"), SyncPolicy::PerOp)
+            .expect("open cks"),
+    );
+    let dml = DmlService::with_record_store_and_table_write_executor(
+        manager.clone(),
+        record_store,
+        Arc::new(PlannedOnlyTableWriteExecutor::new()),
+    )
+    .with_conditional_key_store(cks);
+    let run = |sql: &'static str| parser.parse_dml(sql).expect("parse dml").expect("dml");
+
+    // Insert u1 (registers the PK in the fenced store).
+    dml.execute(run(
+        "INSERT INTO users (id, email) VALUES ('u1', 'a@x.com');",
+    ))
+    .await
+    .expect("insert u1");
+    // A duplicate before delete is rejected (baseline: the fence is live).
+    dml.execute(run(
+        "INSERT INTO users (id, email) VALUES ('u1', 'dup@x.com');",
+    ))
+    .await
+    .expect_err("duplicate PK must be rejected while the row is live");
+    // Delete u1 — must tombstone the fenced entry.
+    dml.execute(run("DELETE FROM users WHERE id = 'u1';"))
+        .await
+        .expect("delete u1");
+    // Re-insert the same PK — must SUCCEED (the tombstone freed the fenced entry;
+    // proves the delete-side Identity matched the insert-side registration).
+    dml.execute(run(
+        "INSERT INTO users (id, email) VALUES ('u1', 'b@x.com');",
+    ))
+    .await
+    .expect("re-inserting a deleted PK must succeed after the tombstone");
+}
+
 #[tokio::test]
 async fn insert_enforces_foreign_key_reference() {
     // TD-110: a FOREIGN KEY referencing the parent PK is enforced on INSERT —


### PR DESCRIPTION
Follow-up to #1236. Slice 1 routed FK existence through the fenced `ConditionalKeyStore`, but the DELETE path didn't tombstone the store — so under `oltp-integrity` a deleted parent stayed *live*: a child FK to it would wrongly succeed, and re-inserting a deleted PK would wrongly conflict (a latent F2 gap too). **This closes it.**

`execute_delete` now tombstones each removed row's PK `Identity` in the CKS after the record store confirms the delete. The identities are derived from the **same tombstone records the delete already builds** (insert-path record builder), so `tenant_id` + typed PK match the `put_if_absent` registration **byte-for-byte** — a delete→reinsert round-trip proves it. Single-column PKs only (F2's fencing scope); **feature-inert by default**.

New test `delete_tombstones_pk_in_fenced_store_allowing_reinsert` — which caught a real bug during development (inserts register with the record's `tenant_id`, `""` by default, not `DEFAULT_TENANT_PLACEHOLDER`). **3 fenced tests pass; feature-off compiles clean.**