### PR TITLE
fix(sst): wire the coarse-probe TOML config to the serving engine (TD-COMPACT-9)

### DIFF
--- a/docs/10-quality/td/TD-COMPACT-9-coarse-probe-toml-config-dead.adoc
+++ b/docs/10-quality/td/TD-COMPACT-9-coarse-probe-toml-config-dead.adoc
@@ -1,0 +1,54 @@
+= TD-COMPACT-9: the `[storage.sst_config.coarse_probe]` TOML surface was silently dead (serving engine used defaults)
+:status: S1 shipped (2026-07-27)
+:filed: 2026-07-27
+:priority: P1 (a shipped config surface that does nothing — recall/GET tuning unavailable)
+
+== The finding (1M needle verification of #1234)
+
+#1234 added a TOML config surface `[storage.sst_config.coarse_probe]`
+(`enable_read_probe`, `enable_write_train`, `nprobe_multiplier`, …) as the
+per-deployment tuning knob for the coarse probe. Measured on merged develop:
+setting `nprobe_multiplier = 1.5` had **no effect** on recall or GETs, while
+the env `PROXIMADB_PAX_READ_COARSE_NPROBE=64` clearly did (recall
+0.9825→0.9845, GETs 68.8→102.5). So the env path worked; the TOML path was
+dead.
+
+== Two root causes
+
+1. **The serving engine never receives the config.** Every production
+   `SstEngine::new()` (shared_services.rs:1141, factory.rs:464/473,
+   legacy.rs:5052, engine.rs:152) constructs with `SstConfig::default()`
+   (core.rs:383) — `coarse_probe = None`. The parsed
+   `config.storage.sst_config.coarse_probe` is dropped on the floor; the
+   engine always sees `CoarseProbeConfig::default()`.
+2. **`OnceLock` first-wins + silent set.** `init_coarse_probe_settings` used
+   `let _ = OnceLock.set(...)`. The FIRST (default-config) `SstEngine::new()`
+   seeded the default; the real config's `set()` then failed silently. So
+   even threading the config to one engine wouldn't have won.
+
+The *defaults* worked (that's why training/probe are on by default post-#1234)
+— only CUSTOM values were unreachable.
+
+== S1 (shipped)
+
+* `SHARED_COARSE_PROBE` is now an overwritable `RwLock<Option<..>>`, not a
+  first-wins `OnceLock`: a REAL (`Some`) config always wins; a `None` init
+  (default-config engine) only fills the default if nothing real was set.
+  Order-independent, poison-safe (mandate #4).
+* **Authoritative seed** in `ProximaDB::start` from the loaded server config
+  (`self._config.storage.sst_config.coarse_probe`), so the TOML is effective
+  regardless of engine-construction order. Env vars still override at call time.
+* Regression test `toml_coarse_probe_config_wins_over_default_init`: a real
+  config survives a later default init, and the multiplier reaches
+  `geometric_nprobe` (sqrt(64)×1.5=12 vs ×1.0=8).
+
+== Verification
+
+The 1M needle bed with `[storage.sst_config.coarse_probe] nprobe_multiplier`
+set must now move recall/GETs (was inert). Env path unchanged.
+
+== Related
+
+#1234 (added the surface), TD-RDSTRAT-8 (the probe), the 1M needle verification
+(recall 0.9825 default is a deliberate speed-favoring point — clears the 0.90
+ratchet; the multiplier is how you buy recall back, once it actually works).

--- a/src/database.rs
+++ b/src/database.rs
@@ -748,6 +748,21 @@ impl ProximaDB {
     pub async fn start(&mut self) -> anyhow::Result<()> {
         tracing::info!("🚀 ProximaDB::start - Starting database services...");
 
+        // TD-COMPACT-9: seed the coarse-probe (IVF) settings AUTHORITATIVELY from
+        // the loaded server config. Production `SstEngine::new()` uses
+        // `SstConfig::default()` (coarse_probe = None), so without this the
+        // `[storage.sst_config.coarse_probe]` TOML surface (nprobe_multiplier,
+        // enable_read_probe/write_train) was silently ignored. The overwritable
+        // seed (a `Some` config always wins) makes the TOML effective regardless
+        // of engine-construction order; env vars still override at call time.
+        crate::storage::engines::sst::segment_format::init_coarse_probe_settings(
+            self._config
+                .storage
+                .sst_config
+                .as_ref()
+                .and_then(|sst| sst.coarse_probe.as_ref()),
+        );
+
         // Step 1: Start the storage engine. It restores the catalog, registers
         // collection storage engines, and replays WAL in that dependency order.
         tracing::info!(

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -1366,13 +1366,29 @@ pub struct CoarseProbeSettings {
     pub nprobe_max: usize,
 }
 
-static SHARED_COARSE_PROBE: std::sync::OnceLock<CoarseProbeSettings> = std::sync::OnceLock::new();
+// TD-COMPACT-9: overwritable, NOT first-wins. Every production `SstEngine::new()`
+// (shared_services.rs, factory.rs, legacy.rs) is built with `SstConfig::default()`
+// (coarse_probe = None), so an OnceLock first-wins seeded the DEFAULT and the
+// real `[storage.sst_config.coarse_probe]` TOML was silently ignored (measured:
+// nprobe_multiplier=1.5 had no effect while env nprobe DID). An RwLock lets a
+// REAL (Some) config — set authoritatively from the loaded server Config in
+// `ProximaDB::start` — override the default regardless of construction order.
+static SHARED_COARSE_PROBE: std::sync::RwLock<Option<CoarseProbeSettings>> =
+    std::sync::RwLock::new(None);
 
-/// Initialize the coarse-probe settings from the parsed TOML config (called once
-/// at SstEngine boot). Subsequent calls are no-ops (first wins, matching
-/// SHARED_INVARIANTS_CACHE). `None` ⇒ `CoarseProbeConfig::default()`.
+/// Seed the coarse-probe settings. A real (`Some`) config ALWAYS wins (the
+/// authoritative call from server startup); a `None` call (a default-config
+/// `SstEngine::new()`) only fills the default if nothing real was set yet.
+/// Poison-safe (no-panic mandate #4).
 pub fn init_coarse_probe_settings(cfg: Option<&crate::core::config::CoarseProbeConfig>) {
-    let _ = SHARED_COARSE_PROBE.set(cfg.cloned().unwrap_or_default().into());
+    if let Ok(mut g) = SHARED_COARSE_PROBE.write() {
+        match cfg {
+            Some(c) => *g = Some(c.clone().into()),
+            None => {
+                g.get_or_insert_with(CoarseProbeSettings::default);
+            }
+        }
+    }
 }
 
 impl Default for CoarseProbeSettings {
@@ -1393,8 +1409,12 @@ impl From<crate::core::config::CoarseProbeConfig> for CoarseProbeSettings {
     }
 }
 
-pub(crate) fn coarse_probe_settings() -> &'static CoarseProbeSettings {
-    SHARED_COARSE_PROBE.get_or_init(CoarseProbeSettings::default)
+pub(crate) fn coarse_probe_settings() -> CoarseProbeSettings {
+    SHARED_COARSE_PROBE
+        .read()
+        .ok()
+        .and_then(|g| *g)
+        .unwrap_or_default()
 }
 
 /// Geometric nprobe: `ceil(sqrt(k_c) × multiplier)`, clamped to `[min, max]`
@@ -1402,7 +1422,7 @@ pub(crate) fn coarse_probe_settings() -> &'static CoarseProbeSettings {
 /// at 1M, recall ~0.98 at multiplier 1.0. Bump `nprobe_multiplier` (TOML) for
 /// higher recall. The max-then-min ordering avoids the `clamp(min, k_c)` panic
 /// when `k_c < min` (no-panic mandate #4).
-fn geometric_nprobe(k_c: usize, s: &CoarseProbeSettings) -> usize {
+fn geometric_nprobe(k_c: usize, s: CoarseProbeSettings) -> usize {
     let raw = ((k_c as f32).sqrt() * s.nprobe_multiplier).ceil() as usize;
     let floored = raw.max(s.nprobe_min);
     let bounded = if s.nprobe_max > 0 {
@@ -2162,6 +2182,36 @@ pub async fn rabitq_search_segment_coalesced(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cp_cfg(mult: f32) -> crate::core::config::CoarseProbeConfig {
+        crate::core::config::CoarseProbeConfig {
+            enable_read_probe: true,
+            enable_write_train: true,
+            nprobe_multiplier: mult,
+            nprobe_min: 3,
+            nprobe_max: 0,
+        }
+    }
+
+    /// TD-COMPACT-9: a REAL (Some) coarse-probe config must WIN and must NOT be
+    /// clobbered by a later default-config `SstEngine::new()` init(None) — the
+    /// bug that made `[storage.sst_config.coarse_probe] nprobe_multiplier`
+    /// silently dead in production. Also verifies the multiplier reaches
+    /// geometric_nprobe. (nextest = process isolation; the static won't leak.)
+    #[test]
+    fn toml_coarse_probe_config_wins_over_default_init() {
+        // Simulate a default-config engine seeding first...
+        init_coarse_probe_settings(None);
+        // ...then the authoritative TOML config (server startup) — must override.
+        init_coarse_probe_settings(Some(&cp_cfg(1.5)));
+        assert!((coarse_probe_settings().nprobe_multiplier - 1.5).abs() < 1e-6);
+        // A later default-config engine init(None) must NOT clobber it.
+        init_coarse_probe_settings(None);
+        assert!((coarse_probe_settings().nprobe_multiplier - 1.5).abs() < 1e-6);
+        // The multiplier actually reaches nprobe: sqrt(64)*1.5 = 12 vs *1.0 = 8.
+        assert_eq!(geometric_nprobe(64, coarse_probe_settings()), 12);
+        assert_eq!(geometric_nprobe(64, cp_cfg(1.0).into()), 8);
+    }
 
     /// TD-CACHE-2 S2b: Region A and control bytes are separate eviction
     /// units — a put with a region splits into two entries; invalidate


### PR DESCRIPTION
## Problem

The `[storage.sst_config.coarse_probe]` config surface added in #1234 —
`nprobe_multiplier`, `enable_read_probe`, `enable_write_train` — was **silently
dead**. Setting `nprobe_multiplier = 1.5` on merged develop had **no effect** on
recall or GETs, while the env `PROXIMADB_PAX_READ_COARSE_NPROBE=64` clearly did
(recall 0.9825→0.9845, GETs 68.8→102.5). The env lever worked; the TOML lever
did nothing — so per-deployment recall/GET tuning was unavailable.

## Two root causes

1. **The serving engine never receives the config.** Every production
   `SstEngine::new()` (`shared_services.rs`, `factory.rs`, `legacy.rs`,
   `engine.rs`) is constructed with `SstConfig::default()` (`coarse_probe =
   None`). The parsed `config.storage.sst_config.coarse_probe` is dropped; the
   engine always sees `CoarseProbeConfig::default()`.
2. **`OnceLock` first-wins + silent `set`.** `init_coarse_probe_settings` used
   `let _ = OnceLock.set(...)`. The first (default-config) engine seeded the
   default; the real config's `set()` then failed silently.

The *defaults* worked (why training/probe are on by default post-#1234) — only
CUSTOM values were unreachable.

## Fix

- `SHARED_COARSE_PROBE`: `OnceLock` → overwritable `RwLock<Option<..>>`. A real
  (`Some`) config **always wins**; a `None` init (default-config engine) only
  fills the default if nothing real was set. Order-independent, poison-safe
  (mandate #4, no unwrap/panic).
- **Authoritative seed** in `ProximaDB::start` from the loaded server config
  (`self._config.storage.sst_config.coarse_probe`), so the TOML is effective
  regardless of engine-construction order. Env vars still override at call time.
- `coarse_probe_settings()`/`geometric_nprobe` take `CoarseProbeSettings` by
  value (`Copy`).

## Test

`toml_coarse_probe_config_wins_over_default_init`: a real config survives a
later default init, and the multiplier reaches `geometric_nprobe`
(sqrt(64)×1.5 = 12 vs ×1.0 = 8). Green: fmt, clippy, work-commit-check,
td-adr-unique, release-server build.

TD: `docs/10-quality/td/TD-COMPACT-9-coarse-probe-toml-config-dead.adoc`