### PR TITLE
docs(td,review): TD-DML-1 UPSERT bypass + verified cross-model red-team results

### DIFF
--- a/docs/10-quality/td/TD-DML-1-upsert-skips-uniqueness-fk-enforcement.adoc
+++ b/docs/10-quality/td/TD-DML-1-upsert-skips-uniqueness-fk-enforcement.adoc
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DML-1: UPSERT bypasses uniqueness and foreign-key enforcement
+:status: Open
+:date: 2026-07-28
+:authors: cross-model red-team (Lens C), verified 2026-07-28
+:found-by: multi-LLM adversarial review of the FA/identity work (docs/_internal/cross-model-review-adr-077-fa-track-identity.md)
+:lane: services / F5 (OLTP write path) — not the catalog/FA lane that filed this
+
+[cols="1,3"]
+|===
+| Status | Open — silent integrity violation on the UPSERT path
+| Severity | High — a declared UNIQUE or FK can be violated by any UPSERT
+| Lane | `src/services/dml/mod.rs` (the F5 / OLTP write-path owner)
+|===
+
+== The defect
+
+`DmlService::execute_upsert` (`src/services/dml/mod.rs:3513`) builds mutation
+records and calls `record_store.write_mutations` with `TableRecordMutationKind::Upsert`
+— and does **nothing else**. Unlike `execute_insert` and `execute_update`, it never
+calls:
+
+* `build_unique_candidate_sets` / `check_unique_conflict` — the secondary-UNIQUE
+  conflict probe;
+* `conditional_key_store.put_if_absent` — the PK fence (F2 / ADR-072 D3);
+* `enforce_foreign_keys_for_batch` — the FK existence check.
+
+The `DirectWalTableRecordStore` Upsert branch (`src/services/record_store.rs:1936`)
+likewise skips the `exists` check the Insert branch performs.
+
+== Concrete exploit (verified against the code path)
+
+```sql
+CREATE TABLE t (id BIGINT PRIMARY KEY, email TEXT UNIQUE);
+INSERT INTO t (id, email) VALUES (1, 'a@x');
+UPSERT INTO t (id, email) VALUES (2, 'a@x');   -- admitted
+SELECT * FROM t WHERE email = 'a@x';            -- returns TWO rows
+```
+
+The `email` UNIQUE is silently violated. The same bypass defeats a FOREIGN KEY:
+a UPSERT into a child table with a non-existent parent is admitted (no
+`enforce_foreign_keys` call).
+
+There is also a CKS-divergence follow-on: because UPSERT never claims the PK in
+the CKS, a later `INSERT` of the same PK passes `put_if_absent`, and only
+`write_mutations`' oid-existence check catches it — leaving a stale CKS state.
+
+== Why this is not caught downstream
+
+`write_mutations` keys its INSERT-conflict check on `record.oid` (the PK tuple),
+so it backstops **PK** duplicates only. It does **not** check secondary UNIQUE
+constraints — that is `check_unique_conflict`'s job, which UPSERT skips. So
+secondary-UNIQUE and FK enforcement have no backstop on this path.
+
+== Scope note
+
+This is independent of the FA / catalog-identity work in the same red-team
+review. It is a missing-probe bug on the UPSERT path, not an encoder mismatch
+(Lens C confirmed the two key encoders do **not** produce a silent PK-duplicate
+admit — `write_mutations`' oid backstop catches those). Filed here for the F5 /
+write-path owner because it is the highest-severity finding from the review and
+sits in actively-developed code.
+
+== Suggested fix (for the lane owner)
+
+Route `execute_upsert` through the same enforcement sequence as
+`execute_insert`/`execute_update`: `build_unique_candidate_sets` +
+`check_unique_conflict`, the CKS PK claim (or its update equivalent), and
+`enforce_foreign_keys_for_batch`. An UPSERT that *replaces* an existing row must
+also release/refresh the prior row's UNIQUE and CKS claims, or the divergence
+above persists.

--- a/docs/_internal/cross-model-review-adr-077-fa-track-identity.md
+++ b/docs/_internal/cross-model-review-adr-077-fa-track-identity.md
@@ -1,0 +1,34 @@
+
+---
+
+## PART 3 — Verified Results (2026-07-28)
+
+Two lenses were run through Claude agents (the first model in the multi-LLM pass); both were **verified against source by the session lead before relay**, not forwarded raw. Lens A and D are left for external models.
+
+### Lens B (security lowering) — one real fail-open, found and fixed
+
+| # | Finding (verified) | Disposition |
+|---|---|---|
+| 1 | "Strict walker is dead code in production" | **Severity overstated.** RLS enforcement is dead-wired (`apply_rls_filter` has zero callers), so nothing is *live*. The strict walker being inert is by design (FA-c wiring is lane-blocked). Real risk is documentation implying FA-a2 is shipped defense — wording tightened. |
+| 2 | `Not(Equals)` admits a cross-class row that `NotEquals` denies; generalizes to `Not(any comparison)` | **Real, fixed** in #1277 via a 3-valued substrate (`Not(None)=None→deny`). |
+| 3 | The deny-biased property test's grammar had no cross-class rows | **Real** — the test that should have caught #2 couldn't. Widened in #1277. |
+| 4 | Over-deny on `Not(And([Eq,Eq]))` (availability) | **Real, NOT fixed.** A De-Morgan lowering was tried and **reverted**: the property test caught it introduced a fail-open on `Not(Not(Eq))`. Over-deny is the safe direction; documented as a known limitation. |
+| 5 | `json_eq` epsilon vs `compare_json_values` exact float | **Real, low severity, noted**, not changed. |
+
+### Lens C (key encoders) — the scary headline is a negative result
+
+**No encoder-disagreement missed-fence exists.** Every disagreement the lens could construct is caught by `write_mutations`' oid-keyed INSERT-conflict backstop, or fails closed. The two-encoder situation is ugly but **not exploitable for silent PK duplicates** — recorded so it isn't re-investigated.
+
+The real finding redirected to the services lane:
+
+| # | Finding (verified) | Disposition |
+|---|---|---|
+| 2 | `execute_upsert` bypasses `check_unique_conflict`, the CKS PK fence, and FK enforcement → silent UNIQUE/FK violation | **Real, High.** Filed as **TD-DML-1** for the F5/write-path owner. Not in the catalog/FA lane. |
+| 1 | CKS fence encodes only the first column of a composite PK (over-fence, spurious reject) | **Real, Medium.** This is the known single-column-PK limitation already documented in ADR-077; services lane. |
+| 3–5 | UPDATE bypasses CKS; Decimal/structured PK fail closed; DELETE rejects some PK types | Lower severity, services lane. |
+
+### Lessons from the pass
+
+- **Verify before relay.** The agent overstated #B1's severity ("live in production" — it's dead-wired) and proposed a fix for #B4 (`re-add the guard`) that doesn't work, plus the De-Morgan fix that introduced a worse bug. Correct diagnosis, wrong severity and wrong fixes — caught only by checking against source.
+- **The property test earned its keep twice**: it was too narrow to catch #B2 (the finding), then it caught the unsound De-Morgan "fix" for #B4. A narrow grammar gives false assurance; the grammar is now widened.
+- **Cross-model value was concrete**: Lens B found a fail-open in code the session lead wrote and had "verified," and Lens C turned a scary-looking encoder situation into a clean negative result plus a real bug in a different lane.


### PR DESCRIPTION
Two docs artifacts from the multi-LLM red-team pass.

**TD-DML-1** — `execute_upsert` bypasses uniqueness + FK enforcement (verified). The highest-severity finding; filed for the F5/write-path owner.

**Cross-model review Part 3** — verified results: Lens B's fail-open (fixed in #1277), Lens C's negative result on encoder disagreement, and the lessons (verify before relay; the property test caught an unsound fix).