### PR TITLE
feat(delvec): MVCC-versioned deletion vector — F3v WI-1 + design gate

### DIFF
--- a/crates/storage/proximadb-storage-common/src/deletion_vector.rs
+++ b/crates/storage/proximadb-storage-common/src/deletion_vector.rs
@@ -14,11 +14,26 @@
 //! (skip deleted nodes during traversal). The relational OLAP read-merge instead
 //! uses an oid-keyed suppress-set (Parquet has no row directory), so the two
 //! representations are complementary: positions here, oids there.
+//!
+//! Two forms live here:
+//! - [`DeletionVector`] — a **plain** position bitmap (the ADR-025 N0 primitive).
+//!   Correct only when every reader observes the same delete set.
+//! - [`VersionedDeletionVector`] — an **MVCC** form (TD-DELVEC-1 F3v/§7.2-1) that
+//!   tags each deleted position with the **generation / delete LSN**. Merge-on-read
+//!   applies only bits whose gen ≤ the reader's snapshot LSN, so a delete that
+//!   lands after a reader's snapshot stays invisible to it. This is what makes the
+//!   cold-tier DV snapshot-correct **independently of reclaim**; a plain bitmap
+//!   cannot (it would drop a live reader's rows).
+
+use std::collections::BTreeMap;
 
 use crate::bitmap::{BitmapError, RoaringBitmap};
 
-/// Versioned magic prefix for a serialized deletion vector.
+/// Versioned magic prefix for a serialized plain deletion vector.
 const DV_MAGIC: &[u8; 4] = b"PDV1";
+
+/// Versioned magic prefix for a serialized MVCC (generation-tagged) DV.
+const VDV_MAGIC: &[u8; 4] = b"PDV2";
 
 /// A set of deleted row positions within a single cold file / index segment.
 #[derive(Debug, Clone, Default)]
@@ -86,6 +101,135 @@ impl DeletionVector {
     }
 }
 
