### PR TITLE
feat(delvec): F3v WI-2c — persist OID resolver as a footer region

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -624,7 +624,7 @@ pub struct PaxSegmentWriter {
     /// TD-DELVEC-1 WI-2b: when true, capture each record's canonical oid in
     /// add_record (stream) order into `oids`, and expose it via
     /// [`PaxSegmentWriter::oid_resolver_bytes`] as a serialized
-    /// `OidPositionResolver` (the flush path writes a `.opr` sidecar in WI-2c).
+    /// `OidPositionResolver` (WI-2c persists it as a footer region inside the segment).
     /// Default OFF — zero cost; the default flush path is byte-for-byte unchanged.
     compute_oid_resolver: bool,
     /// Captured canonical oids in add_record (stream) order, one per record,
@@ -716,8 +716,8 @@ impl PaxSegmentWriter {
     /// TD-DELVEC-1 WI-2b: opt in to capturing the segment's oid→footer-block
     /// position resolver. When on, `add_record` records each canonical oid in
     /// stream order; [`PaxSegmentWriter::oid_resolver_bytes`] then serializes a
-    /// CRC32'd `ORP1` resolver (the flush path writes it as a `.opr` sidecar in
-    /// WI-2c). Default OFF — pre-existing callers pay nothing. Builder form
+    /// CRC32'd `ORP1` resolver (WI-2c persists it as a footer region inside
+    /// the segment). Default OFF — pre-existing callers pay nothing. Builder form
     /// mirroring [`with_block_centroids`]; no block-writer rebuild needed.
     pub fn with_oid_resolver(mut self, enabled: bool) -> Self {
         self.compute_oid_resolver = enabled;
@@ -728,7 +728,7 @@ impl PaxSegmentWriter {
     /// resolver (CRC32'd `ORP1`), or `Ok(None)` if `with_oid_resolver` was not
     /// enabled. The oids are complete once every record is added, so call this
     /// BEFORE [`finish`](Self::finish) consumes the writer; the flush path
-    /// (WI-2c) writes the bytes as a `.opr` sidecar beside the segment.
+    /// (WI-2c) persists the bytes as a footer region inside the segment.
     pub fn oid_resolver_bytes(&self) -> Result<Option<Vec<u8>>, crate::bitmap::BitmapError> {
         if !self.compute_oid_resolver {
             return Ok(None);
@@ -1463,8 +1463,19 @@ impl PaxSegmentWriter {
         let rabitq_len = region_bytes.len() as u64;
         let sq8_off = rabitq_off + rabitq_len;
         let sq8_len = sq8_region_bytes.len() as u64;
-        // Blocks (Region D) begin after header [+ A0] + Region A + Region B.
+        // Resolver region (TD-DELVEC-1 WI-2c): the OID→position resolver is an
+        // immutable write-time component → a region *inside* the segment (atomic
+        // with it on the single PUT), not a sidecar. It sits between Region B
+        // (SQ8) and the blocks, so the block table's absolute offsets
+        // (data_offset + b.offset below) account for its space. Absent
+        // (opr_off/opr_len = 0) when `with_oid_resolver` is off or no oids were
+        // captured — the segment is then byte-identical to the pre-WI-2c form.
+        let opr_bytes = self.oid_resolver_bytes()?;
+        // Blocks (Region D) begin after header [+ A0] + Region A + Region B [+ resolver].
         let data_offset = sq8_off + sq8_len;
+        let opr_off = data_offset;
+        let opr_len = opr_bytes.as_ref().map_or(0u64, |b| b.len() as u64);
+        let data_offset = data_offset + opr_len;
 
         // Serialize A0 (v3 only). Per-cell extents are ABSOLUTE file offsets
         // into the fixed-stride code payloads of Regions A/B (the writer owns
@@ -1554,6 +1565,8 @@ impl PaxSegmentWriter {
             block_tier_assignments,
             a0_off,
             a0_len,
+            opr_off,
+            opr_len,
         };
         let footer_body = footer.to_bytes()?;
         let footer_off = data_offset + self.file_buf.len() as u64;
@@ -1578,6 +1591,7 @@ impl PaxSegmentWriter {
                 + a0_len as usize
                 + region_bytes.len()
                 + sq8_region_bytes.len()
+                + opr_len as usize
                 + self.file_buf.len()
                 + footer_body.len()
                 + 16,
@@ -1588,6 +1602,9 @@ impl PaxSegmentWriter {
         }
         out.extend_from_slice(&region_bytes);
         out.extend_from_slice(&sq8_region_bytes);
+        if let Some(opr) = &opr_bytes {
+            out.extend_from_slice(opr);
+        }
         out.extend_from_slice(&self.file_buf);
         out.extend(segment_tail(&footer_body));
 
@@ -2012,6 +2029,85 @@ mod tests {
                 && assignment.descriptor_id == transformed.descriptor_id
         }));
         assert_eq!(transformed.rebuild_source_id, EXTERNAL_CANONICAL_SOURCE_ID);
+        Ok(())
+    }
+
+    /// TD-DELVEC-1 WI-2c: a coalesced segment written with `with_oid_resolver(true)`
+    /// embeds the OID→position resolver as a **footer region** — locatable via
+    /// `SegmentFooterIndex::locate_in_segment`, fetchable by `(opr_off, opr_len)`,
+    /// and round-tripping through `OidPositionResolver::deserialize` with the oids
+    /// in add_record (stream) order. With the opt-in OFF, no resolver region is
+    /// emitted (`opr_len == 0`) — the segment is byte-for-byte the pre-WI-2c form.
+    #[test]
+    fn coalesced_segment_embeds_oid_resolver_footer_region() -> Result<()> {
+        use proximadb_records::{EmbeddingCell, EmbeddingValues};
+
+        const DIM: usize = 32;
+        let oids: Vec<String> = (0..8).map(|i| format!("oid-{i}")).collect();
+
+        let write_segment = |path: &std::path::Path, resolver: bool| -> Result<()> {
+            let mut writer = PaxSegmentWriter::new(
+                path,
+                BlockMode::Pax,
+                BlockCompression::None,
+                "col",
+                0,
+                1,
+                Some(8 * 2 * 1024),
+            )
+            .with_quant(VectorQuant::RaBitQ)
+            .with_coalesced_rabitq(true);
+            if resolver {
+                writer = writer.with_oid_resolver(true);
+            }
+            for oid in &oids {
+                let mut record = make_record(oid, "t", 1);
+                record.embeddings.push(EmbeddingCell {
+                    modality: "dense".into(),
+                    dim: DIM as u32,
+                    values: EmbeddingValues::Fp32(vec![0.5; DIM]),
+                    ..Default::default()
+                });
+                writer.add_record(&record)?;
+            }
+            writer.finish()?;
+            Ok(())
+        };
+
+        let dir = tempfile::tempdir()?;
+
+        // Opt-in ON → resolver region present, locatable, and round-trips with the
+        // oids in add_record (stream) order.
+        let on_path = dir.path().join("resolver-on.pax");
+        write_segment(&on_path, true)?;
+        let segment = std::fs::read(&on_path)?;
+        let footer = SegmentFooterIndex::locate_in_segment(&segment)?
+            .ok_or_else(|| anyhow::anyhow!("coalesced footer missing"))?;
+        assert!(
+            footer.opr_len > 0,
+            "resolver region must be present when opted in"
+        );
+        let region = &segment[footer.opr_off as usize..(footer.opr_off + footer.opr_len) as usize];
+        let resolver = crate::oid_position_resolver::OidPositionResolver::deserialize(region)?;
+        assert_eq!(resolver.len(), oids.len() as u32);
+        for (i, oid) in oids.iter().enumerate() {
+            assert_eq!(
+                resolver.position_of(oid),
+                Some(i as u32),
+                "oid must map to its add_record (stream) position"
+            );
+        }
+
+        // Opt-in OFF → no resolver region (opr_off/opr_len == 0); segment parses.
+        let off_path = dir.path().join("resolver-off.pax");
+        write_segment(&off_path, false)?;
+        let footer_off = SegmentFooterIndex::locate_in_segment(&std::fs::read(&off_path)?)?
+            .ok_or_else(|| anyhow::anyhow!("coalesced footer missing"))?;
+        assert_eq!(footer_off.opr_off, 0);
+        assert_eq!(
+            footer_off.opr_len, 0,
+            "no resolver region when the opt-in is off"
+        );
         Ok(())
     }
 

--- a/crates/storage/proximadb-storage-common/src/segment_layout.rs
+++ b/crates/storage/proximadb-storage-common/src/segment_layout.rs
@@ -331,6 +331,15 @@ const SECTION_VERSION_V1: u8 = 1;
 const FOOTER_V1: u8 = 1;
 /// `[a0_off u64][a0_len u64]`.
 const COARSE_DIRECTORY_SECTION_LEN: usize = 16;
+/// Optional footer section mirroring the OID→position resolver region extent
+/// (TD-DELVEC-1 WI-2c). The resolver is an immutable write-time component, so it
+/// is persisted as a region *inside* the segment (atomic with it), not a sidecar.
+/// Additive: parsers that predate it skip unknown section tags. `opr_len == 0`
+/// ⇒ no resolver region ⇒ WI-3 tombstone fallback. The region payload is a
+/// self-CRC'd `ORP1` blob (`OidPositionResolver::serialize`).
+const SECTION_OID_RESOLVER: u8 = 4;
+/// `[opr_off u64][opr_len u64]`.
+const OID_RESOLVER_SECTION_LEN: usize = 16;
 
 /// The self-describing footer-index (Parquet-style metadata hub): block table +
 /// schema snapshot + per-stripe encoding map + RaBitQ mirror + row count. Located
@@ -381,6 +390,14 @@ pub struct SegmentFooterIndex {
     /// an optional trailing section, so v1 footers are byte-unchanged.
     pub a0_off: u64,
     pub a0_len: u64,
+    /// OID→position resolver region extent (TD-DELVEC-1 WI-2c). The resolver is
+    /// an immutable write-time component persisted as a region *inside* the
+    /// segment (atomic with it on the single PUT), not a sidecar. `0/0` = no
+    /// resolver (legacy/non-coalesced segments, or `with_oid_resolver` off) ⇒
+    /// WI-3 tombstone fallback. Serialized as an optional trailing section
+    /// (forward-compatible — old parsers skip the unknown tag).
+    pub opr_off: u64,
+    pub opr_len: u64,
 }
 
 /// `[footer_len u64][SEGMENT_MAGIC 8B]` — the 16 B tail that locates the footer.
@@ -726,6 +743,12 @@ impl SegmentFooterIndex {
             payload.extend_from_slice(&self.a0_len.to_le_bytes());
             sections.push((SECTION_COARSE_DIRECTORY, payload));
         }
+        if self.opr_len > 0 {
+            let mut payload = Vec::with_capacity(OID_RESOLVER_SECTION_LEN);
+            payload.extend_from_slice(&self.opr_off.to_le_bytes());
+            payload.extend_from_slice(&self.opr_len.to_le_bytes());
+            sections.push((SECTION_OID_RESOLVER, payload));
+        }
         if !sections.is_empty() {
             let section_count = u16::try_from(sections.len())
                 .map_err(|_| anyhow::anyhow!("footer section count exceeds u16"))?;
@@ -865,6 +888,8 @@ impl SegmentFooterIndex {
         let mut block_tier_assignments = Vec::new();
         let mut a0_off = 0u64;
         let mut a0_len = 0u64;
+        let mut opr_off = 0u64;
+        let mut opr_len = 0u64;
         if p != body.len() {
             let section_count = read_u16(body, &mut p)? as usize;
             if section_count > body.len().saturating_sub(p) / 6 {
@@ -893,6 +918,15 @@ impl SegmentFooterIndex {
                     }
                     a0_off = u64::from_le_bytes(section[..8].try_into()?);
                     a0_len = u64::from_le_bytes(section[8..16].try_into()?);
+                } else if tag == SECTION_OID_RESOLVER {
+                    if version != SECTION_VERSION_V1 {
+                        bail!("unsupported oid-resolver section version {version}");
+                    }
+                    if section.len() != OID_RESOLVER_SECTION_LEN {
+                        bail!("oid-resolver section has wrong length");
+                    }
+                    opr_off = u64::from_le_bytes(section[..8].try_into()?);
+                    opr_len = u64::from_le_bytes(section[8..16].try_into()?);
                 }
             }
             if p != body.len() {
@@ -916,6 +950,8 @@ impl SegmentFooterIndex {
             block_tier_assignments,
             a0_off,
             a0_len,
+            opr_off,
+            opr_len,
         })
     }
 
@@ -971,6 +1007,8 @@ mod tests {
             block_tier_assignments: Vec::new(),
             a0_off: 0,
             a0_len: 0,
+            opr_off: 0,
+            opr_len: 0,
             blocks: vec![
                 FooterBlockEntry {
                     offset: 152_056,
@@ -1246,6 +1284,45 @@ mod tests {
         let reparsed = SegmentFooterIndex::parse(&plain.to_bytes().unwrap()).unwrap();
         assert_eq!(reparsed.a0_off, 0);
         assert_eq!(reparsed.a0_len, 0);
+    }
+
+    #[test]
+    fn footer_oid_resolver_section_round_trips() {
+        // TD-DELVEC-1 WI-2c: the OID→position resolver region extent is an
+        // optional footer section (tag 4), mirroring the coarse-directory
+        // section. Round-trips, coexists with other sections, and is absent
+        // (byte-identical to the sectionless footer) when opr_len == 0.
+        let mut footer = sample_footer();
+        footer.opr_off = 500_000;
+        footer.opr_len = 7_777;
+        let bytes = footer.to_bytes().unwrap();
+        let parsed = SegmentFooterIndex::parse(&bytes).unwrap();
+        assert_eq!(parsed.opr_off, 500_000);
+        assert_eq!(parsed.opr_len, 7_777);
+        assert_eq!(parsed.blocks.len(), 2);
+        // Coexists with the encoding-map + coarse-directory sections (three).
+        let mut v2 = sample_v2_footer();
+        v2.a0_off = 72;
+        v2.a0_len = 99;
+        v2.opr_off = 8_000;
+        v2.opr_len = 4_000;
+        let parsed2 = SegmentFooterIndex::parse(&v2.to_bytes().unwrap()).unwrap();
+        assert_eq!(parsed2.encoding_map, v2.encoding_map);
+        assert_eq!(parsed2.a0_len, 99);
+        assert_eq!(parsed2.opr_off, 8_000);
+        assert_eq!(parsed2.opr_len, 4_000);
+        // Absent resolver (opr_len == 0) ⇒ byte-identical to the sectionless
+        // footer (v1 / non-coalesced segments unchanged on disk by this feature).
+        let plain = sample_footer();
+        assert_eq!(plain.to_bytes().unwrap(), {
+            let mut same = sample_footer();
+            same.opr_off = 999; // off without len must NOT emit a section
+            same.opr_len = 0;
+            same.to_bytes().unwrap()
+        });
+        let reparsed = SegmentFooterIndex::parse(&plain.to_bytes().unwrap()).unwrap();
+        assert_eq!(reparsed.opr_off, 0);
+        assert_eq!(reparsed.opr_len, 0);
     }
 
     #[test]


### PR DESCRIPTION
Persists the OID→position resolver as a **region inside the segment file** (atomic with the single PUT), not a sidecar — the rev-5 (#1286) correction. The resolver is immutable/write-time, so it lands in the coalesced path's `finish_coalesced` alongside the RaBitQ/SQ8 regions. Design gate: rev-5 (TD-DELVEC-1 §8/§9.4).

**`segment_layout.rs` (SegmentFooterIndex):** new optional footer section (tag 4, `SECTION_OID_RESOLVER` = `[opr_off u64][opr_len u64]`), mirroring the coarse-directory (`a0`) section exactly. Old readers skip unknown tags (forward-compatible); new readers see `opr_off == 0` on legacy/non-resolver segments → WI-3 tombstone fallback. Added as an optional section (**not** positional fields) so mixed-read safety is preserved. + round-trip + absent-byte-identical test.

**`pax_block.rs` (`finish_coalesced`):** when `with_oid_resolver` is on, serialize the resolver and write it as a region between SQ8 and the blocks; record `opr_off/opr_len` in the footer; block-table absolute offsets account for the region's space. Off-by-default → `opr_len 0` → segment byte-identical to pre-WI-2c. + end-to-end test (opt-in on → `locate_in_segment` → fetch by offset → `OidPositionResolver::deserialize` → oids in add_record order; opt-in off → no region).

**Scope:** coalesced path only (legacy `finish_legacy` has no footer/region mechanism → `opr_off/len 0` → WI-3 tombstone fallback; a follow-up can extend legacy). Resolver's inner CRC32 (WI-2b) kept — stricter than Regions A/B (bare).

**Verified:** `cargo test -p proximadb-storage-common --lib` → 459 passed incl. both new tests; `clippy --lib` clean; fmt clean. (2 pre-existing `clippy --tests` errors in `storage_error`/`zero_copy_traits` test code are unrelated + present on the base — stricter local rust-1.95.)

**Why footer-region, not a sidecar:** atomicity (one PUT, crash/DR-safe — a sidecar's two PUTs can tear), read speed (range GET on the segment the reader already opens vs a separate object GET), and object-store immutable-PUT compatibility (assembled before the single PUT). See rev-5 §9.4. Compaction correctness (drop purged deletes / carry live ones via the resolver's oid↔pos translation) is WI-6; it's resolver-location-independent.

**Next:** WI-3 (delete path + `cold-deletion-vectors` feature gate + multi-segment dedup), then a CI ratchet gating develop→qa→main on deletion-vector scenarios.