### PR TITLE
feat(oltp): F5 — activate the fenced ConditionalKeyStore at the composition root (TD-OLTP-WIRING-1)

### DIFF
--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -325,7 +325,8 @@ impl MultiServer {
                 "🐘 pgwire reusing shared canonical record store (unified cross-surface relational state)"
             );
             return Ok(Some(
-                crate::network::postgres::DirectPgwireWriteServices::new(store),
+                crate::network::postgres::DirectPgwireWriteServices::new(store)
+                    .with_conditional_key_store(self.shared_services.conditional_key_store.clone()),
             ));
         }
 
@@ -396,7 +397,8 @@ impl MultiServer {
         );
 
         Ok(Some(
-            crate::network::postgres::DirectPgwireWriteServices::new(canonical_store),
+            crate::network::postgres::DirectPgwireWriteServices::new(canonical_store)
+                .with_conditional_key_store(self.shared_services.conditional_key_store.clone()),
         ))
     }
 

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -49,6 +49,12 @@ pub struct DirectPgwireWriteServices {
     /// pgwire connections so their in-memory partitions hold one authoritative
     /// state.
     canonical_store: Arc<crate::services::record_store::DirectWalTableRecordStore>,
+
+    /// F5 / TD-OLTP-WIRING-1: the SAME process-shared fenced `ConditionalKeyStore`
+    /// held by `SharedServices` (set via [`Self::with_conditional_key_store`]).
+    /// Threaded into the pgwire `DmlService` so PK/FK uniqueness is fenced
+    /// identically across pgwire and gRPC/REST. `None` ⇒ unfenced legacy probe.
+    conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
 }
 
 impl DirectPgwireWriteServices {
@@ -56,7 +62,21 @@ impl DirectPgwireWriteServices {
     pub fn new(
         canonical_store: Arc<crate::services::record_store::DirectWalTableRecordStore>,
     ) -> Self {
-        Self { canonical_store }
+        Self {
+            canonical_store,
+            conditional_key_store: None,
+        }
+    }
+
+    /// Attach the process-shared fenced `ConditionalKeyStore` (the ONE instance
+    /// from `SharedServices`), so pgwire writes fence PK/FK uniqueness on the same
+    /// store as gRPC/REST.
+    pub fn with_conditional_key_store(
+        mut self,
+        cks: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
+    ) -> Self {
+        self.conditional_key_store = cks;
+        self
     }
 }
 
@@ -377,8 +397,11 @@ impl PostgresServer {
         )
         .with_session_manager(session_manager.clone());
         let mut protocol = if let Some(direct_write_services) = direct_write_services {
-            protocol
-                .with_direct_catalog_manager(catalog_manager, direct_write_services.canonical_store)
+            protocol.with_direct_catalog_manager(
+                catalog_manager,
+                direct_write_services.canonical_store,
+                direct_write_services.conditional_key_store,
+            )
         } else {
             protocol.with_catalog_manager(catalog_manager)
         };

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -665,13 +665,20 @@ impl PostgresProtocol {
         mut self,
         catalog_manager: Arc<CatalogManager>,
         canonical_store: Arc<crate::services::record_store::DirectWalTableRecordStore>,
+        conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
     ) -> Self {
         self.ddl_service = Some(Arc::new(DdlService::new(catalog_manager.clone())));
-        self.dml_service = Some(Arc::new(DmlService::with_direct_record_storage(
+        // F5 / TD-OLTP-WIRING-1: fence pgwire writes on the SAME shared CKS as
+        // gRPC/REST (threaded from SharedServices via DirectPgwireWriteServices).
+        let mut dml = DmlService::with_direct_record_storage(
             catalog_manager.clone(),
             self.vector_ops.clone(),
             canonical_store,
-        )));
+        );
+        if let Some(cks) = conditional_key_store {
+            dml = dml.with_conditional_key_store(cks);
+        }
+        self.dml_service = Some(Arc::new(dml));
         self.catalog_manager = Some(catalog_manager);
         self
     }

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -369,6 +369,14 @@ pub struct SharedServices {
     pub canonical_record_store:
         Option<Arc<crate::services::record_store::DirectWalTableRecordStore>>,
 
+    /// F5 / TD-OLTP-WIRING-1: the process-shared fenced `ConditionalKeyStore`
+    /// (ADR-072). `Some` only under the `oltp-integrity` feature with a durable
+    /// `data_dir`. Held here as the single source of truth so pgwire
+    /// (`multi_server.rs`) threads the SAME instance — one uniqueness index across
+    /// every write surface (two stores would corrupt one WAL or fence
+    /// inconsistently across gRPC vs pgwire).
+    pub conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
+
     /// Process-wide recall-probe gate (TD-064 / LLD §5). The gate enables
     /// the quantized candidate route only after the recall-probe set passes
     /// the tenant's target for three consecutive builds; a single failure
@@ -475,6 +483,46 @@ impl SharedServices {
 }
 
 impl SharedServices {
+    /// Open the ONE process-shared fenced `ConditionalKeyStore`
+    /// (TD-OLTP-WIRING-1 / ADR-072). Returns `Some` only when the
+    /// `oltp-integrity` feature is compiled AND a durable `data_dir` is
+    /// configured — an in-memory store would lose uniqueness across restart. The
+    /// WAL is replayed by `open`, so PK/FK fencing state survives a restart.
+    /// `None` on default builds and embedded/ephemeral paths (unchanged behavior).
+    fn open_shared_conditional_key_store(
+        opt_config: Option<&crate::core::config::Config>,
+    ) -> Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>> {
+        #[cfg(not(feature = "oltp-integrity"))]
+        {
+            let _ = opt_config;
+            None
+        }
+        #[cfg(feature = "oltp-integrity")]
+        {
+            let data_dir = opt_config?.server.data_dir.clone();
+            let path = std::path::Path::new(&data_dir).join("oltp-cks.wal");
+            match proximadb_cks_local::LocalWalKeyStore::open(
+                &path,
+                proximadb_cks_local::SyncPolicy::PerOp,
+            ) {
+                Ok(store) => {
+                    tracing::info!(
+                        "oltp-integrity: fenced ConditionalKeyStore active at {}",
+                        path.display()
+                    );
+                    Some(Arc::new(store) as Arc<dyn proximadb_storage_ports::ConditionalKeyStore>)
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "oltp-integrity: failed to open ConditionalKeyStore at {}: {e}; fencing DISABLED",
+                        path.display()
+                    );
+                    None
+                }
+            }
+        }
+    }
+
     /// Create shared services with full business logic configuration
     /// SharedServices owns all business logic and configuration decisions
     /// Returns (SharedServices, CollectionService) - the collection service is needed by StorageEngine
@@ -2249,6 +2297,16 @@ impl SharedServices {
                 ) as Arc<dyn crate::storage::write_fence::StorageWriteFence>
             });
 
