### PR TITLE
feat(search-types): FA-a2 — type-strict comparison so a numeric threshold cannot admit a string (TF-2 S3)

### DIFF
--- a/crates/foundation/proximadb-search-types/src/json_comparison.rs
+++ b/crates/foundation/proximadb-search-types/src/json_comparison.rs
@@ -170,3 +170,124 @@ pub fn evaluate_filter(
     // remain the shared comparison source that the seam calls into.
     crate::sql_value_filter::evaluate_filter_resolved(expr, &|field| metadata.get(field).cloned())
 }
+
+// ===========================================================================
+// Type-strict comparison (TD-FOUNDATION-3 slice FA-a2 / TF-2 S3)
+// ===========================================================================
+
+/// The class of JSON value an ordered comparison is meaningful *within*.
+///
+/// [`compare_json_values`] deliberately total-orders across classes
+/// (`Null < Bool < Number < String < Array < Object`) so it can sort a mixed
+/// column. That is right for sorting and wrong for authorization: it makes
+/// `clearance >= 3` answer `true` for **every** record whose `clearance` holds a
+/// string, because `String` outranks `Number` by precedence alone, whatever the
+/// string says. See [`compare_json_values_strict`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparableClass {
+    /// JSON `null`.
+    Null,
+    /// `true` / `false`.
+    Bool,
+    /// Any JSON number (integers and floats share a class — cross-numeric
+    /// comparison is exact and meaningful).
+    Number,
+    /// A JSON string.
+    String,
+    /// A JSON array.
+    Array,
+    /// A JSON object.
+    Object,
+}
+
+/// The [`ComparableClass`] of a value.
+pub fn comparable_class(v: &Value) -> ComparableClass {
+    match v {
+        Value::Null => ComparableClass::Null,
+        Value::Bool(_) => ComparableClass::Bool,
+        Value::Number(_) => ComparableClass::Number,
+        Value::String(_) => ComparableClass::String,
+        Value::Array(_) => ComparableClass::Array,
+        Value::Object(_) => ComparableClass::Object,
+    }
+}
+
+/// Ordered comparison that **refuses to answer across classes**.
+///
+/// Returns `None` when the two operands are of different [`ComparableClass`]es,
+/// so the caller must decide what an incomparable pair means. An authorization
+/// evaluator decides *deny*; that is the whole point — the alternative is the
+/// type-precedence fallthrough, under which a numeric threshold silently admits
+/// every string-valued record.
+///
+/// This is additive: [`compare_json_values`] is unchanged, so sorting and the
+/// live user-facing filter paths keep their existing total order.
+pub fn compare_json_values_strict(a: &Value, b: &Value) -> Option<Ordering> {
+    if comparable_class(a) != comparable_class(b) {
+        return None;
+    }
+    Some(compare_json_values(a, b))
+}
+
+#[cfg(test)]
+mod type_strict_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn the_permissive_order_admits_a_string_against_a_numeric_threshold() {
+        // Characterizing the defect this exists to fix, not endorsing it: under
+        // the total order a string outranks any number by precedence, so
+        // `clearance >= 3` is true for a record whose clearance is *any* string.
+        assert_eq!(
+            compare_json_values(&json!("TOP_SECRET"), &json!(3)),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_json_values(&json!("2"), &json!(3)),
+            Ordering::Greater,
+            "even a string that looks like a smaller number outranks it"
+        );
+    }
+
+    #[test]
+    fn the_strict_order_refuses_to_compare_across_classes() {
+        assert_eq!(
+            compare_json_values_strict(&json!("TOP_SECRET"), &json!(3)),
+            None
+        );
+        assert_eq!(compare_json_values_strict(&json!("2"), &json!(3)), None);
+        assert_eq!(compare_json_values_strict(&json!(true), &json!(1)), None);
+        assert_eq!(compare_json_values_strict(&json!(null), &json!(0)), None);
+        assert_eq!(compare_json_values_strict(&json!([1]), &json!("a")), None);
+    }
+
+    #[test]
+    fn the_strict_order_agrees_with_the_total_order_within_a_class() {
+        for (a, b) in [
+            (json!(1), json!(2)),
+            (json!(2.5), json!(2.5)),
+            (json!("a"), json!("b")),
+            (json!(false), json!(true)),
+            (json!([1, 2]), json!([1, 3])),
+            (json!(null), json!(null)),
+        ] {
+            assert_eq!(
+                compare_json_values_strict(&a, &b),
+                Some(compare_json_values(&a, &b)),
+                "strict and total order disagree within a class for {a} vs {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn integers_and_floats_share_a_class() {
+        // Cross-numeric comparison is exact and meaningful, so it must not be
+        // refused — a `score > 0.8` policy has to work against an integer 1.
+        assert_eq!(
+            compare_json_values_strict(&json!(1), &json!(0.8)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(comparable_class(&json!(1)), comparable_class(&json!(1.5)));
+    }
+}

--- a/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
+++ b/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
@@ -1095,3 +1095,277 @@ mod tests {
         }
     }
 }
+
+// ===========================================================================
+// Type-strict operator evaluation (TD-FOUNDATION-3 slice FA-a2 / TF-2 S3)
+// ===========================================================================
+
+/// [`compare_json_op`], but **deny-biased on a type mismatch**.
+///
+/// The permissive dispatch answers every comparison, falling back to JSON type
+/// precedence when the operands are of different classes. For a *user* filter
+/// that is a defensible total order. For an *authorization* predicate it is a
+/// fail-open channel, in two directions:
+///
+/// * **Ordered operators widen.** `String` outranks `Number` by precedence, so a
+///   `clearance >= 3` policy returns `true` for every record whose `clearance`
+///   holds a string — regardless of the string's content. A clearance gate
+///   admits the corpus it exists to withhold.
+/// * **Negative operators widen.** `dept != 5` is `true` for a string-valued
+///   `dept`, because "not equal" is trivially satisfied by "not comparable".
+///
+/// The rule here is one line: **if the operands are not comparable, the
+/// predicate does not admit.** Operators that are already type-exact
+/// (`Equals`/`In` via `json_eq`, the string operators via `as_str`, the null
+/// tests via presence) delegate unchanged — this only tightens the cases that
+/// could widen.
+///
+/// Additive: [`compare_json_op`] is untouched, so the live metadata-search,
+/// document-filter and pushdown paths keep their current semantics. The security
+/// path opts in.
+pub fn compare_json_op_type_strict(
+    operator: &ComparisonOperator,
+    json_val: &serde_json::Value,
+    value: &serde_json::Value,
+) -> bool {
+    use crate::json_comparison::comparable_class;
+
+    let same_class =
+        |other: &serde_json::Value| comparable_class(json_val) == comparable_class(other);
+
+    match operator {
+        // Ordered comparisons are meaningless across classes — deny rather than
+        // fall through to precedence ordering.
+        ComparisonOperator::LessThan
+        | ComparisonOperator::LessThanOrEqual
+        | ComparisonOperator::GreaterThan
+        | ComparisonOperator::GreaterThanOrEqual => {
+            same_class(value) && compare_json_op(operator, json_val, value)
+        }
+
+        // Both bounds must be comparable with the field, or the range is
+        // meaningless.
+        ComparisonOperator::Between => value.as_array().is_some_and(|bounds| {
+            bounds.len() == 2
+                && same_class(&bounds[0])
+                && same_class(&bounds[1])
+                && compare_json_op(operator, json_val, value)
+        }),
+
+        // "Not equal" must not be satisfied merely by being incomparable.
+        ComparisonOperator::NotEquals => {
+            same_class(value) && compare_json_op(operator, json_val, value)
+        }
+
+        // Likewise "not in": require at least one list element the field could
+        // actually have equalled, else the exclusion is vacuous.
+        ComparisonOperator::NotIn => value.as_array().is_some_and(|values| {
+            values.iter().any(same_class) && compare_json_op(operator, json_val, value)
+        }),
+
+        // Already type-exact: Equals/In compare via `json_eq`, the string
+        // operators require `as_str` on both sides, and the null tests are
+        // decided by presence.
+        _ => compare_json_op(operator, json_val, value),
+    }
+}
+
+#[cfg(test)]
+mod type_strict_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn permissive(
+        op: ComparisonOperator,
+        field: serde_json::Value,
+        lit: serde_json::Value,
+    ) -> bool {
+        compare_json_op(&op, &field, &lit)
+    }
+    fn strict(op: ComparisonOperator, field: serde_json::Value, lit: serde_json::Value) -> bool {
+        compare_json_op_type_strict(&op, &field, &lit)
+    }
+
+    #[test]
+    fn a_numeric_threshold_no_longer_admits_a_string_clearance() {
+        // TF-2 §1.4's case, end to end: `clearance >= 3` against a record whose
+        // clearance is a string.
+        assert!(
+            permissive(
+                ComparisonOperator::GreaterThanOrEqual,
+                json!("TOP_SECRET"),
+                json!(3)
+            ),
+            "characterizing the defect: the permissive dispatch admits"
+        );
+        assert!(!strict(
+            ComparisonOperator::GreaterThanOrEqual,
+            json!("TOP_SECRET"),
+            json!(3)
+        ));
+        // …including the string that merely looks like a smaller number.
+        assert!(!strict(
+            ComparisonOperator::GreaterThanOrEqual,
+            json!("2"),
+            json!(3)
+        ));
+    }
+
+    #[test]
+    fn ordered_operators_still_work_within_a_class() {
+        assert!(strict(ComparisonOperator::GreaterThan, json!(5), json!(3)));
+        assert!(!strict(ComparisonOperator::GreaterThan, json!(2), json!(3)));
+        assert!(strict(ComparisonOperator::LessThan, json!("a"), json!("b")));
+        // Integer field against a float literal must keep working.
+        assert!(strict(
+            ComparisonOperator::GreaterThan,
+            json!(1),
+            json!(0.8)
+        ));
+    }
+
+    #[test]
+    fn not_equals_is_not_satisfied_by_being_incomparable() {
+        assert!(
+            permissive(ComparisonOperator::NotEquals, json!("eng"), json!(5)),
+            "characterizing the defect: incomparable satisfies !="
+        );
+        assert!(!strict(
+            ComparisonOperator::NotEquals,
+            json!("eng"),
+            json!(5)
+        ));
+        // Same-class inequality is unaffected.
+        assert!(strict(
+            ComparisonOperator::NotEquals,
+            json!("eng"),
+            json!("hr")
+        ));
+        assert!(!strict(
+            ComparisonOperator::NotEquals,
+            json!("eng"),
+            json!("eng")
+        ));
+    }
+
+    #[test]
+    fn not_in_requires_a_comparable_list_element() {
+        assert!(
+            permissive(ComparisonOperator::NotIn, json!("eng"), json!([1, 2])),
+            "characterizing the defect: a wholly incomparable list excludes nothing"
+        );
+        assert!(!strict(
+            ComparisonOperator::NotIn,
+            json!("eng"),
+            json!([1, 2])
+        ));
+        // A same-class list behaves normally.
+        assert!(strict(
+            ComparisonOperator::NotIn,
+            json!("eng"),
+            json!(["hr", "legal"])
+        ));
+        assert!(!strict(
+            ComparisonOperator::NotIn,
+            json!("eng"),
+            json!(["eng", "hr"])
+        ));
+    }
+
+    #[test]
+    fn between_requires_both_bounds_to_be_comparable() {
+        assert!(strict(
+            ComparisonOperator::Between,
+            json!(5),
+            json!([1, 10])
+        ));
+        assert!(!strict(
+            ComparisonOperator::Between,
+            json!(5),
+            json!([1, "10"])
+        ));
+        assert!(!strict(
+            ComparisonOperator::Between,
+            json!("5"),
+            json!([1, 10])
+        ));
+    }
+
+    #[test]
+    fn already_exact_operators_are_unchanged() {
+        // Equals, In, the string operators and the null tests are type-exact
+        // already; strict mode must not alter them.
+        for (op, field, lit) in [
+            (ComparisonOperator::Equals, json!("eng"), json!("eng")),
+            (ComparisonOperator::Equals, json!("eng"), json!(5)),
+            (ComparisonOperator::In, json!("eng"), json!(["eng", "hr"])),
+            (ComparisonOperator::In, json!("eng"), json!([1, 2])),
+            (
+                ComparisonOperator::StartsWith,
+                json!("engineering"),
+                json!("eng"),
+            ),
+            (ComparisonOperator::StartsWith, json!(5), json!("eng")),
+            (
+                ComparisonOperator::Contains,
+                json!("engineering"),
+                json!("gin"),
+            ),
+            (
+                ComparisonOperator::Like,
+                json!("engineering"),
+                json!("eng%"),
+            ),
+            (ComparisonOperator::IsNull, json!(null), json!(null)),
+            (ComparisonOperator::IsNotNull, json!("eng"), json!(null)),
+        ] {
+            assert_eq!(
+                compare_json_op_type_strict(&op, &field, &lit),
+                compare_json_op(&op, &field, &lit),
+                "strict mode changed an already-exact operator: {op:?} {field} {lit}"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_never_admits_more_than_permissive() {
+        // The deny-biased property, over the operator × value grid: strict mode
+        // may only ever tighten.
+        let values = [
+            json!(3),
+            json!(3.5),
+            json!("3"),
+            json!("eng"),
+            json!(true),
+            json!(null),
+            json!([1, 2]),
+        ];
+        let ops = [
+            ComparisonOperator::Equals,
+            ComparisonOperator::NotEquals,
+            ComparisonOperator::LessThan,
+            ComparisonOperator::LessThanOrEqual,
+            ComparisonOperator::GreaterThan,
+            ComparisonOperator::GreaterThanOrEqual,
+            ComparisonOperator::In,
+            ComparisonOperator::NotIn,
+            ComparisonOperator::Between,
+            ComparisonOperator::Contains,
+            ComparisonOperator::StartsWith,
+            ComparisonOperator::EndsWith,
+            ComparisonOperator::Like,
+        ];
+        for op in &ops {
+            for field in &values {
+                for lit in &values {
+                    if compare_json_op_type_strict(op, field, lit) {
+                        assert!(
+                            compare_json_op(op, field, lit),
+                            "strict admitted what permissive denies: {op:?} {field} {lit}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Slice FA-a2 of the FA track, part 1 (the reusable primitive). Independent of #1245.

## The defect, measured not asserted

`compare_json_values` total-orders across JSON types (`Null < Bool < Number < String <
Array < Object`). Right for sorting a mixed column; wrong for authorization, because
precedence *answers a comparison the values cannot*:

```rust
compare_json_values(&json!("TOP_SECRET"), &json!(3)) == Ordering::Greater
```

So a `clearance >= 3` policy returns **true for every record whose `clearance` holds a
string** — whatever the string says. The gate admits precisely the corpus it exists to
withhold. `"2" >= 3` is true for the same reason.

It widens the other way too, through negative operators: `dept != 5` is satisfied by a
string-valued `dept`, because *not equal* is trivially true of *not comparable*.

Both behaviours are pinned by **characterization tests** in this PR, so the defect is
documented rather than merely fixed somewhere else.

## What's added (additive only)

| Item | Contract |
|---|---|
| `ComparableClass` / `comparable_class()` | The class an ordered comparison is meaningful within. Integers and floats deliberately share one, so `score > 0.8` keeps working against an integer `1`. |
| `compare_json_values_strict()` | Returns `None` across classes instead of answering by precedence — the caller must decide what incomparable means. |
| `compare_json_op_type_strict()` | The operator dispatch, under one rule: **if the operands are not comparable, the predicate does not admit.** |

It tightens only the operators that *can* widen — ordered (`<`, `<=`, `>`, `>=`),
`Between` (both bounds must be comparable), `NotEquals`, and `NotIn` (requires at least
one same-class list element, else the exclusion is vacuous). `Equals`/`In` are already
type-exact via `json_eq`, the string operators via `as_str`, and the null tests are
decided by presence — those delegate unchanged, with a test asserting strict mode does
not alter them.

## No live behavior change

`compare_json_values` and `compare_json_op` are **untouched**. `sql_value_filter` is live
under metadata search, document filtering and the pushdown paths, where moving to strict
typing is a user-visible semantics decision that is not mine to make here. This is the
mode the security path opts into.

## Why this arrives as a primitive rather than wired

TD-FOUNDATION-3 originally scoped S3 as "type-gate literals against the column's declared
type at compile" — which needs a schema at the bridge seam that `build_filter` does not
have. Checking the *runtime* value's class instead reaches S3's actual goal with no schema
at all. Part 2 wires the security lowering onto it, after #1245 lands.

## Verification

51 crate tests + 11 new, all green. `cargo clippy -p proximadb-search-types --all-targets
-- -D warnings` clean; `make work-commit-check` passes. The new tests include a
deny-biased property over the operator × value grid: **strict never admits what permissive
denies.**

Refs TD-FOUNDATION-3 slice FA-a2, TD-FOUNDATION-2 §1.4 / §8 S3.