### PR TITLE
fix(config): anchor WAL write buffer + SST/VIPER data dirs under data_dir (TD-WAL-4 S1)

### DIFF
--- a/docs/10-quality/td/TD-WAL-4-cwd-relative-write-buffer-breaks-instance-isolation.adoc
+++ b/docs/10-quality/td/TD-WAL-4-cwd-relative-write-buffer-breaks-instance-isolation.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed.** Found 2026-07-23 during the restart/recovery pressure tests: two servers with fully disjoint `data_dir`, `metadata_url`, and `storage_locations` cross-contaminated through a shared WAL write buffer.
+| Status | **S1 shipped (2026-07-28); S2 pending.** Found 2026-07-23 during the restart/recovery pressure tests: two servers with fully disjoint `data_dir`, `metadata_url`, and `storage_locations` cross-contaminated through a shared WAL write buffer. **S1 fix:** `ConfigLoader::resolve_path_under` anchors `write_buffer_directory` + SST/VIPER `data_directory` under the resolved `server.data_dir` (not cwd) — `config_loader.rs`. S2 (startup flock/pid guard against a still-shared buffer) remains a follow-up.
 | Priority | **P1** — silent cross-instance WAL sharing corrupts recovery: each instance lists and replays the other's collections. Any host running two proximadb-server processes from the same working directory (CI, side-by-side test/prod, blue-green) hits this. Data-path config that ignores the configured storage roots also violates the DrPathBuilder/tenant-isolation posture (co-design mandate #3: isolation is structural).
 | Component | `WriteBufferUserConfig.write_buffer_directory` default (cwd-relative `data/write_buffer`); `SstConfig.data_directory` default (`sst_data`); `ViperConfig.data_directory` default (`data/viper_data`) — see the resolved-config dump in the server startup log.
 | Evidence | Server A: `-c config.toml` (all paths under `…/pdb/`). Server B: `-c config2.toml` (all paths under `…/pdb2/`, distinct ports). Both resolved `write_buffer_directory: "<cwd>/data/write_buffer"` because the TOMLs did not set the key. Result: `GET /api/v2/collections` on **each** server listed **both** servers' collections (`sift1m` from A, `sweep` from B); B's ingested records went into the shared global memtable/WAL; B's flush produced no files under B's own storage locations. Fixed for the test run only by explicitly setting `[storage.wal_config] write_buffer_directory` under the instance root.
@@ -28,9 +28,13 @@ resolved-config dump and proceeds.
 
 == Direction
 
