### PR TITLE
feat(delvec): F3v WI-2b — OID resolver capture at write + CRC32 format

### DIFF
--- a/crates/storage/proximadb-storage-common/src/oid_position_resolver.rs
+++ b/crates/storage/proximadb-storage-common/src/oid_position_resolver.rs
@@ -62,8 +62,10 @@ impl OidPositionResolver {
         self.oids.is_empty()
     }
 
-    /// Serialize as `[OPR_MAGIC | count u32 | (oid_len u32, utf8 bytes)* ]` in
-    /// position order, all little-endian.
+    /// Serialize as `[OPR_MAGIC | count u32 | (oid_len u32, utf8 bytes)* | crc32 u32]`
+    /// in position order, all little-endian. The trailing CRC32 (over the whole
+    /// preceding body) lets a loader reject a correct-magic-but-corrupt sidecar
+    /// instead of mapping a delete to the wrong position (TD-DELVEC-1 §9 / WI-2b).
     pub fn serialize(&self) -> Result<Vec<u8>, BitmapError> {
         let mut out = Vec::new();
         out.extend_from_slice(OPR_MAGIC);
@@ -73,30 +75,46 @@ impl OidPositionResolver {
             out.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
             out.extend_from_slice(bytes);
         }
+        let crc = crc32fast::hash(&out);
+        out.extend_from_slice(&crc.to_le_bytes());
         Ok(out)
     }
 
     /// Deserialize, rejecting an absent/unknown magic (so a caller can fall back