+/// An MVCC deletion vector: each deleted position carries the **generation**
+/// (the delete's LSN) at which it was removed, so merge-on-read can apply only
+/// the deletes a given reader should see.
+///
+/// TD-DELVEC-1 §7.2-1. Positions are stored as disjoint per-generation runs
+/// (`gen -> RoaringBitmap`): a row is deleted exactly once, at the LSN of its
+/// delete, so no position appears in two runs (the earliest delete wins if a
+/// position is marked twice). A reader at `snapshot_lsn` sees a position as
+/// deleted iff it was deleted at some `gen <= snapshot_lsn`; a later delete is
+/// invisible to that reader. This is the property a plain [`DeletionVector`]
+/// cannot provide.
+#[derive(Debug, Clone, Default)]
+pub struct VersionedDeletionVector {
+    /// `gen` (delete LSN) -> positions deleted at that gen. Runs are disjoint by
+    /// position and iterated in ascending gen order (a `BTreeMap`).
+    runs: BTreeMap<u64, RoaringBitmap>,
+}
+
+impl VersionedDeletionVector {
+    /// An empty versioned deletion vector.
+    pub fn new() -> Self {
+        Self {
+            runs: BTreeMap::new(),
+        }
+    }
+
+    /// The generation (delete LSN) at which `position` was deleted, if any.
+    pub fn delete_gen(&self, position: u32) -> Option<u64> {
+        self.runs
+            .iter()
+            .find_map(|(generation, bm)| bm.contains(position).then_some(*generation))
+    }
+
+    /// Mark the row at `position` deleted at generation (delete LSN) `gen`.
+    ///
+    /// No-op if the position is already deleted at *any* generation — a row is
+    /// deleted once, and the earliest delete wins. Returns `true` if newly
+    /// marked.
+    pub fn mark_deleted(&mut self, position: u32, generation: u64) -> bool {
+        if self.delete_gen(position).is_some() {
+            return false;
+        }
+        self.runs.entry(generation).or_default().insert(position);
+        true
+    }
+
+    /// Whether the row at `position` is deleted **as of** a reader whose
+    /// snapshot is `snapshot_lsn`: it was deleted at some `gen <= snapshot_lsn`.
+    /// Deletes newer than the reader's snapshot are invisible (MVCC).
+    pub fn is_deleted_as_of(&self, position: u32, snapshot_lsn: u64) -> bool {
+        self.runs
+            .range(..=snapshot_lsn)
+            .any(|(_, bm)| bm.contains(position))
+    }
+
+    /// Whether `position` is deleted at the latest generation (any reader).
+    pub fn is_deleted(&self, position: u32) -> bool {
+        self.is_deleted_as_of(position, u64::MAX)
+    }
+
+    /// Count of positions deleted as of `snapshot_lsn`. Runs are disjoint by
+    /// position, so this is the sum of the cardinalities of runs `<= snapshot`.
+    pub fn deleted_count_as_of(&self, snapshot_lsn: u64) -> u64 {
+        self.runs
+            .range(..=snapshot_lsn)
+            .map(|(_, bm)| bm.cardinality())
+            .sum()
+    }
+
+    /// Total deleted count across all generations.
+    pub fn deleted_count(&self) -> u64 {
+        self.deleted_count_as_of(u64::MAX)
+    }
+
+    /// Whether no row is deleted at any generation.
+    pub fn is_empty(&self) -> bool {
+        self.runs.values().all(RoaringBitmap::is_empty)
+    }
+
+    /// Live-row count for a segment of `total` rows, as of `snapshot_lsn`.
+    pub fn live_count_as_of(&self, total: u64, snapshot_lsn: u64) -> u64 {
+        total.saturating_sub(self.deleted_count_as_of(snapshot_lsn))
+    }
+
+    /// Serialize as `[VDV_MAGIC | run_count u32 | (gen u64, body_len u32, roaring
+    /// body)* ]`, all little-endian.
+    pub fn serialize(&self) -> Result<Vec<u8>, BitmapError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(VDV_MAGIC);
+        out.extend_from_slice(&(self.runs.len() as u32).to_le_bytes());
+        for (generation, bm) in &self.runs {
+            let body = bm.serialize()?;
+            out.extend_from_slice(&generation.to_le_bytes());
+            out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            out.extend_from_slice(&body);
+        }
+        Ok(out)
+    }
+
+    /// Deserialize, rejecting an absent/unknown magic (so a caller can fall back
+    /// to the legacy no-DV path) or a truncated body.
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, BitmapError> {
+        let err = |m: &str| BitmapError::SerializationError(m.to_string());
+        if bytes.len() < VDV_MAGIC.len() + 4 || &bytes[..VDV_MAGIC.len()] != VDV_MAGIC {
+            return Err(err("versioned deletion vector: missing or unknown magic"));
+        }
+        let mut off = VDV_MAGIC.len();
+        let run_count = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+        off += 4;
+        let mut runs = BTreeMap::new();
+        for _ in 0..run_count {
+            if off + 12 > bytes.len() {
+                return Err(err("versioned deletion vector: truncated run header"));
+            }
+            let generation = u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap());
+            off += 8;
+            let body_len = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as usize;
+            off += 4;
+            if off + body_len > bytes.len() {
+                return Err(err("versioned deletion vector: truncated run body"));
+            }
+            let bm = RoaringBitmap::deserialize(&bytes[off..off + body_len])?;
+            off += body_len;
+            runs.insert(generation, bm);
+        }
+        Ok(Self { runs })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,5 +272,91 @@ mod tests {
         assert!(back.is_empty());
         assert_eq!(back.deleted_count(), 0);
         assert!(back.deleted_positions().is_empty());
+    }
+
+    #[test]
+    fn versioned_dv_is_snapshot_correct() {
+        // Position 2 deleted at LSN 10, position 5 at LSN 20.
+        let mut dv = VersionedDeletionVector::new();
+        assert!(dv.mark_deleted(2, 10));
+        assert!(dv.mark_deleted(5, 20));
+
+        // A reader at snapshot 15 sees position 2's delete (10 <= 15) but NOT
+        // position 5's (20 > 15) — the later delete is invisible to it.
+        assert!(dv.is_deleted_as_of(2, 15));
+        assert!(!dv.is_deleted_as_of(5, 15));
+        assert_eq!(dv.deleted_count_as_of(15), 1);
+        assert_eq!(dv.live_count_as_of(100, 15), 99);
+
+        // A reader at snapshot 25 sees both.
+        assert!(dv.is_deleted_as_of(2, 25));
+        assert!(dv.is_deleted_as_of(5, 25));
+        assert_eq!(dv.deleted_count_as_of(25), 2);
+
+        // A reader older than either delete sees neither.
+        assert!(!dv.is_deleted_as_of(2, 9));
+        assert_eq!(dv.deleted_count_as_of(9), 0);
+
+        // Latest view sees everything.
+        assert!(dv.is_deleted(2) && dv.is_deleted(5));
+        assert_eq!(dv.deleted_count(), 2);
+        assert_eq!(dv.delete_gen(2), Some(10));
+        assert_eq!(dv.delete_gen(5), Some(20));
+        assert_eq!(dv.delete_gen(6), None);
+    }
+
+    #[test]
+    fn versioned_dv_earliest_delete_wins_and_is_idempotent() {
+        let mut dv = VersionedDeletionVector::new();
+        assert!(dv.mark_deleted(7, 30));
+        // Re-marking an already-deleted position (at any gen) is a no-op and
+        // keeps the original (earliest) generation.
+        assert!(!dv.mark_deleted(7, 40));
+        assert!(!dv.mark_deleted(7, 5));
+        assert_eq!(dv.delete_gen(7), Some(30));
+        assert_eq!(dv.deleted_count(), 1);
+    }
+
+    #[test]
+    fn versioned_dv_roundtrips_over_multiple_generations() {
+        let mut dv = VersionedDeletionVector::new();
+        dv.mark_deleted(1, 10);
+        dv.mark_deleted(100_000, 10);
+        dv.mark_deleted(42, 20);
+        dv.mark_deleted(7, 30);
+
+        let bytes = dv.serialize().expect("serialize");
+        assert_eq!(&bytes[..4], VDV_MAGIC, "versioned magic prefix");
+        let back = VersionedDeletionVector::deserialize(&bytes).expect("deserialize");
+
+        assert_eq!(back.deleted_count(), 4);
+        assert_eq!(back.delete_gen(1), Some(10));
+        assert_eq!(back.delete_gen(100_000), Some(10));
+        assert_eq!(back.delete_gen(42), Some(20));
+        assert_eq!(back.delete_gen(7), Some(30));
+        // Snapshot filtering survives the round trip.
+        assert_eq!(back.deleted_count_as_of(10), 2);
+        assert_eq!(back.deleted_count_as_of(20), 3);
+    }
+
+    #[test]
+    fn versioned_dv_rejects_bad_magic_and_truncation() {
+        assert!(VersionedDeletionVector::deserialize(&[]).is_err());
+        // Plain-DV magic must not be read as a versioned DV.
+        assert!(VersionedDeletionVector::deserialize(b"PDV1\0\0\0\0").is_err());
+        // Correct magic but a run header that overruns the buffer.
+        let mut truncated = VDV_MAGIC.to_vec();
+        truncated.extend_from_slice(&1u32.to_le_bytes()); // claims 1 run
+        assert!(VersionedDeletionVector::deserialize(&truncated).is_err());
+    }
+
+    #[test]
+    fn empty_versioned_dv_roundtrips() {
+        let dv = VersionedDeletionVector::new();
+        assert!(dv.is_empty());
+        let bytes = dv.serialize().expect("serialize empty");
+        let back = VersionedDeletionVector::deserialize(&bytes).expect("deserialize empty");
+        assert!(back.is_empty());
+        assert_eq!(back.deleted_count(), 0);
     }
 }

