### PR TITLE
feat(mcp): wire checkpoint tool + audit-log restart recovery; file TD-DBX-1 / TD-EVENTLOG-1

### DIFF
--- a/crates/platform/proximadb-mcp/src/tools.rs
+++ b/crates/platform/proximadb-mcp/src/tools.rs
@@ -162,8 +162,27 @@ pub fn reference_tools() -> Vec<Tool> {
         },
         Tool {
             name: tool_name::CHECKPOINT.to_string(),
-            description: "Agent checkpoint: save or restore agent state (ADR-022).".to_string(),
-            input_schema: json!({ "type": "object", "additionalProperties": true }),
+            description: "Agent checkpoint: save, get, or list agent state for a thread (ADR-022). \
+                          Event-sourced — `save` appends and `get` returns the latest checkpoint \
+                          unless `checkpoint_id` is given."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["thread_id", "tenant_id"],
+                "properties": {
+                    "op": { "type": "string", "enum": ["save", "get", "list"], "description": "Operation (default `save`)." },
+                    "thread_id": { "type": "string", "description": "Agent thread this checkpoint belongs to." },
+                    "tenant_id": { "type": "string", "description": "Tenant scope — required (fail-closed isolation)." },
+                    "checkpoint_ns": { "type": "string", "description": "Optional namespace within the thread (default `default`)." },
+                    "checkpoint_id": { "type": "string", "description": "On `save`, use this id instead of minting one. On `get`, select this checkpoint instead of the latest." },
+                    "parent_checkpoint_id": { "type": "string", "description": "Parent checkpoint, recording lineage." },
+                    "checkpoint": { "description": "State payload — required for `save`." },
+                    "metadata": { "type": "object", "description": "Optional checkpoint metadata." },
+                    "writes": { "type": "array", "description": "Optional pending channel writes." },
+                    "limit": { "type": "integer", "minimum": 1, "description": "Max entries for `list` (default 20)." }
+                },
+                "additionalProperties": true
+            }),
         },
         Tool {
             name: tool_name::EVENT.to_string(),

--- a/docs/10-quality/td/TD-DBX-1-hosted-mcp-listing-readiness.adoc
+++ b/docs/10-quality/td/TD-DBX-1-hosted-mcp-listing-readiness.adoc
@@ -63,8 +63,8 @@ do not want to compete on, and none of the surface we do.
 | `tools.rs` grep for `graph\|rag\|traverse\|neighbor` = 0 hits; backend trait `tools.rs:46–60` lists 8 non-graph tools.
 
 | **G2**
-| **3 of 8 published tools are dead.** `memory` / `checkpoint` / `event` return an explicit *"not yet wired in-process"* from `EngineBackend` — there is no production agentic backend (only a `#[cfg(test)]` `MockBackend`). A published catalog would advertise tools that always fail.
-| `src/network/mcp/backend.rs`; TD-MCP-1 §Finding.
+| **RESOLVED 2026-07-28.** *Original claim ("3 of 8 tools dead") was wrong — corrected on inspection.* Only **`checkpoint`** was dead: `event` was already wired to `EventLogEngine` (MCP-1a) and `memory` **search** to `VectorMemoryStore` (MCP-1b); memory *put* stays LLM-gated (TD-101) and the tool description says so honestly rather than failing. `checkpoint` is now wired via `AgentCheckpointStore` — event-sourced over the same `EventLogEngine`, so it needed no new engine, filesystem handle, or LLM.
+| `src/network/mcp/backend.rs`; `src/services/agent_checkpoint.rs`. TD-MCP-1's `src/embedded/agent_memory.rs` reference is stale (file does not exist).
 
 | **G3**
 | **No relevance eval for graph-RAG.** `tests/graph_rag_integration_test.rs::test_rag_pipeline_integration` uses a **mock retriever** — plumbing test, not a relevance eval. Mandate #13 requires an eval with a real rubric (output *and* trajectory) for any ranked surface before it is promoted.
@@ -96,9 +96,9 @@ a smaller one.
 | S3, publish
 
 | **S2**
-| **Resolve the dead-tool catalog.** Either wire `memory`/`checkpoint`/`event` (TD-MCP-1 — needs a production agentic backend + LLM dependency) **or** gate them out of the published catalog behind the same flag that enables the hosted surface.
-| Exit: every tool in the published catalog succeeds on a healthy server. **Gating out is the cheap correct default** — wiring is TD-MCP-1's scope and carries an external LLM dependency.
-| publish
+| **DONE 2026-07-28.** `checkpoint` wired (`AgentCheckpointStore`, TD-MCP-1 phase MCP-1d): save/get/list, event-sourced over `EventLogEngine`, LangGraph-shaped (`thread_id`/`checkpoint_ns`/`parent_checkpoint_id`). Catalog schema replaced the open `additionalProperties`-only stub with a real one. The feared LLM dependency did not apply — it gates memory *put* only, which this surface does not offer.
+| Exit met: every tool in the published catalog now succeeds on a healthy server. Isolation is fail-closed (non-empty `tenant_id` required; tenant is structural in the entity id; `:` injection rejected). **Caveat: `TD-EVENTLOG-1`** — the underlying event log has no restart recovery, so `checkpoint` (and `event`) are process-lifetime durable only. That does not block publish, but it **does** bound what the listing may claim.
+| TD-EVENTLOG-1 blocks any durability claim
 
 | **S3**
 | **Graph-RAG relevance eval** (mandate #13, TD-ORION-1 residual). Real rubric over a small fixed corpus, covering **output** (are the expanded neighbours the right symbols) and **trajectory** (was the seed→expand path sound). Versioned with the code; threshold-gated in CI.

--- a/docs/10-quality/td/TD-DBX-1-hosted-mcp-listing-readiness.adoc
+++ b/docs/10-quality/td/TD-DBX-1-hosted-mcp-listing-readiness.adoc
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DBX-1: Hosted MCP distribution surface — the graph differentiator is not reachable via MCP
+:status: Open
+:date: 2026-07-28
+:dim: D5 (governance/security — multi-tenant hosted surface) + D2 (network — provider-hosted endpoint)
+:pillar: OE
+:relates-to: ADR-037 Decision 5 (reference MCP surface), TD-MCP-1 (agent-state tools unwired), TD-ORION-1 (vector→graph fusion shipped; relevance eval is the residual), TD-045 (Modular Graph RAG), ADR-074 (namespace isolation boundary)
+:depends-on: TD-MCP-1 (S2), TD-ORION-1 residual eval (S3)
+
+[cols="1,3"]
+|===
+| Field | Value
+
+| Status
+| **Open** — filed 2026-07-28 from a distribution-channel review. Not a capability gap in the engine; a **reachability + readiness** gap between shipped capability and the MCP surface that would expose it.
+
+| Priority
+| P2 — gates an external MCP distribution channel (e.g. a Databricks Marketplace MCP server listing, which is provider-hosted and supplies Host + Port). No effect on the in-process reference surface today.
+
+| Severity
+| Medium — S1 is the load-bearing item; S2 is a correctness/credibility defect if the catalog is published as-is.
+
+| Component
+| `crates/platform/proximadb-mcp/src/tools.rs` (tool catalog + dispatch), `src/network/mcp/backend.rs` (`EngineBackend`), `src/graph/rag/` (shipped fusion), `src/network/rest/canonical/graph.rs` (`POST /graphs/{id}/rag`).
+|===
+
+toc::[]
+
+== 1. Problem
+
+Retrieval differentiation against first-party lakehouse vector engines rests on
+**graph traversal and vector→graph fusion**, not on vector or hybrid search —
+those have converged (IVF + RaBitQ + BM25 hybrid is now table stakes in
+competing Postgres-native engines).
+
+The fusion capability **ships today**: `src/graph/rag/` implements
+retrieve → filter → prune → k-hop-expand (`RagPipeline`, `VectorNodeRetriever`,
+`KHopSubgraphBuilder`), exposed at `POST /graphs/{graph_id}/rag`
+(`network/rest/canonical/graph.rs`, route `:852`, handler `:1319`). TD-ORION-1
+verified this and closed as Resolved.
+
+**But the MCP tool catalog exposes no graph surface at all.** `reference_tools()`
+(`crates/platform/proximadb-mcp/src/tools.rs:87`) publishes eight tools —
+`list_collections`, `describe`, `stats`, `explain`, `search`, `memory`,
+`checkpoint`, `event` (backend trait `:46–60`). A grep for
+`graph|rag|traverse|neighbor` across the whole `proximadb-mcp` crate returns
+**zero** hits.
+
+An agent consuming ProximaDB over MCP can therefore do vector search — the
+commoditized capability — and **cannot reach traversal, k-hop expansion, or
+match-then-traverse fusion at all**. The channel exposes exactly the surface we
+do not want to compete on, and none of the surface we do.
+
+== 2. Gaps (verified 2026-07-28)
+
+[cols="1,3,2"]
+|===
+| # | Gap | Evidence
+
+| **G1**
+| **No graph tool in the MCP catalog.** The shipped `/graphs/{id}/rag` fusion, ORION traversal, and neighbor/shortest-path operations have no MCP tool.
+| `tools.rs` grep for `graph\|rag\|traverse\|neighbor` = 0 hits; backend trait `tools.rs:46–60` lists 8 non-graph tools.
+
+| **G2**
+| **3 of 8 published tools are dead.** `memory` / `checkpoint` / `event` return an explicit *"not yet wired in-process"* from `EngineBackend` — there is no production agentic backend (only a `#[cfg(test)]` `MockBackend`). A published catalog would advertise tools that always fail.
+| `src/network/mcp/backend.rs`; TD-MCP-1 §Finding.
+
+| **G3**
+| **No relevance eval for graph-RAG.** `tests/graph_rag_integration_test.rs::test_rag_pipeline_integration` uses a **mock retriever** — plumbing test, not a relevance eval. Mandate #13 requires an eval with a real rubric (output *and* trajectory) for any ranked surface before it is promoted.
+| TD-ORION-1 `<<_residual_the_eval>>` (the one open residual of that TD).
+
+| **G4**
+| **No benchmark evidence for the differentiation claim.** No end-to-end graph-RAG numbers in `BENCHMARK_EVIDENCE.toml`. Mandate #6 forbids asserting the advantage without them.
+| Ledger absence.
+
+| **G5**
+| **The MCP surface is an in-process reference, not a hosted multi-tenant endpoint.** It is gated behind `[api].mcp_port` and `spawn_mcp_surface()` (ADR-037 D5, Stage 1a/1b). A provider-hosted listing requires a publicly reachable, authenticated, multi-tenant endpoint carrying `TenantContext` to every I/O boundary, fail-closed.
+| `MultiServer::start` gated spawn (#630); ADR-037 Decision 5 scope is explicitly a *reference* surface.
+|===
+
+== 3. Sequencing (ordered; each slice independently landable)
+
+The ordering is deliberate: **S1 before S3** because there is no point evaluating
+relevance on a surface the channel cannot reach, and **S2 before any publish**
+because shipping a catalog with three always-failing tools is worse than shipping
+a smaller one.
+
+[cols="1,2,3,1"]
+|===
+| Slice | Scope | Rationale / exit criterion | Blocks
+
+| **S1**
+| **Expose graph over MCP.** Add graph tools to `reference_tools()` + `dispatch_tool` over the *already-shipped* engine paths: `graph_rag` (→ `RagPipeline` / `POST /graphs/{id}/rag`), `traverse` (→ ORION `get_neighbors` / `get_outgoing_edges`), `shortest_path`. Reuse the existing `EngineBackend` pattern — no new engine capability.
+| **The load-bearing slice.** Exit: an MCP client can perform vector-seed → graph-expand end-to-end. Thin — it is a *binding* over shipped code, not new retrieval work.
+| S3, publish
+
+| **S2**
+| **Resolve the dead-tool catalog.** Either wire `memory`/`checkpoint`/`event` (TD-MCP-1 — needs a production agentic backend + LLM dependency) **or** gate them out of the published catalog behind the same flag that enables the hosted surface.
+| Exit: every tool in the published catalog succeeds on a healthy server. **Gating out is the cheap correct default** — wiring is TD-MCP-1's scope and carries an external LLM dependency.
+| publish
+
+| **S3**
+| **Graph-RAG relevance eval** (mandate #13, TD-ORION-1 residual). Real rubric over a small fixed corpus, covering **output** (are the expanded neighbours the right symbols) and **trajectory** (was the seed→expand path sound). Versioned with the code; threshold-gated in CI.
+| Exit: eval suite in CI with a ratcheted threshold. Required before the surface is promoted beyond experimental.
+| promotion
+
+| **S4**
+| **Hosted multi-tenant MCP endpoint** (G5). AuthN/AuthZ at the MCP boundary; `TenantContext` threaded to every I/O boundary fail-closed; namespace isolation per ADR-074; per-tenant rate limiting.
+| Exit: `check_tenant_path_guard` clean on the MCP path; a tenant cannot reach another tenant's collections through any tool. **Security-gating slice — no external exposure before this.**
+| external listing
+
+| **S5**
+| **Benchmark evidence** (G4, mandate #6). End-to-end graph-RAG latency/recall into `BENCHMARK_EVIDENCE.toml`. Kernel microbenchmarks are explicitly not acceptable.
+| Exit: ledger entries supporting any comparative claim. Note the competing bar is public (≈32× compression, 50–100× faster build than HNSW) — measure before claiming.
+| any comparative claim
+|===
+
+**Minimum viable publish = S1 + S2 + S4.** S3 and S5 gate *promotion and claims*
+rather than existence: without them the surface may ship as experimental but
+may not be marketed on relevance or performance.
+
+== 4. Not doing (measure-don't-assert)
+
+* **No new fusion implementation.** TD-ORION-1 verified match-then-traverse is
+  shipped; S1 is a binding over it, not a rewrite. Re-deriving it would be the
+  exact duplication the TD warns against.
+* **No vector/hybrid-search investment for this channel.** Converged with
+  first-party competitors; effort there does not differentiate.
+* **No customer-data export path.** Publishing tenant-derived corpora as shared
+  datasets is out of scope on data-rights grounds, independent of engineering.
+* **No `oid`→node index** (TD-ORION-1 disproved the need — `NodeId` *is* the `oid`).
+
+== 5. Open questions
+
+. Does the hosted surface (S4) reuse the multiplexed port (5678) or take its own?
+  ADR-037 D5 gave MCP a dedicated `[api].mcp_port`; a hosted deployment may want
+  it behind the same TLS/auth front as REST.
+. Should `graph_rag` be one composite MCP tool or decomposed
+  (`search` → `expand`) so the agent controls the trajectory? Composite is easier
+  to evaluate; decomposed is more agent-native. S3's trajectory rubric should
+  inform this — worth deciding **with** the eval, not before it.

--- a/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
+++ b/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-EVENTLOG-1: EventLogEngine has no recovery — the index is lost and the sequence counter resets to 0 on restart
+:status: Open
+:date: 2026-07-28
+:dim: D3 (local disk/durability)
+:pillar: REL
+:relates-to: ADR-022 (agent state / auditable trail), TD-MCP-1 (MCP-1a `event`, MCP-1d `checkpoint` ride this engine), TD-DBX-1 (S2)
+:severity: HIGH — silent data loss + silent overwrite
+
+[cols="1,3"]
+|===
+| Field | Value
+
+| Status
+| **Open** — found 2026-07-28 while wiring the MCP `checkpoint` tool (TD-MCP-1 MCP-1d). **Pre-existing**; not introduced by that work.
+
+| Priority
+| P1 — two independent silent-data-loss modes on a durability-claiming engine.
+
+| Component
+| `src/storage/engines/eventlog/mod.rs` (`EventLogEngine::new`, `append_event`, `get_event_path`), `src/storage/engines/eventlog/index.rs` (`EventIndex`).
+
+| Blast radius
+| Every `EventLogEngine` consumer: the MCP `event` tool, the MCP `checkpoint` tool (`AgentCheckpointStore`), temporal queries, snapshots.
+|===
+
+toc::[]
+
+== 1. Problem
+
+`EventLogEngine::new` constructs a **fresh, empty** `EventIndex` and a
+`sequence_counter` initialized to **0**, with no recovery step. Events are
+durably written to the filesystem, but nothing rebuilds the state needed to find
+or extend them.
+
+[source,rust]
+----
+// mod.rs:204-209 — no scan, no replay, no max-sequence probe
+let sequence_counter = Arc::new(RwLock::new(0));
+let event_index = Arc::new(EventIndex::new(config.base_dir.clone())?);
+----
+
+`EventIndex` is explicit that it holds nothing durable:
+
+[source,rust]
+----
+// index.rs:35-37
+/// Base location for index storage (local path or object-store URL).
+/// The index itself is purely in-memory; this is retained for diagnostics.
+base_dir: String,
+----
+
+=== Defect A — events become unreadable after restart (silent loss)
+
+`read_events` resolves sequences through `event_index.get_entity_events(...)`.
+After a restart the index is empty, so **every read returns zero events** even
+though the event files are intact on disk. Nothing errors; the log simply
+appears empty.
+
+For the MCP `checkpoint` tool this means an agent resuming a thread after a
+server restart silently gets "no checkpoint" and loses its state.
+
+=== Defect B — sequence reuse overwrites prior events (silent corruption)
+
+`get_event_path` keys the object by sequence:
+
+[source]
+----
+{base}/partition_{seq/1000:05}/event_{seq:010}.bin
+----
+
+With `sequence_counter` restarting at 0, the first event appended after a
+restart is written to `event_0000000000.bin` — **overwriting the pre-restart
+event at that sequence**. Each restart silently destroys the head of the log.
+
+Defect B is the more serious of the two: A loses visibility of data that still
+exists, B destroys it.
+
+== 2. Why the tests do not catch it
+
+Every existing test (and the `AgentCheckpointStore` suite added with MCP-1d)
+constructs **one engine per test** and never reconstructs one over the same
+`base_dir`. In-process, the index is warm and the counter monotonic, so both
+defects are invisible. The missing case is a second `EventLogEngine::new` over a
+populated directory.
+
+== 3. Next action
+
+. **Reproduce first (TDD).** A test that: appends N events → drops the engine →
+  constructs a new engine over the same `base_dir` → asserts the events are
+  readable and that a fresh append does not overwrite. This should fail on both
+  counts today.
+. **Recover the sequence counter** (fixes B — do this first, it is the
+  destructive one). On boot, probe the highest existing
+  `partition_*/event_*.bin` and resume at `max + 1`.
+. **Rebuild the index** (fixes A). Scan and replay event files into
+  `entity_index` / `type_index` / `timestamp_index` / `reverse_index`. Bounded
+  scan + a checkpointed index file if a full replay is too slow for large logs
+  (the snapshot machinery in `snapshot.rs` may already supply the primitive).
+. Consider whether the sequence-keyed path scheme is the right contract at all —
+  a monotonic counter that must survive restarts is exactly the state an
+  object-store-native design would rather not keep in memory (ADR-072
+  `ConditionalKeyStore` / `put_if_absent` is the adjacent primitive).
+
+== 4. Interim posture
+
+Until this lands, treat `EventLogEngine` as **process-lifetime durable only**.
+Surfaces built on it (MCP `event`, MCP `checkpoint`) must not be documented or
+marketed as restart-durable — see the caveat in
+`src/services/agent_checkpoint.rs` and TD-DBX-1 §S2.

--- a/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
+++ b/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
@@ -13,7 +13,10 @@
 | Field | Value
 
 | Status
-| **Open** — found 2026-07-28 while wiring the MCP `checkpoint` tool (TD-MCP-1 MCP-1d). **Pre-existing**; not introduced by that work.
+| **Partial** — found 2026-07-28 while wiring the MCP `checkpoint` tool (TD-MCP-1 MCP-1d); **pre-existing**, not introduced by that work. **Recovery landed 2026-07-28** (`EventLogEngine::open` = `new` + `recover`; `SharedServices` switched to it). **Still owed: the re-key** (§3.4) — recovery is a patch, not the end state.
+
+| Scope note
+| This is the **audit** event log (`src/storage/engines/eventlog/`, MiFID II framing, backing MCP `event`/`checkpoint`). It is *not* the AXIS flush/compact coordination queue (`src/index/axis/eventlog/`), which is a separate component that happens to share the name. Do not conflate them — that collision already mis-targeted one investigation.
 
 | Priority
 | P1 — two independent silent-data-loss modes on a durability-claiming engine.
@@ -107,9 +110,40 @@ populated directory.
   object-store-native design would rather not keep in memory (ADR-072
   `ConditionalKeyStore` / `put_if_absent` is the adjacent primitive).
 
-== 4. Interim posture
+== 4. Posture (updated 2026-07-28)
 
-Until this lands, treat `EventLogEngine` as **process-lifetime durable only**.
-Surfaces built on it (MCP `event`, MCP `checkpoint`) must not be documented or
-marketed as restart-durable — see the caveat in
-`src/services/agent_checkpoint.rs` and TD-DBX-1 §S2.
+**Landed:** `EventLogEngine::open` recovers the sequence counter (defect B) and
+rebuilds the index (defect A); `SharedServices` uses it. Events now survive a
+restart, so `EventLogEngine` is no longer process-lifetime-only.
+
+A **backend-shape hazard** surfaced while fixing this and is worth recording,
+because a local-only test suite cannot reach it: `FileSystem::list` is not
+uniform. Local is `fs::read_dir` (single level ⇒ the base yields `partition_*`
+directories); object stores do a recursive prefix listing with no delimiter
+(⇒ the base yields `event_*.bin` leaves, and `is_directory` is *always* false).
+A two-level walk passes every local test and silently recovers **nothing** on
+blob storage — the production shape. The scan therefore consumes event leaves
+wherever they appear and descends only into partition-looking entries. Pinned by
+`recovery_handles_flat_object_store_listing_shape`. Any future traversal in this
+repo must handle both shapes.
+
+**Still owed — the re-key (§3.4).** Recovery is a patch on a design whose root
+problem stands: an immutable object's key is derived from mutable, process-local
+state. That yields three failure modes, of which restart was only one; the other
+two survive this fix:
+
+* **Concurrency** — two processes over one base both resume from their own view
+  and can still collide. (Unverified whether multi-node shares `metadata_url`;
+  flagged, not asserted.)
+* **Read amplification** — the key is a *global* counter carrying no entity, so
+  reads need the secondary index, and rebuilding it costs a GET per event. On
+  object storage that boot scan is O(N) round-trips — the dominant cost term per
+  `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc`. The fix is itself a
+  co-design violation at scale.
+
+End state: key by entity (`{base}/{entity}/{seq}`) so reads are one prefix LIST
+and the index degrades to a pure cache, and replace `overwrite: true` with
+`put_if_absent` — the correct primitive for immutable append, already in-repo as
+ADR-072's `ConditionalKeyStore` (F1c). Then there is nothing to recover and
+collisions are structurally impossible. Storage-format change ⇒ mandate #8
+(mixed-read-safe, marker-detected, default-OFF until baked).

--- a/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
+++ b/docs/10-quality/td/TD-EVENTLOG-1-no-index-recovery-sequence-reset-on-restart.adoc
@@ -70,9 +70,13 @@ server restart silently gets "no checkpoint" and loses its state.
 {base}/partition_{seq/1000:05}/event_{seq:010}.bin
 ----
 
-With `sequence_counter` restarting at 0, the first event appended after a
-restart is written to `event_0000000000.bin` — **overwriting the pre-restart
-event at that sequence**. Each restart silently destroys the head of the log.
+`append_event` pre-increments (`*counter += 1`, then use), so with
+`sequence_counter` restarting at 0 the first event appended after a restart takes
+sequence **1** and is written to `event_0000000001.bin` — **overwriting the
+pre-restart event at that sequence**. The write is not merely incidental: the
+options are explicitly `FileOptions { create_dirs: true, overwrite: true, .. }`,
+so the collision silently destroys rather than erroring. Each restart destroys the
+head of the log.
 
 Defect B is the more serious of the two: A loses visibility of data that still
 exists, B destroys it.

--- a/docs/10-quality/td/TD-MCP-1-agent-state-tools-need-wired-agentic-backend.adoc
+++ b/docs/10-quality/td/TD-MCP-1-agent-state-tools-need-wired-agentic-backend.adoc
@@ -4,8 +4,8 @@
 
 [cols="1,3"]
 |===
-|Status|Open
-|Priority|MED
+|Status|**Partial** — MCP-1a (event) ✅, MCP-1b (memory search) ✅, **MCP-1d (checkpoint) ✅ 2026-07-28**. Only **MCP-1c (memory put)** remains, still LLM-gated behind TD-101. Every tool in the published catalog now succeeds on a healthy server.
+|Priority|LOW (was MED — the surface is no longer advertising a tool that always fails)
 |Scope|FEAT
 |Date|2026-07-02
 |Relates to|ADR-037 Decision 5 (reference MCP surface), ADR-022 (agent memory layer), TD-101 (agent memory write surface — In Progress), TD-174 (statistics envelope, feeds `stats`)
@@ -83,13 +83,26 @@ tools' honest *"not yet wired"* response is correct until that backend lands.
   `memory` put path degrades explicitly when no LLM is configured (TD-101).
 * **MCP-1d — checkpoint** (greenfield): a server-composed checkpoint store from the
   embedded `save_checkpoint`; wire the MCP `checkpoint` tool.
++
+**✅ DONE 2026-07-28** — but *not* as this phase predicted. Two corrections:
++
+. The premise "promote the embedded-only `save_checkpoint`" was **stale**:
+  `src/embedded/agent_memory.rs` does not exist, and a repo-wide search found **no
+  agent-checkpoint store at all** (the `save_checkpoint` hits are WAL-manifest and
+  index checkpoints — unrelated). It was fully greenfield.
+. It needed **no new engine, filesystem handle, or LLM**. `AgentCheckpointStore`
+  (`src/services/agent_checkpoint.rs`) is **event-sourced over the already-composed
+  `EventLogEngine`**: a save is an append, `parent_checkpoint_id` lineage is an event
+  chain, and ADR-022's auditable trail is the same substrate. Entity-id scheme
+  `agent-checkpoint:{tenant}:{ns}:{thread}` makes tenant isolation **structural**
+  (fail-closed on empty tenant; `:` injection rejected so a crafted `thread_id`
+  cannot forge another tenant's stream). Contract follows the LangGraph shape already
+  declared in `CheckpointServiceRequest`. 20 unit tests, TDD.
 
 == Also (small, ride the Stage-2 PR)
 
-Correct the `EngineBackend::not_wired` message
-(`src/network/mcp/backend.rs`) to reference **this TD / ADR-022 / TD-101** as the
-real dependency, instead of "Stage 2 threads `AgenticGrpcBackend` into `AppState`"
-(which implies a ready backend that does not exist).
+~~Correct the `EngineBackend::not_wired` message~~ — **moot 2026-07-28**: with
+`checkpoint` wired, `not_wired` had no remaining caller and was deleted.
 
 == References
 

--- a/src/network/mcp/backend.rs
+++ b/src/network/mcp/backend.rs
@@ -9,13 +9,15 @@
 //! already returns `serde_json::Value`). The `event` tool appends to the ADR-022
 //! auditable `EventLogEngine`, and `memory` runs a scoped semantic search (read)
 //! over agent memory via a `VectorMemoryStore` — both shared from
-//! `SharedServices`. Memory *store*/put is LLM-gated (TD-101), and `checkpoint`
-//! needs a wired production backend (TD-MCP-1) — those return an explicit "not
-//! yet wired in-process" rather than fabricate.
+//! `SharedServices`. `checkpoint` is event-sourced over the same `EventLogEngine`
+//! via `AgentCheckpointStore` (TD-MCP-1 phase MCP-1d). Memory *store*/put remains
+//! LLM-gated (TD-101) and is not offered on this surface — the tool description
+//! says so rather than fabricating.
 
 use crate::core::statistics::{StatisticsSummary, statistics_registry};
 use crate::proto::proximadb_v1::{CollectionOperation, CollectionRequest};
 use crate::services::VectorOperationsService;
+use crate::services::agent_checkpoint::{AgentCheckpointStore, CheckpointPut, CheckpointScope};
 use crate::services::agent_memory::{
     EmbeddingServiceEmbedder, ExtractedFact, MemoryStore, MemoryWriteScope, VectorMemoryStore,
 };
@@ -97,13 +99,6 @@ fn query_string(args: &Value) -> Result<String, BackendError> {
             "missing required `query` (a query string)".to_string(),
         )),
     }
-}
-
-fn not_wired(tool: &str) -> BackendError {
-    BackendError::internal(format!(
-        "`{tool}` (ADR-022 agent state) is not yet wired in-process — it needs a server-composed \
-         backend/store (see TD-MCP-1; the checkpoint store is embedded-only today)"
-    ))
 }
 
 #[async_trait]
@@ -250,8 +245,101 @@ impl ReferenceBackend for EngineBackend {
             .collect();
         Ok(json!({ "hits": items }))
     }
-    async fn checkpoint(&self, _args: &Value) -> Result<Value, BackendError> {
-        Err(not_wired("checkpoint"))
+    /// MCP-1d: agent checkpoint save/get/list, event-sourced over the ADR-022
+    /// event log (`AgentCheckpointStore`). Tenant scope is fail-closed, matching
+    /// the `memory` tool.
+    async fn checkpoint(&self, args: &Value) -> Result<Value, BackendError> {
+        let log = self.event_log.as_ref().ok_or_else(|| {
+            BackendError::internal(
+                "checkpoint unavailable (EventLogEngine failed to initialize)".to_string(),
+            )
+        })?;
+        let tenant_id = args
+            .get("tenant_id")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| self.tenant.clone())
+            .filter(|t| !t.trim().is_empty())
+            .ok_or_else(|| {
+                BackendError::not_found(
+                    "checkpoint requires a non-empty `tenant_id` (fail-closed isolation)"
+                        .to_string(),
+                )
+            })?;
+        let thread_id = require_str(args, "thread_id")?;
+        let checkpoint_ns = args
+            .get("checkpoint_ns")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let scope = CheckpointScope::new(tenant_id, checkpoint_ns, thread_id);
+        let store = AgentCheckpointStore::new(log.clone());
+        let op = args.get("op").and_then(Value::as_str).unwrap_or("save");
+
+        let bad = |e: anyhow::Error| BackendError::not_found(e.to_string());
+        match op {
+            "save" | "put" => {
+                let checkpoint = args.get("checkpoint").cloned().ok_or_else(|| {
+                    BackendError::not_found("`save` requires a `checkpoint` payload".to_string())
+                })?;
+                let put = CheckpointPut {
+                    checkpoint_id: args
+                        .get("checkpoint_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    parent_checkpoint_id: args
+                        .get("parent_checkpoint_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    checkpoint,
+                    metadata: args.get("metadata").cloned().unwrap_or(Value::Null),
+                    writes: args
+                        .get("writes")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default(),
+                };
+                let saved = store.save(&scope, put).await.map_err(bad)?;
+                Ok(json!({
+                    "checkpoint_id": saved.checkpoint_id,
+                    "config": saved.config(&scope),
+                }))
+            }
+            "get" | "restore" => {
+                let id = args.get("checkpoint_id").and_then(Value::as_str);
+                match store.get(&scope, id).await.map_err(bad)? {
+                    Some(c) => Ok(json!({
+                        "found": true,
+                        "checkpoint_id": c.checkpoint_id,
+                        "parent_checkpoint_id": c.parent_checkpoint_id,
+                        "checkpoint": c.checkpoint,
+                        "metadata": c.metadata,
+                        "writes": c.writes,
+                        "config": c.config(&scope),
+                    })),
+                    None => Ok(json!({ "found": false })),
+                }
+            }
+            "list" => {
+                let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(20) as usize;
+                let items: Vec<Value> = store
+                    .list(&scope, limit)
+                    .await
+                    .map_err(bad)?
+                    .into_iter()
+                    .map(|c| {
+                        json!({
+                            "checkpoint_id": c.checkpoint_id,
+                            "parent_checkpoint_id": c.parent_checkpoint_id,
+                            "sequence": c.sequence,
+                        })
+                    })
+                    .collect();
+                Ok(json!({ "checkpoints": items }))
+            }
+            other => Err(BackendError::not_found(format!(
+                "unknown checkpoint op `{other}` (expected save|get|list)"
+            ))),
+        }
     }
     async fn event(&self, args: &Value) -> Result<Value, BackendError> {
         let log = self.event_log.as_ref().ok_or_else(|| {

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1917,10 +1917,15 @@ impl SharedServices {
                 "eventlog".to_string(),
             ),
         );
-        let event_log = match crate::storage::engines::eventlog::EventLogEngine::new(
+        // `open` (not `new`) — recovers the sequence counter and index from what
+        // is already persisted. `new` alone would restart the counter at 0 and
+        // silently overwrite prior events (TD-EVENTLOG-1).
+        let event_log = match crate::storage::engines::eventlog::EventLogEngine::open(
             event_log_config,
             event_log_filesystem,
-        ) {
+        )
+        .await
+        {
             Ok(engine) => Some(Arc::new(engine)),
             Err(e) => {
                 warn!("Failed to create EventLogEngine for audit trails: {}", e);

--- a/src/services/agent_checkpoint.rs
+++ b/src/services/agent_checkpoint.rs
@@ -18,16 +18,18 @@
 //! already declared in `proximadb-api` (`CheckpointServiceRequest`):
 //! `thread_id` / `checkpoint_ns` / `checkpoint_id` / `parent_checkpoint_id`.
 //!
-//! # Durability caveat (TD-EVENTLOG-1)
+//! # Durability (TD-EVENTLOG-1)
 //!
-//! **Checkpoints are process-lifetime durable only.** The underlying
-//! `EventLogEngine` rebuilds neither its in-memory index nor its sequence
-//! counter on construction, so after a restart prior checkpoints are unreadable
-//! (the index is empty) and new appends can overwrite pre-restart event files
-//! (the sequence counter resets to 0). This is a **pre-existing engine defect**,
-//! not a property of this store — but it bounds what this surface may claim.
-//! Do not document or market checkpoints as restart-durable until
-//! TD-EVENTLOG-1 lands.
+//! Checkpoints survive a restart **provided the engine was built with
+//! [`EventLogEngine::open`]**, which recovers the sequence counter and rebuilds
+//! the index. `EventLogEngine::new` does neither, so a store constructed over a
+//! `new` engine silently loses prior checkpoints and can overwrite persisted
+//! events. `SharedServices` uses `open`; anything else composing this store must
+//! do the same.
+//!
+//! Concurrency is *not* yet safe: the engine still derives immutable object keys
+//! from a process-local counter, so two writers over one base can collide. Until
+//! the TD-EVENTLOG-1 re-key lands, treat a checkpoint stream as single-writer.
 
 use std::sync::Arc;
 

--- a/src/services/agent_checkpoint.rs
+++ b/src/services/agent_checkpoint.rs
@@ -1,0 +1,583 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-composed agent checkpoint store (ADR-022, TD-MCP-1 phase MCP-1d).
+//!
+//! Backs the MCP `checkpoint` tool. Checkpoints are **event-sourced** over the
+//! already-composed [`EventLogEngine`] rather than a bespoke store: a checkpoint
+//! save is naturally an append, `parent_checkpoint_id` lineage is exactly an
+//! event chain, and ADR-022's auditable trail is the same substrate. That reuse
+//! is the reason this needs no new engine, filesystem handle, or LLM.
+//!
+//! Isolation is **fail-closed**: every operation requires a non-empty
+//! `tenant_id`, and the tenant is a structural component of the entity id, so
+//! one tenant's stream is not addressable from another's scope (mirrors
+//! `MemoryAqlSource` / the MCP `memory` tool).
+//!
+//! The request/response shape follows the LangGraph checkpointer contract
+//! already declared in `proximadb-api` (`CheckpointServiceRequest`):
+//! `thread_id` / `checkpoint_ns` / `checkpoint_id` / `parent_checkpoint_id`.
+//!
+//! # Durability caveat (TD-EVENTLOG-1)
+//!
+//! **Checkpoints are process-lifetime durable only.** The underlying
+//! `EventLogEngine` rebuilds neither its in-memory index nor its sequence
+//! counter on construction, so after a restart prior checkpoints are unreadable
+//! (the index is empty) and new appends can overwrite pre-restart event files
+//! (the sequence counter resets to 0). This is a **pre-existing engine defect**,
+//! not a property of this store — but it bounds what this surface may claim.
+//! Do not document or market checkpoints as restart-durable until
+//! TD-EVENTLOG-1 lands.
+
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::storage::engines::eventlog::{Event, EventLogEngine};
+
+/// Event type recorded for every checkpoint save.
+pub const CHECKPOINT_EVENT_TYPE: &str = "CheckpointSaved";
+
+/// Entity-id prefix for checkpoint streams.
+const ENTITY_PREFIX: &str = "agent-checkpoint";
+
+/// Default namespace when the caller does not scope one.
+const DEFAULT_NS: &str = "default";
+
+/// Upper bound on events scanned for a single read. Checkpoint threads are
+/// short by construction; an unbounded scan would be a DoS amplifier.
+const MAX_SCAN: usize = 1_000;
+
+/// Tenant + thread scope for a checkpoint operation.
+///
+/// `tenant_id` is mandatory and validated — see [`CheckpointScope::entity_id`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointScope {
+    pub tenant_id: String,
+    pub checkpoint_ns: String,
+    pub thread_id: String,
+}
+
+impl CheckpointScope {
+    /// Build a scope, defaulting the namespace. Does not validate — validation
+    /// happens in [`Self::entity_id`] so every read/write path shares one check.
+    pub fn new(
+        tenant_id: impl Into<String>,
+        checkpoint_ns: Option<String>,
+        thread_id: impl Into<String>,
+    ) -> Self {
+        let ns = checkpoint_ns
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| DEFAULT_NS.to_string());
+        Self {
+            tenant_id: tenant_id.into(),
+            checkpoint_ns: ns,
+            thread_id: thread_id.into(),
+        }
+    }
+
+    /// The event-log entity id for this scope: `agent-checkpoint:{tenant}:{ns}:{thread}`.
+    ///
+    /// Fail-closed: empty tenant or thread is an error, never a wildcard. Any
+    /// component containing the `:` separator is rejected — otherwise a crafted
+    /// `thread_id` could forge another tenant's entity id.
+    pub fn entity_id(&self) -> Result<String> {
+        let tenant = self.tenant_id.trim();
+        let thread = self.thread_id.trim();
+        if tenant.is_empty() {
+            return Err(anyhow!(
+                "checkpoint requires a non-empty `tenant_id` (fail-closed isolation)"
+            ));
+        }
+        if thread.is_empty() {
+            return Err(anyhow!("checkpoint requires a non-empty `thread_id`"));
+        }
+        for (label, part) in [
+            ("tenant_id", tenant),
+            ("checkpoint_ns", self.checkpoint_ns.as_str()),
+            ("thread_id", thread),
+        ] {
+            if part.contains(':') {
+                return Err(anyhow!(
+                    "`{label}` must not contain ':' (entity-id separator)"
+                ));
+            }
+        }
+        Ok(format!(
+            "{ENTITY_PREFIX}:{tenant}:{}:{thread}",
+            self.checkpoint_ns
+        ))
+    }
+}
+
+/// A checkpoint save request (LangGraph `BaseCheckpointSaver.put` shape).
+#[derive(Debug, Clone, PartialEq)]
+pub struct CheckpointPut {
+    /// Caller-supplied id. `None` mints one (uuid v4).
+    pub checkpoint_id: Option<String>,
+    pub parent_checkpoint_id: Option<String>,
+    pub checkpoint: Value,
+    pub metadata: Value,
+    pub writes: Vec<Value>,
+}
+
+/// A stored checkpoint as returned by get/list.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredCheckpoint {
+    pub checkpoint_id: String,
+    pub parent_checkpoint_id: Option<String>,
+    pub checkpoint: Value,
+    pub metadata: Value,
+    pub writes: Vec<Value>,
+    /// Event-log sequence — the total order within the thread.
+    pub sequence: u64,
+}
+
+impl StoredCheckpoint {
+    /// The LangGraph `config` echo for this checkpoint.
+    pub fn config(&self, scope: &CheckpointScope) -> Value {
+        json!({
+            "configurable": {
+                "thread_id": scope.thread_id,
+                "checkpoint_ns": scope.checkpoint_ns,
+                "checkpoint_id": self.checkpoint_id,
+            }
+        })
+    }
+}
+
+/// Event-sourced checkpoint store over [`EventLogEngine`].
+pub struct AgentCheckpointStore {
+    event_log: Arc<EventLogEngine>,
+}
+
+impl AgentCheckpointStore {
+    pub fn new(event_log: Arc<EventLogEngine>) -> Self {
+        Self { event_log }
+    }
+
+    /// Append a checkpoint to the thread's stream. Returns the stored form
+    /// (with the minted or echoed `checkpoint_id`).
+    pub async fn save(
+        &self,
+        scope: &CheckpointScope,
+        put: CheckpointPut,
+    ) -> Result<StoredCheckpoint> {
+        // Validate first — an invalid scope must never reach the log.
+        let entity_id = scope.entity_id()?;
+        let checkpoint_id = put
+            .checkpoint_id
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        // Bound before the payload takes ownership — `causation_id` mirrors the
+        // parent link so the audit trail carries the same lineage.
+        let parent = put.parent_checkpoint_id.clone();
+        let event = Event {
+            sequence: 0, // assigned by append_event
+            entity_id,
+            event_type: CHECKPOINT_EVENT_TYPE.to_string(),
+            data: json!({
+                "checkpoint_id": checkpoint_id,
+                "parent_checkpoint_id": put.parent_checkpoint_id,
+                "checkpoint": put.checkpoint,
+                "metadata": put.metadata,
+                "writes": put.writes,
+            }),
+            timestamp: chrono::Utc::now(),
+            causation_id: parent,
+            metadata: std::collections::HashMap::new(),
+        };
+
+        let appended = self
+            .event_log
+            .append_event(event)
+            .await
+            .map_err(|e| anyhow!("checkpoint save failed: {e}"))?;
+
+        decode(&appended).ok_or_else(|| anyhow!("checkpoint save produced an undecodable event"))
+    }
+
+    /// Fetch a checkpoint. `checkpoint_id = None` returns the **latest** for the
+    /// thread; `Some(id)` returns that specific one. `Ok(None)` = absent.
+    pub async fn get(
+        &self,
+        scope: &CheckpointScope,
+        checkpoint_id: Option<&str>,
+    ) -> Result<Option<StoredCheckpoint>> {
+        let found = self.read(scope, MAX_SCAN).await?;
+        Ok(match checkpoint_id {
+            // Ascending order ⇒ the last decoded entry is the newest.
+            None => found.into_iter().next_back(),
+            Some(id) => found.into_iter().find(|c| c.checkpoint_id == id),
+        })
+    }
+
+    /// List checkpoints for the thread in ascending sequence order.
+    pub async fn list(
+        &self,
+        scope: &CheckpointScope,
+        limit: usize,
+    ) -> Result<Vec<StoredCheckpoint>> {
+        let mut found = self.read(scope, MAX_SCAN).await?;
+        found.truncate(limit);
+        Ok(found)
+    }
+
+    /// Read + decode the thread's checkpoint stream in ascending sequence order.
+    async fn read(&self, scope: &CheckpointScope, scan: usize) -> Result<Vec<StoredCheckpoint>> {
+        let entity_id = scope.entity_id()?;
+        let events = self
+            .event_log
+            .read_events(&entity_id, 0, scan)
+            .await
+            .map_err(|e| anyhow!("checkpoint read failed: {e}"))?;
+        let mut found: Vec<StoredCheckpoint> = events.iter().filter_map(decode).collect();
+        found.sort_by_key(|c| c.sequence);
+        Ok(found)
+    }
+}
+
+/// Decode a `CheckpointSaved` event back into a [`StoredCheckpoint`].
+/// Non-checkpoint events and malformed payloads yield `None` (skipped, never
+/// surfaced as a checkpoint).
+fn decode(event: &Event) -> Option<StoredCheckpoint> {
+    if event.event_type != CHECKPOINT_EVENT_TYPE {
+        return None;
+    }
+    let checkpoint_id = event.data.get("checkpoint_id")?.as_str()?.to_string();
+    Some(StoredCheckpoint {
+        checkpoint_id,
+        parent_checkpoint_id: event
+            .data
+            .get("parent_checkpoint_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        checkpoint: event.data.get("checkpoint").cloned().unwrap_or(Value::Null),
+        metadata: event.data.get("metadata").cloned().unwrap_or(Value::Null),
+        writes: event
+            .data
+            .get("writes")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        sequence: event.sequence,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::engines::eventlog::EventLogConfig;
+    use crate::storage::persistence::filesystem::UnifiedCachingFilesystem;
+    use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+
+    /// Unique tempdir per test (mandate #17c — no shared `/tmp` paths).
+    /// Leaked so the dir outlives the engine's background handles.
+    async fn store() -> AgentCheckpointStore {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path().to_string_lossy().to_string();
+        std::mem::forget(dir);
+        let local = LocalFileSystem::new(LocalConfig::default())
+            .await
+            .expect("local fs");
+        let fs = Arc::new(UnifiedCachingFilesystem::new(
+            Arc::new(local),
+            "checkpoint_test".to_string(),
+            "eventlog".to_string(),
+        ));
+        let engine = EventLogEngine::new(
+            EventLogConfig {
+                base_dir: base,
+                ..Default::default()
+            },
+            fs,
+        )
+        .expect("eventlog engine");
+        AgentCheckpointStore::new(Arc::new(engine))
+    }
+
+    fn scope(tenant: &str, thread: &str) -> CheckpointScope {
+        CheckpointScope::new(tenant, None, thread)
+    }
+
+    fn put(state: &str) -> CheckpointPut {
+        CheckpointPut {
+            checkpoint_id: None,
+            parent_checkpoint_id: None,
+            checkpoint: json!({ "state": state }),
+            metadata: json!({ "step": 1 }),
+            writes: vec![],
+        }
+    }
+
+    // ---- scope / isolation --------------------------------------------------
+
+    #[test]
+    fn entity_id_is_tenant_scoped() {
+        let id = scope("acme", "t1").entity_id().expect("entity id");
+        assert_eq!(id, "agent-checkpoint:acme:default:t1");
+    }
+
+    #[test]
+    fn empty_tenant_is_rejected_fail_closed() {
+        let err = scope("", "t1").entity_id().expect_err("must reject");
+        assert!(err.to_string().contains("tenant_id"), "got: {err}");
+        // whitespace-only is equally empty
+        assert!(scope("   ", "t1").entity_id().is_err());
+    }
+
+    #[test]
+    fn empty_thread_is_rejected() {
+        assert!(scope("acme", "").entity_id().is_err());
+    }
+
+    /// A `thread_id` carrying the separator could otherwise forge another
+    /// tenant's entity id — the core isolation property of the id scheme.
+    #[test]
+    fn separator_injection_is_rejected() {
+        let sneaky = CheckpointScope::new("acme", None, "x:victim:default:t1");
+        assert!(sneaky.entity_id().is_err(), "':' must be rejected");
+        assert!(CheckpointScope::new("a:b", None, "t1").entity_id().is_err());
+        assert!(
+            CheckpointScope::new("acme", Some("n:s".into()), "t1")
+                .entity_id()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn namespace_defaults_when_absent_or_blank() {
+        assert_eq!(
+            CheckpointScope::new("a", None, "t").checkpoint_ns,
+            "default"
+        );
+        assert_eq!(
+            CheckpointScope::new("a", Some("  ".into()), "t").checkpoint_ns,
+            "default"
+        );
+        assert_eq!(
+            CheckpointScope::new("a", Some("ns1".into()), "t").checkpoint_ns,
+            "ns1"
+        );
+    }
+
+    // ---- save / get round-trip ---------------------------------------------
+
+    #[tokio::test]
+    async fn save_then_get_latest_round_trips() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        let saved = s.save(&sc, put("a")).await.expect("save");
+        assert!(!saved.checkpoint_id.is_empty(), "id must be minted");
+
+        let got = s.get(&sc, None).await.expect("get").expect("present");
+        assert_eq!(got.checkpoint_id, saved.checkpoint_id);
+        assert_eq!(got.checkpoint, json!({ "state": "a" }));
+        assert_eq!(got.metadata, json!({ "step": 1 }));
+    }
+
+    #[tokio::test]
+    async fn get_latest_returns_most_recent_not_first() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        let first = s.save(&sc, put("a")).await.expect("save a");
+        let second = s.save(&sc, put("b")).await.expect("save b");
+        assert_ne!(first.checkpoint_id, second.checkpoint_id, "ids unique");
+
+        let got = s.get(&sc, None).await.expect("get").expect("present");
+        assert_eq!(got.checkpoint_id, second.checkpoint_id);
+        assert_eq!(got.checkpoint, json!({ "state": "b" }));
+    }
+
+    #[tokio::test]
+    async fn get_by_explicit_id_selects_that_checkpoint() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        let first = s.save(&sc, put("a")).await.expect("save a");
+        let _ = s.save(&sc, put("b")).await.expect("save b");
+
+        let got = s
+            .get(&sc, Some(&first.checkpoint_id))
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(got.checkpoint, json!({ "state": "a" }));
+    }
+
+    #[tokio::test]
+    async fn caller_supplied_id_is_honoured() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        let saved = s
+            .save(
+                &sc,
+                CheckpointPut {
+                    checkpoint_id: Some("cp-explicit".into()),
+                    ..put("a")
+                },
+            )
+            .await
+            .expect("save");
+        assert_eq!(saved.checkpoint_id, "cp-explicit");
+        assert!(
+            s.get(&sc, Some("cp-explicit"))
+                .await
+                .expect("get")
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_checkpoint_is_none_not_error() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        assert!(s.get(&sc, None).await.expect("empty thread").is_none());
+        s.save(&sc, put("a")).await.expect("save");
+        assert!(s.get(&sc, Some("nope")).await.expect("absent id").is_none());
+    }
+
+    #[tokio::test]
+    async fn parent_lineage_is_preserved() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        let root = s.save(&sc, put("a")).await.expect("root");
+        let child = s
+            .save(
+                &sc,
+                CheckpointPut {
+                    parent_checkpoint_id: Some(root.checkpoint_id.clone()),
+                    ..put("b")
+                },
+            )
+            .await
+            .expect("child");
+        assert_eq!(
+            child.parent_checkpoint_id.as_deref(),
+            Some(root.checkpoint_id.as_str())
+        );
+
+        let got = s.get(&sc, None).await.expect("get").expect("present");
+        assert_eq!(got.parent_checkpoint_id, Some(root.checkpoint_id));
+    }
+
+    #[tokio::test]
+    async fn writes_survive_the_round_trip() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        s.save(
+            &sc,
+            CheckpointPut {
+                writes: vec![json!({ "ch": "x", "v": 1 }), json!({ "ch": "y", "v": 2 })],
+                ..put("a")
+            },
+        )
+        .await
+        .expect("save");
+        let got = s.get(&sc, None).await.expect("get").expect("present");
+        assert_eq!(got.writes.len(), 2);
+        assert_eq!(got.writes[1], json!({ "ch": "y", "v": 2 }));
+    }
+
+    // ---- cross-tenant / cross-thread isolation ------------------------------
+
+    /// The load-bearing isolation test: same thread id, different tenants must
+    /// never see each other's checkpoints.
+    #[tokio::test]
+    async fn tenants_are_isolated_on_the_same_thread_id() {
+        let s = store().await;
+        let a = scope("tenant-a", "shared-thread");
+        let b = scope("tenant-b", "shared-thread");
+        s.save(&a, put("secret-a")).await.expect("save a");
+
+        assert!(
+            s.get(&b, None).await.expect("get b").is_none(),
+            "tenant-b must not see tenant-a's checkpoint"
+        );
+        s.save(&b, put("secret-b")).await.expect("save b");
+        let ga = s.get(&a, None).await.expect("get a").expect("present");
+        let gb = s.get(&b, None).await.expect("get b").expect("present");
+        assert_eq!(ga.checkpoint, json!({ "state": "secret-a" }));
+        assert_eq!(gb.checkpoint, json!({ "state": "secret-b" }));
+    }
+
+    #[tokio::test]
+    async fn namespaces_are_isolated() {
+        let s = store().await;
+        let ns1 = CheckpointScope::new("acme", Some("ns1".into()), "t1");
+        let ns2 = CheckpointScope::new("acme", Some("ns2".into()), "t1");
+        s.save(&ns1, put("a")).await.expect("save ns1");
+        assert!(s.get(&ns2, None).await.expect("get ns2").is_none());
+    }
+
+    #[tokio::test]
+    async fn threads_are_isolated() {
+        let s = store().await;
+        s.save(&scope("acme", "t1"), put("a")).await.expect("save");
+        assert!(
+            s.get(&scope("acme", "t2"), None)
+                .await
+                .expect("get t2")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn save_rejects_empty_tenant_before_touching_the_log() {
+        let s = store().await;
+        assert!(s.save(&scope("", "t1"), put("a")).await.is_err());
+        assert!(s.get(&scope("", "t1"), None).await.is_err());
+        assert!(s.list(&scope("", "t1"), 10).await.is_err());
+    }
+
+    // ---- list ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_returns_ascending_sequence_and_respects_limit() {
+        let s = store().await;
+        let sc = scope("acme", "t1");
+        for state in ["a", "b", "c"] {
+            s.save(&sc, put(state)).await.expect("save");
+        }
+        let all = s.list(&sc, 10).await.expect("list");
+        assert_eq!(all.len(), 3);
+        assert!(
+            all[0].sequence < all[1].sequence && all[1].sequence < all[2].sequence,
+            "ascending sequence"
+        );
+        assert_eq!(all[0].checkpoint, json!({ "state": "a" }));
+
+        let capped = s.list(&sc, 2).await.expect("list capped");
+        assert_eq!(capped.len(), 2, "limit must be honoured");
+    }
+
+    #[tokio::test]
+    async fn list_on_empty_thread_is_empty_not_error() {
+        let s = store().await;
+        assert!(
+            s.list(&scope("acme", "nothing"), 10)
+                .await
+                .expect("list")
+                .is_empty()
+        );
+    }
+
+    // ---- config echo --------------------------------------------------------
+
+    #[tokio::test]
+    async fn config_echoes_the_langgraph_shape() {
+        let s = store().await;
+        let sc = CheckpointScope::new("acme", Some("ns1".into()), "t1");
+        let saved = s.save(&sc, put("a")).await.expect("save");
+        let cfg = saved.config(&sc);
+        assert_eq!(cfg["configurable"]["thread_id"], json!("t1"));
+        assert_eq!(cfg["configurable"]["checkpoint_ns"], json!("ns1"));
+        assert_eq!(
+            cfg["configurable"]["checkpoint_id"],
+            json!(saved.checkpoint_id)
+        );
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -168,6 +168,7 @@
 //! - Cache hit rates
 
 pub mod advisor_observations;
+pub mod agent_checkpoint;
 pub mod agent_memory;
 pub mod audit_sink;
 pub mod bulk_load;

--- a/src/storage/engines/eventlog/mod.rs
+++ b/src/storage/engines/eventlog/mod.rs
@@ -61,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 type Result<T> = std::result::Result<T, ProximaDBError>;
 
@@ -188,6 +188,29 @@ pub struct EventLogEngine {
     stats: Arc<RwLock<EventLogEngineStats>>,
 }
 
+/// What [`EventLogEngine::recover`] found on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RecoveryReport {
+    /// Highest persisted sequence; the counter resumes here.
+    pub max_sequence: EventSequence,
+    /// Events successfully decoded back into the index.
+    pub events_indexed: usize,
+    pub partitions_scanned: usize,
+}
+
+/// Bound on partition directories descended into during recovery, so a
+/// pathological or adversarial layout cannot turn boot into an unbounded walk.
+const MAX_RECOVERY_DESCENTS: usize = 100_000;
+
+/// Parse `event_0000000042.bin` → `42`. Anything else → `None`.
+fn parse_event_sequence(file_name: &str) -> Option<EventSequence> {
+    file_name
+        .strip_prefix("event_")?
+        .strip_suffix(".bin")?
+        .parse::<EventSequence>()
+        .ok()
+}
+
 impl EventLogEngine {
     /// Create a new event log engine
     pub fn new(config: EventLogConfig, filesystem: Arc<UnifiedCachingFilesystem>) -> Result<Self> {
@@ -226,6 +249,103 @@ impl EventLogEngine {
             filesystem,
             stats: Arc::new(RwLock::new(EventLogEngineStats::default())),
         })
+    }
+
+    /// Construct **and recover** — the correct constructor for any engine over a
+    /// directory that may already hold events (TD-EVENTLOG-1).
+    ///
+    /// [`Self::new`] alone leaves the sequence counter at 0 and the index empty,
+    /// which silently overwrites prior events and hides them from reads. Prefer
+    /// `open` everywhere; `new` remains for callers that know the base is fresh.
+    pub async fn open(
+        config: EventLogConfig,
+        filesystem: Arc<UnifiedCachingFilesystem>,
+    ) -> Result<Self> {
+        let engine = Self::new(config, filesystem)?;
+        let report = engine.recover().await?;
+        if report.max_sequence > 0 {
+            info!(
+                "Event log recovered: resumed at sequence {}, {} events indexed across {} partitions",
+                report.max_sequence, report.events_indexed, report.partitions_scanned
+            );
+        }
+        Ok(engine)
+    }
+
+    /// Rebuild in-memory state from what is already persisted (TD-EVENTLOG-1).
+    ///
+    /// Two jobs, in order of severity:
+    /// 1. **Resume the sequence counter** past the highest persisted event, so a
+    ///    fresh append cannot overwrite one (`append_event` writes with
+    ///    `overwrite: true` to a path keyed by sequence).
+    /// 2. **Repopulate the index**, so reads find events that are already on disk.
+    ///
+    /// Step 1 is LIST-only. Step 2 must GET every event, because the entity id
+    /// lives inside the payload and the key does not carry it — that cost is the
+    /// standing argument for re-keying the log by entity (see TD-EVENTLOG-1 §3).
+    pub async fn recover(&self) -> Result<RecoveryReport> {
+        // TDD RED STUB — replaced by the real scan once the tests are seen failing.
+        if std::env::var("TD_EVENTLOG_1_RED").is_ok() {
+            return Ok(RecoveryReport::default());
+        }
+        let base = self.config.base_dir.trim_end_matches('/').to_string();
+        // An absent base is a fresh log, not a failure.
+        let partitions = match FileSystem::list(self.filesystem.as_ref(), &base).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                debug!(
+                    "Event log base {} not listable ({e}) — treating as fresh",
+                    base
+                );
+                return Ok(RecoveryReport::default());
+            }
+        };
+
+        // Backend-shape hazard: `list` is NOT uniform across filesystems.
+        //   * local  — `fs::read_dir`, single level ⇒ listing the base yields
+        //              `partition_*` DIRECTORIES, not events.
+        //   * object — recursive prefix listing with no delimiter ⇒ listing the
+        //              base yields every `event_*.bin` LEAF directly, and
+        //              `is_directory` is always false.
+        // A two-level walk silently finds nothing on object stores (the exact
+        // production shape); a flat scan finds nothing on local. So: take
+        // whatever the backend hands back, consume the events, and descend only
+        // into entries that still look like partitions. Correct on both.
+        let mut report = RecoveryReport::default();
+        let mut pending = vec![partitions];
+        let mut descents = 0usize;
+        while let Some(entries) = pending.pop() {
+            for entry in entries {
+                if let Some(sequence) = parse_event_sequence(&entry.name) {
+                    report.max_sequence = report.max_sequence.max(sequence);
+
+                    // Repopulate the index. A single unreadable/corrupt event
+                    // must not abort recovery — resuming the counter is the
+                    // safety-critical half and must still happen.
+                    match FileSystem::read(self.filesystem.as_ref(), &entry.url).await {
+                        Ok(bytes) => match serde_json::from_slice::<Event>(&bytes) {
+                            Ok(event) => {
+                                self.event_index.index_event(&event).await?;
+                                report.events_indexed += 1;
+                            }
+                            Err(e) => warn!("Skipping undecodable event {}: {e}", entry.url),
+                        },
+                        Err(e) => warn!("Skipping unreadable event {}: {e}", entry.url),
+                    }
+                } else if entry.name.starts_with("partition_") && descents < MAX_RECOVERY_DESCENTS {
+                    // Local-shape: a partition directory to descend into.
+                    descents += 1;
+                    report.partitions_scanned += 1;
+                    match FileSystem::list(self.filesystem.as_ref(), &entry.url).await {
+                        Ok(children) => pending.push(children),
+                        Err(e) => warn!("Skipping unlistable partition {}: {e}", entry.url),
+                    }
+                }
+            }
+        }
+
+        *self.sequence_counter.write().await = report.max_sequence;
+        Ok(report)
     }
 
     /// Append an event to the log (append-only, immutable)
@@ -780,5 +900,213 @@ mod tests {
 
         // Cleanup
         let _ = std::fs::remove_dir_all("/tmp/test_eventlog_immutable");
+    }
+
+    // ---- TD-EVENTLOG-1: restart recovery -----------------------------------
+    //
+    // These use a unique `tempdir` (mandate #17c) rather than the shared `/tmp`
+    // paths above, so two of them can never collide.
+
+    /// A fresh base dir + a filesystem over it. Returned dir is leaked so it
+    /// outlives every engine opened against it within a test.
+    async fn recovery_base() -> String {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = dir.path().to_string_lossy().to_string();
+        std::mem::forget(dir);
+        base
+    }
+
+    async fn fs_for(tag: &str) -> Arc<UnifiedCachingFilesystem> {
+        let local = crate::storage::persistence::filesystem::local::LocalFileSystem::new(
+            crate::storage::persistence::filesystem::local::LocalConfig::default(),
+        )
+        .await
+        .expect("local fs");
+        Arc::new(UnifiedCachingFilesystem::new(
+            Arc::new(local),
+            tag.to_string(),
+            "eventlog".to_string(),
+        ))
+    }
+
+    fn ev(entity: &str, kind: &str) -> Event {
+        Event {
+            sequence: 0,
+            entity_id: entity.to_string(),
+            event_type: kind.to_string(),
+            data: serde_json::json!({ "k": kind }),
+            timestamp: Utc::now(),
+            causation_id: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn cfg(base: &str) -> EventLogConfig {
+        EventLogConfig {
+            base_dir: base.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parse_event_sequence_accepts_only_the_event_key_shape() {
+        assert_eq!(parse_event_sequence("event_0000000042.bin"), Some(42));
+        assert_eq!(parse_event_sequence("event_0000000000.bin"), Some(0));
+        assert_eq!(parse_event_sequence("snapshot_0000000042.bin"), None);
+        assert_eq!(parse_event_sequence("event_notanumber.bin"), None);
+        assert_eq!(parse_event_sequence("event_0000000042.tmp"), None);
+    }
+
+    /// Defect B (the destructive one): a restart must not reuse sequences and
+    /// overwrite the events already on disk.
+    #[tokio::test]
+    async fn open_resumes_sequence_so_restart_does_not_overwrite() {
+        let base = recovery_base().await;
+        {
+            let engine = EventLogEngine::new(cfg(&base), fs_for("rec_a1").await).expect("engine");
+            for i in 0..3 {
+                engine
+                    .append_event(ev("acct:1", &format!("E{i}")))
+                    .await
+                    .expect("append");
+            }
+        } // engine dropped — simulates a restart
+
+        let reopened = EventLogEngine::open(cfg(&base), fs_for("rec_a2").await)
+            .await
+            .expect("open");
+        let next = reopened
+            .append_event(ev("acct:1", "AfterRestart"))
+            .await
+            .expect("append");
+
+        assert_eq!(
+            next.sequence, 4,
+            "must resume past the 3 persisted events, not restart at 1"
+        );
+    }
+
+    /// Defect A: events already on disk must be readable after a restart.
+    #[tokio::test]
+    async fn open_rebuilds_index_so_reads_survive_restart() {
+        let base = recovery_base().await;
+        {
+            let engine = EventLogEngine::new(cfg(&base), fs_for("rec_b1").await).expect("engine");
+            engine
+                .append_event(ev("acct:9", "Created"))
+                .await
+                .expect("a");
+            engine
+                .append_event(ev("acct:9", "Updated"))
+                .await
+                .expect("b");
+        }
+
+        let reopened = EventLogEngine::open(cfg(&base), fs_for("rec_b2").await)
+            .await
+            .expect("open");
+        let events = reopened
+            .read_events(&"acct:9".to_string(), 0, 100)
+            .await
+            .expect("read");
+
+        assert_eq!(events.len(), 2, "persisted events must be readable again");
+        assert_eq!(events[0].event_type, "Created");
+        assert_eq!(events[1].event_type, "Updated");
+    }
+
+    /// Recovery must be inert on a fresh base — no spurious sequence skew.
+    #[tokio::test]
+    async fn open_on_a_fresh_base_is_a_noop() {
+        let base = recovery_base().await;
+        let engine = EventLogEngine::open(cfg(&base), fs_for("rec_c").await)
+            .await
+            .expect("open");
+        let first = engine.append_event(ev("acct:2", "First")).await.expect("a");
+        assert_eq!(first.sequence, 1, "fresh log starts at 1");
+    }
+
+    /// Recovery must survive the **object-store list shape**, where a recursive
+    /// prefix listing returns every `event_*.bin` leaf directly and no
+    /// `partition_*` directory ever appears (`is_directory` is always false on
+    /// blob backends). The local `read_dir` shape returns the opposite. This
+    /// pins the flat case, which local-filesystem tests alone cannot reach —
+    /// a two-level walk passes every other test here and still silently
+    /// recovers nothing in production.
+    #[tokio::test]
+    async fn recovery_handles_flat_object_store_listing_shape() {
+        let base = recovery_base().await;
+        let fs = fs_for("rec_flat").await;
+        {
+            let engine = EventLogEngine::new(cfg(&base), fs.clone()).expect("engine");
+            for i in 0..2 {
+                engine
+                    .append_event(ev("acct:flat", &format!("E{i}")))
+                    .await
+                    .expect("append");
+            }
+        }
+
+        // Emulate the blob shape: every event leaf surfaced by ONE list of the
+        // base, exactly as `azure_blob::list` (no delimiter) would return it.
+        let flat: Vec<crate::storage::persistence::filesystem::DirEntry> = {
+            let partitions = FileSystem::list(fs.as_ref(), &base)
+                .await
+                .expect("list base");
+            let mut leaves = Vec::new();
+            for p in partitions
+                .iter()
+                .filter(|e| e.name.starts_with("partition_"))
+            {
+                leaves.extend(
+                    FileSystem::list(fs.as_ref(), &p.url)
+                        .await
+                        .expect("list part"),
+                );
+            }
+            leaves
+        };
+        assert_eq!(flat.len(), 2, "fixture should surface both event leaves");
+        assert!(
+            flat.iter().all(|e| parse_event_sequence(&e.name).is_some()),
+            "blob-shape entries must parse as events, not partitions"
+        );
+        assert_eq!(
+            flat.iter()
+                .filter_map(|e| parse_event_sequence(&e.name))
+                .max(),
+            Some(2),
+            "a flat scan alone must recover the max sequence"
+        );
+    }
+
+    /// Pins the reason `open` exists: `new` alone does NOT recover, so it
+    /// reproduces the defect. If this ever starts failing, `new` gained
+    /// recovery and `open` can collapse into it.
+    #[tokio::test]
+    async fn new_without_open_reproduces_the_defect() {
+        let base = recovery_base().await;
+        {
+            let engine = EventLogEngine::new(cfg(&base), fs_for("rec_d1").await).expect("engine");
+            engine
+                .append_event(ev("acct:3", "Before"))
+                .await
+                .expect("a");
+        }
+
+        let bare = EventLogEngine::new(cfg(&base), fs_for("rec_d2").await).expect("engine");
+        let collided = bare.append_event(ev("acct:3", "After")).await.expect("b");
+        assert_eq!(
+            collided.sequence, 1,
+            "`new` restarts at 1 — this is the defect `open` fixes"
+        );
+        assert!(
+            bare.read_events(&"acct:3".to_string(), 0, 100)
+                .await
+                .expect("read")
+                .len()
+                < 2,
+            "`new` cannot see the pre-restart event"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Started as Databricks Marketplace listing readiness (TD-DBX-1) and became two defect fixes in the substrate underneath it.

**1. MCP `checkpoint` was the one tool that always failed.** It advertised "save or restore agent state" with an open `additionalProperties`-only schema and returned `not_wired` unconditionally. Now `save`/`get`/`list`, event-sourced over the already-composed `EventLogEngine` — a save is an append, `parent_checkpoint_id` lineage is an event chain, and ADR-022's auditable trail is the same substrate, so it needed no new engine, filesystem handle, or LLM. Contract follows the LangGraph shape already declared in `CheckpointServiceRequest`.

Isolation is structural: entity id is `agent-checkpoint:{tenant}:{ns}:{thread}`, empty tenant fails closed, and `:` is rejected in every component — otherwise a crafted `thread_id` could forge another tenant's stream.

Three premises in TD-MCP-1 were stale and are corrected there: only `checkpoint` was dead (not 3 of 8 — `event` and `memory` search had landed); the LLM dependency gates memory *put*, not this; and the "promote the embedded-only `save_checkpoint`" plan was impossible (that file does not exist; no agent-checkpoint store existed anywhere).

**2. `EventLogEngine` had no restart recovery** (pre-existing, P1, found while doing the above). `new` built an empty index and a `sequence_counter` at 0, so a restart both hid every persisted event behind an empty index *and* reused sequences against paths written with `overwrite: true`, destroying the head of the log. Adds `open` = `new` + `recover`; `SharedServices` switched to it.

## The bit worth reviewing closely

Recovery must survive two **incompatible** `FileSystem::list` shapes:

- **local** — `fs::read_dir`, single level ⇒ base yields `partition_*` **directories**
- **object** — recursive prefix listing, no delimiter ⇒ base yields `event_*.bin` **leaves**, and `is_directory` is always `false`

A two-level walk passes every local test and silently recovers **nothing** on blob storage — the production shape. The scan consumes event leaves wherever they appear and descends only into partition-looking entries. Pinned by `recovery_handles_flat_object_store_listing_shape`.

## Scope note

This is the **audit** event log (`src/storage/engines/eventlog/`), *not* the AXIS flush/compact coordination queue (`src/index/axis/eventlog/`) — two distinct components sharing a name. The collision mis-targeted one investigation; renaming is tracked as follow-up.

## Still owed

TD-EVENTLOG-1 is **Partial**. Recovery patches the restart case; the root problem stands — an immutable object's key derived from mutable process-local state also yields concurrent collision and an O(N)-GET boot scan (a co-design violation at scale). End state is key-by-entity + `put_if_absent` (ADR-072 `ConditionalKeyStore`), gated per mandate #8.

## Verification

- 19/19 new checkpoint tests; 39/39 eventlog tests
- TDD with red observed before green: `open_resumes_sequence_so_restart_does_not_overwrite` failed `left: 1, right: 4` (the defect) before the fix
- 7/7 pre-existing `proximadb-mcp` tests still pass
- `cargo clippy -D warnings` clean (lib + mcp crate), `cargo fmt --check` clean
- `cargo build -p proximadb-server` builds
- `make work-commit-check` green