### PR TITLE
docs(td): record verified F-track scope — TD-WAL-2 V1 done, TD-HYBRID-1 rev 4

### DIFF
--- a/docs/10-quality/td/TD-HYBRID-1-cost-based-hybrid-filter-planner.adoc
+++ b/docs/10-quality/td/TD-HYBRID-1-cost-based-hybrid-filter-planner.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-HYBRID-1: Cost-based hybrid ANN+filter planner + woven RLS/ABAC filter — F7
-:status: Draft — hardened after a 2-agent red-team (2026-07-27); §2/§3 reframed, §8 supersedes the naïve tenancy design
+:status: Draft — mechanism (D2) built + merged (#1260, #1264); rev-4 §9 records the verified scope (WI-2 already done, per-collection policy deferred to TD-073). Hardened after a 2-agent red-team (2026-07-27); §2/§3 reframed, §8 supersedes the naïve tenancy design
 :date: 2026-07-27
 :authors: co-design session 2026-07-27
 :realizes: ADR-072 D15 (hybrid ANN+filter is a cost-based planner decision; RLS/ABAC rides the same always-ANDed global filter)
@@ -151,3 +151,40 @@ Two adversarial agents attacked the draft against the code; a third verification
 5. **Added the single-brain + `unwrap_or(1.0)` fix (D1)** from the two-brain finding.
 
 **Re-scope:** the *planner* mechanism is **smaller than the 2w estimate** (much is extraction + wiring). The isolation concerns (§4) turned out to be **hardening, not a live vuln**. TD stays **Draft** until D3's RLS-reuse-vs-delete call is made with FA; there is no longer a blocking security item.
+
+== 9. Build outcome + verified scope (rev 4, 2026-07-28)
+
+D2 (the mechanism) was built and shipped as two PRs:
+
+* **#1260 (WI-1a) — `CompiledGlobalFilter`** in `proximadb-search-types::compiled_filter`: the single
+  id + metadata predicate, co-located with `evaluate_filter` (foundation leaf — no layering inversion,
+  no operator-enum duplication). 6 parity unit tests. **Merged.**
+* **#1264 (WI-1b) — rewire** the three `AxisManager` sites (Inline closure, residual re-filter, exact
+  PreFilter) through it. Behaviour-preserving; verified by the 6 unit tests + the 2 direct parity tests
+  (`test_predicate_search_all_pass_matches_unfiltered`, `test_bloom_filter_prefiltering`) + 364 axis
+  lib tests.
+
+**WI-2/WI-3 verification changed the remaining scope (this is the load-bearing rev-4 finding):**
+
+* **WI-2 ("thread policy + selectivity") is ALREADY DONE.** The canonical path builds the query via
+  `build_axis_hybrid_query_with_policy` (`services/operations/vectors/hybrid/axis_builder.rs`, called at
+  `legacy.rs:3599`), which threads `estimated_selectivity` + `ann_filtering_mode` + a policy into AXIS;
+  the policy-driven Pre/Inline/Post branches (`manager.rs:1448/1459/1474`) are reachable. The recon's
+  "`contract.rs:113` drops the fields via `..default()`" was the **storage-DTO boundary**, not the
+  service path — a conflation.
+* **The real gap is a DORMANT feature, not missing wiring.** The per-collection `AnnFilteringPolicy`
+  (`CollectionRecord.ann_filtering_policy`, catalog `lib.rs:674`; builder `with_ann_filtering_policy`
+  `:940`) is **settable nowhere and read nowhere** — `legacy.rs:3610` hardcodes
+  `AnnFilteringPolicy::default()`, and the builder has zero callers. Activating it (proto/config surface
+  to *set* a policy + read-side resolution) is a **multi-layer feature = TD-073**, deferred. Wiring only
+  the read side would be inert (every collection has the default).
+* **WI-3 (two-brain) is live but deterministic.** `UnifiedQueryOptimizer` runs on the vector path
+  (`legacy.rs:2580` et al.) and computes `plan.ann_filtering_mode`, but for filtered queries the catalog
+  policy's `routing_mode` at `manager.rs:1421` **always overrides** it (a policy is always present via the
+  hardcoded default). Per D15 the catalog policy is authoritative, so this is correct-by-design — the
+  optimizer's mode is advisory/EXPLAIN for filtered ANN. No live bug; a clarity/dead-value cleanup at most.
+
+**Decision (2026-07-28):** F7's shippable code = the D2 unification (#1260 + #1264). The per-collection
+policy activation is folded into **TD-073** (dormant-feature, multi-layer). WI-4 (the `access_predicate`
+FA seam) and WI-5 (EXPLAIN trace) remain available but are additive/speculative until FA unblocks. TD
+stays **Draft**; no further F7 code is queued pending a TD-073 or FA decision.

