### PR TITLE
ci: break the cold-cache failure loop on the Azurite restart job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1589,6 +1589,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-objstore-restart"
+          # This job is compile-bound and sits at the edge of its 90-minute
+          # budget: a WARM run finishes in ~75 min, a COLD one does not finish at
+          # all (observed: 72 min in, still emitting compile warnings, then
+          # killed). rust-cache saves `target/` only on success by default, so a
+          # single failure starts a loop it cannot leave — the run fails, saves
+          # nothing, and the next run is cold again and fails for the same
+          # reason. Caching on failure persists the partial `target/` so the next
+          # attempt starts warm and completes. (`CARGO_BUILD_JOBS=1` is already
+          # set inside run_cloud_emulator_tests.sh for the memory cliff; this is
+          # the other half.)
+          cache-on-failure: true
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## The loop

The **Object-store restart recovery (Azurite)** job has failed every run today — #1230
(×2) and #1235 (×2) — and **cannot recover on its own**.

It is compile-bound and sits right at the edge of its 90-minute budget:

| Run | Cache | Outcome |
|---|---|---|
| #1231 | warm | ✅ passed at **1h15m** |
| #1230, #1235 | cold | ❌ killed — most recently **72 min in and still emitting compile warnings**, having never reached the Azurite test |

`Swatinem/rust-cache` saves `target/` **only on success** by default. So a single failure
starts a loop with no exit:

```
run fails → saves nothing → next run is cold → fails for the same reason → …
```

Every subsequent PR that trips the `object_store_restart_changes` path filter inherits it.

## The fix

`cache-on-failure: true` persists the partial `target/` from a failed run, so the next
attempt starts warm and finishes inside the budget. The job's post-steps **do** run on
these failures — the logs end with `Complete job / Cleaning up orphan processes` — so the
save will actually happen.

## Why this and not something else

- **Not the timeout.** The last failure died at 72 min against a 90-min limit, so raising
  the limit would not have saved it; it was killed, not timed out.
- **Not `CARGO_BUILD_JOBS`.** Already `1` inside `run_cloud_emulator_tests.sh` for the
  memory cliff — that lever is pulled.
- **Not the path filter.** Narrowing `crates/control/proximadb-catalog/**` would reduce
  coverage, and this job protects a real durability property. Worth discussing separately,
  but it is not the cause and not a change to make quietly.

This touches **caching only**: no coverage reduced, no guard weakened, no assertion
changed.

## Verification

YAML parses. The effect is observable rather than assertable — the next cold run of this
job should save its cache, and the run after it should complete.