### PR TITLE
docs(td): TD-CAT-6 — schema interrogation belongs to the crate that owns the schema

### DIFF
--- a/docs/10-quality/td/TD-CAT-6-schema-interrogation-seam.adoc
+++ b/docs/10-quality/td/TD-CAT-6-schema-interrogation-seam.adoc
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-CAT-6: Schema interrogation belongs to the crate that owns the schema
+:status: Proposed
+:date: 2026-07-27
+:authors: foundation session 2026-07-27
+:realizes: ADR-072 (F2 uniqueness), ADR-039 / SOLID standards §17(a)
+:found-by: verifying the FC metamodel against the live enforcement path (PRs #1256, #1261)
+
+[cols="1,3"]
+|===
+| Status | Proposed — slice 1 is in-lane and small; slice 2 needs the `services` owner
+| Problem | "Which column sets does this table declare UNIQUE?" is answered by **two independent implementations** that covered different, non-overlapping route subsets and silently disagreed for months.
+| Thesis | The duplication is **structurally forced**, not careless. Move the answer down to the crate that owns the type, and the duplication becomes unrepresentable.
+|===
+
+== 1. The observed defect
+
+Two implementations answered the same question, from different fields:
+
+[cols="2,1,1"]
+|===
+| Route a `UNIQUE` arrives by | `services::record_store::schema_unique_column_sets` | `catalog::fc_metamodel::identity_slot_from_table_schema`
+
+| `schema.indexes` (`is_unique`)                     | ✗ | ✓
+| `relational_capabilities.unique_indexes`           | ✓ | ✗ (until #1261)
+| `constraints` → `ColumnConstraint::Unique`         | ✗ (until TD-110 C) → ✓ | ✗ (until #1256) → ✓
+|===
+
+Neither covered all three. The metamodel missed
+`relational_capabilities.unique_indexes` — **the route relational DDL actually
+uses** (`services/ddl/mod.rs` lowers an inline `UNIQUE (...)` to a `CatalogIndex`
+there, never into `schema.indexes`). Since TF-2 §2 D12-b makes the identity slot
+the seam by which F2's ConditionalKeyStore learns which keys to fence, the
+dominant real-world UNIQUE derived no facet at all.
+
+NOTE: No *live* uniqueness was unenforced. `DdlStatement::CreateIndex` carries no
+`unique` field, so unique indexes cannot be created through the path
+`schema_unique_column_sets` ignores. The live path is correct for every route
+that can be populated today; the defect was in the metamodel. This TD is about
+why the pair was allowed to diverge, not about a production escape.
+
+== 2. Why it was structurally forced
+
+This is the part worth keeping. The canonical answer lives in the **root** crate
+(`src/services/record_store.rs`), which sits *above* `proximadb-catalog` in the
+layering. `check_workspace_boundaries.py` forbids `control → root`. So the
+catalog crate **cannot** call `schema_unique_column_sets` — not by choice, by
+compile-time policy.
+
+Therefore *every* consumer below the root crate must re-derive the answer. The
+proliferation is the predicted consequence of putting knowledge about a type
+above the type that owns it. A census over `src/` + `crates/` finds **14 files**
+interrogating `CatalogTableSchema` for key/uniqueness facts.
+
+The instinct was already right once and applied one level too low: TD-110 Slice C
+introduced `schema_unique_column_sets` precisely so `DmlService` and
+`DirectWalTableRecordStore` "agree on exactly which sets are enforced". That is
+the same fix as this one, at the wrong altitude — it unified two callers *within*
+the root crate while leaving every lower layer to guess.
+
+== 3. The boundary
+
+**The crate that owns `CatalogTableSchema` owns the answers to questions about
+it.** `crates/control/proximadb-catalog/src/schema.rs` already exists for exactly
+this and states its own contract: "All types used here are defined in this crate
+so this module can be consumed without depending on the root `proximadb` crate."
+
+Consolidating there inverts the dependency the right way: the answer sits at or
+below every consumer, so *reuse becomes possible* and re-derivation stops being
+the only option. This is SOLID-standards §17(a) — depend on stable crate paths,
+not on knowledge re-created per layer.
+
+[source]
+----
+// proximadb-catalog::schema — single source of truth
+pub fn unique_column_sets(schema: &CatalogTableSchema) -> Vec<Vec<String>>
+pub fn same_column_set(a: &[String], b: &[String]) -> bool
+----
+
+`unique_column_sets` returns the **declared** sets across all three routes,
+deduplicated order-insensitively (`UNIQUE(a,b)` and `UNIQUE(b,a)` fence one
+tuple). It deliberately does *not* apply a primary-key policy: the identity slot
+excludes a UNIQUE restating the PK (it is not a *secondary*), while the write
+path does not need to. Each consumer keeps its own policy; only the *discovery*
+is shared — which is precisely where they diverged.
+
+== 4. Slices
+
+[cols="1,3,1"]
+|===
+| # | Content | Lane
+
+| **1**
+| Add `unique_column_sets` + `same_column_set` to `proximadb-catalog::schema`; make `fc_metamodel`'s derivation consume them instead of walking the three routes itself. Behaviour-preserving; the #1261 tests (including the metamodel↔live agreement test) are the guard.
+| catalog — in-lane, do now
+
+| **2**
+| `services::record_store::schema_unique_column_sets` becomes a one-line delegate to the catalog function (or is deleted and its two callers use the catalog path directly). Behaviour-preserving.
+| `services` owner — small and reviewable, but not a quiet edit from another lane
+
+| **3**
+| Census the other 12 files for the same shape (notably `schema_primary_key_column`'s "explicit, else conventional `id`/`record_id`" rule, which is a second re-derived policy) and pull each answer down to the catalog crate as it is touched. Opportunistic, not a big-bang migration.
+| mixed
+|===
+
+== 5. Gate
+
+Slice 1 lands with the agreement test from #1261 still green — that test derives
+the key set the way the live path does and requires the metamodel to match, so it
+fails if the two ever diverge again. After slice 2 the test becomes tautological
+by construction, which is the point: **the invariant stops needing a test because
+it stops being expressible.**
+
+Until slice 2, the agreement test is the only thing holding the two
+implementations together, and it should not be deleted.


### PR DESCRIPTION
Filed after #1256/#1261, because the interesting part isn't the bug — it's why the pair
was allowed to diverge at all.

## The duplication is structurally forced, not careless

"Which column sets does this table declare UNIQUE?" has two independent
implementations reading **different fields**:

| Route a `UNIQUE` arrives by | `record_store::schema_unique_column_sets` | `fc_metamodel::identity_slot_…` |
|---|---|---|
| `schema.indexes` (`is_unique`) | ✗ | ✓ |
| `relational_capabilities.unique_indexes` | ✓ | ✗ *(until #1261)* |
| `constraints → ColumnConstraint::Unique` | ✓ | ✗ *(until #1256)* |

Neither covered all three. But the root cause is structural: the canonical answer lives
in the **root** crate, which sits *above* `proximadb-catalog`, and
`check_workspace_boundaries.py` forbids `control → root`. **The catalog crate cannot call
it** — not by choice, by compile-time policy.

So every consumer below the root crate *must* re-derive. A census finds **14 files**
interrogating `CatalogTableSchema` for key/uniqueness facts. The proliferation is the
predicted consequence of putting knowledge about a type above the type that owns it.

The instinct was already right once, one level too low: **TD-110 Slice C** added
`schema_unique_column_sets` precisely so `DmlService` and `DirectWalTableRecordStore`
would "agree on exactly which sets are enforced" — the same fix, at an altitude that
unified two callers *inside* the root crate while leaving every lower layer to guess.

## The boundary

`crates/control/proximadb-catalog/src/schema.rs` already exists for this and documents its
own contract: *"All types used here are defined in this crate so this module can be
consumed without depending on the root `proximadb` crate."*

Moving discovery there inverts the dependency correctly — the answer sits at or below
every consumer, so reuse becomes *possible* and re-derivation stops being the only option.

**It shares discovery, not policy.** The identity slot excludes a UNIQUE restating the PK
(it isn't a *secondary*); the write path doesn't care. Policy stays per-consumer — and
policy was never where they diverged.

## Slices

1. **catalog, in-lane** — add `unique_column_sets` + `same_column_set`; `fc_metamodel`
   consumes them instead of walking three routes itself.
2. **`services` owner** — `schema_unique_column_sets` becomes a one-line delegate.
   Behaviour-preserving, small, but not a quiet edit from another lane.
3. **opportunistic** — the other 12 files, notably `schema_primary_key_column`'s
   "explicit, else conventional `id`/`record_id`", which is a second re-derived policy.

## What this is *not* claiming

No live uniqueness was unenforced. `DdlStatement::CreateIndex` has no `unique` field, so
the route the live path ignores cannot be populated. The live path is correct for
everything reachable today; the defect was in the metamodel.

## Gate

The #1261 agreement test — which derives the key set the way the live path does and
requires the metamodel to match — is the only thing holding the two together until slice 2.
After slice 2 it becomes tautological by construction, which is the point: **the invariant
stops needing a test because it stops being expressible.**