--- a/docs/10-quality/td/TD-WAL-2-multimodal-wal-convergence.adoc
+++ b/docs/10-quality/td/TD-WAL-2-multimodal-wal-convergence.adoc
@@ -45,10 +45,14 @@ a dead per-strategy `MemtableManager` stack beside the live global write buffer.
 
 == Slices (each begins with anchor re-verification)
 
-V1 — **Estimator + config dedup (immediate, behavior-neutral).** Point
-`BulkWriteRouter::estimate_record_batch_size` at `WALVectorBatch::estimate_records_size`
-(one owner; router keeps its own routing thresholds). Decide + document the fate of the
-`WalStorageConfig` vs `WriteBufferUserConfig` duplication (fold or mark one canonical).
+V1 — **Estimator + config dedup (immediate, behavior-neutral). ✅ DONE (verified 2026-07-28).**
+`BulkWriteRouter::estimate_record_batch_size` (`bulk_write_router.rs:214`) now delegates to the
+single canonical owner `WALVectorBatch::estimate_records_size` (`wal_behavior.rs:69`) — both carry
+the `TD-WAL-2 V1` marker; the owner is precision-aware (fp16/bf16/int8 at real width), fixing the
+former fp32-only 2× over-count. The config half is **resolved by separation, not fold**:
+`WriteBufferUserConfig` (`core/config.rs:1010`, the live write-buffer watermark/flush config) and
+`WalStorageConfig` (now re-exported from the `proximadb_config` crate, `core/config.rs:1618`, a
+distribution-strategy config) are **distinct concerns** — no duplication remains to reconcile.
 
 V2 — **Unified recovery handlers.** Extend `RecoveryManager` replay to dispatch on all
 `UnifiedWALOperation` variants; implement `GraphOp`/`DocumentOp`/`TimeSeriesOp` handlers.
@@ -76,9 +80,18 @@ serialization-strategy flush stack (after confirming zero live callers — the s
 
 == Sequencing
 
-V1 (dedup, immediate) → V2 (recovery replay) → V3 (graph parity) → V4 (per-modality
-scheduler) → V6 (retirements). V5 (TS WAL) rides its named trigger independently.
+V1 (dedup, immediate) **✅ done** → V2 (recovery replay) → V3 (graph parity) → V4 (per-modality
+scheduler) → V6 (retirements). V5 (TS WAL) rides its named trigger independently — **note: the
+crash-durable timeseries WAL landed early via #1249** (`f007165a7`), ahead of V5's stated trigger.
 V2 before V3/V4 is load-bearing: never let a modality write WAL ops recovery cannot replay.
+
+**Remaining P2 work is substantial, not small-and-safe (verified 2026-07-28):** V2 needs new
+replay handlers for `GraphOp`/`DocumentOp`/`TimeSeriesOp` (correctness-flavored — the write side
+already emits `GraphOp`/`DocumentOp`, `wal_operations.rs:775/1133`, but `RecoveryManager` has no
+handlers, so the shared-WAL copy is currently unreplayed); V6's `MemtableManager` retirement still
+has **live constructors** in the avro/proto/bincode serialization strategies + `flush_coordinator`,
+so "zero live callers" is not yet true and deletion needs a full call-graph pass first. Neither is
+a behavior-neutral quick slice.
 
 == Non-goals
 


### PR DESCRIPTION
Bookkeeping PR folding two verification-first findings into the TDs so nobody rebuilds finished work or chases dormant features.

## TD-WAL-2 (F3 P2)
- **V1 estimator dedup is DONE** — `bulk_write_router.rs:214` already delegates to the canonical, precision-aware `WALVectorBatch::estimate_records_size` (both marked `TD-WAL-2 V1`).
- **V1 config half resolved by separation** — `WriteBufferUserConfig` (write-buffer watermarks) vs `proximadb_config::WalStorageConfig` (distribution strategy) are distinct concerns, no fold needed.
- **Remaining P2 is substantial, not small** — V2 (GraphOp/DocumentOp/TimeSeriesOp replay handlers; write side already emits them but `RecoveryManager` has none) and V6 (`MemtableManager` retirement still has live constructors in the avro/proto/bincode strategies). Neither is a behavior-neutral quick slice. Recorded so the 'small health slice' framing isn't chased.

## TD-HYBRID-1 rev 4 (§9)
- F7 mechanism (D2) **built + merged** (#1260 `CompiledGlobalFilter`, #1264 rewire).
- **WI-2 already done** — the canonical path threads selectivity+mode+policy via `build_axis_hybrid_query_with_policy` (`legacy.rs:3599`); the recon's '`contract.rs` drops the fields' was the storage-DTO boundary, not the service path.
- **Real gap is a dormant feature** — per-collection `AnnFilteringPolicy` is settable nowhere / read nowhere (`legacy.rs:3610` hardcodes default; builder has zero callers) = multi-layer **TD-073**, deferred.
- **WI-3 two-brain live-but-deterministic** — catalog policy authoritative per D15; optimizer mode advisory. No live bug.

Guards: all 5 pass. Docs-only. Not on the OLTP critical path.