-S1 — Derive the defaults from `server.data_dir` (e.g.
+S1 — **✅ DONE (2026-07-28).** Derive the defaults from `server.data_dir` (e.g.
 `<data_dir>/write_buffer`, `<data_dir>/sst`, `<data_dir>/viper`) instead of
 cwd, so instance isolation follows the one knob operators actually set.
+Implemented as `ConfigLoader::resolve_path_under(&server.data_dir, …)` applied to
+`write_buffer_directory` + SST/VIPER `data_directory` in `resolve_config_paths`
+(`src/core/config_loader.rs`); object-store URLs and explicit absolute paths pass
+through unchanged. Unit-tested: distinct `data_dir` → distinct write-buffer paths.
 
 S2 — At startup, fail (or at minimum `warn!`) when the write buffer directory
 is already locked by another live process (flock/pid file) — silent sharing is

--- a/src/core/config_loader.rs
+++ b/src/core/config_loader.rs
@@ -231,6 +231,35 @@ impl ConfigLoader {
         Ok(output)
     }
 
+    /// Resolve `path_str` to an absolute path anchored at `base_dir` (rather
+    /// than the process cwd). URLs and already-absolute paths pass through
+    /// unchanged.
+    ///
+    /// TD-WAL-4: the WAL write buffer and the SST/VIPER data dirs are rooted
+    /// under the instance's `data_dir` with this, so two servers launched from
+    /// the same working directory with distinct `data_dir` never silently share
+    /// a physical WAL write buffer (which cross-contaminated recovery — each
+    /// instance listed and replayed the other's collections).
+    pub(crate) fn resolve_path_under(base_dir: &std::path::Path, path_str: &str) -> String {
+        use std::path::Path;
+        if path_str.contains("://") || Path::new(path_str).is_absolute() {
+            return path_str.to_string();
+        }
+        let mut resolved = base_dir.to_path_buf();
+        let mut remaining = path_str;
+        while let Some(rest) = remaining.strip_prefix("../") {
+            if let Some(parent) = resolved.parent() {
+                resolved = parent.to_path_buf();
+            }
+            remaining = rest;
+        }
+        let clean = remaining.strip_prefix("./").unwrap_or(remaining);
+        if clean.is_empty() || clean == "." {
+            return resolved.to_string_lossy().into_owned();
+        }
+        resolved.join(clean).to_string_lossy().into_owned()
+    }
+
     /// Resolve all relative paths in config to absolute paths
     fn resolve_config_paths(
         config: &mut Config,
@@ -315,18 +344,27 @@ impl ConfigLoader {
         // Resolve metadata URL
         config.storage.metadata_url = to_file_url(&config.storage.metadata_url)?;
 
-        // Resolve write buffer directory
+        // TD-WAL-4: anchor the WAL write buffer + SST/VIPER data dirs under the
+        // instance's `data_dir` (already resolved to absolute above), NOT the
+        // process cwd that `resolve_path` uses. Without this, two servers
+        // launched from the same directory with distinct `data_dir` but an unset
+        // (cwd-relative default) write_buffer_directory shared one physical WAL,
+        // cross-contaminating recovery. A remote/object-store URL or an explicit
+        // absolute path passes through unchanged.
+        let data_dir = config.server.data_dir.clone();
         config.storage.wal_config.write_buffer_directory =
-            resolve_path(&config.storage.wal_config.write_buffer_directory)?;
+            Self::resolve_path_under(&data_dir, &config.storage.wal_config.write_buffer_directory);
 
         // Resolve SST data directory if configured
         if let Some(ref mut sst_config) = config.storage.sst_config {
-            sst_config.data_directory = resolve_path(&sst_config.data_directory)?;
+            sst_config.data_directory =
+                Self::resolve_path_under(&data_dir, &sst_config.data_directory);
         }
 
         // Resolve VIPER data directory if configured
         if let Some(ref mut viper_config) = config.storage.viper_config {
-            viper_config.data_directory = resolve_path(&viper_config.data_directory)?;
+            viper_config.data_directory =
+                Self::resolve_path_under(&data_dir, &viper_config.data_directory);
         }
 
         // Resolve TLS certificate paths if configured
@@ -340,5 +378,43 @@ impl ConfigLoader {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod wal4_tests {
+    use super::ConfigLoader;
+    use std::path::Path;
+
+    #[test]
+    fn data_dirs_anchor_under_data_dir_not_cwd() {
+        // TD-WAL-4 repro: two instances with distinct data_dir and the SAME
+        // unset (cwd-relative default) write_buffer_directory must resolve to
+        // DISTINCT physical paths — otherwise they share one WAL write buffer.
+        let a = ConfigLoader::resolve_path_under(Path::new("/srv/pdb"), "./data/write_buffer");
+        let b = ConfigLoader::resolve_path_under(Path::new("/srv/pdb2"), "./data/write_buffer");
+        assert_eq!(a, "/srv/pdb/data/write_buffer");
+        assert_eq!(b, "/srv/pdb2/data/write_buffer");
+        assert_ne!(a, b, "distinct data_dir must not share a write buffer");
+
+        // Bare-relative (no leading ./) also anchors under data_dir.
+        assert_eq!(
+            ConfigLoader::resolve_path_under(Path::new("/srv/pdb"), "sst_data"),
+            "/srv/pdb/sst_data"
+        );
+    }
+
+    #[test]
+    fn absolute_and_url_paths_pass_through_unchanged() {
+        // An explicit absolute path or object-store URL is an intentional
+        // override and is never re-rooted.
+        assert_eq!(
+            ConfigLoader::resolve_path_under(Path::new("/srv/pdb"), "/mnt/wb"),
+            "/mnt/wb"
+        );
+        assert_eq!(
+            ConfigLoader::resolve_path_under(Path::new("/srv/pdb"), "s3://bucket/wb"),
+            "s3://bucket/wb"
+        );
     }
 }


### PR DESCRIPTION
Foundation hardening PR-C (approved plan) — the **P1 isolation bug**.

## Problem (TD-WAL-4)
`write_buffer_directory`, `SstConfig.data_directory`, and `ViperConfig.data_directory` defaulted to **cwd-relative** paths that no top-level setting re-rooted. Two servers launched from the same working directory with fully disjoint `data_dir`/`metadata_url`/`storage_locations` (unset write_buffer_directory) **silently shared one physical WAL write buffer** — each instance listed and replayed the other's collections on recovery. Found during restart/recovery pressure tests.

## Fix (S1)
Resolve those three data paths under the resolved `server.data_dir` instead of the process cwd, via a new `ConfigLoader::resolve_path_under` helper (`src/core/config_loader.rs`). Object-store URLs and explicit absolute paths pass through unchanged. Isolation now follows the one knob operators set (`data_dir`), matching the co-design "isolation is structural" mandate.

## Tests
- `data_dirs_anchor_under_data_dir_not_cwd` — distinct `data_dir` → **distinct** write-buffer paths (the exact repro).
- `absolute_and_url_paths_pass_through_unchanged` — explicit overrides respected.

TD-WAL-4 updated to **S1 shipped**; S2 (startup flock/pid guard) remains a follow-up. Both new tests pass; compiles clean.