### PR TITLE
fix(catalog): identity slot missed the route relational DDL actually uses for UNIQUE

### DIFF
--- a/crates/control/proximadb-catalog/src/fc_metamodel.rs
+++ b/crates/control/proximadb-catalog/src/fc_metamodel.rs
@@ -475,6 +475,19 @@ pub fn identity_slot_from_table_schema(schema: &CatalogTableSchema) -> IdentityS
             );
         }
     }
+    // The route relational DDL actually uses: an inline `UNIQUE (...)` in
+    // CREATE TABLE is lowered to a `CatalogIndex` here, NOT into `schema.indexes`
+    // (`services/ddl/mod.rs` → `capabilities.unique_indexes`). Note these entries
+    // are unique by virtue of the field they sit in — `is_unique` is not
+    // necessarily set on them, so it must not be filtered on.
+    for idx in &schema.relational_capabilities.unique_indexes {
+        push_secondary(
+            &idx.columns,
+            format!("unique index '{}'", idx.name),
+            &mut facets,
+            &mut gaps,
+        );
+    }
     for constraint in &schema.relational_capabilities.constraints {
         if let ColumnConstraint::Unique { columns } = constraint {
             push_secondary(
@@ -1514,6 +1527,114 @@ mod tests {
             secondary_key_names(&identity_slot_from_table_schema(&schema)).len(),
             1
         );
+    }
+
+    #[test]
+    fn a_unique_declared_inline_in_create_table_is_fenced() {
+        // The dominant route: `CREATE TABLE t (..., UNIQUE (email))` is lowered
+        // into relational_capabilities.unique_indexes, not schema.indexes.
+        let schema = CatalogTableSchema::new("t")
+            .with_column(CatalogColumn::new(
+                0,
+                "id",
+                proximadb_data_model::ProximaType::Int64,
+            ))
+            .with_column(str_col(1, "email"))
+            .with_primary_key(vec!["id".to_string()])
+            .with_relational_capabilities(crate::RelationalCapabilities {
+                unique_indexes: vec![crate::CatalogIndex::new(
+                    "unique_email",
+                    vec!["email".to_string()],
+                    crate::CatalogIndexType::BTree,
+                )],
+                ..Default::default()
+            });
+
+        assert_eq!(
+            secondary_key_names(&identity_slot_from_table_schema(&schema)),
+            vec![vec!["email".to_string()]],
+            "an inline UNIQUE must produce a CKS-fenced facet"
+        );
+    }
+
+    #[test]
+    fn a_unique_index_entry_is_not_filtered_on_is_unique() {
+        // Entries in `unique_indexes` are unique by virtue of the field they sit
+        // in; `CatalogIndex::new` leaves `is_unique` false, and DDL does not set
+        // it. Filtering on the flag here would silently drop every DDL UNIQUE.
+        let idx = crate::CatalogIndex::new(
+            "unique_email",
+            vec!["email".to_string()],
+            crate::CatalogIndexType::BTree,
+        );
+        assert!(!idx.is_unique, "precondition: DDL leaves the flag unset");
+
+        let schema = CatalogTableSchema::new("t")
+            .with_column(CatalogColumn::new(
+                0,
+                "id",
+                proximadb_data_model::ProximaType::Int64,
+            ))
+            .with_column(str_col(1, "email"))
+            .with_primary_key(vec!["id".to_string()])
+            .with_relational_capabilities(crate::RelationalCapabilities {
+                unique_indexes: vec![idx],
+                ..Default::default()
+            });
+        assert_eq!(
+            secondary_key_names(&identity_slot_from_table_schema(&schema)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn the_metamodel_agrees_with_the_live_unique_key_discovery() {
+        // The live enforcement path (services/record_store.rs::schema_unique_column_sets)
+        // reads unique_indexes + constraints. The metamodel must not disagree,
+        // or F2's CKS and the identity slot would fence different key sets once
+        // D12-b wires the slot as the seam.
+        let schema = CatalogTableSchema::new("t")
+            .with_column(CatalogColumn::new(
+                0,
+                "id",
+                proximadb_data_model::ProximaType::Int64,
+            ))
+            .with_column(str_col(1, "email"))
+            .with_column(str_col(2, "tenant"))
+            .with_primary_key(vec!["id".to_string()])
+            .with_relational_capabilities(crate::RelationalCapabilities {
+                unique_indexes: vec![crate::CatalogIndex::new(
+                    "unique_email",
+                    vec!["email".to_string()],
+                    crate::CatalogIndexType::BTree,
+                )],
+                constraints: vec![ColumnConstraint::Unique {
+                    columns: vec!["tenant".to_string()],
+                }],
+                ..Default::default()
+            });
+
+        // Mirrors schema_unique_column_sets: unique_indexes ++ Unique constraints.
+        let mut live: Vec<Vec<String>> = schema
+            .relational_capabilities
+            .unique_indexes
+            .iter()
+            .map(|i| i.columns.clone())
+            .chain(
+                schema
+                    .relational_capabilities
+                    .constraints
+                    .iter()
+                    .filter_map(|c| match c {
+                        ColumnConstraint::Unique { columns } => Some(columns.clone()),
+                        _ => None,
+                    }),
+            )
+            .collect();
+        let mut derived = secondary_key_names(&identity_slot_from_table_schema(&schema));
+        live.sort();
+        derived.sort();
+        assert_eq!(derived, live, "metamodel and live enforcement disagree");
     }
 
     #[test]


### PR DESCRIPTION
Found by verifying the FC metamodel against the **live** enforcement path rather than
against the spec. #1256 added the `ColumnConstraint::Unique` route and I assumed that
closed the gap — it closed the smaller half.

## Three routes, two implementations, non-overlapping coverage

| Route | Live `schema_unique_column_sets` | Metamodel (before this PR) |
|---|---|---|
| `schema.indexes` (`is_unique`) | ❌ no | ✅ yes |
| `relational_capabilities.unique_indexes` | ✅ yes | ❌ **no** |
| `constraints → ColumnConstraint::Unique` | ✅ yes | ✅ yes (#1256) |

`unique_indexes` is **the route relational DDL actually uses**: an inline `UNIQUE (...)`
in `CREATE TABLE` is lowered to a `CatalogIndex` there (`services/ddl/mod.rs:1543`), never
into `schema.indexes`. So the dominant real-world UNIQUE produced **no identity facet at
all** — and the identity slot is how F2's ConditionalKeyStore is meant to learn which keys
to fence (TF-2 §2 D12-b).

## A subtlety that would have silently re-broken it

Entries in `unique_indexes` are unique **by virtue of the field they sit in**.
`CatalogIndex::new` leaves `is_unique` false and DDL never sets it — so filtering on the
flag (the obvious thing to write, and what the `schema.indexes` loop correctly does) would
drop every DDL UNIQUE. `a_unique_index_entry_is_not_filtered_on_is_unique` asserts that
precondition explicitly so the next person doesn't "tidy" it back in.

## Drift guard

`the_metamodel_agrees_with_the_live_unique_key_discovery` derives the key set the way the
live path does and requires the metamodel to match. The two cannot silently diverge again
before D12-b wires the slot as the seam.

## What I checked and am *not* claiming

I initially suspected a live bug — that a `CREATE UNIQUE INDEX` could land in
`schema.indexes` and escape enforcement. It cannot: `DdlStatement::CreateIndex` has no
`unique` field, so unique indexes are not representable through that path. **The live
enforcement path is correct for every route that can actually be populated today.** The
defect was in the metamodel only.

## Verification

38 tests pass. The 3 new ones were checked for teeth — with the route removed and the
tests kept, all 3 fail:

```
a_unique_declared_inline_in_create_table_is_fenced .............. FAILED
a_unique_index_entry_is_not_filtered_on_is_unique ............... FAILED
the_metamodel_agrees_with_the_live_unique_key_discovery ......... FAILED
```

clippy `-D warnings` clean, `make work-commit-check` passes. Still additive and inert
behind `fc-metamodel`.