### PR TITLE
ci(qa-gate): add deletion-vector ratchet (TD-DELVEC-1 F3v)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -126,6 +126,16 @@ jobs:
         # sst_block_serialization_roundtrip missed (why TD-165 was marked Resolved
         # prematurely). Well-separated seeded vectors → recall@10 = 1.0 on both paths.
         run: cargo test --test embedded_flush_recovery recall -- --nocapture
+      - name: Run deletion-vector ratchet (TD-DELVEC-1 F3v)
+        # F3v cold-tier deletion vectors — gates the develop→qa→main promotion.
+        # Currently runs the OID→position resolver substrate (ORP1+CRC32 format,
+        # footer-region round-trip, add_record capture-order, end-to-end
+        # "writer→footer→fetch region→deserialize"). WI-3 extends this with the
+        # delete→scan-survivors scenarios (the actual deletion correctness) — add
+        # them here as they land.
+        run: |
+          cargo test -p proximadb-storage-common --lib oid_position_resolver -- --nocapture
+          cargo test -p proximadb-storage-common --lib oid_resolver -- --nocapture
       # TD-182 P0b: vector-recall ratchets that previously ran in NO CI tier
       # (orphaned). Each asserts recall@k / exact-match vs an f32 baseline. The
       # td112 suite runs only its `recall` test here; its `axis_index_rebuilt_*`


### PR DESCRIPTION
Adds a **deletion-vector ratchet** step to the `QA Gate` job — the required check gating **develop→qa→main**. Runs the F3v cold-tier deletion-vector tests so a regression blocks promotion. No branch-protection change (step in the already-required job). Today gates the OID→position resolver substrate (WI-2a/2b/2c: ORP1+CRC32, footer-region round-trip, capture-order, end-to-end region embed). WI-3 extends it with the delete→scan-survivors scenarios.