### PR TITLE
fix(compaction): global precision resolver + factory persistent runtime (ADR-076 follow-ups)

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -390,16 +390,17 @@ impl ProximaDB {
                         resolver_cache,
                     ),
                 );
-                if storage_engine
-                    .compaction_manager()
-                    .set_precision_resolver(resolver.clone())
-                    .is_ok()
-                {
-                    tracing::info!(
-                        "✅ Compaction wired with CanonicalPrecisionResolver — \
-                         fp16 collections will preserve precision through compaction"
-                    );
-                }
+                // TD-PRECISE-GLOBAL: arm the process-global resolver so EVERY
+                // Compaction stamps precision_hint — including the per-collection
+                // SstEngines the boot path can't individually wire. The former
+                // `storage_engine.compaction_manager().set_precision_resolver(..)`
+                // targeted the StorageEngine's idle instance, so fp16/bf16/int8
+                // collections silently degraded to fp32 at compaction.
+                crate::storage::engines::sst::set_global_precision_resolver(resolver.clone());
+                tracing::info!(
+                    "✅ Global compaction precision resolver armed — fp16/bf16/int8 \
+                     collections preserve precision through compaction"
+                );
                 // Also wire the resolver into the REST/gRPC vector
                 // batch path so direct inserts coerce to the
                 // collection's canonical precision (matches what the

--- a/src/storage/engines/factory.rs
+++ b/src/storage/engines/factory.rs
@@ -397,6 +397,32 @@ impl StorageEngineFactory {
         ))
     }
 
