### PR TITLE
docs(td): TD-DML-2 composite-PK not fenced by CKS (cross-model red-team, verified)

### DIFF
--- a/docs/10-quality/td/TD-DML-2-composite-pk-cks-fence.adoc
+++ b/docs/10-quality/td/TD-DML-2-composite-pk-cks-fence.adoc
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DML-2: Composite primary keys are not fenced by the ConditionalKeyStore
+:status: Open
+:date: 2026-07-28
+:authors: cross-model red-team (Lens C Claude + DeepSeek v4-Pro), verified 2026-07-28
+:found-by: multi-LLM adversarial review of the FA/identity work (docs/_internal/cross-model-review-adr-077-fa-track-identity.md)
+:lane: services / F5 (OLTP write path)
+:related: TD-DML-1 (UPSERT bypass), ADR-072 D3, ADR-077
+
+[cols="1,3"]
+|===
+| Status | Open — composite-PK tables get spurious rejects (or skip the fence) on the CKS path
+| Severity | Medium-High (functionality) — the common `(tenant_id, id)` pattern is unusable through the fenced path
+| Lane | `src/services/dml/mod.rs` + `crates/foundation/proximadb-data-model/src/key_codec.rs`
+|===
+
+== The defect
+
+The F2 fenced-PK path (`ConditionalKeyStore::put_if_absent`) is **single-column
+only**:
+
+* `DmlService::execute_insert` (`src/services/dml/mod.rs:3024`) gates on
+  `primary_key_column` (singular = `schema.primary_key.first()`), then builds the
+  CKS identity at `:3064-3068` with `std::slice::from_ref(&pk_value)` — a
+  one-element slice **regardless of PK arity**.
+* The DELETE-tombstone path (`:3434`) and the FK-existence CKS branch (`:4939`)
+  explicitly guard on `pk_cols.len() == 1` / `values.len() == 1`, **skipping the
+  CKS** for composite keys and falling back to the record-store probe.
+
+So a composite PK has two failure modes depending on the path:
+
+. **INSERT** — the fence runs but on the *first column only*, so two rows sharing
+  the first PK column collide in the CKS:
++
+```sql
+CREATE TABLE t (tenant_id TEXT, id BIGINT, payload TEXT, PRIMARY KEY (tenant_id, id));
+INSERT INTO t (tenant_id, id) VALUES ('acme', 1);   -- OK
+INSERT INTO t (tenant_id, id) VALUES ('acme', 2);   -- REJECTED: 'acme' already claimed
+```
+Both rows compute `Identity = encode_identity(tenant, "t", [String("acme")])`. The
+second is a spurious **reject** (false positive), not a miss.
+
+. **DELETE / FK existence** — composite keys skip the CKS entirely and use the
+  record-store probe (`encode_primary_key_tuple`).
+
+== What this is NOT (verified, settling a cross-model disagreement)
+
+The DeepSeek review flagged this as a **TOCTOU admit-window**; the Claude review
+flagged it as a **spurious reject**. The code settles it: **spurious reject**, and
+**the concurrency is sound either way**.
+
+* There is no check-then-act window: `execute_insert`/`execute_update` hold both
+  the in-process `_op_lock` (`:2984`/`:3207`) and the durable `dml_lock_guard`
+  (`:2978`) via RAII across the check *and* `write_mutations` — "held for the whole
+  INSERT" (`:2980`). Within-pod is serialized by the op_lock; cross-pod by the
+  durable lock.
+* The encoder layer is not at fault: `encode_identity` (`key_codec.rs:57`) is
+  injective and handles multi-value tuples correctly. The defect is that the DML
+  path only ever passes it **one** value.
+* `write_mutations` keys its INSERT-conflict check on `record.oid`
+  (`encode_primary_key_tuple`, full composite), so it is the actual backstop for
+  composite-PK duplicate detection today — but it is check-then-act, and only
+  correct because the op_lock serializes it.
+
+== Suggested fix (for the lane owner)
+
+Feed the **full** PK value vector to `encode_identity` (it already accepts
+`&[ProximaValue]`), not `slice::from_ref` of the first. The `primary_key_column`
+singular helper should become `primary_key_columns` at this call site, and the
+`pk_cols.len() == 1` / `values.len() == 1` guards on the DELETE/FK paths lifted so
+composite keys fence through the CKS like single-column ones. The CKS and
+`encode_identity` need no change — only the DML call sites do.
+
+== Scope note
+
+This is the second finding from the same red-team pass that lands in the F5 /
+write-path lane (the first was TD-DML-1, the UPSERT bypass). Both are independent
+of the catalog-identity and FA work; both were verified against source before
+filing.


### PR DESCRIPTION
Second services-lane finding from the FA/identity red-team. Surfaced independently by **both** Claude (Lens C) and DeepSeek v4-Pro — the strongest signal from the pass.

Composite-PK tables don't fence correctly through the ConditionalKeyStore: INSERT fences on the first column only (spurious reject), DELETE/FK skip the CKS via a `len()==1` guard.

**Settles the cross-model disagreement:** DeepSeek called it a TOCTOU admit-window; Claude called it a spurious reject. Verified against source — spurious reject, and concurrency is sound (op_lock + durable DML lock held across check+write). Fix is DML-call-site only (`encode_identity` already accepts multi-value).