### PR TITLE
ci(azurite): bump object-store restart-recovery timeout 90→150min (cold-compile headroom)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1560,7 +1560,14 @@ jobs:
   object-store-restart-recovery:
     name: Object-store restart recovery (Azurite)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # The `--restart` scope (scripts/run_cloud_emulator_tests.sh) builds 3 test
+    # targets across distinct cloud feature sets (azure; aws,azure,gcp) at
+    # CARGO_BUILD_JOBS=1 (OOM-safe on the 16GB runner). No other CI job builds
+    # these feature sets, so they are always a COLD compile (~85-90 min) — the
+    # prior 90-min budget timed out at the edge. Bumped to 150 for reliable
+    # headroom. (Efficiency follow-up: warm these feature sets in a shared
+    # earlier job, or split the contract test out of --restart.)
+    timeout-minutes: 150
     needs: [changes]
     if: |
       !inputs.skip_tests &&


### PR DESCRIPTION
Unblocks PRs (e.g. #1253) that are code-green but fail the \`Object-store restart recovery (Azurite)\` gate on a **cold-compile timeout**.

**Root cause:** the \`--restart\` scope (\`scripts/run_cloud_emulator_tests.sh\`) builds 3 test targets across distinct cloud feature sets (\`azure\`; then \`aws,azure,gcp\`) at \`CARGO_BUILD_JOBS=1\` (OOM-safe on the 16GB runner). **No other CI job builds these feature sets**, so they're always a cold compile (~85–90 min) — the prior 90-min budget timed out at the edge. The restart tests themselves pass (8/8); the job just ran out of clock compiling.

**Why not the other levers:**
- \`CARGO_BUILD_JOBS\` can't go up — peak RSS is ~21GB at jobs=3 (build-peak-RSS methodology); jobs=2 is too close to the 16GB runner ceiling.
- Cache can't warm from other jobs — these cloud feature sets are unique to this job.

**Fix:** \`timeout-minutes: 90 → 150\` for reliable headroom (~88-min cold compile + variance).

**Efficiency follow-up (separate TD):** warm these cloud feature sets in a shared earlier CI job, or split the backend-contract test out of \`--restart\`.

This is a ci.yml-only change; after it merges, #1253 rebases onto develop to inherit the new budget.