### PR TITLE
feat(search): route AXIS filtered-ANN through CompiledGlobalFilter (F7 WI-1b)

### DIFF
--- a/src/core/search/mod.rs
+++ b/src/core/search/mod.rs
@@ -7,8 +7,8 @@
 // path resolves unchanged. The non-extractable orchestration types
 // (`UnifiedSearchParams`, the search engines) remain in this module.
 pub use proximadb_search_types::{
-    block_prune::BlockPruneMode, bounded_queue, json_comparison, json_value_serde, results,
-    sql_value_filter,
+    block_prune::BlockPruneMode, bounded_queue, compiled_filter::CompiledGlobalFilter,
+    json_comparison, json_value_serde, results, sql_value_filter,
 };
 
 pub mod cross_modal_fusion;

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -1919,27 +1919,17 @@ impl AxisManager {
             Arc::new(HashMap::new())
         };
 
-        let predicate_id_filters = query.id_filters.clone();
+        // F7 / TD-HYBRID-1 D2: one compiled predicate (id filters + metadata
+        // expression) shared by the traversal closure below and the residual
+        // re-filter further down, replacing three hand-rolled copies.
+        let compiled_filter = crate::core::search::CompiledGlobalFilter::new(
+            query.id_filters.clone(),
+            metadata_expression.clone(),
+        );
         let predicate_metadata = Arc::clone(&metadata_by_id);
-        let predicate_expression = metadata_expression.clone();
-        let predicate = move |id: &str| -> bool {
-            if !predicate_id_filters.is_empty()
-                && !predicate_id_filters
-                    .iter()
-                    .any(|filter_id| filter_id.as_str() == id)
-            {
-                return false;
-            }
-
-            let Some(expr) = &predicate_expression else {
-                return true;
-            };
-            let Some(metadata) = predicate_metadata.get(id) else {
-                return false;
-            };
-
-            crate::core::search::json_comparison::evaluate_filter(expr, metadata)
-        };
+        let predicate_filter = compiled_filter.clone();
+        let predicate =
+            move |id: &str| -> bool { predicate_filter.matches(id, predicate_metadata.get(id)) };
 
         // TD-064 / ADR-011 §4.3: oversample to absorb post-filter recall loss.
         // PostFilter uses the catalog policy's effective_top_k_for_post_filter
@@ -1980,20 +1970,7 @@ impl AxisManager {
         let metric = index.distance_metric();
         let results: Vec<ScoredResult> = raw
             .into_iter()
-            .filter(|(id, _)| {
-                if !query.id_filters.is_empty() && !query.id_filters.contains(id) {
-                    return false;
-                }
-
-                let Some(expr) = &metadata_expression else {
-                    return true;
-                };
-                let Some(metadata) = metadata_by_id.get(id) else {
-                    return false;
-                };
-
-                crate::core::search::json_comparison::evaluate_filter(expr, metadata)
-            })
+            .filter(|(id, _)| compiled_filter.matches(id, metadata_by_id.get(id)))
             .take(query.top_k)
             .map(|(id, raw_distance)| {
                 let raw_for_similarity = if metric.is_similarity() {
@@ -4384,18 +4361,18 @@ impl AxisManager {
         } else {
             Some(self.metadata_filters_to_expression(&query.metadata_filters))
         };
+        // F7 / TD-HYBRID-1 D2: same compiled predicate as the Inline path — the
+        // exact branch applies it to every record, id filter then metadata.
+        let compiled_filter = crate::core::search::CompiledGlobalFilter::new(
+            query.id_filters.clone(),
+            metadata_expression,
+        );
 
         let mut results = Vec::new();
 
         for record in records {
-            if !query.id_filters.is_empty() && !query.id_filters.contains(&record.oid) {
-                continue;
-            }
-
             let metadata = self.record_filter_metadata(&record);
-            if let Some(expr) = &metadata_expression
-                && !crate::core::search::json_comparison::evaluate_filter(expr, &metadata)
-            {
+            if !compiled_filter.matches(&record.oid, Some(&metadata)) {
                 continue;
             }
 


### PR DESCRIPTION
Second slice of **F7 / TD-HYBRID-1** (D2), stacked on #1260 (now merged).

## What
Rewires the three hand-rolled id-filter + metadata-expression predicates in `AxisManager` to the shared `CompiledGlobalFilter` introduced in #1260:
- the Inline HNSW traversal closure (`query_hnsw_with_predicate`, `manager.rs:~1922`),
- its post-search residual re-filter,
- the exact PreFilter branch (`execute_exact_filtered_query`, `manager.rs:~4382`).

## Why it's safe
Pure, behaviour-preserving refactor. All three sites already built the same `FilterExpression` via `metadata_filters_to_expression` and evaluated it via `json_comparison::evaluate_filter` — this just collapses the duplicated glue into one object + one `matches()`, removing the divergence risk the red-team flagged. `similarity_threshold`/expiry stay PreFilter-local (unchanged).

## Verification (local)
- 6 `CompiledGlobalFilter` unit tests (from #1260)
- 2 direct parity tests: `test_predicate_search_all_pass_matches_unfiltered`, `test_bloom_filter_prefiltering`
- 364 axis lib tests — all green
- `cargo clippy -p proximadb --lib` clean (10m29s, no new warnings)

Next: PR-3 threads the policy+selectivity onto the canonical path and single-brains the mode (WI-2/WI-3).