+        // F5 / TD-OLTP-WIRING-1: open the ONE process-shared fenced
+        // ConditionalKeyStore (durable at <data_dir>/oltp-cks.wal; WAL-replayed on
+        // restart), threaded into this gRPC/REST `base_dml` and into pgwire via
+        // `multi_server`. Feature-gated (`oltp-integrity`) AND requires a
+        // `data_dir` — an in-memory store would silently lose uniqueness across a
+        // restart, worse than the honest legacy probe. `None` otherwise ⇒ default
+        // builds and embedded/ephemeral paths are byte-for-byte unchanged.
+        let conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>> =
+            Self::open_shared_conditional_key_store(opt_config);
+
         let base_dml = match canonical_record_store.clone() {
             Some(store) => DmlService::with_direct_record_storage(
                 catalog_manager.clone(),
@@ -2256,6 +2314,10 @@ impl SharedServices {
                 store,
             ),
             None => DmlService::new(catalog_manager.clone(), vector_operations_service.clone()),
+        };
+        let base_dml = match &conditional_key_store {
+            Some(cks) => base_dml.with_conditional_key_store(cks.clone()),
+            None => base_dml,
         };
         let dml_service_for_grpc = Arc::new(match dml_lock_service {
             Some(lock_service) => base_dml.with_dml_lock_service(lock_service),
@@ -2620,6 +2682,7 @@ impl SharedServices {
                 // share the same next_sequence counter.
                 canonical_wal_appender,
                 canonical_record_store,
+                conditional_key_store,
                 #[cfg(feature = "experimental-ledger")]
                 ledger_store,
                 // TD-064 / LLD §5: per-collection recall-probe gate. Empty


### PR DESCRIPTION
Implements **TD-OLTP-WIRING-1** (#1240). The F2/F5 fenced `ConditionalKeyStore` was **inert in production** — `with_conditional_key_store` was only ever called in tests, so every live `DmlService` (gRPC/REST + pgwire) ran with no PK/FK uniqueness fencing. This makes it real.

- **`SharedServices`** opens ONE process-shared store (feature `oltp-integrity` **AND** a durable `data_dir`; `LocalWalKeyStore` at `<data_dir>/oltp-cks.wal`, WAL-replayed on restart), wires it into the gRPC/REST `DmlService`, and holds it as the single source of truth.
- **`DirectPgwireWriteServices`** carries the SAME `Arc` (threaded from `SharedServices` at both `multi_server` sites).
- **pgwire `with_direct_catalog_manager`** wires that shared `Arc` into the per-connection pgwire `DmlService`.

**Single-instance invariant preserved:** gRPC/REST and pgwire fence uniqueness on ONE store (two stores would corrupt one WAL or fence inconsistently across surfaces). Requires a `data_dir` — an in-memory store would lose uniqueness across restart.

**Feature-inert by default** (no `oltp-integrity` or no `data_dir` → `None` → byte-for-byte unchanged). Both feature states compile clean; clippy `-D warnings` (default) clean. Cross-surface-uniqueness integration test is a follow-up (needs a two-server harness); the CKS fencing behavior itself is covered by the merged F2/F5 fenced tests.