### PR TITLE
docs(td): TD-OLTP-WIRING-1 — activate the fenced ConditionalKeyStore at the composition root

### DIFF
--- a/docs/10-quality/td/TD-OLTP-WIRING-1-composition-root-conditionalkeystore.adoc
+++ b/docs/10-quality/td/TD-OLTP-WIRING-1-composition-root-conditionalkeystore.adoc
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-OLTP-WIRING-1: activate the fenced ConditionalKeyStore at the composition root
+:status: Draft — design gate (pre-implementation)
+:date: 2026-07-26
+:authors: co-design session 2026-07-26
+:realizes: ADR-072 (F2 PK uniqueness + F5 FK/tombstone become live, not test-only)
+
+[cols="1,3"]
+|===
+| Status | Draft — design gate
+| Problem | The F2/F5 fenced `ConditionalKeyStore` is **inert in production** — `with_conditional_key_store` is called only in tests; every live `DmlService` is built without a store.
+| Scope | Wire ONE shared `ConditionalKeyStore` into every live `DmlService`, under the `oltp-integrity` feature, durable and crash-safe.
+| Feature | `oltp-integrity` (off by default → default builds byte-for-byte unchanged).
+|===
+
+== 1. The gap
+
+`grep with_conditional_key_store` outside tests: only the definition. The live
+constructions —
+
+* `src/network/shared_services.rs:2252` (`SharedServices::new`, the gRPC/REST
+  `DmlService`), and
+* `src/network/postgres/protocol.rs:531` / `:670` (the pgwire path, which builds
+  its **own** `DmlService` **per connection**)
+
+— all use `DmlService::new` / `with_direct_record_storage` with **no CKS**. So
+F2's fenced PK uniqueness and F5's FK-existence + delete-tombstone do nothing in a
+running server. This TD makes them live.
+
+== 2. The load-bearing invariant: ONE shared store
+
+There is **exactly one** `ConditionalKeyStore` instance per server process, shared
+by every `DmlService` (gRPC/REST **and** every pgwire connection). Violating this
+is a correctness bug, two ways:
+
+* **Two stores on one WAL path** → concurrent appends corrupt the log.
+* **Two stores on two paths** → inconsistent fencing: a pgwire `INSERT` could
+  commit a PK that the gRPC path's store believes is unique (and vice-versa),
+  defeating the fence.
+
+Therefore the store is opened **once** at the composition root and threaded as an
+`Arc<dyn ConditionalKeyStore>` to all `DmlService` builders.
+
+== 3. Design
+
+=== D1 — Ownership root
+Open the store where BOTH server surfaces are constructed — the parent of
+`SharedServices::new` and the pgwire listener setup. If a single parent does not
+exist yet, `SharedServices` holds the `Arc` and exposes it
+(`shared.conditional_key_store()`) so the pgwire listener threads the same `Arc`
+into `with_direct_catalog_services` (which gains a
+`conditional_key_store: Option<Arc<dyn ConditionalKeyStore>>` parameter).
+
+=== D2 — Durable path + crash recovery
+`LocalWalKeyStore::open(<data_dir>/oltp-cks.wal, SyncPolicy::PerOp)` where
+`data_dir = opt_config.map(|c| c.server.data_dir)`. `open` replays the CRC-framed
+WAL (F1b), so PK/FK state survives restart — matching the F2 doc's "durable +
+crash-safe when a store path is set." The WAL is a reserved system file, not a
+data-plane path.
+
+=== D3 — Activation gate (feature AND durability)
+Active only when **both**: the `oltp-integrity` feature is compiled **and** a
+`data_dir` is configured. No `data_dir` (embedded/ephemeral) ⇒ **no CKS** (an
+in-memory store would silently lose uniqueness state across restart — worse than
+the honest legacy probe). This mirrors the "durable when the store path is set,
+volatile otherwise" rule, resolved conservatively toward the durable-only case.
+
+=== D4 — Threading
+[source]
+----
+// composition root (feature-gated):
+#[cfg(feature = "oltp-integrity")]
+let cks: Option<Arc<dyn ConditionalKeyStore>> = data_dir
+    .map(|d| LocalWalKeyStore::open(d.join("oltp-cks.wal"), SyncPolicy::PerOp))
+    .transpose()?
+    .map(|s| Arc::new(s) as _);
+#[cfg(not(feature = "oltp-integrity"))]
+let cks: Option<Arc<dyn ConditionalKeyStore>> = None;
+
+// every DmlService builder:
+let dml = base.pipe_opt(cks.clone(), DmlService::with_conditional_key_store);
+----
+The same `cks` Arc flows into the shared-services `base_dml` and into each pgwire
+`with_direct_catalog_services`.
+
+== 4. Test / gate plan
+* **Cross-surface uniqueness:** with the feature on + a temp `data_dir`, a PK
+  inserted over gRPC is rejected as a duplicate when re-inserted over pgwire
+  (proves one shared store, not two).
+* **Restart recovery:** open store → insert PK → drop → re-open at the same path →
+  the PK is still fenced (WAL replay).
+* **Single-instance guard:** a debug assertion / test that the composition root
+  constructs at most one `LocalWalKeyStore` per `data_dir`.
+* Feature-off: default builds unchanged (no CKS, no new deps in the wheel path).
+
+== 5. Out of scope
+* Multi-column PK fencing (F2 single-column scope holds).
+* The shared/HA (Redis) store backend (a later ADR-0004/0005 item).
+* HTAP delta-merge consistency (separate F5 sub-item; the OLAP read already
+  merges the OLTP delta via `OlapDeltaSource`).


### PR DESCRIPTION
Design gate for the next F5/critical-path slice. **Key finding: the F2/F5 fenced `ConditionalKeyStore` is inert in production** — `with_conditional_key_store` is called only in tests; every live `DmlService` (gRPC/REST + the pgwire path, which builds its own per connection) is constructed with no store. So fenced PK uniqueness + FK existence + delete-tombstone do nothing in a running server.

**Design:** open ONE shared store per process (the single-instance invariant — two stores on one WAL corrupts, two paths gives inconsistent cross-surface fencing), durable at `<data_dir>/oltp-cks.wal` (crash-safe via WAL replay), active only when `oltp-integrity` **and** a `data_dir` are both present, threaded into every `DmlService` builder. Test plan: cross-surface uniqueness (gRPC insert rejected on pgwire re-insert), restart recovery, single-instance guard.

Docs-only; the 3 guards pass. Implementation follows in a code PR.