### PR TITLE
docs(td): TD-DELVEC-1 — cold-tier deletion vectors (F3v design gate)

### DIFF
--- a/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
+++ b/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
@@ -1,0 +1,121 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DELVEC-1: Cold-tier deletion vectors (merge-on-read) — F3v
+:status: Draft — design gate (pre-implementation)
+:date: 2026-07-27
+:authors: co-design session 2026-07-27
+:realizes: ADR-072 D14 (tier-split delete: MVCC visibility + deletion vectors in the immutable cold tier), refines D11/D13
+:depends-on: F1d (MVCC reclaim + reader watermark), F3 (PAX/SST substrate)
+:feeds: F4 (document/vector reads over the shared scan)
+
+[cols="1,3"]
+|===
+| Status | Draft — design gate, no code
+| Problem | The cold tier deletes via **LSM tombstones** (delete-marker records that cascade through levels and are physically removed only at compaction) — every cold delete implies an eventual **segment rewrite**. D14 wants **deletion vectors**: a position bitmap overlaying the *immutable* segment, applied **merge-on-read**, purged at compaction behind the reader watermark — no rewrite on delete.
+| Feature | `cold-deletion-vectors` (additive, feature-gated; default path = today's tombstone+compaction, byte-for-byte unchanged).
+|===
+
+== 1. What exists today (verification-first)
+
+Deletion is currently expressed in **three** places — F3v must reconcile with all
+of them, not add a fourth silo:
+
+[cols="1,2,2"]
+|===
+| Mechanism | Where | Role
+
+| **LSM tombstone** | `sst/mod.rs:460–515` (`SstEntry::tombstone`, `is_tombstone`), reclaimed at `compaction.rs:1769` ("tombstones removed")
+| The hot→cold delete marker: a *record* that cascades down LSM levels and forces a rewrite/removal at compaction. Heavy for the immutable tier.
+
+| **`OlapDeltaMerge` suppress-set** | `query/execution/olap_delta_merge.rs` (the `suppress` set of oids changed since `snapshot_lsn`)
+| The **read-time** merge already in place for HTAP: post-snapshot deletes/updates suppress cold base rows at query time. **This is merge-on-read — F3v makes its cold-side input persistent.**
+
+| **F5 CKS-tombstone** | `conditional_key_store::tombstone` (F1d/F5)
+| The *uniqueness-fence* delete (append-only MVCC reclaim). Orthogonal — a uniqueness gate, not a data-visibility overlay. F3v does not touch it.
+|===
+
+Confirmed greenfield for the DV itself: no `deletion_vector`/`DeletionVector`/
+roaring-bitmap type exists in `src/storage/engines/sst/` today.
+
+== 2. Design — deletion vectors over immutable segments
+
+=== D1 — The DV is a per-segment position bitmap
+For each immutable cold segment `S`, a **deletion vector** `DV(S)` is a compressed
+bitmap (roaring) of the **row positions** in `S` that are logically deleted. It
+lives **beside** `S` (a `.dv` sidecar keyed by segment id, recorded in the segment
+manifest with a monotonic version, mirroring the successor-slot manifest pattern
+F1c uses). A delete of a row in `S` **sets a bit in `DV(S)`** — the immutable
+segment `S` is **never rewritten** on delete.
+
+=== D2 — Delete path: hot tombstone → cold DV entry, not a rewrite
+Today a delete flushes a tombstone record that cascades. Under `cold-deletion-vectors`:
+a hot-tier delete/tombstone that lands on a row already in an immutable cold segment
+resolves the `(segment, position)` and appends to `DV(segment)` (a bitmap set + a
+new manifest version), instead of writing a cascading tombstone record. Rows still
+in the hot memtable delete as today (no cold segment yet).
+
+=== D3 — Read path: merge-on-read applies the DV
+A cold scan of `S` skips positions set in `DV(S)`. This is the **persistent
+cold-side of the existing `OlapDeltaMerge`**: the delta-merge already suppresses
+post-snapshot-deleted oids at read; the DV is the durable, position-indexed form
+so suppression survives across queries and restarts without re-deriving from the
+WAL each time. The two must agree — §4 tests this.
+
+=== D4 — Compaction purges DV'd rows behind the reader watermark (D11)
+Physical reclamation stays a compaction/background-plane concern (F6): compaction
+drops DV-marked rows and clears the DV, but **only behind the oldest-active-reader
+watermark** (F1d) so a snapshot read `get_at(T)` still sees rows deleted after `T`.
+This is the D14 "tier-split": MVCC (D11) is the *visibility* model (is key K live at
+snapshot T?); the DV is its *physical realization* in the immutable tier.
+
+=== D5 — Position stability
+The DV keys on **row position within the segment**, so it is valid only while `S`
+is immutable (positions never shift). A compaction that rewrites `S` re-derives
+fresh DVs for the outputs (or drops the rows). Positions are never exposed above
+the storage layer — the logical identity stays the F0 `Identity`/oid.
+
+== 3. Work breakdown (feature `cold-deletion-vectors`)
+
+[cols="1,4"]
+|===
+| WI | Item
+| WI-1 | `DeletionVector` type (roaring bitmap) + `.dv` sidecar format + manifest-version entry (create-only, rebase-on-conflict — reuse the F1c successor-slot discipline).
+| WI-2 | Delete path: resolve `(segment, position)` for a cold-resident delete; set the bit + bump the DV manifest version. Hot deletes unchanged.
+| WI-3 | Read path: cold scan skips DV positions; reconcile with `OlapDeltaMerge` so the DV and the live suppress-set never double-count or disagree.
+| WI-4 | Compaction purge: drop DV'd rows + clear the DV behind the reader watermark (F6/F1d); re-derive DVs for rewritten outputs.
+| WI-5 | Snapshot-read safety: `get_at(T)` honors the watermark so a post-`T` delete is invisible to the older snapshot.
+|===
+
+== 4. Test / gate plan
+* **Merge-on-read correctness:** insert N rows → flush to a cold segment → delete a
+  subset → scan returns exactly the survivors, and the segment file is **not
+  rewritten** (byte-identical).
+* **DV ⇄ delta-merge agreement:** a post-snapshot delete is suppressed identically
+  whether resolved via the live `OlapDeltaMerge` suppress-set or the persisted DV
+  (no double-suppress, no missed-suppress). Property test over random insert/delete
+  interleavings.
+* **Snapshot isolation:** open reader at `T`; delete after `T`; the `T`-snapshot
+  scan still sees the row; a fresh scan does not; compaction does not purge it while
+  the `T` reader is live (watermark).
+* **Restart:** delete → DV persisted → reopen → scan still suppresses (no WAL
+  re-derivation needed).
+* Coverage ≥75%; evidence to `BENCHMARK_EVIDENCE.toml` for the read-merge overhead
+  (DV-apply cost vs the rewrite-on-delete baseline).
+
+== 5. Adversarial-review targets (design gate — resolve before code)
+1. **Double-suppress / disagreement between the DV and the live `OlapDeltaMerge`
+   suppress-set** — the highest risk: a delete counted by both, or by neither
+   during the hot→cold flush window. Nail the hand-off point precisely.
+2. **Position drift** — any code path that reorders/rewrites a segment while a DV
+   references positions in it (compaction races, partial rewrites) silently
+   mis-deletes. Prove positions are frozen for a segment's DV lifetime.
+3. **Watermark correctness** — a compaction that purges a DV'd row a live snapshot
+   still needs (watermark computed wrong) is silent data loss for that reader.
+4. **Manifest conflict** — concurrent deletes to the same segment's DV must
+   rebase-on-conflict (F1c pattern), never lost-update a bit.
+
+== 6. Out of scope
+* Deletion vectors for the **hot** tier (MVCC tombstone stays, D11) — DVs are the
+  *immutable cold* representation only.
+* The uniqueness-fence CKS tombstone (F5) — orthogonal, untouched.
+* Cross-format DV interchange (Iceberg-v3 wire compat) — a later interop item.


### PR DESCRIPTION
Design gate for **F3v** (ADR-072 D14). The cold tier deletes via **LSM tombstones** today (cascade + compaction rewrite); F3v adds Iceberg-v3/Delta-style **deletion vectors** — a position bitmap over the immutable segment, applied merge-on-read, purged at compaction behind the reader watermark — so a cold delete needs **no segment rewrite**. Reconciles with the **three existing delete mechanisms** (LSM tombstone, `OlapDeltaMerge` suppress-set, F5 CKS-tombstone). 5 WIs + test plan + 4 ranked adversarial-review targets (chiefly DV ⇄ delta-merge agreement + position drift). Guards pass; docs-only.