--- a/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
+++ b/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
@@ -10,7 +10,7 @@
 
 [cols="1,3"]
 |===
-| Status | Draft — **hardened after a 3-agent red-team (2026-07-27); the naïve §2 design is NOT shippable — see §7**. Buildable on this substrate (positions are derivable, D5 holds), but §7 supersedes D1/D2/D3/D4 and adds two new sub-components. **Re-scoped: ~4–5w (not the 2w plan estimate)** — several pieces are new subsystems.
+| Status | **Build started (rev 3, 2026-07-28) — WI-1 in progress.** Hardened after a 3-agent red-team (2026-07-27; §7); the naïve §2 design is superseded by §7.2. Design gate **complete**: §7.2 folded into numbered WIs (§8); a `develop` verification pass re-confirmed the substrate and found the plain-bitmap `DeletionVector` primitive already exists (reusable), so **WI-1 = the MVCC-versioned form** (`VersionedDeletionVector`, per-position delete-gen, snapshot-correct). Additive, feature-gated `cold-deletion-vectors`, default path byte-for-byte unchanged. **Re-scoped: ~4–5w**; off the OLTP critical path.
 | Problem | The cold tier deletes via **LSM tombstones** (delete-marker records that cascade through levels and are physically removed only at compaction) — every cold delete implies an eventual **segment rewrite**. D14 wants **deletion vectors**: a position bitmap overlaying the *immutable* segment, applied **merge-on-read**, purged at compaction behind the reader watermark — no rewrite on delete.
 | Feature | `cold-deletion-vectors` (additive, feature-gated; default path = today's tombstone+compaction, byte-for-byte unchanged).
 |===
@@ -201,3 +201,55 @@ the publish-before-retire ordering, plus the conservative-purge unification. WI-
 in §3 are superseded by §7.2. The design **stays Draft** until §7.2 is folded into
 numbered WIs and a confirmation pass runs over the *versioned-DV + interlock* pieces
 (the newly-introduced structures). None of this is on the OLTP critical path (closed).
+
+== 8. Build plan — numbered work items (rev 3, 2026-07-28)
+
+§7.2 folded into a sequenced, additive WI list (this completes the design gate). A
+verification pass on `develop` (`c6c2f343d`) first re-confirmed the substrate and found
+one **surprise**: a *plain* position-bitmap `DeletionVector` **already exists**
+(`crates/storage/proximadb-storage-common/src/deletion_vector.rs`, ADR-025, wired to
+nothing) over an **in-repo `RoaringBitmap`** (no external `roaring` dep — offline build).
+So the DV *primitive* is reusable; the MVCC form + sidecar + manifest + resolver + all
+wiring are greenfield. Substrate anchors confirmed: footer block table gives a derivable
+stream ordinal (`segment_layout.rs` `FooterBlockEntry.row_count`); LSM tombstone +
+1h-reclaim compaction (`sst/mod.rs:473/505`, `compaction.rs:1178`); `OlapDeltaMerge`
+carries a base-materialization `snapshot_lsn`, **not** a reader-as-of (`olap_delta_merge.rs:149`);
+the SST compactor has **no** interlock — optional `MvccResolver` is `None`, inputs deleted
+unconditionally (`compactor_impl.rs:220/371`).
+
+Each WI is feature-gated `cold-deletion-vectors` (default path byte-for-byte unchanged);
+the feature is introduced at the first *wiring* WI (WI-3), since the pure-additive format
++ resolver types change no behavior.
+
+[cols="1,4,1"]
+|===
+| WI | Slice | Status
+
+| **WI-1** | **MVCC-versioned DV format.** `VersionedDeletionVector` (per-position delete
+`gen`/LSN as disjoint `gen -> RoaringBitmap` runs) beside the plain `DeletionVector`;
+snapshot-correct `is_deleted_as_of(pos, snapshot_lsn)`; versioned `PDV2` magic + serialize
+/deserialize (magic-rejection fallback). Pure-additive, wired to nothing. §7.2-1. | **building**
+| WI-2 | **OID→position resolver.** Dense `OID→footer-ordinal` recorded at write (footer
+sidecar / the reserved `stats_kind` "PR3 OID bloom" hook) or resolve-and-record at delete
+time. Additive to the footer. §7.2-2. | pending
+| WI-3 | **Delete path → set DV bit** (feature-gated): a hot tombstone landing on a row in
+an immutable cold segment resolves `(segment, position)` (WI-2) and sets the versioned DV
+bit at the delete LSN, instead of a cascading cold tombstone. §7.2 D2. | pending
+| WI-4 | **Merge-on-read + reader LSN.** Thread the reader snapshot LSN into the cold scan;
+apply DV bits with `gen <= snapshot`; reconcile with the oid-keyed `OlapDeltaMerge`
+suppress-set (persist its cold-side input). The snapshot-isolation fix. §7.2-1. | pending
+| WI-5 | **Publish-before-retire.** Flush fsyncs the DV manifest bump **before** retiring
+the delete from the change-feed; readers pin one `(snapshot_lsn, DV-version)` tuple;
+straddle detection → re-read. The resurface fix. §7.2-3. | pending
+| WI-6 | **Compaction DV-awareness + interlock.** k-way merge consults the DV; at commit,
+re-read inputs' DVs under one atomic step (manifest-CAS / per-segment lease over
+`compactor_impl.rs`), reduce surviving deleted-OIDs to an OID set and re-apply to the
+re-clustered output, then delete inputs + clear DVs. The lost-bit fix. §7.2-4. | pending
+| WI-7 | **Conservative purge**, unified with the 1h tombstone reclaim: never drop a DV'd
+row below a global static low-watermark; document that long-lived snapshots are not pinned
+(a real cold-reader watermark is a separately-scoped later item). §7.2-5. | pending
+|===
+
+Sequencing WI-1 → WI-7; WI-3 depends on WI-2, WI-4 on WI-1+WI-3. The confirmation pass §7.3
+asks for lands with WI-1 (the versioned format, the load-bearing "newly-introduced
+structure") and WI-6 (the interlock). Re-scope stands at ~4–5w. Off the critical path.


### PR DESCRIPTION
First build slice of **F3v** (cold-tier deletion vectors, TD-DELVEC-1) + completion of its design gate.

## Design gate complete
§7.2 (the red-team-hardened design) folded into numbered, sequenced WIs — **TD-DELVEC-1 §8 (rev 3)**. A verification pass on `develop` re-confirmed the substrate and surfaced one useful finding: a **plain-bitmap `DeletionVector` primitive already exists** (`proximadb-storage-common`, ADR-025, wired to nothing) over an **in-repo `RoaringBitmap`** (no external `roaring` dep — offline build). So WI-1 is the *MVCC form* the red-team requires, not a from-scratch primitive.

## WI-1 — `VersionedDeletionVector`
Alongside the plain DV. Each deleted position carries its **delete generation (LSN)** as disjoint `gen → RoaringBitmap` runs. `is_deleted_as_of(pos, snapshot_lsn)` applies only deletes with `gen ≤ snapshot` — so a delete newer than a reader's snapshot stays **invisible** to it. That's the snapshot-isolation property a plain bitmap **cannot** provide (it would drop a live reader's rows) — the fix for the red-team's BROKEN merge-on-read core (§7.2-1). Earliest-delete-wins on re-mark; `PDV2` versioned magic + serialize/deserialize with magic-rejection + truncation guards.

## Safety
**Pure-additive, wired to nothing** — zero behavior change. The `cold-deletion-vectors` feature is introduced at the first *wiring* WI (WI-3). 6 unit tests (MVCC snapshot visibility, earliest-delete-wins, multi-generation roundtrip, magic/truncation rejection); guards pass. Off the OLTP critical path.

Next: WI-2 (OID→position resolver over the footer block table).