### PR TITLE
feat(abac): FA preconditions P1/P3/P4 — ABAC enforcement substrate + implementable TD-FOUNDATION-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,6 +6895,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proximadb-abac"
+version = "0.2.0"
+dependencies = [
+ "proximadb-catalog",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "proximadb-admin-ui"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "crates/foundation/proximadb-tenant",
     "crates/foundation/proximadb-relational-types",
     "crates/foundation/proximadb-functions",
+    "crates/control/proximadb-abac",
     "crates/control/proximadb-catalog",
     "crates/control/proximadb-metrics",
     "crates/horizontal/proximadb-codec",
@@ -213,6 +214,7 @@ proximadb-relational-planner = { path = "crates/query/proximadb-relational-plann
 proximadb-relational-executor = { path = "crates/query/proximadb-relational-executor" }
 proximadb-relational-frontend = { path = "crates/query/proximadb-relational-frontend" }
 proximadb-relational-engine = { path = "crates/query/proximadb-relational-engine" }
+proximadb-abac = { path = "crates/control/proximadb-abac" }
 proximadb-catalog = { path = "crates/control/proximadb-catalog" }
 proximadb-metrics = { path = "crates/control/proximadb-metrics" }
 arc-swap = "1.7"

--- a/crates/control/proximadb-abac/Cargo.toml
+++ b/crates/control/proximadb-abac/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "proximadb-abac"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "ABAC enforcement substrate (TD-FOUNDATION-3 preconditions P1/P3/P4): attribute authority, subject+epoch cache keying, and the non-optional read context"
+
+[lib]
+name = "proximadb_abac"
+path = "src/lib.rs"
+
+[dependencies]
+proximadb-catalog = { workspace = true, features = ["fc-metamodel"] }
+serde.workspace = true
+sha2 = "0.10"
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/control/proximadb-abac/src/authority.rs
+++ b/crates/control/proximadb-abac/src/authority.rs
@@ -1,0 +1,459 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! P1 — the attribute-authority store.
+//!
+//! ABAC's "A" needs a server-side authority. Today there is none: role
+//! assignments are `user_id`-keyed, single-assignment and permission-only, and
+//! attributes (`dept`/`clearance`/`region`) exist only as SSO claims — i.e. as
+//! values the *tenant's own IdP* asserts. TF-2 §3.1's attribute-trust boundary
+//! says a value a predicate reads to admit or deny must be re-resolved
+//! server-side against the authority of **the tenant whose policy is being
+//! evaluated**. This module is that authority.
+//!
+//! Two structural properties, both tested:
+//!
+//! * **It is the only mint for load-bearing attributes.** Everything it returns
+//!   is `AttrSource::ServerResolved`; claims are never copied in. A caller can
+//!   still attach claim-sourced labels afterwards, and they stay non-load-bearing
+//!   because `SubjectAttributes::load_bearing` refuses them by type.
+//! * **A missing or unavailable binding is an error, never an empty bag.** An
+//!   empty bag would sail through a `Permit`-with-no-predicate policy and admit
+//!   everything — fail-open by omission. [`AuthorityError`] denies instead.
+
+use std::collections::BTreeMap;
+
+use proximadb_catalog::fc_metamodel::{AttrValue, SubjectAttributes, SubjectId, TenantStableId};
+use sha2::{Digest, Sha256};
+
+/// A durable binding of attributes to one `(subject, tenant)` pair — the record
+/// the authority resolves against.
+///
+/// Unlike the `user_role_assignments` it replaces, a binding is
+/// **`(subject, tenant)`-keyed** (so the same principal may hold different
+/// attributes in different tenants) and **multi-valued** (roles are an ordinary
+/// `AttrValue::List` attribute, not a single assignment column — per TF-2 §3.1,
+/// "a role is just an attribute").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttributeBinding {
+    /// The principal this binding is for.
+    pub subject_id: SubjectId,
+    /// The tenant whose authority issued it (ADR-075 stable id).
+    pub tenant_stable_id: TenantStableId,
+    /// The attribute set. Ordered, so the digest is stable.
+    pub attrs: BTreeMap<String, AttrValue>,
+}
+
+impl AttributeBinding {
+    /// A binding with no attributes yet.
+    pub fn new(subject_id: impl Into<String>, tenant_stable_id: TenantStableId) -> Self {
+        Self {
+            subject_id: SubjectId(subject_id.into()),
+            tenant_stable_id,
+            attrs: BTreeMap::new(),
+        }
+    }
+
+    /// Add one attribute (builder form).
+    pub fn with_attr(mut self, key: impl Into<String>, value: AttrValue) -> Self {
+        self.attrs.insert(key.into(), value);
+        self
+    }
+}
+
+/// A collision-resistant digest of the **load-bearing** attribute set a
+/// resolution produced.
+///
+/// It exists so a cache key can bind to "which subject-visible world this result
+/// was computed under" without carrying the attributes themselves. It is minted
+/// only by an [`AttributeAuthority`] — the same component that resolved the
+/// attributes — so it cannot drift from the set it claims to summarize.
+///
+/// SHA-256-derived (truncated to 128 bits): a cache-key collision here is a
+/// **cross-subject disclosure**, so a fast non-cryptographic hash is not an
+/// acceptable trade (TF-2 S10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AttributeDigest([u8; 16]);
+
+impl AttributeDigest {
+    /// Digest an ordered attribute set. Length-prefixed field framing so
+    /// `{"ab": "c"}` and `{"a": "bc"}` cannot collide by concatenation.
+    fn of(tenant_stable_id: TenantStableId, attrs: &BTreeMap<String, AttrValue>) -> Self {
+        let mut h = Sha256::new();
+        h.update(b"proximadb-abac-attrs-v1");
+        h.update(tenant_stable_id.to_be_bytes());
+        h.update((attrs.len() as u64).to_be_bytes());
+        for (k, v) in attrs {
+            h.update((k.len() as u64).to_be_bytes());
+            h.update(k.as_bytes());
+            let encoded = encode_value(v);
+            h.update((encoded.len() as u64).to_be_bytes());
+            h.update(&encoded);
+        }
+        let out = h.finalize();
+        let mut bytes = [0u8; 16];
+        bytes.copy_from_slice(&out[..16]);
+        Self(bytes)
+    }
+
+    /// The raw digest bytes, for folding into a larger cache key.
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    /// Lowercase hex, for cache keys that are strings and for audit logs.
+    pub fn to_hex(&self) -> String {
+        self.0.iter().map(|b| format!("{b:02x}")).collect()
+    }
+}
+
+/// Type-tagged, length-framed encoding of an attribute value, so values of
+/// different types cannot produce the same bytes (`Int(1)` vs `Str("1")`).
+fn encode_value(v: &AttrValue) -> Vec<u8> {
+    let mut out = Vec::new();
+    match v {
+        AttrValue::Str(s) => {
+            out.push(1);
+            out.extend_from_slice(s.as_bytes());
+        }
+        AttrValue::Int(i) => {
+            out.push(2);
+            out.extend_from_slice(&i.to_be_bytes());
+        }
+        AttrValue::Bool(b) => {
+            out.push(3);
+            out.push(u8::from(*b));
+        }
+        AttrValue::List(items) => {
+            out.push(4);
+            out.extend_from_slice(&(items.len() as u64).to_be_bytes());
+            for item in items {
+                out.extend_from_slice(&(item.len() as u64).to_be_bytes());
+                out.extend_from_slice(item.as_bytes());
+            }
+        }
+    }
+    out
+}
+
+/// What an [`AttributeAuthority`] resolved: the load-bearing attribute bag plus
+/// the digest of exactly that bag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSubject {
+    /// The subject's attributes, all `ServerResolved`.
+    pub attributes: SubjectAttributes,
+    /// Digest of the attribute set these were resolved from (P3's cache-key input).
+    pub digest: AttributeDigest,
+}
+
+/// Why an attribute resolution denied.
+///
+/// Every variant is a **deny**. There is deliberately no "resolved to nothing"
+/// success case: an empty bag would satisfy any policy that carries no predicate,
+/// turning a missing binding into full access.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AuthorityError {
+    /// The subject holds no binding in this tenant — it is not a member, or its
+    /// binding was revoked.
+    #[error("subject '{subject}' has no attribute binding in tenant {tenant}")]
+    NoBinding {
+        /// The principal that failed to resolve.
+        subject: String,
+        /// The tenant the lookup was scoped to.
+        tenant: TenantStableId,
+    },
+    /// The authority could not be consulted (store outage, timeout). Denies —
+    /// an authorization substrate does not degrade to "allow" when its source of
+    /// truth is unreachable.
+    #[error("attribute authority unavailable: {detail}")]
+    Unavailable {
+        /// Operator-facing detail.
+        detail: String,
+    },
+}
+
+/// The server-side authority for a subject's ABAC attributes (TF-2 §3.1 / S6).
+///
+/// Implementations are **tenant-scoped by argument**: a resolution for tenant T
+/// must consult T's authority and return only T's bindings, even when the same
+/// principal exists in another tenant. This is what makes a cross-tenant
+/// `Reference` traversal evaluate the far policy against the *far* tenant's
+/// attributes rather than the visitor's self-asserted ones.
+pub trait AttributeAuthority {
+    /// Resolve `subject`'s load-bearing attributes in `tenant_stable_id`.
+    ///
+    /// Fail-closed: `Err` on any doubt. Callers must not treat an error as an
+    /// empty attribute set.
+    fn resolve_effective_attributes(
+        &self,
+        subject: &SubjectId,
+        tenant_stable_id: TenantStableId,
+    ) -> Result<ResolvedSubject, AuthorityError>;
+}
+
+/// An in-memory [`AttributeAuthority`] — the reference implementation, and the
+/// one tests use.
+///
+/// The durable implementation stores bindings as catalog objects in the reserved
+/// system namespace (TF-2 §3.3), which is why this type deliberately keeps the
+/// same shape: a `(subject, tenant)`-keyed lookup returning one binding.
+#[derive(Debug, Default)]
+pub struct InMemoryAttributeAuthority {
+    bindings: BTreeMap<(TenantStableId, String), AttributeBinding>,
+    /// When set, every resolution fails with this detail — models a store outage
+    /// so callers can pin their fail-closed behavior.
+    unavailable: Option<String>,
+}
+
+impl InMemoryAttributeAuthority {
+    /// An authority holding no bindings (so every resolution denies).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a binding.
+    pub fn upsert(&mut self, binding: AttributeBinding) {
+        self.bindings.insert(
+            (binding.tenant_stable_id, binding.subject_id.0.clone()),
+            binding,
+        );
+    }
+
+    /// Remove a subject's binding in one tenant. Subsequent resolutions deny with
+    /// [`AuthorityError::NoBinding`].
+    pub fn revoke(&mut self, subject: &SubjectId, tenant_stable_id: TenantStableId) {
+        self.bindings.remove(&(tenant_stable_id, subject.0.clone()));
+    }
+
+    /// Simulate the authority being unreachable (tests for the fail-closed path).
+    pub fn set_unavailable(&mut self, detail: impl Into<String>) {
+        self.unavailable = Some(detail.into());
+    }
+}
+
+impl AttributeAuthority for InMemoryAttributeAuthority {
+    fn resolve_effective_attributes(
+        &self,
+        subject: &SubjectId,
+        tenant_stable_id: TenantStableId,
+    ) -> Result<ResolvedSubject, AuthorityError> {
+        if let Some(detail) = &self.unavailable {
+            return Err(AuthorityError::Unavailable {
+                detail: detail.clone(),
+            });
+        }
+
+        let binding = self
+            .bindings
+            .get(&(tenant_stable_id, subject.0.clone()))
+            .ok_or_else(|| AuthorityError::NoBinding {
+                subject: subject.0.clone(),
+                tenant: tenant_stable_id,
+            })?;
+
+        // Every attribute the authority emits is ServerResolved — this function is
+        // the only place load-bearing attributes come into existence.
+        let mut attributes = SubjectAttributes::new(subject.0.clone(), tenant_stable_id);
+        for (k, v) in &binding.attrs {
+            attributes = attributes.with_resolved(k.clone(), v.clone());
+        }
+
+        Ok(ResolvedSubject {
+            attributes,
+            digest: AttributeDigest::of(tenant_stable_id, &binding.attrs),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authority() -> InMemoryAttributeAuthority {
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(
+            AttributeBinding::new("alice", 7)
+                .with_attr("dept", AttrValue::Str("eng".into()))
+                .with_attr("clearance", AttrValue::Int(3))
+                .with_attr(
+                    "roles",
+                    AttrValue::List(vec!["reader".into(), "analyst".into()]),
+                ),
+        );
+        a
+    }
+
+    #[test]
+    fn resolved_attributes_are_load_bearing() {
+        let r = authority()
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("alice is bound in tenant 7");
+
+        assert_eq!(
+            r.attributes.load_bearing("dept"),
+            Some(&AttrValue::Str("eng".into()))
+        );
+        assert_eq!(
+            r.attributes.load_bearing("clearance"),
+            Some(&AttrValue::Int(3))
+        );
+        // A role is an ordinary attribute, and multi-valued — the single-assignment
+        // limit of user_role_assignments is gone.
+        assert_eq!(
+            r.attributes.load_bearing("roles"),
+            Some(&AttrValue::List(vec!["reader".into(), "analyst".into()]))
+        );
+    }
+
+    #[test]
+    fn an_unbound_subject_denies_rather_than_resolving_to_an_empty_bag() {
+        // The failure that matters: an empty bag sails through a Permit-with-no-
+        // predicate policy. Resolution must deny instead.
+        let err = authority()
+            .resolve_effective_attributes(&SubjectId("mallory".into()), 7)
+            .expect_err("unbound subject must not resolve");
+        assert!(matches!(err, AuthorityError::NoBinding { .. }));
+    }
+
+    #[test]
+    fn an_unavailable_authority_denies() {
+        let mut a = authority();
+        a.set_unavailable("binding store timeout");
+        let err = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect_err("an unreachable authority must not degrade to allow");
+        assert!(matches!(err, AuthorityError::Unavailable { .. }));
+    }
+
+    #[test]
+    fn a_binding_does_not_leak_across_tenants() {
+        // Same principal name, different tenant: alice@7's clearance must not
+        // answer a lookup scoped to tenant 8.
+        let a = authority();
+        assert!(matches!(
+            a.resolve_effective_attributes(&SubjectId("alice".into()), 8),
+            Err(AuthorityError::NoBinding { tenant: 8, .. })
+        ));
+    }
+
+    #[test]
+    fn revocation_takes_effect_immediately() {
+        let mut a = authority();
+        a.revoke(&SubjectId("alice".into()), 7);
+        assert!(
+            a.resolve_effective_attributes(&SubjectId("alice".into()), 7)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn the_digest_is_stable_for_the_same_attributes_and_differs_otherwise() {
+        let a = authority();
+        let first = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound");
+        let second = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound");
+        assert_eq!(first.digest, second.digest, "same world ⇒ same cache key");
+
+        // A different subject with the *same* attributes shares the digest: the
+        // cache key binds to the visible world, not to the principal.
+        let mut b = InMemoryAttributeAuthority::new();
+        b.upsert(
+            AttributeBinding::new("bob", 7)
+                .with_attr("dept", AttrValue::Str("eng".into()))
+                .with_attr("clearance", AttrValue::Int(3))
+                .with_attr(
+                    "roles",
+                    AttrValue::List(vec!["reader".into(), "analyst".into()]),
+                ),
+        );
+        let bob = b
+            .resolve_effective_attributes(&SubjectId("bob".into()), 7)
+            .expect("bound");
+        assert_eq!(first.digest, bob.digest);
+    }
+
+    #[test]
+    fn a_changed_attribute_changes_the_digest() {
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())));
+        let eng = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound")
+            .digest;
+
+        a.upsert(AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("hr".into())));
+        let hr = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound")
+            .digest;
+
+        assert_ne!(eng, hr, "dept=eng and dept=hr must not share a cache key");
+    }
+
+    #[test]
+    fn the_same_tenant_is_folded_into_the_digest() {
+        // Two tenants, identical attributes: the digests must differ, so a cache
+        // key built from the digest cannot cross the tenant boundary even if the
+        // rest of the key were somehow shared.
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())));
+        a.upsert(AttributeBinding::new("alice", 8).with_attr("dept", AttrValue::Str("eng".into())));
+        let t7 = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound")
+            .digest;
+        let t8 = a
+            .resolve_effective_attributes(&SubjectId("alice".into()), 8)
+            .expect("bound")
+            .digest;
+        assert_ne!(t7, t8);
+    }
+
+    #[test]
+    fn field_framing_prevents_concatenation_collisions() {
+        // {"ab": "c"} and {"a": "bc"} concatenate to the same bytes without
+        // length framing — a collision here is a cross-subject cache hit.
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(AttributeBinding::new("x", 1).with_attr("ab", AttrValue::Str("c".into())));
+        a.upsert(AttributeBinding::new("y", 1).with_attr("a", AttrValue::Str("bc".into())));
+        let x = a
+            .resolve_effective_attributes(&SubjectId("x".into()), 1)
+            .expect("bound")
+            .digest;
+        let y = a
+            .resolve_effective_attributes(&SubjectId("y".into()), 1)
+            .expect("bound")
+            .digest;
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn values_of_different_types_do_not_collide() {
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(AttributeBinding::new("x", 1).with_attr("k", AttrValue::Str("1".into())));
+        a.upsert(AttributeBinding::new("y", 1).with_attr("k", AttrValue::Int(1)));
+        let x = a
+            .resolve_effective_attributes(&SubjectId("x".into()), 1)
+            .expect("bound")
+            .digest;
+        let y = a
+            .resolve_effective_attributes(&SubjectId("y".into()), 1)
+            .expect("bound")
+            .digest;
+        // The same widening that makes `clearance>=3` vs "2" fail open (S3) would
+        // make these share a cache key.
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn the_digest_renders_as_hex_for_audit() {
+        let d = authority()
+            .resolve_effective_attributes(&SubjectId("alice".into()), 7)
+            .expect("bound")
+            .digest;
+        assert_eq!(d.to_hex().len(), 32);
+        assert_eq!(d.as_bytes().len(), 16);
+    }
+}

--- a/crates/control/proximadb-abac/src/cache_key.rs
+++ b/crates/control/proximadb-abac/src/cache_key.rs
@@ -1,0 +1,247 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! P3 — subject + policy-epoch cache keying (TF-2 S10).
+//!
+//! A cache above the enforcement seam defeats the whole plane: subject A warms
+//! `SELECT *`, subject B in the same tenant issues the identical query, and the
+//! result cache — keyed on `(tenant, namespace, query)` — hands B the rows B is
+//! not allowed to see. The result cache, the vector-search cache and the LLM
+//! semantic cache all have this shape today.
+//!
+//! Two things must be folded into every client-servable cache key:
+//!
+//! * **The subject's effective-attribute digest**, so two subjects who see
+//!   different worlds cannot share an entry. It keys on the *world*, not the
+//!   principal — two subjects with identical load-bearing attributes legitimately
+//!   share cache entries, which is where the hit rate comes back.
+//! * **The policy epoch**, so editing a policy invalidates every dependent entry
+//!   without walking the cache. A stale epoch is a stale key, and a stale key
+//!   simply misses.
+//!
+//! Caches that cannot adopt the key are **bypassed** while `abac-policy` is on;
+//! there is no third option.
+
+use std::collections::BTreeMap;
+
+use proximadb_catalog::fc_metamodel::{NamespaceId, TenantStableId};
+
+use crate::authority::AttributeDigest;
+
+/// A monotonically increasing counter, bumped on every change to the policy
+/// bindings that govern a `(tenant, namespace)`.
+///
+/// Monotonic and opaque: consumers may only compare it for equality and read it
+/// as an opaque key component. Bumping is the invalidation hook — no cache walk,
+/// no per-entry tracking of which policy produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct PolicyEpoch(pub u64);
+
+impl PolicyEpoch {
+    /// The epoch of a `(tenant, namespace)` whose policy has never changed.
+    pub const INITIAL: PolicyEpoch = PolicyEpoch(0);
+
+    /// The next epoch. Saturating: an epoch that stops advancing would silently
+    /// stop invalidating, so it pins at `u64::MAX` rather than wrapping back into
+    /// a previously used value.
+    pub fn next(self) -> Self {
+        PolicyEpoch(self.0.saturating_add(1))
+    }
+}
+
+/// Where a read's current policy epoch comes from.
+pub trait PolicyEpochSource {
+    /// The current epoch for a `(tenant, namespace)`.
+    ///
+    /// A `(tenant, namespace)` never seen before reads as [`PolicyEpoch::INITIAL`]
+    /// — safe because the epoch only ever needs to *change* when policy changes;
+    /// a never-edited scope has nothing to invalidate.
+    fn epoch(&self, tenant_stable_id: TenantStableId, namespace: NamespaceId) -> PolicyEpoch;
+}
+
+/// An in-memory [`PolicyEpochSource`] — the reference implementation.
+#[derive(Debug, Default)]
+pub struct InMemoryPolicyEpochs {
+    epochs: BTreeMap<(TenantStableId, NamespaceId), PolicyEpoch>,
+}
+
+impl InMemoryPolicyEpochs {
+    /// An epoch registry where every scope is at [`PolicyEpoch::INITIAL`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Advance the epoch for a `(tenant, namespace)` — the invalidation hook a
+    /// policy write calls after it commits. Returns the new epoch.
+    pub fn bump(
+        &mut self,
+        tenant_stable_id: TenantStableId,
+        namespace: NamespaceId,
+    ) -> PolicyEpoch {
+        let entry = self
+            .epochs
+            .entry((tenant_stable_id, namespace))
+            .or_insert(PolicyEpoch::INITIAL);
+        *entry = entry.next();
+        *entry
+    }
+}
+
+impl PolicyEpochSource for InMemoryPolicyEpochs {
+    fn epoch(&self, tenant_stable_id: TenantStableId, namespace: NamespaceId) -> PolicyEpoch {
+        self.epochs
+            .get(&(tenant_stable_id, namespace))
+            .copied()
+            .unwrap_or(PolicyEpoch::INITIAL)
+    }
+}
+
+/// The component every client-servable cache key must fold in, alongside
+/// whatever the cache already keys on (query text, vector, question, …).
+///
+/// It is deliberately *not* a whole cache key: each cache keeps its own key type
+/// and adds this. That keeps the invariant checkable — "does this cache's key
+/// contain a `SubjectCacheKey`?" — instead of asking every cache to reimplement
+/// subject binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SubjectCacheKey {
+    /// Tenant (ADR-075 stable id) — structural isolation, still keyed explicitly.
+    pub tenant_stable_id: TenantStableId,
+    /// Namespace (ADR-074 boundary).
+    pub namespace: NamespaceId,
+    /// The policy generation this entry was computed under.
+    pub policy_epoch: PolicyEpoch,
+    /// Digest of the subject's load-bearing attributes.
+    pub attribute_digest: AttributeDigest,
+}
+
+impl SubjectCacheKey {
+    /// Build the key component for a subject in a scope.
+    pub fn new(
+        tenant_stable_id: TenantStableId,
+        namespace: NamespaceId,
+        policy_epoch: PolicyEpoch,
+        attribute_digest: AttributeDigest,
+    ) -> Self {
+        Self {
+            tenant_stable_id,
+            namespace,
+            policy_epoch,
+            attribute_digest,
+        }
+    }
+
+    /// A stable string rendering, for caches whose keys are strings.
+    pub fn as_key_component(&self) -> String {
+        format!(
+            "t{}:n{}:e{}:a{}",
+            self.tenant_stable_id,
+            self.namespace,
+            self.policy_epoch.0,
+            self.attribute_digest.to_hex()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proximadb_catalog::fc_metamodel::{AttrValue, SubjectId};
+
+    use super::*;
+    use crate::authority::{
+        AttributeAuthority, AttributeBinding, InMemoryAttributeAuthority, ResolvedSubject,
+    };
+
+    fn world() -> InMemoryAttributeAuthority {
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())));
+        a.upsert(AttributeBinding::new("bob", 7).with_attr("dept", AttrValue::Str("hr".into())));
+        a.upsert(AttributeBinding::new("carol", 7).with_attr("dept", AttrValue::Str("eng".into())));
+        a
+    }
+
+    fn resolve(a: &InMemoryAttributeAuthority, who: &str) -> ResolvedSubject {
+        a.resolve_effective_attributes(&SubjectId(who.into()), 7)
+            .expect("bound")
+    }
+
+    fn key_for(a: &InMemoryAttributeAuthority, who: &str, epoch: PolicyEpoch) -> SubjectCacheKey {
+        SubjectCacheKey::new(7, 3, epoch, resolve(a, who).digest)
+    }
+
+    #[test]
+    fn two_subjects_in_different_departments_do_not_share_a_cache_entry() {
+        // The S10 scenario: alice warms a query, bob issues the identical one.
+        let a = world();
+        assert_ne!(
+            key_for(&a, "alice", PolicyEpoch::INITIAL),
+            key_for(&a, "bob", PolicyEpoch::INITIAL)
+        );
+    }
+
+    #[test]
+    fn subjects_seeing_the_same_world_do_share_a_cache_entry() {
+        // Keying on the world rather than the principal is what keeps the cache
+        // useful — alice and carol are both dept=eng.
+        let a = world();
+        assert_eq!(
+            key_for(&a, "alice", PolicyEpoch::INITIAL),
+            key_for(&a, "carol", PolicyEpoch::INITIAL)
+        );
+    }
+
+    #[test]
+    fn a_policy_change_invalidates_by_changing_the_key() {
+        let a = world();
+        let mut epochs = InMemoryPolicyEpochs::new();
+        let before = key_for(&a, "alice", epochs.epoch(7, 3));
+        let after_epoch = epochs.bump(7, 3);
+        let after = key_for(&a, "alice", after_epoch);
+
+        assert_ne!(before, after);
+        assert_eq!(after_epoch, PolicyEpoch(1));
+    }
+
+    #[test]
+    fn epochs_are_scoped_per_tenant_and_namespace() {
+        let mut epochs = InMemoryPolicyEpochs::new();
+        epochs.bump(7, 3);
+        // Bumping tenant 7's namespace 3 must not invalidate anyone else's cache.
+        assert_eq!(epochs.epoch(7, 3), PolicyEpoch(1));
+        assert_eq!(epochs.epoch(7, 4), PolicyEpoch::INITIAL);
+        assert_eq!(epochs.epoch(8, 3), PolicyEpoch::INITIAL);
+    }
+
+    #[test]
+    fn an_unknown_scope_reads_as_the_initial_epoch() {
+        assert_eq!(
+            InMemoryPolicyEpochs::new().epoch(99, 99),
+            PolicyEpoch::INITIAL
+        );
+    }
+
+    #[test]
+    fn the_epoch_never_wraps_back_onto_a_used_value() {
+        // Wrapping would resurrect a key that cached results already live under.
+        assert_eq!(PolicyEpoch(u64::MAX).next(), PolicyEpoch(u64::MAX));
+    }
+
+    #[test]
+    fn the_string_rendering_carries_every_component() {
+        let a = world();
+        let k = key_for(&a, "alice", PolicyEpoch(5));
+        let s = k.as_key_component();
+        assert!(s.starts_with("t7:n3:e5:a"));
+        // …and distinguishes the same subject at a different epoch.
+        assert_ne!(s, key_for(&a, "alice", PolicyEpoch(6)).as_key_component());
+    }
+
+    #[test]
+    fn the_key_separates_namespaces_within_a_tenant() {
+        let a = world();
+        let digest = resolve(&a, "alice").digest;
+        assert_ne!(
+            SubjectCacheKey::new(7, 3, PolicyEpoch::INITIAL, digest),
+            SubjectCacheKey::new(7, 4, PolicyEpoch::INITIAL, digest)
+        );
+    }
+}