+    /// Run an async engine constructor on a fresh multi-thread tokio runtime,
+    /// returning its output — WITHOUT dropping the runtime.
+    ///
+    /// The engine constructors (`SstEngine::new`, `ViperEngine::new`, …) spawn
+    /// background workers (compaction, etc.) on the runtime they're called from.
+    /// A plain `let rt = Runtime::new()?; rt.block_on(..)` would drop `rt` on
+    /// return, and `Runtime::drop` shuts the runtime down + aborts those workers
+    /// — they'd silently never run (the compaction-queue hang). `mem::forget`
+    /// skips `Drop`, so the runtime (and its workers) live for the process —
+    /// matching the lifecycle of the engine it bootstraps. The sync factory
+    /// exists only for non-server contexts; the server boots engines on its own
+    /// live runtime via the `_async` variants.
+    fn block_on_with_persistent_runtime<T, F>(fut: F) -> Result<T>
+    where
+        F: std::future::Future<Output = Result<T>>,
+    {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()?;
+        let out = runtime.block_on(fut);
+        // Intentionally leak: keep the runtime (and any workers the engine
+        // constructor spawned on it) alive for the process lifetime.
+        std::mem::forget(runtime);
+        out
+    }
+
     /// Async version for use within async contexts (e.g., tests)
     pub async fn create_tst_async() -> Result<Arc<dyn UnifiedStorageFormat>> {
         Self::create_tst()
@@ -431,8 +457,7 @@ impl StorageEngineFactory {
     /// In production, prefer async factory methods.
     pub fn create_viper() -> Result<Arc<dyn UnifiedStorageFormat>> {
         info!("Creating VIPER storage engine");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(async { ViperEngine::new().await })?;
+        let engine = Self::block_on_with_persistent_runtime(async { ViperEngine::new().await })?;
         let engine: Arc<dyn UnifiedStorageFormat> = Arc::new(engine);
         register_engine_capabilities(&engine);
         Ok(engine)
@@ -460,8 +485,7 @@ impl StorageEngineFactory {
     /// general-purpose nature and production stability.
     pub fn create_sst() -> Result<Arc<dyn UnifiedStorageFormat>> {
         info!("Creating SST storage engine");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(async { SstEngine::new().await })?;
+        let engine = Self::block_on_with_persistent_runtime(async { SstEngine::new().await })?;
         let engine: Arc<dyn UnifiedStorageFormat> = Arc::new(engine);
         register_engine_capabilities(&engine);
         Ok(engine)
@@ -494,8 +518,7 @@ impl StorageEngineFactory {
     pub fn create_swift() -> Result<Arc<dyn UnifiedStorageFormat>> {
         warn!("SWIFT engine is experimental and not production-ready");
         info!("Creating SWIFT (Storage With Instant Fast Traversal) storage engine");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(async { SwiftEngine::new().await })?;
+        let engine = Self::block_on_with_persistent_runtime(async { SwiftEngine::new().await })?;
         Ok(Arc::new(engine))
     }
 
@@ -524,8 +547,7 @@ impl StorageEngineFactory {
     /// while preserving 95%+ of variance.
     pub fn create_helix() -> Result<Arc<dyn UnifiedStorageFormat>> {
         info!("Creating HELIX storage engine");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(async {
+        let engine = Self::block_on_with_persistent_runtime(async {
             use crate::storage::engines::helix::HelixEngine;
             HelixEngine::new().await
         })?;
@@ -553,8 +575,7 @@ impl StorageEngineFactory {
     /// and statistics for superior analytics performance.
     pub fn create_nova() -> Result<Arc<dyn UnifiedStorageFormat>> {
         info!("Creating NOVA (Next-gen Optimized Vector Analytics) storage engine");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(NovaEngine::new())?;
+        let engine = Self::block_on_with_persistent_runtime(NovaEngine::new())?;
         let engine: Arc<dyn UnifiedStorageFormat> = Arc::new(engine);
         register_engine_capabilities(&engine);
         Ok(engine)
@@ -587,8 +608,7 @@ impl StorageEngineFactory {
     #[allow(deprecated)]
     pub fn create_raptor() -> Result<Arc<dyn UnifiedStorageFormat>> {
         warn!("RAPTOR engine is experimental and not production-ready");
-        let runtime = tokio::runtime::Runtime::new()?;
-        let engine = runtime.block_on(async { RaptorEngine::new().await })?;
+        let engine = Self::block_on_with_persistent_runtime(async { RaptorEngine::new().await })?;
         Ok(Arc::new(engine))
     }
 
@@ -987,9 +1007,38 @@ impl StorageEngineFactory {
 mod tests {
     use super::*;
 
-    // -----------------------------------------------------------------------
-    // Engine creation tests via async factory methods
-    // -----------------------------------------------------------------------
+    /// TD-FACTORY-RUNTIME: the sync `create_*` factory methods must not drop the
+    /// temp tokio runtime while engine constructors have background workers
+    /// (compaction, etc.) spawned on it. Previously `let rt = Runtime::new()?;
+    /// rt.block_on(..)` dropped `rt` on return → `Runtime::drop` aborted those
+    /// workers (they'd silently never run — the compaction-queue hang). The fix
+    /// (`block_on_with_persistent_runtime`, which `mem::forget`s the runtime) is
+    /// asserted here by spawning a task that completes AFTER `block_on` returns;
+    /// it can only have run if the runtime survived.
+    #[test]
+    fn block_on_with_persistent_runtime_keeps_spawned_workers_alive() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Duration;
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let f = flag.clone();
+        let _: Result<()> = StorageFormatFactory::block_on_with_persistent_runtime(async move {
+            // Spawn a worker that completes AFTER block_on returns.
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+                f.store(true, Ordering::SeqCst);
+            });
+            Ok(())
+        });
+        // Give the spawned worker time to fire on the (leaked) runtime.
+        std::thread::sleep(Duration::from_millis(150));
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "the temp runtime must survive block_on so background workers spawned by \
+             engine constructors actually run (otherwise compaction workers are aborted)"
+        );
+    }
 
     #[tokio::test]
     async fn test_create_sst_engine() {

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -62,6 +62,35 @@ use tracing::{debug, error, info, warn};
 /// Backwards-compat alias for [`SstCompactionTask`].
 pub type CompactionTask = SstCompactionTask;
 
+/// TD-PRECISE-GLOBAL: process-global `CanonicalPrecisionResolver`, set ONCE at
+/// boot (database.rs) and consulted by EVERY `Compaction` as the fallback when
+/// its per-instance resolver is unset. This closes the "wrong instance" wiring
+/// defect: the SST engine creates a fresh `Compaction` per collection (each with
+/// its own empty resolver), and the boot-time `storage_engine
+/// .compaction_manager().set_precision_resolver(..)` targeted the StorageEngine's
+/// idle instance — so fp16/bf16/int8 collections silently degraded to fp32 at
+/// compaction. A global (same pattern as `GLOBAL_SST_AXIS_MANAGER` /
+/// `GLOBAL_WARM_TIER_CACHES` in core.rs) reaches every per-collection Compaction
+/// without per-instance wiring. Per-instance wiring (`set_precision_resolver` /
+/// `with_precision_resolver`) still takes precedence for tests/overrides.
+static GLOBAL_PRECISION_RESOLVER: std::sync::OnceLock<
+    Arc<proximadb_catalog::canonical_precision::CanonicalPrecisionResolver>,
+> = std::sync::OnceLock::new();
+
+/// Set the process-global precision resolver (first writer wins; idempotent
+/// thereafter — mirrors the OnceLock registry pattern). Called once at boot.
+pub fn set_global_precision_resolver(
+    resolver: Arc<proximadb_catalog::canonical_precision::CanonicalPrecisionResolver>,
+) {
+    let _ = GLOBAL_PRECISION_RESOLVER.set(resolver);
+}
+
+/// The process-global precision resolver, if boot armed one.
+pub fn get_global_precision_resolver()
+-> Option<&'static Arc<proximadb_catalog::canonical_precision::CanonicalPrecisionResolver>> {
+    GLOBAL_PRECISION_RESOLVER.get()
+}
+
 /// Stage-boundary process-RSS checkpoints for the unified compaction pipeline
 /// (memory-holder triage: the PAX writer's own peak buffer is ~65 MB while the
 /// process grows by tens of GB at N=120k, so the holder is an intermediate
@@ -658,6 +687,43 @@ impl Compaction {
         Ok(true)
     }
 
+    /// Resolve the canonical embedding precision for a collection, to stamp on
+    /// a produced `SstCompactionTask.precision_hint`. Consults the per-instance
+    /// resolver first (test/override), then falls back to the process-global
+    /// resolver (TD-PRECISE-GLOBAL: set once at boot, reaches every
+    /// per-collection `Compaction` that the boot path can't individually wire).
+    /// Returns `None` when no resolver is armed (records keep fp32) or the
+    /// resolver errors (best-effort — a precision failure must never break
+    /// compaction).
+    pub async fn resolve_precision_hint(
+        &self,
+        collection_id: &str,
+    ) -> Option<proximadb_records::EmbeddingScalarType> {
+        // Per-instance resolver first (test/override), then the process-global
+        // fallback (TD-PRECISE-GLOBAL). Clone the Arc out so no borrow from
+        // `self` is held across the `.await` below.
+        let resolver: Arc<proximadb_catalog::canonical_precision::CanonicalPrecisionResolver> =
+            if let Some(r) = self.precision_resolver.get() {
+                Arc::clone(r)
+            } else if let Some(g) = get_global_precision_resolver() {
+                Arc::clone(g)
+            } else {
+                return None;
+            };
+        let table_id = Self::collection_to_table_identifier(collection_id);
+        match resolver.resolve(&table_id).await {
+            Ok(precision) => Some(precision),
+            Err(e) => {
+                warn!(
+                    collection = %collection_id,
+                    error = %e,
+                    "compaction: precision resolver failed; falling back to fp32"
+                );
+                None
+            }
+        }
+    }
+
     /// Check if compaction is needed for the given collection and level.
     ///
     /// `l0_threshold_override` (TD-WLP-7 / TD-WLP-2): when `Some`, the L0
@@ -747,23 +813,7 @@ impl Compaction {
                 CompactionPriority::Medium
             };
 
-            let precision_hint = match self.precision_resolver.get() {
-                None => None,
-                Some(resolver) => {
-                    let table_id = Self::collection_to_table_identifier(collection_id);
-                    match resolver.resolve(&table_id).await {
-                        Ok(precision) => Some(precision),
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_id,
-                                error = %e,
-                                "compaction: precision resolver failed; falling back to fp32"
-                            );
-                            None
-                        }
-                    }
-                }
-            };
+            let precision_hint = self.resolve_precision_hint(collection_id).await;
 
             return Ok(Some(SstCompactionTask {
                 level: task.level as u8,

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -381,6 +381,68 @@ async fn check_compaction_needed_stamps_precision_hint_from_resolver() {
     drop(manager);
 }
 
+/// TD-PRECISE-GLOBAL: the precision resolver must reach a `Compaction` that was
+/// NEVER per-instance-wired. This is the production case — the SST engine mints
+/// a fresh `Compaction` per collection (each with its own empty resolver), and
+/// the boot-time wiring used to target the StorageEngine's idle instance, so
+/// fp16/bf16/int8 collections silently degraded to fp32 at compaction. The fix:
+/// a process-global resolver (set once at boot) consulted as the fallback.
+///
+/// Asserts `resolve_precision_hint` returns `Some(Fp16)` for a Compaction with
+/// NO per-instance resolver, after the global is armed — proving the global
+/// fallback reaches unwired instances. (nextest runs each test in its own
+/// process, so the set-once global is fresh here.)
+#[tokio::test]
+async fn td_global_precision_resolver_stamps_hint_without_per_instance_wiring() {
+    use crate::storage::engines::sst::compaction::set_global_precision_resolver;
+    use proximadb_catalog::cache::CatalogCache;
+    use proximadb_catalog::canonical_precision::CanonicalPrecisionResolver;
+    use proximadb_catalog::oltp::{OltpCatalog, OltpCatalogConfig};
+    use proximadb_catalog::{Catalog, CatalogTableSchema, TableIdentifier};
+    use std::collections::HashMap as StdHashMap;
+    use std::sync::Arc;
+
+    let cache = Arc::new(CatalogCache::new(1000, 60));
+    let cat: Arc<OltpCatalog> = Arc::new(
+        OltpCatalog::new(
+            "compaction-test-global",
+            OltpCatalogConfig::sqlite("sqlite::memory:"),
+            cache.clone(),
+        )
+        .await
+        .unwrap(),
+    );
+    cat.create_namespace(&["default".to_string()], StdHashMap::new())
+        .await
+        .unwrap();
+    let table_id = TableIdentifier::new(vec!["default".to_string()], "fp16_global_coll");
+    let mut schema = CatalogTableSchema {
+        name: "fp16_global_coll".to_string(),
+        ..Default::default()
+    };
+    schema.canonical_embedding_precision = proximadb_records::EmbeddingScalarType::Fp16;
+    cat.create_table(&table_id, schema).await.unwrap();
+    let resolver = Arc::new(CanonicalPrecisionResolver::new(
+        cat.clone() as Arc<dyn Catalog>,
+        cache,
+    ));
+
+    // Arm the GLOBAL resolver (mirrors database.rs boot wiring). Idempotent.
+    set_global_precision_resolver(resolver);
+
+    // A Compaction with NO per-instance resolver — the production case for a
+    // per-collection SstEngine that the boot path never individually wires.
+    let manager = Compaction::new(SstConfig::default()).await.unwrap();
+
+    let hint = manager.resolve_precision_hint("fp16_global_coll").await;
+    assert_eq!(
+        hint,
+        Some(proximadb_records::EmbeddingScalarType::Fp16),
+        "the global precision resolver must stamp precision_hint on a Compaction \
+         that was never per-instance-wired (the per-collection-SstEngine case)"
+    );
+}
+
 /// INT-3-followup-d wiring: with `CompactionTask.precision_hint =
 /// Some(Fp16)`, the rewritten block recovers fp16 bit-exact from
 /// the fp32-flattened VectorRecord intermediate. Exercises the

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -268,7 +268,9 @@ pub mod warming; // ADR-065 Q3: ranged RAM cache for survivor/OID byte ranges //
 pub use bloom_filter::{
     BloomFilterStats, HierarchicalBloomConfig, SerializedSstableBloomFilter, SstableBloomFilter,
 };
-pub use compaction::{Compaction, CompactionPriority, CompactionStats, CompactionTask};
+pub use compaction::{
+    Compaction, CompactionPriority, CompactionStats, CompactionTask, set_global_precision_resolver,
+};
 pub use compactor_impl::{CompactionSortStrategy, SstCompactor, ZeroCopyCompactionStats};
 pub use readers::UnifiedSstableReader;
 


### PR DESCRIPTION
Two follow-ups to the async-compaction work (#1253, TD-COMPACT-6/7), each **TDD'd** (failing test → fix → green). Independent of #1253 — different `compaction.rs` regions (precision-resolver vs worker-loop), rebases cleanly either merge order.

## 1. Global precision resolver — fp16/bf16/int8 preservation through compaction

**Bug:** the boot wiring set the `CanonicalPrecisionResolver` on the StorageEngine's **idle** Compaction (`storage_engine.compaction_manager()`), but the SST engine mints a fresh `Compaction` per collection (each with its own empty resolver) — the one that actually compacts. So `task.precision_hint` was always `None` and **fp16/bf16/int8 collections silently degraded to fp32 at compaction**.

**Fix:** a process-global resolver (OnceLock — same pattern as `GLOBAL_SST_AXIS_MANAGER` / `GLOBAL_WARM_TIER_CACHES`), armed once at boot, consulted as the **fallback** by every Compaction. Reaches all per-collection instances without per-instance wiring; per-instance wiring still takes precedence for tests/overrides. `database.rs` arms the global (not the idle instance).

**Test:** `td_global_precision_resolver_stamps_hint_without_per_instance_wiring` — a `Compaction` with NO per-instance resolver returns `Some(Fp16)` after the global is armed.

## 2. Factory sync `create_*` — keep the temp runtime alive

**Bug:** `create_sst`/`create_viper`/`create_swift`/`create_helix`/`create_nova`/`create_raptor` each did `let rt = Runtime::new()?; rt.block_on(XEngine::new())` and **dropped `rt`** on return. Engine constructors spawn background workers (compaction) on that runtime; `Runtime::drop` shuts it down + aborts them — they'd silently never run. (Not production-reachable — the server boots engines on its own live runtime via the `_async` variants — but a latent hang for any sync-factory user.)

**Fix:** extracted `block_on_with_persistent_runtime` (`mem::forget`s the runtime so its `Drop` doesn't abort workers; lives for the process, matching the engine). All six sync `create_*` now use it.

**Test:** `block_on_with_persistent_runtime_keeps_spawned_workers_alive` — a task spawned inside completes AFTER `block_on` returns, proving the runtime survived.

## Verification
- Both new tests pass; 70 compaction + 46 factory lib tests pass (no regressions).
- `clippy --lib --bins -D warnings` clean; `make work-commit-check` clean.