### PR TITLE
fix(compaction): TD-COMPACT-6 D0 start workers on SstEngine's own Compaction instance

### DIFF
--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -429,10 +429,27 @@ impl SstEngine {
         // Register cache providers with orchestrator
         let orchestrator = Self::register_cache_providers(decompression_cache.clone()).await?;
 
-        // Initialize compaction manager (always enabled)
-        let compaction_manager = Some(Arc::new(Compaction::new(config.clone()).await.map_err(
-            |e| SstError::Internal(format!("Failed to create compaction manager: {}", e)),
-        )?));
+        // Initialize compaction manager (always enabled) — TD-COMPACT-6 D0: start
+        // background workers on THIS instance (the one the flush path uses via
+        // self.compaction_manager()). Without this, schedule_compaction enqueues to
+        // a workerless queue — the 2 workers at engine.rs:212 run on a DIFFERENT
+        // Compaction instance (the StorageEngine's), leaving the SstEngine's
+        // task_queue with zero consumers. Wire the worker count to the existing
+        // SstConfig.background_thread_count (was hardcoded 2 at engine.rs:212;
+        // the config field existed but was unused at the spawn site).
+        let mut compaction = Compaction::new(config.clone()).await.map_err(|e| {
+            SstError::Internal(format!("Failed to create compaction manager: {}", e))
+        })?;
+        compaction
+            .start_workers(config.background_thread_count as usize)
+            .await
+            .map_err(|e| {
+                SstError::Internal(format!(
+                    "Failed to start {} compaction workers: {}",
+                    config.background_thread_count, e
+                ))
+            })?;
+        let compaction_manager = Some(Arc::new(compaction));
 
         // Initialize universal performance optimization
         let universal_optimizer =


### PR DESCRIPTION
## What
**D0** of the cross-model-reviewed ADR-076 compaction co-design. The wiring prerequisite for D1 (async compaction). Without this, `schedule_compaction` enqueues into a **workerless queue** → compaction silently never runs (Opus 5 🔴 CRITICAL finding, independently verified by Kimi + DeepSeek).

## The defect (three reviewers verified)
Two separate `Compaction` instances exist:
- **SstEngine's** (`core.rs:433`) — created by `Compaction::new(...)`, **NO `start_workers`**. The flush path uses this one.
- **StorageEngine's** (`engine.rs:211-213`) — created separately, `start_workers(2)`. Different instance, different `task_queue`.

The flush path's `run_due_compaction` works today (inline, doesn't need workers). But swapping to `schedule_compaction` (D1) would enqueue tasks into the SstEngine's queue — which has zero consumers. Silent failure.

## The fix (1 region in core.rs)
Start `background_thread_count` workers on the SstEngine's own `Compaction` instance **at construction time** (before the `Arc` wrap):

```rust
let mut compaction = Compaction::new(config.clone()).await?;
compaction.start_workers(config.background_thread_count as usize).await?;
let compaction_manager = Some(Arc::new(compaction));
```

This also wires the previously-unused `SstConfig.background_thread_count` (was hardcoded `2` at `engine.rs:212`; the config field existed but was unused at the spawn site — DeepSeek's "seam drift" finding).

The StorageEngine's redundant instance + workers (`engine.rs:211-213`) become harmless (idle on a different instance, never fed). Cleanup deferred to D1+D2.

## Scope
1 file (`core.rs`), ~15 lines. No behavior change (the SstEngine's workers sit idle until D1 wires `schedule_compaction`). `cargo check --lib` ✅ · `work-commit-check` ✅.