--- a/crates/control/proximadb-abac/src/context.rs
+++ b/crates/control/proximadb-abac/src/context.rs
@@ -1,0 +1,692 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! P4 — the non-`Option` read context (TF-2 S4/S7).
+//!
+//! Today's shape is `tenant_context: Option<&TenantContext>` with a permissive
+//! default body on `scan_records` — i.e. *unfiltered* is what you get by writing
+//! less code. FA inverts that: [`AuthorizedReadContext`] is a **required**
+//! parameter of every read primitive, and the type offers no way to produce one
+//! that means "no restriction".
+//!
+//! * There is no `Default`, no `unfiltered()`, and no `new()` taking a policy you
+//!   chose yourself. The only constructor is [`AuthorizedReadContext::resolve`],
+//!   which returns a [`ReadDecision`] — and the deny arm carries **no context at
+//!   all**, so a denied read has nothing to pass to a primitive.
+//! * Internal callers that genuinely need unfiltered access (compaction, index
+//!   build, recovery, replication) use [`SystemReadContext`], which names its
+//!   reason and, crucially, does **not** implement [`ClientServable`]. A sink that
+//!   serves clients accepts `impl ClientServable`; handing it a
+//!   `SystemReadContext` does not compile.
+//!
+//! What is deliberately **not** here: the compiled row filter. Turning
+//! [`AuthorizedReadContext::row_predicate_refs`] into an executable predicate is
+//! the total-or-fail-closed bridge (FA-2 / TF-2 S1–S3), which lives against the
+//! filter-expression crates. This module carries the refs and the field masks;
+//! FA-2 adds the compiled filter to the same context.
+
+use std::collections::BTreeMap;
+
+use proximadb_catalog::fc_metamodel::{
+    Effect, EffectivePolicy, FieldMask, NamespaceId, ObjectId, PolicyBinding, Scope,
+    SubjectAttributes, SubjectId, Target, TenantStableId, resolve_effective_policy,
+};
+
+use crate::authority::{AttributeAuthority, AttributeDigest, AuthorityError};
+use crate::cache_key::{PolicyEpoch, PolicyEpochSource, SubjectCacheKey};
+
+/// Why a read was denied. Every variant means **zero rows**, never "unfiltered".
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DenyReason {
+    /// The subject's attributes could not be resolved server-side. Note this is
+    /// a deny even though the *policy* might have permitted: a policy evaluated
+    /// against unresolved attributes is not evaluated at all.
+    #[error("subject attributes could not be resolved: {0}")]
+    AttributeResolution(#[from] AuthorityError),
+    /// No binding covers the target. The fail-closed default — an unconfigured
+    /// container is closed, not open.
+    #[error("no policy binding applies to the target; default is deny")]
+    NoApplicablePolicy,
+    /// A binding at some scope explicitly denied (deny wins over any permit).
+    #[error("an applicable policy binding denies this read")]
+    ExplicitDeny,
+}
+
+/// The outcome of resolving a read: an admitted context, or a reason and nothing
+/// else.
+///
+/// The shape is the point. A `Result<Option<Context>, E>` would let a caller
+/// `unwrap_or(None)` its way back to unfiltered; here the deny arm simply has no
+/// context to unwrap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadDecision {
+    /// The read may proceed under this context.
+    Admit(AuthorizedReadContext),
+    /// The read is denied.
+    Deny(DenyReason),
+}
+
+impl ReadDecision {
+    /// The context, if admitted.
+    pub fn admitted(self) -> Option<AuthorizedReadContext> {
+        match self {
+            ReadDecision::Admit(ctx) => Some(ctx),
+            ReadDecision::Deny(_) => None,
+        }
+    }
+
+    /// Whether this decision denied.
+    pub fn is_deny(&self) -> bool {
+        matches!(self, ReadDecision::Deny(_))
+    }
+}
+
+/// What a subject may see of one column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ColumnDecision {
+    /// Returned as stored.
+    Visible,
+    /// Returned as NULL.
+    Null,
+    /// Returned masked.
+    Redact,
+    /// Not returnable at all — the **query is rejected**, not silently nulled
+    /// (TF-2 §3.4.7: a null projection would leak the column's existence and let
+    /// a caller distinguish "masked" from "absent").
+    Forbidden,
+}
+
+impl ColumnDecision {
+    fn of(mask: FieldMask) -> Self {
+        match mask {
+            FieldMask::Null => ColumnDecision::Null,
+            FieldMask::Redact => ColumnDecision::Redact,
+            FieldMask::Forbid => ColumnDecision::Forbidden,
+        }
+    }
+}
+
+/// A projection was rejected because it referenced a forbidden column.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("column {ordinal} is forbidden to this subject; the query is rejected")]
+pub struct ForbiddenColumn {
+    /// The offending column ordinal.
+    pub ordinal: u32,
+}
+
+/// The mandatory context every client-serving read primitive takes.
+///
+/// Construct it only via [`AuthorizedReadContext::resolve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizedReadContext {
+    subject: SubjectAttributes,
+    digest: AttributeDigest,
+    target: Target,
+    namespace: NamespaceId,
+    tenant_stable_id: TenantStableId,
+    policy: EffectivePolicy,
+    epoch: PolicyEpoch,
+    column_decisions: BTreeMap<u32, ColumnDecision>,
+}
+
+impl AuthorizedReadContext {
+    /// Resolve a subject's read authorization for `target`.
+    ///
+    /// Order matters and is fail-closed at each step:
+    ///
+    /// 1. Resolve the subject's attributes **server-side** (P1). A failure denies
+    ///    before any policy is consulted — claims never substitute.
+    /// 2. Compose the applicable bindings deny-biased (FC's
+    ///    `resolve_effective_policy`). No applicable binding denies.
+    /// 3. Collect column decisions from column-scoped bindings, strictest-wins.
+    ///
+    /// `target.column` is ignored for the row decision — the context is resolved
+    /// at table granularity and answers per-column questions through
+    /// [`Self::column_decision`].
+    pub fn resolve(
+        authority: &dyn AttributeAuthority,
+        epochs: &dyn PolicyEpochSource,
+        bindings: &[PolicyBinding],
+        subject_id: &SubjectId,
+        tenant_stable_id: TenantStableId,
+        target: Target,
+    ) -> ReadDecision {
+        let resolved = match authority.resolve_effective_attributes(subject_id, tenant_stable_id) {
+            Ok(r) => r,
+            Err(e) => return ReadDecision::Deny(DenyReason::AttributeResolution(e)),
+        };
+
+        // Only this tenant's bindings may govern this tenant's read. Isolation is
+        // structural: a foreign binding is filtered out here, never compared.
+        let own: Vec<PolicyBinding> = bindings
+            .iter()
+            .filter(|b| b.tenant_stable_id == tenant_stable_id)
+            .cloned()
+            .collect();
+
+        let row_target = Target {
+            column: None,
+            ..target
+        };
+        let policy = resolve_effective_policy(&own, &row_target);
+        if policy.applicable == 0 {
+            return ReadDecision::Deny(DenyReason::NoApplicablePolicy);
+        }
+        if policy.decision == Effect::Deny {
+            return ReadDecision::Deny(DenyReason::ExplicitDeny);
+        }
+
+        let mut column_decisions: BTreeMap<u32, ColumnDecision> = BTreeMap::new();
+        for b in &own {
+            let Scope::Column { table, column } = b.scope else {
+                continue;
+            };
+            if table != target.table {
+                continue;
+            }
+            // A column-scoped Deny forbids the column outright, whether or not it
+            // also carries a mask — the strictest reading of an explicit deny.
+            let decision = if b.effect == Effect::Deny {
+                ColumnDecision::Forbidden
+            } else {
+                match b.field_mask {
+                    Some(m) => ColumnDecision::of(m),
+                    None => continue,
+                }
+            };
+            let slot = column_decisions.entry(column).or_insert(decision);
+            // Strictest wins when two bindings mask the same column
+            // (Forbidden > Redact > Null > Visible, per the enum's order).
+            *slot = (*slot).max(decision);
+        }
+
+        ReadDecision::Admit(AuthorizedReadContext {
+            subject: resolved.attributes,
+            digest: resolved.digest,
+            target: row_target,
+            namespace: target.namespace,
+            tenant_stable_id,
+            policy,
+            epoch: epochs.epoch(tenant_stable_id, target.namespace),
+            column_decisions,
+        })
+    }
+
+    /// The subject's server-resolved attributes. A predicate reads values through
+    /// `SubjectAttributes::load_bearing`, which refuses claim-sourced values.
+    pub fn subject(&self) -> &SubjectAttributes {
+        &self.subject
+    }
+
+    /// The container this context authorizes reads of.
+    pub fn target(&self) -> Target {
+        self.target
+    }
+
+    /// The tenant this read is scoped to.
+    pub fn tenant_stable_id(&self) -> TenantStableId {
+        self.tenant_stable_id
+    }
+
+    /// The row-predicate object refs to AND into the scan. FA-2 compiles these
+    /// through the total-or-fail-closed bridge; an empty list means the applicable
+    /// permits carried no row restriction, **not** that the read is unauthorized —
+    /// authorization already happened.
+    pub fn row_predicate_refs(&self) -> &[ObjectId] {
+        &self.policy.predicate_refs
+    }
+
+    /// What the subject may see of one column. Unmentioned columns are
+    /// [`ColumnDecision::Visible`] — the row-level decision already admitted the
+    /// row, and masks are the exception, not the rule.
+    pub fn column_decision(&self, ordinal: u32) -> ColumnDecision {
+        self.column_decisions
+            .get(&ordinal)
+            .copied()
+            .unwrap_or(ColumnDecision::Visible)
+    }
+
+    /// The columns carrying any mask.
+    ///
+    /// FA's policy-compile step uses this for TF-2 S8: a masked column must not
+    /// be referenced by a row predicate, or its value leaks through the admit/deny
+    /// channel despite the output mask.
+    pub fn masked_columns(&self) -> impl Iterator<Item = (u32, ColumnDecision)> + '_ {
+        self.column_decisions.iter().map(|(k, v)| (*k, *v))
+    }
+
+    /// Decide a projection. A forbidden column **rejects the query** rather than
+    /// nulling itself out.
+    pub fn project(&self, columns: &[u32]) -> Result<Vec<(u32, ColumnDecision)>, ForbiddenColumn> {
+        let mut out = Vec::with_capacity(columns.len());
+        for &ordinal in columns {
+            let decision = self.column_decision(ordinal);
+            if decision == ColumnDecision::Forbidden {
+                return Err(ForbiddenColumn { ordinal });
+            }
+            out.push((ordinal, decision));
+        }
+        Ok(out)
+    }
+
+    /// The key component any client-servable cache must fold in (P3 / TF-2 S10).
+    pub fn subject_cache_key(&self) -> SubjectCacheKey {
+        SubjectCacheKey::new(
+            self.tenant_stable_id,
+            self.namespace,
+            self.epoch,
+            self.digest,
+        )
+    }
+}
+
+/// Why an unfiltered internal read is legitimate. Naming the reason is what makes
+/// [`SystemReadContext`] auditable rather than a blanket escape hatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemReadReason {
+    /// Compaction / merge rewriting segments.
+    Compaction,
+    /// Building or rebuilding an index.
+    IndexBuild,
+    /// Resolving a foreign-key target during constraint checking.
+    ForeignKeyResolution,
+    /// Refreshing a materialized view.
+    MaterializedViewRefresh,
+    /// Node-to-node replication of storage state.
+    Replication,
+    /// WAL recovery / restart warming.
+    Recovery,
+    /// Emitting internal statistics or metrics.
+    Statistics,
+}
+
+/// An explicit, audited unfiltered read, for internal machinery that has no
+/// subject to filter by.
+///
+/// It carries no subject, produces no cache key, and — deliberately — does **not**
+/// implement [`ClientServable`]. That omission is the enforcement: a sink that
+/// serves clients is written against `impl ClientServable`, so handing it a
+/// `SystemReadContext` fails to compile rather than failing in review.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemReadContext {
+    reason: SystemReadReason,
+    /// Free-text provenance for the audit log — typically the calling subsystem.
+    origin: String,
+}
+
+impl SystemReadContext {
+    /// Declare an unfiltered internal read, naming why and from where.
+    pub fn audited(reason: SystemReadReason, origin: impl Into<String>) -> Self {
+        Self {
+            reason,
+            origin: origin.into(),
+        }
+    }
+
+    /// Why this read is unfiltered.
+    pub fn reason(&self) -> SystemReadReason {
+        self.reason
+    }
+
+    /// Where it came from.
+    pub fn origin(&self) -> &str {
+        &self.origin
+    }
+}
+
+/// A context that may serve results **to a client**.
+///
+/// Implemented for [`AuthorizedReadContext`] and nothing else. Client-facing
+/// sinks (query results, CDC sinks fed by a client subscription, Flight streams)
+/// take `impl ClientServable`; internal-only sinks take whichever context they
+/// like. This is TF-2 S5's "a `SystemReadContext` must never feed a client
+/// sink", expressed as a trait bound instead of a code-review rule.
+///
+/// ```compile_fail
+/// use proximadb_abac::{ClientServable, SystemReadContext, SystemReadReason};
+///
+/// fn serve_to_client(_ctx: &impl ClientServable) {}
+///
+/// // A SystemReadContext is unfiltered; it must not reach a client sink.
+/// let sys = SystemReadContext::audited(SystemReadReason::Compaction, "compactor");
+/// serve_to_client(&sys);
+/// ```
+pub trait ClientServable {
+    /// The subject the results will be served to.
+    fn subject(&self) -> &SubjectAttributes;
+    /// The cache key component results must be stored under.
+    fn subject_cache_key(&self) -> SubjectCacheKey;
+}
+
+impl ClientServable for AuthorizedReadContext {
+    fn subject(&self) -> &SubjectAttributes {
+        AuthorizedReadContext::subject(self)
+    }
+
+    fn subject_cache_key(&self) -> SubjectCacheKey {
+        AuthorizedReadContext::subject_cache_key(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proximadb_catalog::fc_metamodel::AttrValue;
+
+    use super::*;
+    use crate::authority::{AttributeBinding, InMemoryAttributeAuthority};
+    use crate::cache_key::InMemoryPolicyEpochs;
+
+    const TENANT: TenantStableId = 7;
+    const NS: NamespaceId = 3;
+    const TABLE: u32 = 200;
+
+    fn authority() -> InMemoryAttributeAuthority {
+        let mut a = InMemoryAttributeAuthority::new();
+        a.upsert(
+            AttributeBinding::new("alice", TENANT).with_attr("dept", AttrValue::Str("eng".into())),
+        );
+        a.upsert(
+            AttributeBinding::new("bob", TENANT).with_attr("dept", AttrValue::Str("hr".into())),
+        );
+        a
+    }
+
+    fn target() -> Target {
+        Target {
+            namespace: NS,
+            table: TABLE,
+            column: None,
+        }
+    }
+
+    fn binding(object_id: ObjectId, scope: Scope, effect: Effect) -> PolicyBinding {
+        PolicyBinding {
+            object_id,
+            tenant_stable_id: TENANT,
+            scope,
+            effect,
+            predicate_ref: None,
+            field_mask: None,
+        }
+    }
+
+    fn decide(bindings: &[PolicyBinding], who: &str) -> ReadDecision {
+        AuthorizedReadContext::resolve(
+            &authority(),
+            &InMemoryPolicyEpochs::new(),
+            bindings,
+            &SubjectId(who.into()),
+            TENANT,
+            target(),
+        )
+    }
+
+    #[test]
+    fn a_table_permit_admits() {
+        let d = decide(&[binding(1, Scope::Table(TABLE), Effect::Permit)], "alice");
+        let ctx = d.admitted().expect("permitted");
+        assert_eq!(ctx.target().table, TABLE);
+        assert_eq!(
+            ctx.subject().load_bearing("dept"),
+            Some(&AttrValue::Str("eng".into()))
+        );
+    }
+
+    #[test]
+    fn no_binding_denies_rather_than_returning_an_unfiltered_context() {
+        // The fail-closed default: an unconfigured container is closed.
+        assert_eq!(
+            decide(&[], "alice"),
+            ReadDecision::Deny(DenyReason::NoApplicablePolicy)
+        );
+    }
+
+    #[test]
+    fn a_namespace_deny_masks_a_table_permit() {
+        let d = decide(
+            &[
+                binding(1, Scope::Table(TABLE), Effect::Permit),
+                binding(2, Scope::Namespace(NS), Effect::Deny),
+            ],
+            "alice",
+        );
+        assert_eq!(d, ReadDecision::Deny(DenyReason::ExplicitDeny));
+    }
+
+    #[test]
+    fn an_unresolvable_subject_denies_before_policy_is_consulted() {
+        // Even with a blanket Permit, an unresolved subject reads nothing — a
+        // policy evaluated against unresolved attributes is not evaluated.
+        let d = decide(
+            &[binding(1, Scope::Table(TABLE), Effect::Permit)],
+            "mallory",
+        );
+        assert!(matches!(
+            d,
+            ReadDecision::Deny(DenyReason::AttributeResolution(
+                AuthorityError::NoBinding { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn an_unavailable_authority_denies_even_under_a_permit() {
+        let mut a = authority();
+        a.set_unavailable("store timeout");
+        let d = AuthorizedReadContext::resolve(
+            &a,
+            &InMemoryPolicyEpochs::new(),
+            &[binding(1, Scope::Table(TABLE), Effect::Permit)],
+            &SubjectId("alice".into()),
+            TENANT,
+            target(),
+        );
+        assert!(matches!(
+            d,
+            ReadDecision::Deny(DenyReason::AttributeResolution(
+                AuthorityError::Unavailable { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn another_tenants_binding_cannot_authorize_this_read() {
+        // A Permit issued by tenant 8 must not admit a tenant-7 read; it is
+        // filtered out, so the read falls through to the fail-closed default.
+        let mut foreign = binding(1, Scope::Table(TABLE), Effect::Permit);
+        foreign.tenant_stable_id = TENANT + 1;
+        assert_eq!(
+            decide(&[foreign], "alice"),
+            ReadDecision::Deny(DenyReason::NoApplicablePolicy)
+        );
+    }
+
+    #[test]
+    fn a_foreign_tenants_deny_cannot_veto_this_read_either() {
+        // Isolation cuts both ways — tenant 8 must not be able to deny tenant 7.
+        let mut foreign_deny = binding(2, Scope::Namespace(NS), Effect::Deny);
+        foreign_deny.tenant_stable_id = TENANT + 1;
+        let d = decide(
+            &[
+                binding(1, Scope::Table(TABLE), Effect::Permit),
+                foreign_deny,
+            ],
+            "alice",
+        );
+        assert!(d.admitted().is_some());
+    }
+
+    #[test]
+    fn row_predicates_from_applicable_permits_ride_the_context() {
+        let mut permit = binding(1, Scope::Table(TABLE), Effect::Permit);
+        permit.predicate_ref = Some(555);
+        let ctx = decide(&[permit], "alice").admitted().expect("permitted");
+        assert_eq!(ctx.row_predicate_refs(), &[555]);
+    }
+
+    #[test]
+    fn field_masks_apply_per_column_and_default_to_visible() {
+        let mut mask = binding(
+            2,
+            Scope::Column {
+                table: TABLE,
+                column: 4,
+            },
+            Effect::Permit,
+        );
+        mask.field_mask = Some(FieldMask::Redact);
+        let ctx = decide(
+            &[binding(1, Scope::Table(TABLE), Effect::Permit), mask],
+            "alice",
+        )
+        .admitted()
+        .expect("permitted");
+
+        assert_eq!(ctx.column_decision(4), ColumnDecision::Redact);
+        assert_eq!(ctx.column_decision(0), ColumnDecision::Visible);
+        assert_eq!(
+            ctx.masked_columns().collect::<Vec<_>>(),
+            vec![(4, ColumnDecision::Redact)]
+        );
+    }
+
+    #[test]
+    fn the_strictest_mask_wins_when_two_bindings_cover_one_column() {
+        let col = Scope::Column {
+            table: TABLE,
+            column: 4,
+        };
+        let mut lenient = binding(2, col.clone(), Effect::Permit);
+        lenient.field_mask = Some(FieldMask::Null);
+        let mut strict = binding(3, col, Effect::Permit);
+        strict.field_mask = Some(FieldMask::Forbid);
+
+        let ctx = decide(
+            &[
+                binding(1, Scope::Table(TABLE), Effect::Permit),
+                lenient,
+                strict,
+            ],
+            "alice",
+        )
+        .admitted()
+        .expect("permitted");
+        assert_eq!(ctx.column_decision(4), ColumnDecision::Forbidden);
+    }
+
+    #[test]
+    fn a_column_scoped_deny_forbids_that_column_even_without_a_mask() {
+        let deny_col = binding(
+            2,
+            Scope::Column {
+                table: TABLE,
+                column: 4,
+            },
+            Effect::Deny,
+        );
+        let ctx = decide(
+            &[binding(1, Scope::Table(TABLE), Effect::Permit), deny_col],
+            "alice",
+        )
+        .admitted()
+        .expect("row read is still permitted");
+        assert_eq!(ctx.column_decision(4), ColumnDecision::Forbidden);
+    }
+
+    #[test]
+    fn a_forbidden_column_rejects_the_query_rather_than_nulling_itself() {
+        let mut forbid = binding(
+            2,
+            Scope::Column {
+                table: TABLE,
+                column: 4,
+            },
+            Effect::Permit,
+        );
+        forbid.field_mask = Some(FieldMask::Forbid);
+        let ctx = decide(
+            &[binding(1, Scope::Table(TABLE), Effect::Permit), forbid],
+            "alice",
+        )
+        .admitted()
+        .expect("permitted");
+
+        assert_eq!(ctx.project(&[0, 1]).expect("visible columns").len(), 2);
+        assert_eq!(
+            ctx.project(&[0, 4]),
+            Err(ForbiddenColumn { ordinal: 4 }),
+            "forbid is query-rejection, not a null projection"
+        );
+    }
+
+    #[test]
+    fn two_subjects_with_different_attributes_get_different_cache_keys() {
+        let permits = [binding(1, Scope::Table(TABLE), Effect::Permit)];
+        let alice = decide(&permits, "alice").admitted().expect("permitted");
+        let bob = decide(&permits, "bob").admitted().expect("permitted");
+        assert_ne!(alice.subject_cache_key(), bob.subject_cache_key());
+    }
+
+    #[test]
+    fn the_cache_key_tracks_the_policy_epoch() {
+        let permits = [binding(1, Scope::Table(TABLE), Effect::Permit)];
+        let a = authority();
+        let mut epochs = InMemoryPolicyEpochs::new();
+
+        let before = AuthorizedReadContext::resolve(
+            &a,
+            &epochs,
+            &permits,
+            &SubjectId("alice".into()),
+            TENANT,
+            target(),
+        )
+        .admitted()
+        .expect("permitted")
+        .subject_cache_key();
+
+        epochs.bump(TENANT, NS);
+
+        let after = AuthorizedReadContext::resolve(
+            &a,
+            &epochs,
+            &permits,
+            &SubjectId("alice".into()),
+            TENANT,
+            target(),
+        )
+        .admitted()
+        .expect("permitted")
+        .subject_cache_key();
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn a_client_sink_accepts_an_authorized_context() {
+        // The positive half of the compile_fail doctest on ClientServable: an
+        // AuthorizedReadContext is exactly what a client sink takes.
+        fn serve(ctx: &impl ClientServable) -> SubjectCacheKey {
+            ctx.subject_cache_key()
+        }
+        let ctx = decide(&[binding(1, Scope::Table(TABLE), Effect::Permit)], "alice")
+            .admitted()
+            .expect("permitted");
+        assert_eq!(serve(&ctx), ctx.subject_cache_key());
+    }
+
+    #[test]
+    fn a_system_read_context_names_its_reason() {
+        let sys = SystemReadContext::audited(SystemReadReason::Compaction, "flush_materializer");
+        assert_eq!(sys.reason(), SystemReadReason::Compaction);
+        assert_eq!(sys.origin(), "flush_materializer");
+        // It has no subject and no cache key by construction — there is nothing
+        // to serve a client with.
+    }
+
+    #[test]
+    fn a_denied_decision_yields_no_context_to_unwrap() {
+        let d = decide(&[], "alice");
+        assert!(d.is_deny());
+        assert!(d.admitted().is_none());
+    }
+}

--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! # FA enforcement substrate — the TD-FOUNDATION-3 preconditions
+//!
+//! TD-FOUNDATION-3 (the ABAC **enforcement** track, "FA") is gated on four
+//! preconditions, three of which are *subsystems that do not exist today*. This
+//! crate is those three, built ahead of the enforcement wiring so FA is startable:
+//!
+//! | P | Precondition | Module |
+//! |---|---|---|
+//! | **P1** | Attribute-authority store — a first-class `(subject_id, tenant_stable_id) → {roles, attrs}` binding. Today's `user_role_assignments` is `user_id`-keyed, single-assignment, permission-only; ABAC attributes have **no** server-side authority. | [`authority`] |
+//! | **P3** | Subject + policy-epoch cache keying, so no client-servable cache can hand subject A's rows to subject B (TF-2 S10). | [`cache_key`] |
+//! | **P4** | A **non-`Option`** read context — the type that makes "unfiltered by default" unrepresentable (TF-2 S4/S7). | [`context`] |
+//!
+//! P2 (live JWT signature verification) is not here: it is an independent
+//! security defect on the whole auth boundary, tracked on its own security TD.
+//!
+//! ## Status: substrate only, wired into nothing
+//!
+//! Nothing in the workspace depends on this crate. It defines the types and the
+//! traits FA will attach at the read primitives; it performs **no enforcement**,
+//! reads no storage, and is on no request path. (It is deliberately *not*
+//! `#[cfg]`-gated out of the default build: a security substrate that never
+//! compiles is a security substrate that is never tested. Inertness comes from
+//! having no reverse dependency, which is checkable; the `abac-policy` feature
+//! gates the *wiring*, in FA.)
+//!
+//! ## The three properties everything here exists to make structural
+//!
+//! 1. **Fail-closed is the type's default, not the caller's discipline.** There
+//!    is no `AuthorizedReadContext::default()`, no `unfiltered()` constructor, and
+//!    no `Option<Context>` — resolution yields [`context::ReadDecision`], and the
+//!    deny arm carries no context at all. An unresolvable subject, an absent
+//!    binding, and a store outage all deny.
+//! 2. **Claims are never load-bearing.** Only [`authority::AttributeAuthority`]
+//!    mints `ServerResolved` attributes, and only from a server-side binding. A
+//!    forged `clearance`/`role` claim cannot reach an admit/deny decision because
+//!    the value a predicate reads comes from the authority, not the token.
+//! 3. **A `SystemReadContext` cannot serve a client.** Unfiltered internal reads
+//!    (compaction, index build, recovery) are explicit and audited, and the
+//!    [`context::ClientServable`] trait they do **not** implement is what stops
+//!    them reaching a client sink — at compile time, not by review.
+//!
+//! Design of record: `docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc`
+//! (build track) and `TD-FOUNDATION-2` §3.4 / §8 (architecture + S1–S10).
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+pub mod authority;
+pub mod cache_key;
+pub mod context;
+
+pub use authority::{
+    AttributeAuthority, AttributeBinding, AttributeDigest, AuthorityError,
+    InMemoryAttributeAuthority, ResolvedSubject,
+};
+pub use cache_key::{InMemoryPolicyEpochs, PolicyEpoch, PolicyEpochSource, SubjectCacheKey};
+pub use context::{
+    AuthorizedReadContext, ClientServable, ColumnDecision, DenyReason, ForbiddenColumn,
+    ReadDecision, SystemReadContext, SystemReadReason,
+};

--- a/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
+++ b/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
@@ -245,7 +245,7 @@ gate is mechanical. Every S-item is a merge-blocking test, not a review note.
 
 | **S3**
 | Literals are type-gated against the column's declared type at compile; a mismatch **denies** rather than falling through to precedence ordering.
-| `json_comparison` / bridge unit: `numeric_predicate_against_string_column_denies`. Asserts deny, **not** admit-all.
+| `json_comparison` / bridge unit: `numeric_predicate_against_string_column_denies`. Asserts deny, **not** admit-all. **Slice FA-a2** — needs a schema at the bridge seam or a type-strict comparison mode; `compare_json_values` is live under metadata search, so it cannot simply be made strict.
 
 | **S1–S3 (joint)**
 | **Deny-biased subset property.** For a random `SecurityPredicate`, the bridged predicate admits a **subset** of the source's row set; a non-convertible node admits **zero** rows (not a dropped conjunct).
@@ -296,8 +296,12 @@ while silently widening.
 | Slice | Content | Gates
 
 | **FA-a**
-| The bridge (FA-2): `build_filter → Result`, null-safe `Not`, type-gated literals, the deny-biased subset property test. Touches only the currently-dead RLS/filter code, so no live path changes behavior.
-| S1, S2, S3
+| The bridge, part 1 (FA-2): the total deny-biased lattice replacing `Ok(None)`, null-safe `Not` lowering, and the deny-biased subset property test. Touches only the dead RLS/filter code, so no live path changes behavior.
+| S1, S2
+
+| **FA-a2**
+| The bridge, part 2: **type-gated literals**. Split out because it needs input FA-a does not have — the column's declared type. `build_filter` sees only a `SecurityPredicate` and a subject; there is no schema at that seam, and the alternative (making `compare_json_values` type-strict) would change **live** user-query semantics, since `sql_value_filter` serves metadata search, document filtering and pushdown. So FA-a2 is either a schema seam into the bridge or a type-strict comparison *mode* the security path opts into — a design choice, not a patch.
+| S3
 
 | **FA-b**
 | Signature change at the three read primitives (FA-1) + the CI signature check. Behavior-neutral while every caller passes a `SystemReadContext`; the point is that the *shape* becomes non-optional.

--- a/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
+++ b/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-FOUNDATION-3: ABAC enforcement subsystem (FA)
-:status: Draft — P1/P3/P4 substrate landed; blocked on P2 (JWT verification)
+:status: Draft — P1/P3/P4 substrate landed; P2 in flight (#1243)
 :date: 2026-07-26
 :authors: co-design session 2026-07-26
 :realizes: ADR-072 D6 (structural tenancy), D15 (RLS-as-global-filter)
@@ -10,7 +10,7 @@
 
 [cols="1,3"]
 |===
-| Status | Draft — **blocked on P2**; P1/P3/P4 substrate has landed (§2), the S-items are specified (§4), and the slices are startable in order once P2 clears
+| Status | Draft — **P2 in flight** (#1243); P1/P3/P4 substrate has landed (§2), the S-items are specified (§4), and the slices are startable in order once P2 clears
 | Scope | The runtime ABAC **enforcement** subsystem split out of FC (TD-FOUNDATION-2 §0.1) after three red-team rounds proved it is a multi-package subsystem, not a wiring job.
 | Design of record | **TD-FOUNDATION-2** — the enforcement architecture (§3.4), the S1–S10 acceptance criteria (§8), and the fail-closed bridge (§1.4) live there, attacked across three rounds. This doc is the **build track**: preconditions, the surface-by-surface contract, the S-item test targets, and the slice order.
 | Consumes | FC's metamodel + policy model (`PolicyBinding`, `resolve_effective_policy`, `SubjectAttributes`, `filterable_columns`), the FA substrate crate `proximadb-abac`, the F0 codec, the F1b/F1d store.
@@ -68,9 +68,9 @@ The enforcement design is TF-2 §3.4. FA implements it as work items:
 | ✅ **Landed** — `proximadb-abac::authority`
 
 | **P2**
-| **Live JWT signature verification** — the unwired OIDC path decodes tokens **without** signature verification (`src/auth/sso/oidc.rs`). Until real verification ships, every claim (incl. `iss`) is forgeable and S6 is void. **This is an independent security defect** affecting the whole auth boundary, not just ABAC.
+| **Live JWT signature verification** — two unwired OIDC stubs decoded/fabricated identity without signature verification, so every claim (incl. `iss`) was forgeable and S6 was void. **An independent security defect** affecting the whole auth boundary, not just ABAC.
 | **separate security TD** (urgent)
-| ⛔ **Outstanding** — the stubs are `#[deprecated]`-guarded (#1232) but not fixed; see §2.3
+| 🟡 **In flight** — `#[deprecated]`-guarded by #1232, **deleted** by #1243 via the §2.3 alternative; flips to ✅ when #1243 merges
 
 | **P3**
 | **Subject-keyed cache substrate** — the result/vector/LLM caches must accept a subject+policy-epoch key component and an epoch-invalidation hook (S10).
@@ -130,6 +130,22 @@ satisfied when, for the live token path:
 Alternatively P2 is satisfied by **deleting** the unwired stubs, provided no live
 path can reach a signature-blind decode. Either way the gate needs the negative
 test: a token with a valid body and a garbage signature authenticates **nobody**.
+
+**This is the route taken (#1243).** Both stubs were dead — `OidcProvider`
+decoded the payload with `split('.')` + base64 and no signature check (and its
+own tests forged tokens and asserted they authenticated), and
+`OIDCIntegration::validate_id_token` fabricated a user from a random UUID without
+decoding anything. An audit found `security/auth/oidc.rs:126` was the **only**
+signature-blind JWT decode in `src/`, so with both removed the sole JWT path is
+`network::auth::jwt`'s `JwtService::verify_token` (`jsonwebtoken::decode` with a
+real `DecodingKey` + `Validation`, plus an explicit `exp`/`nbf` recheck).
+
+Note what that does and does not buy. It closes the *forgeable* path: there is no
+longer any code that trusts an unverified token. It does **not** deliver external
+IdP federation — there is now no OIDC/JWKS path at all. That is the safe state
+(no consumer, no attack surface), and building a real one is the separate
+security TD's job, with its own design for a per-tenant issuer registry, key
+cache, and rotation.
 
 Even with P2 open, S6 holds structurally for the *attribute* channel: FA reads
 values via `SubjectAttributes::load_bearing`, which returns `None` for anything
@@ -323,6 +339,7 @@ while silently widening.
 == 7. Gate
 
 FA promotes from `Draft` and begins code (slice FA-a onward) when **P2** is
-satisfied per §2.3 or explicitly waived with a recorded risk; P1/P3/P4 are met.
+satisfied per §2.3 (#1243 is that route) or explicitly waived with a recorded
+risk; P1/P3/P4 are met.
 Each slice merges only with its S-item tests green (§4). FA is **off the OLTP
 critical path**; there is no schedule pressure to cut a corner on any S-item.

--- a/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
+++ b/docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-FOUNDATION-3: ABAC enforcement subsystem (FA)
-:status: Draft — blocked on preconditions (not startable)
+:status: Draft — P1/P3/P4 substrate landed; blocked on P2 (JWT verification)
 :date: 2026-07-26
 :authors: co-design session 2026-07-26
 :realizes: ADR-072 D6 (structural tenancy), D15 (RLS-as-global-filter)
@@ -10,17 +10,21 @@
 
 [cols="1,3"]
 |===
-| Status | Draft — **blocked**; do not start until §2 preconditions are met
+| Status | Draft — **blocked on P2**; P1/P3/P4 substrate has landed (§2), the S-items are specified (§4), and the slices are startable in order once P2 clears
 | Scope | The runtime ABAC **enforcement** subsystem split out of FC (TD-FOUNDATION-2 §0.1) after three red-team rounds proved it is a multi-package subsystem, not a wiring job.
-| Design of record | **TD-FOUNDATION-2** — the enforcement architecture (§3.4), the S1–S10 acceptance criteria (§8), and the fail-closed bridge (§1.4) live there, attacked across three rounds. This doc is the **build track**: preconditions, package split, and gate.
-| Consumes | FC's policy model (`PolicyBinding`, resolver, `SubjectAttributes`, `filterable_columns`), the F0 codec, the F1b/F1d store.
-| Depends on | ADR-074 (namespace/tenant seam), a live JWT-verification fix (external, §2)
+| Design of record | **TD-FOUNDATION-2** — the enforcement architecture (§3.4), the S1–S10 acceptance criteria (§8), and the fail-closed bridge (§1.4) live there, attacked across three rounds. This doc is the **build track**: preconditions, the surface-by-surface contract, the S-item test targets, and the slice order.
+| Consumes | FC's metamodel + policy model (`PolicyBinding`, `resolve_effective_policy`, `SubjectAttributes`, `filterable_columns`), the FA substrate crate `proximadb-abac`, the F0 codec, the F1b/F1d store.
+| Depends on | ADR-074 (namespace/tenant seam), ADR-075 (stable ids), a live JWT-verification fix (external, §2 P2)
 |===
+
+NOTE: Code references below are `file::symbol` with a line number **as of
+2026-07-26**. `develop` moves; trust the symbol, re-locate the line.
 
 == 0. Why this is its own track
 
-TD-FOUNDATION-2 set out to "wire an always-ANDed ABAC filter into the scan." Three
-adversarial red-team rounds (TF-2 §6.1) showed the real surface is far larger:
+TD-FOUNDATION-2 set out to "wire an always-ANDed ABAC filter into the scan."
+Three adversarial red-team rounds (TF-2 §6.1) showed the real surface is far
+larger:
 
 * enforcement must cover **four surfaces**, not one — reads (3 primitives),
   the **write path** (uniqueness-conflict disclosure, S9), the **cache tier**
@@ -50,42 +54,275 @@ The enforcement design is TF-2 §3.4. FA implements it as work items:
 | FA-6 | Two-layer wiring (TF-2 §3.0/§3.1): operation authz (Layer A) unchanged; ABAC row/field visibility (Layer B) at the primitives; the **attribute-trust boundary** (S6).
 |===
 
-== 2. Preconditions — FA is NOT startable until these exist
+== 2. Preconditions
 
-[cols="1,3,1"]
+=== 2.1 Status
+
+[cols="1,3,1,1"]
 |===
-| P | Precondition | Owner
+| P | Precondition | Owner | State
 
 | **P1**
-| **Attribute-authority store** — a first-class `(subject_id, tenant_id) → {roles, attrs}` binding store. The current `user_role_assignments` is `user_id`-keyed, single-assignment, permission-only (round 3); ABAC attributes (`dept`/`clearance`/`region`) have **no** server-side authority today. `resolve_effective_attributes` is a new subsystem, not a one-liner over `validate_admin_access`.
+| **Attribute-authority store** — a first-class `(subject_id, tenant_stable_id) → {roles, attrs}` binding store. The pre-existing `user_role_assignments` is `user_id`-keyed, single-assignment, permission-only; ABAC attributes (`dept`/`clearance`/`region`) had **no** server-side authority.
 | FA design
+| ✅ **Landed** — `proximadb-abac::authority`
 
 | **P2**
-| **Live JWT signature verification** — `oidc.rs:106` decodes tokens **without** signature verification (round 3). Until real verification ships, every claim (incl. `iss`) is forgeable and S6 is void. **This is an independent security defect** affecting the whole auth boundary, not just ABAC — must be verified against the live path and fixed on its own security TD **before** FA can trust any claim.
+| **Live JWT signature verification** — the unwired OIDC path decodes tokens **without** signature verification (`src/auth/sso/oidc.rs`). Until real verification ships, every claim (incl. `iss`) is forgeable and S6 is void. **This is an independent security defect** affecting the whole auth boundary, not just ABAC.
 | **separate security TD** (urgent)
+| ⛔ **Outstanding** — the stubs are `#[deprecated]`-guarded (#1232) but not fixed; see §2.3
 
 | **P3**
 | **Subject-keyed cache substrate** — the result/vector/LLM caches must accept a subject+policy-epoch key component and an epoch-invalidation hook (S10).
 | FA design
+| ✅ **Landed** — `proximadb-abac::cache_key`
 
 | **P4**
-| **Non-`Option` context plumbing** — the three read primitives (and the graph read trait) must carry a required context (S4/S7). This is a signature change across `record_store.rs`, `unified_search_native`, and the graph traits.
+| **Non-`Option` context plumbing** — a required read context at the three read primitives (and the graph read trait) (S4/S7).
 | FA design
+| 🟡 **Type landed** (`proximadb-abac::context`); the *signature change* across the primitives is FA-1 itself
 |===
 
-== 3. Deferred (not in FA's first slice)
+=== 2.2 What the substrate crate provides
+
+`crates/control/proximadb-abac` is inert — nothing in the workspace depends on
+it — and is where FA attaches. It is deliberately **not** `#[cfg]`-gated out of
+the default build: a security substrate that never compiles is one that is never
+tested. The `abac-policy` feature gates the *wiring*, which is FA's work.
+
+[cols="1,3"]
+|===
+| Type | Contract
+
+| `AttributeAuthority` (P1)
+| `resolve_effective_attributes(&SubjectId, TenantStableId) -> Result<ResolvedSubject, AuthorityError>`. **The only mint for `AttrSource::ServerResolved`.** No success case returns an empty bag: an unbound subject and an unreachable store both `Err`, because an empty bag satisfies any `Permit`-with-no-predicate policy.
+
+| `AttributeDigest` (P1→P3)
+| SHA-256/128 over the *tenant + ordered load-bearing attribute set*, length-framed and type-tagged. Minted by the authority that resolved the set, so it cannot drift from what it summarizes. A collision here is a cross-subject disclosure, hence cryptographic rather than fast.
+
+| `PolicyEpoch` / `PolicyEpochSource` (P3)
+| Monotonic per `(tenant, namespace)`; `bump()` after a policy write is the invalidation hook. Saturating, never wrapping — a wrapped epoch resurrects a key that cached results already live under.
+
+| `SubjectCacheKey` (P3)
+| `(tenant, namespace, policy_epoch, attribute_digest)`. A key *component*, not a whole key: each cache keeps its own key type and folds this in, so "does this cache's key contain a `SubjectCacheKey`?" stays mechanically checkable. Keys on the **world**, not the principal — subjects with identical load-bearing attributes legitimately share entries, which is where hit rate comes back.
+
+| `AuthorizedReadContext` (P4)
+| No `Default`, no `unfiltered()`, no field-wise public constructor. The only constructor is `resolve(...) -> ReadDecision`, whose `Deny` arm carries **no context**, so a denied read has nothing to hand a primitive. Exposes `row_predicate_refs()`, `column_decision()`, `project()` (forbid ⇒ query rejection), `subject_cache_key()`.
+
+| `SystemReadContext` + `ClientServable` (P4/S5)
+| `SystemReadContext::audited(reason, origin)` names *why* an internal read is unfiltered. It does **not** implement `ClientServable`; a client-facing sink written against `impl ClientServable` therefore rejects it **at compile time**. Pinned by a `compile_fail` doctest.
+|===
+
+=== 2.3 P2 — what "satisfied" means
+
+P2 is not FA's to build, but FA's gate needs a testable definition. P2 is
+satisfied when, for the live token path:
+
+. Signatures are verified against the issuer's JWKS, keyed by `kid`, with the key
+  set cached and refreshed on unknown-`kid` (not a per-request fetch).
+. `alg` is validated against an **allow-list** of asymmetric algorithms; `none`
+  and HMAC-with-public-key confusion are rejected.
+. `iss` / `aud` / `exp` / `nbf` are validated, and `iss` is matched against the
+  tenant's *registered* issuer — not merely parsed out of the token.
+. A token failing any check yields no principal at all — not an anonymous or
+  partially-populated one.
+
+Alternatively P2 is satisfied by **deleting** the unwired stubs, provided no live
+path can reach a signature-blind decode. Either way the gate needs the negative
+test: a token with a valid body and a garbage signature authenticates **nobody**.
+
+Even with P2 open, S6 holds structurally for the *attribute* channel: FA reads
+values via `SubjectAttributes::load_bearing`, which returns `None` for anything
+claim-sourced. P2 governs whether the **identity** (`subject_id`) itself is
+trustworthy — which is why FA cannot ship without it, but can be *built* against
+it.
+
+== 3. The `AuthorizedReadContext` across the four surfaces
+
+One context type, four attachment surfaces. The rule that makes this tractable:
+**enforcement lives below the ingress dialects.** pgwire, REST, gRPC, Arrow
+Flight and MCP inherit it by construction because every read funnels into one of
+the primitives below — no dialect gets its own copy of the policy logic.
+
+=== Surface 1 — Storage reads (3 primitives)
+
+[cols="1,2,2"]
+|===
+| Primitive | Today | FA contract
+
+| `TableRecordStore::get_by_key` / `scan_records` +
+  (`src/services/record_store.rs:511`)
+| `tenant_context: Option<&TenantContext>`, with a permissive default body on the trait — *unfiltered is what you get by writing less code*
+| Add a required `ctx: &AuthorizedReadContext` (or a `ReadContext` enum where system reads are legitimate). **Remove the default body** — an implementor that does not filter must fail to compile. A PK match is **not** an authorization: `get_by_key` resolves the row, *then* applies the predicate, and a denied hit is reported identically to a miss.
+
+| `unified_search_native` +
+  (`src/services/operations/vectors/legacy.rs:2663`)
+| Allow-list is optional; `None` means "no restriction"
+| Allow-list becomes **non-optional**; `None` is unrepresentable, and an empty allow-list means **deny-empty**, not unfiltered. Routed through `AnnFilteringPolicy` (pre-filter / index-integrated — **never naïve post-filter**, which returns fewer than `k` admissible rows and leaks cardinality). The `_with_tenant_context` sibling (`:2633`) collapses into it rather than persisting as a second door.
+
+| `GraphQueryExecutorBackend::query_nodes` / `query_edges` +
+  (`src/graph/query/executor.rs:32`)
+| No context at all
+| Required context **per hop**, so traversal re-enters the filter at every step (S7). Type-enforced, not probed: a runtime probe cannot prove "no hop derefs a node directly", but a required parameter makes the unfiltered deref **not compile**.
+|===
+
+The DataFusion `combined_filter` (`src/datafusion/…/table_provider.rs`) remains a
+*consumer* of the compiled predicate for the OLAP arm — necessary, far from
+sufficient, and explicitly not the seam.
+
+=== Surface 2 — The write path (S9)
+
+A write discloses reads. `put_if_absent → Conflict{holder}` and
+`check_unique_conflict → UniqueConflict{tuple}` tell the inserting subject that a
+row exists and what is in it. The CKS gains **no** context parameter — it is a
+key-space primitive and should stay one. The gate is in the DML insert path's
+**error construction**: when the conflict holder is not ABAC-readable by the
+inserting subject, the error carries neither key, tuple, nor holder oid.
+
+Mutation `WHERE`-scans take the read context too (`DELETE`/`UPDATE … WHERE`
+locates rows by scanning) — otherwise a subject deletes rows it cannot `SELECT`.
+
+=== Surface 3 — The cache tier (S10)
+
+Three client-servable caches sit **above** the read seam and are subject-blind
+today: the query result cache, the vector-search optimization cache, and the LLM
+semantic cache. Each either folds a `SubjectCacheKey` into its key type, or is
+**bypassed** while `abac-policy` is on. There is no third option, and "the query
+text is the same, so the result is the same" is precisely the bug.
+
+Policy writes call `PolicyEpochSource::bump(tenant, namespace)` after commit;
+that one hook invalidates every dependent entry without walking any cache.
+
+=== Surface 4 — Egress (S5)
+
+CDC (`WalSubscriber`, `src/cdc/outbound/`), sinks (`CdcSink::send`), and
+node-to-node replication (`src/cluster/replication.rs`) reconstruct full row state
+**directly from the WAL, below `record_store`**. These are not "reads", but they
+exfiltrate rows all the same. Under `abac-policy` they are denied by default, or
+each `ChangeEvent` passes a per-subscription `AuthorizedReadContext` — and the
+mask covers the **event envelope** (key, existence, timing), not just
+`before`/`after` bodies, since existence-and-timing alone reconstructs a row set.
+
+`ClientServable` is the type-level backstop: a `SystemReadContext` cannot be
+handed to a client-fed sink.
+
+Direct-file export (`src/network/arrow_ipc/file_export.rs`) cannot be row-filtered
+as a byte stream — under `abac-policy` it is denied or force-rerouted through the
+filtered scan primitive.
+
+== 4. Acceptance criteria S1–S10, with pinned test targets
+
+TF-2 §8 defines the criteria; this table pins **where each test lives** so the
+gate is mechanical. Every S-item is a merge-blocking test, not a review note.
+
+[cols="1,3,3"]
+|===
+| # | Criterion (abbreviated — TF-2 §8 is normative) | Test target
+
+| **S1**
+| `build_filter` returns `Result<FilterExpression>` — **no `Ok(None)`**. "No restriction" is producible only by the top-level "no binding exists" path; every deny-derived / empty-`And`/`Or`/`Not(None)` node lowers to an explicit **unsatisfiable** filter.
+| `src/security/rls/service.rs` unit + property: `not_always_allow_yields_zero_rows`, `empty_and_is_unsatisfiable_not_unfiltered`. Regression-pinned from TF-2 §6.3.
+
+| **S2**
+| `Not(P)` is null-safe — lowered as `And(Not(P), IS_NOT_NULL(f)…)` over each field in `P`, or evaluated on a 3-valued substrate. Until then `Not` over a nullable field fails closed.
+| `sql_value_filter` unit: `not_eq_over_null_column_excludes_the_row`. Fixture: a row with `classification = NULL` under `Not(Eq(classification,"TS"))`.
+
+| **S3**
+| Literals are type-gated against the column's declared type at compile; a mismatch **denies** rather than falling through to precedence ordering.
+| `json_comparison` / bridge unit: `numeric_predicate_against_string_column_denies`. Asserts deny, **not** admit-all.
+
+| **S1–S3 (joint)**
+| **Deny-biased subset property.** For a random `SecurityPredicate`, the bridged predicate admits a **subset** of the source's row set; a non-convertible node admits **zero** rows (not a dropped conjunct).
+| Property test over generated predicates × generated rows. This is the highest-value test in FA — it is what would have caught the evaporating clearance filter.
+
+| **S4**
+| The read context is a required, non-`Option` parameter of every read primitive; no `_unfiltered` sibling; internal unfiltered access uses `SystemReadContext`.
+| CI signature check (a script, not a runtime probe) over `TableRecordStore`, `unified_search_native`, and the graph read trait, plus `compile_fail` doctests. `proximadb-abac`'s `ClientServable` doctest is the pattern.
+
+| **S5**
+| **Default-deny reconstruction audit.** *Any* `RecordState`/`ProximaRecord` construction in `src/` not statically inside an `AuthorizedReadContext`/`SystemReadContext` scope fails CI; each site is classified internal-storage vs client-egress. No `SystemReadContext` may reach a client-servable sink.
+| New CI guard `scripts/check_record_reconstruction.py`, with a **downward-only ratchet** on the allow-list (per the repo's ratchet mandate). The round-3 finding was that a two-directory grep passes green while records egress via the flush materializer and ~19 WAL sites.
+
+| **S6**
+| **Attribute-trust boundary.** Any attribute or role a predicate reads is re-resolved server-side against the **policy's tenant** authority; claims are never load-bearing.
+| Already structural in the substrate (`SubjectAttributes::load_bearing` returns `None` for `AttrSource::Claim`; only `AttributeAuthority` mints `ServerResolved`) — pinned by `claim_sourced_attribute_is_not_load_bearing` and `an_unresolvable_subject_denies_before_policy_is_consulted`. FA adds the end-to-end case: an SSO claim `role=system_admin` / `clearance=TS` changes **no** admit/deny.
+
+| **S7**
+| Graph reads are type-enforced, not probed: `query_nodes`/`query_edges` (and the operator-level derefs) take a required context.
+| CI signature check + a traversal test asserting a denied node is unreachable **at hop 2**, not merely absent from hop 1.
+
+| **S8**
+| **Mask/predicate isolation.** A `redact`/`forbid` column cannot be referenced by a row predicate, else its value leaks through the admit/deny channel despite the output mask. `forbid` = query rejection.
+| Policy-compile rejection test taking `AuthorizedReadContext::masked_columns()` as input. The substrate half is pinned by `a_forbidden_column_rejects_the_query_rather_than_nulling_itself`.
+
+| **S9**
+| **Write-path uniqueness disclosure.** A PK/UNIQUE conflict must not disclose the existence or values of a row the inserting subject cannot ABAC-read; the error is value-free.
+| DML insert-path test: a denied subject `INSERT`s a colliding PK/UNIQUE ⇒ the error body contains neither the key nor the conflicting values. Assert on the **rendered** error string, not just the variant.
+
+| **S10**
+| **Cache/materialization subject-binding.** No cached client-servable result reaches a subject whose effective attribute + policy fingerprint differs from the one it was produced under; a policy change invalidates dependents.
+| Per-cache test: subject A warms `SELECT *` / a vector search / an LLM question; subject B (same tenant, `dept ≠ A`) issues the identical request ⇒ **cache miss**. The substrate half is pinned by `two_subjects_in_different_departments_do_not_share_a_cache_entry` and `a_policy_change_invalidates_by_changing_the_key`.
+|===
+
+S1–S3, S6, S9, S10 are **security-critical** (fail-open inversion / claims
+escalation / cross-subject disclosure); S4–S5 are the completeness spine; S7–S8
+close side channels.
+
+== 5. Slice order
+
+Each slice is independently mergeable, default-OFF, and carries its S-item tests.
+The order is chosen so the fail-open substrate is closed **before** anything is
+wired to depend on it — wiring first would ship a plane that reports enforcement
+while silently widening.
+
+[cols="1,3,2"]
+|===
+| Slice | Content | Gates
+
+| **FA-a**
+| The bridge (FA-2): `build_filter → Result`, null-safe `Not`, type-gated literals, the deny-biased subset property test. Touches only the currently-dead RLS/filter code, so no live path changes behavior.
+| S1, S2, S3
+
+| **FA-b**
+| Signature change at the three read primitives (FA-1) + the CI signature check. Behavior-neutral while every caller passes a `SystemReadContext`; the point is that the *shape* becomes non-optional.
+| S4, S7
+
+| **FA-c**
+| Policy resolution wired at the primitives behind `abac-policy` (FA-6): resolve → bridge → AND. Default-OFF.
+| End-to-end: a `dept=eng` subject sees only `dept=eng` rows through **both** `SELECT *` and a vector search — the D15 unification claim
+
+| **FA-d**
+| Cache subject-binding + bypass (FA-4), and the epoch-bump hook on policy writes.
+| S10
+
+| **FA-e**
+| Write-path disclosure gating (FA-3) and mask/predicate isolation at policy compile.
+| S8, S9
+
+| **FA-f**
+| Egress coverage (FA-5) + the reconstruction audit guard.
+| S5
+|===
+
+== 6. Deferred (not in FA's first slice)
 
 * **Cross-tenant `Reference`/`Brokered`** (TF-2 §2 D12-d) — `Brokered` needs a
   tenant-aware graph executor (the current one is a stub returning `Ok(vec![])` /
   `Count(0)`); `Reference` needs P1 **plus** a cross-tenant attribute-federation
   model (how tenant O holds a binding for visitor A). Both are their own package,
   blocked on a real graph executor and a federation design.
+* **Attribute-authority durability.** `proximadb-abac` ships an in-memory
+  reference implementation. The durable one stores bindings as catalog objects in
+  the reserved system namespace (TF-2 §3.3), which is why the in-memory type keeps
+  the same `(subject, tenant)`-keyed shape — the swap is an implementation of the
+  same trait, not a redesign.
+* **Predicate-compilation caching.** Per-read policy resolution + bridge is
+  measurable overhead on the OLTP path; it is deliberately *not* optimized before
+  it is correct. Evidence goes to `BENCHMARK_EVIDENCE.toml` when FA-c lands.
 
-== 4. Gate
+== 7. Gate
 
-FA promotes from `Draft` and begins code only when **P1–P4 are satisfied** (or
-each explicitly waived with a recorded risk) and the TF-2 §8 acceptance criteria
-**S1–S10** have green tests. Until then this track is a **hold** — the design of
-record is complete and attacked (TF-2), but the substrate and preconditions are
-not there. FA is **off the OLTP critical path**; there is no schedule pressure to
-start it before its preconditions land.
+FA promotes from `Draft` and begins code (slice FA-a onward) when **P2** is
+satisfied per §2.3 or explicitly waived with a recorded risk; P1/P3/P4 are met.
+Each slice merges only with its S-item tests green (§4). FA is **off the OLTP
+critical path**; there is no schedule pressure to cut a corner on any S-item.


### PR DESCRIPTION
Stacked on #1230 (FC slices 2–4), sibling of #1235. **Base retargets to `develop` once #1230 merges.**

TD-FOUNDATION-3 was a 91-line hold note blocked on four preconditions, three of which
are subsystems that did not exist. This builds those three as a new inert crate, and
turns the TD into a spec someone can pick up.

## New crate: `crates/control/proximadb-abac`

Nothing in the workspace depends on it.

### P1 — attribute authority (`authority`)

A `(subject_id, tenant_stable_id) → {roles, attrs}` binding store. The
`user_role_assignments` it replaces is `user_id`-keyed, single-assignment and
permission-only — ABAC attributes (`dept`/`clearance`/`region`) have **no** server-side
authority today, only SSO claims the tenant's own IdP asserts.

- It is the **only mint** for `AttrSource::ServerResolved`. That is what makes TF-2's
  attribute-trust boundary structural rather than a convention: a forged
  `clearance`/`role` claim cannot reach an admit/deny, because the value a predicate
  reads comes from the authority, not the token.
- A missing binding or an unreachable store is an **`Err`, never an empty bag** — an
  empty bag sails straight through a `Permit`-with-no-predicate policy, i.e. fail-open
  by omission.
- Roles are an ordinary multi-valued attribute (TF-2 §3.1: "a role is just an
  attribute"), so the single-assignment limit is gone.

### P3 — subject + policy-epoch cache keying (`cache_key`)

`SubjectCacheKey = (tenant, namespace, policy_epoch, attribute_digest)` — the component
every client-servable cache key must fold in (S10: today subject A warms `SELECT *` and
subject B gets A's rows).

- Keys on the **world, not the principal**: two subjects with identical load-bearing
  attributes legitimately share entries, which is where the hit rate comes back.
- The digest is SHA-256/128, length-framed and type-tagged. A collision here is a
  cross-subject disclosure, so a fast non-cryptographic hash is not an acceptable trade.
  Tests pin the two collisions that matter: `{"ab":"c"}` vs `{"a":"bc"}`, and
  `Str("1")` vs `Int(1)`.
- Epochs are per `(tenant, namespace)` and **saturate rather than wrap** — a wrapped
  epoch resurrects a key that cached results already live under.

### P4 — the non-`Option` read context (`context`)

- No `Default`, no `unfiltered()`, no field-wise constructor. The only constructor
  returns a `ReadDecision` whose `Deny` arm **carries no context**, so a denied read has
  nothing to hand a primitive. Contrast today's `Option<&TenantContext>` + permissive
  trait default body, where unfiltered is what you get by writing less code.
- `SystemReadContext::audited(reason, origin)` names why an internal read is unfiltered
  and deliberately does **not** implement `ClientServable` — so a client sink written
  against `impl ClientServable` rejects it **at compile time**. Pinned by a
  `compile_fail` doctest, not a review rule.
- `forbid` is query-rejection (`project()` returns `Err`), not a null projection.
  Column masks compose strictest-wins, and a column-scoped `Deny` forbids outright.

## TD-FOUNDATION-3, fleshed out

| Was | Now |
|---|---|
| "blocked on preconditions" | P1/P3/P4 marked met with what landed; **P2 gets a testable definition** of "satisfied" (JWKS by `kid`, asymmetric `alg` allow-list, registered-issuer match, no partial principal) |
| enforcement described in prose | **§3: the contract per surface** — the 3 read primitives, the write path's uniqueness disclosure, the cache tier, egress — each with today's shape and the target shape side by side |
| S1–S10 listed in TF-2 | **§4: each S-item with a pinned test target**, including which substrate tests already discharge half of S6/S8/S10 |
| no build order | **§5: six slices**, ordered so the fail-open substrate (S1–S3) closes *before* anything is wired to depend on it |

## One deliberate deviation

The crate is **not** `#[cfg]`-gated out of the default build. A security substrate that
never compiles is one that is never tested; inertness here comes from having no reverse
dependency (mechanically checkable), and the `abac-policy` feature gates the *wiring*,
which is FA's work. Flagging it since the brief said "feature-gated".

## Verification

36 unit tests + 1 `compile_fail` doctest, all green. `cargo clippy -p proximadb-abac
--all-targets -- -D warnings` clean. `make work-commit-check` passes (incl. workspace
boundaries with the new `control`-layer crate, panic policy, env gates), as do the five
doc guards.

Refs ADR-072 D6/D15, TD-FOUNDATION-2 §3.4/§8, ADR-074, ADR-075.