-    /// to a no-resolver path) or a truncated body.
+    /// to a no-resolver path), a truncated body, OR a CRC32 mismatch — a
+    /// correct-magic-but-corrupt sidecar must never yield a wrong-position map
+    /// (TD-DELVEC-1 §9 / WI-2b).
     pub fn deserialize(bytes: &[u8]) -> Result<Self, BitmapError> {
         let err = |m: &str| BitmapError::SerializationError(m.to_string());
-        if bytes.len() < OPR_MAGIC.len() + 4 || &bytes[..OPR_MAGIC.len()] != OPR_MAGIC {
+        if bytes.len() < OPR_MAGIC.len() {
+            return Err(err("oid-position resolver: too short for magic"));
+        }
+        if &bytes[..OPR_MAGIC.len()] != OPR_MAGIC {
             return Err(err("oid-position resolver: missing or unknown magic"));
         }
+        // Trailing CRC32 over the body = everything except the last 4 bytes.
+        if bytes.len() < OPR_MAGIC.len() + 4 + 4 {
+            return Err(err("oid-position resolver: too short for count + crc"));
+        }
+        let body = &bytes[..bytes.len() - 4];
+        let stored_crc = u32::from_le_bytes(bytes[bytes.len() - 4..].try_into().unwrap());
+        if crc32fast::hash(body) != stored_crc {
+            return Err(err("oid-position resolver: crc32 mismatch (corrupt body)"));
+        }
         let mut off = OPR_MAGIC.len();
-        let count = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as usize;
+        let count = u32::from_le_bytes(body[off..off + 4].try_into().unwrap()) as usize;
         off += 4;
         let mut oids = Vec::with_capacity(count);
         for _ in 0..count {
-            if off + 4 > bytes.len() {
+            if off + 4 > body.len() {
                 return Err(err("oid-position resolver: truncated length"));
             }
-            let len = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as usize;
+            let len = u32::from_le_bytes(body[off..off + 4].try_into().unwrap()) as usize;
             off += 4;
-            if off + len > bytes.len() {
+            if off + len > body.len() {
                 return Err(err("oid-position resolver: truncated oid"));
             }
-            let oid = std::str::from_utf8(&bytes[off..off + len])
+            let oid = std::str::from_utf8(&body[off..off + len])
                 .map_err(|_| err("oid-position resolver: invalid utf8 oid"))?
                 .to_string();
             off += len;
@@ -172,6 +190,21 @@ mod tests {
         short_body.extend_from_slice(&10u32.to_le_bytes());
         short_body.extend_from_slice(b"abc");
         assert!(OidPositionResolver::deserialize(&short_body).is_err());
+    }
+
+    #[test]
+    fn crc_rejects_corrupt_body_not_wrong_position() {
+        // TD-DELVEC-1 §9 (DeepSeek T4): correct magic + a corrupt body must NOT
+        // deserialize to a wrong-position map. Flip one body byte (not the CRC
+        // trailer) and assert the loader rejects it outright.
+        let r = OidPositionResolver::from_stream_order(vec!["a".into(), "b".into(), "c".into()]);
+        let mut bytes = r.serialize().expect("serialize");
+        // Byte 8 sits inside the body (after magic + count), before the CRC.
+        bytes[8] ^= 0xFF;
+        assert!(
+            OidPositionResolver::deserialize(&bytes).is_err(),
+            "a corrupt body must be rejected at the CRC, never silently yield a wrong-position resolver"
+        );
     }
 
     #[test]

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -621,6 +621,17 @@ pub struct PaxSegmentWriter {
     /// dim + the quant/f32_tier/embedding_count config). Replaces the flat 1024
     /// that overestimated SQ8 blocks by ~4.5×. 0 = not yet computed.
     per_row_estimate: usize,
+    /// TD-DELVEC-1 WI-2b: when true, capture each record's canonical oid in
+    /// add_record (stream) order into `oids`, and expose it via
+    /// [`PaxSegmentWriter::oid_resolver_bytes`] as a serialized
+    /// `OidPositionResolver` (the flush path writes a `.opr` sidecar in WI-2c).
+    /// Default OFF — zero cost; the default flush path is byte-for-byte unchanged.
+    compute_oid_resolver: bool,
+    /// Captured canonical oids in add_record (stream) order, one per record,
+    /// populated only when `compute_oid_resolver` is on. Position `i` here is the
+    /// segment's footer-block position `i` (verified: `add_record` call-order is
+    /// the on-disk order; TD-DELVEC-1 §9.2).
+    oids: Vec<String>,
     /// TD-COMPACT-1 S2: `Some` iff `PROXIMADB_TRACE_PAX_WRITE` was set when the
     /// writer was constructed (read ONCE, here) — cumulative sub-phase timers.
     write_trace: Option<Box<WriteTraceStats>>,
@@ -683,6 +694,8 @@ impl PaxSegmentWriter {
             rabitq_vectors: Vec::new(),
             two_level: None,
             per_row_estimate: 0,
+            compute_oid_resolver: false,
+            oids: Vec::new(),
             write_trace: std::env::var_os("PROXIMADB_TRACE_PAX_WRITE")
                 .is_some()
                 .then(|| Box::new(WriteTraceStats::default())),
@@ -698,6 +711,32 @@ impl PaxSegmentWriter {
     pub fn with_block_centroids(mut self, enabled: bool) -> Self {
         self.compute_centroids = enabled;
         self
+    }
+
+    /// TD-DELVEC-1 WI-2b: opt in to capturing the segment's oid→footer-block
+    /// position resolver. When on, `add_record` records each canonical oid in
+    /// stream order; [`PaxSegmentWriter::oid_resolver_bytes`] then serializes a
+    /// CRC32'd `ORP1` resolver (the flush path writes it as a `.opr` sidecar in
+    /// WI-2c). Default OFF — pre-existing callers pay nothing. Builder form
+    /// mirroring [`with_block_centroids`]; no block-writer rebuild needed.
+    pub fn with_oid_resolver(mut self, enabled: bool) -> Self {
+        self.compute_oid_resolver = enabled;
+        self
+    }
+
+    /// TD-DELVEC-1 WI-2b: serialize the captured oid→footer-block-position
+    /// resolver (CRC32'd `ORP1`), or `Ok(None)` if `with_oid_resolver` was not
+    /// enabled. The oids are complete once every record is added, so call this
+    /// BEFORE [`finish`](Self::finish) consumes the writer; the flush path
+    /// (WI-2c) writes the bytes as a `.opr` sidecar beside the segment.
+    pub fn oid_resolver_bytes(&self) -> Result<Option<Vec<u8>>, crate::bitmap::BitmapError> {
+        if !self.compute_oid_resolver {
+            return Ok(None);
+        }
+        let bytes =
+            crate::oid_position_resolver::OidPositionResolver::from_stream_order(self.oids.clone())
+                .serialize()?;
+        Ok(Some(bytes))
     }
 
     /// Set the vector quantization strategy for this segment (P3 Phase D). Builder form
@@ -886,6 +925,13 @@ impl PaxSegmentWriter {
             if let Some(t) = t {
                 d_cluster = t.elapsed();
             }
+        }
+        // TD-DELVEC-1 WI-2b: capture the canonical oid in add_record (stream)
+        // order — the only point that sees post-cluster-reorder footer-block
+        // order (verified: call-order == on-disk position; §9.2). Default off;
+        // mirrors the centroid opt-in above.
+        if self.compute_oid_resolver {
+            self.oids.push(record.oid.clone());
         }
         // ADR-062: buffer the embedding-0 f32 vector (in cluster/add order) for
         // the segment-level RaBitQ region. The caller has already reordered
@@ -2031,6 +2077,84 @@ mod tests {
             vec![11.0, 11.0],
             "mean of [10,10],[12,12]"
         );
+    }
+
+    /// TD-DELVEC-1 WI-2b: with `with_oid_resolver(true)`, the writer captures
+    /// each record's canonical oid in add_record (stream) order and exposes a
+    /// CRC32'd `ORP1` resolver whose positions match that order. Default OFF ⇒
+    /// `oid_resolver_bytes()` is `Ok(None)` (the default flush path is unchanged).
+    /// The footer-block-order property (capture order == on-disk scan order) is
+    /// verified by code read (§9.2) + a WI-2c scan integration test.
+    #[test]
+    fn oid_resolver_captures_stream_order_and_is_off_by_default() {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+        let rec = |oid: &str| {
+            let mut r = ProximaRecord {
+                oid: oid.into(),
+                tenant_id: "t".into(),
+                created_at_ns: 1,
+                updated_at_ns: 1,
+                ..Default::default()
+            };
+            r.embeddings.push(EmbeddingCell {
+                modality: "dense".into(),
+                dim: 1,
+                values: EmbeddingValues::Fp32(vec![0.0]),
+                ..Default::default()
+            });
+            r
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+
+        // Default OFF: no resolver captured.
+        let mut w0 = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RawF32);
+        w0.add_record(&rec("x")).unwrap();
+        assert!(
+            w0.oid_resolver_bytes().unwrap().is_none(),
+            "default off ⇒ no resolver bytes"
+        );
+
+        // Opt in: capture oids in add_record order, round-trip through ORP1+CRC.
+        let mut w = PaxSegmentWriter::new(
+            &path,
+            BlockMode::Pax,
+            BlockCompression::None,
+            "col",
+            0,
+            1,
+            None,
+        )
+        .with_quant(VectorQuant::RawF32)
+        .with_oid_resolver(true);
+        for oid in ["a", "b", "", "d"] {
+            w.add_record(&rec(oid)).unwrap();
+        }
+        let bytes = w
+            .oid_resolver_bytes()
+            .unwrap()
+            .expect("captured when enabled");
+        let resolver =
+            crate::oid_position_resolver::OidPositionResolver::deserialize(&bytes).unwrap();
+        assert_eq!(resolver.len(), 4);
+        assert_eq!(resolver.position_of("a"), Some(0));
+        assert_eq!(resolver.position_of("b"), Some(1));
+        assert_eq!(
+            resolver.position_of(""),
+            Some(2),
+            "an empty oid is kept at its position (append-only rows are non-addressable, harmless)"
+        );
+        assert_eq!(resolver.position_of("d"), Some(3));
+        assert_eq!(resolver.oid_at(1), Some("b"));
     }
 
     /// TD-WLP-3 (TD-RDSTRAT-5 lever-3): the writer emits one RMS radius per


### PR DESCRIPTION
Writer-side persistence primitive for cold-tier deletion vectors (**TD-DELVEC-1 WI-2b**). Additive, wired to nothing (default off); the default flush path is byte-for-byte unchanged. Design gate: rev-4 (#1279, §8/§9).

**What lands:**
- `PaxSegmentWriter::with_oid_resolver(enabled)` builder (mirrors `with_block_centroids`). `add_record` captures `record.oid` in stream order — the only post-reorder point (verified: call-order == footer-block position, §9.2).
- `PaxSegmentWriter::oid_resolver_bytes()` serializes the captured resolver as a CRC32'd `ORP1` blob (call before `finish()` consumes the writer).
- `OidPositionResolver` serialize/deserialize now carry a trailing **CRC32** (`crc32fast`, same primitive as the PAX footer): a correct-magic-but-corrupt sidecar is rejected at the CRC (DeepSeek T4) instead of mapping a delete to a wrong position. No live readers of `ORP1` yet, so the format change is safe.
- Tests: capture-in-stream-order (off-by-default + opt-in round-trip) and CRC corrupt-body rejection.

**Scope split (WI-2b / WI-2c):** rev-4's WI-2b described the full "persist at flush incl. `.opr` sidecar write." This PR delivers the **writer-side half** (capture + serialize + CRC + getter). The flush-path `.opr` sidecar write (the async finalize in `flush/mod.rs`) is **WI-2c** — its own focused PR + a scan-based integration test. The TD WI-2b row will be split when WI-2c lands.

**Local verification:** `cargo test -p proximadb-storage-common --lib` → 457 passed incl. both new tests; clippy clean (`-D warnings`); fmt clean. 4 pre-existing failures (`block_centroids_*`, `block_radii_*`, `coalesced_footer_*`) are **unrelated block-cutting tests verified to fail identically on the clean base** (env-specific byte estimates; CI-green on `develop`).