### PR TITLE
feat(security): FA-c Phase 2 — abac-policy feature + end-to-end enforcement proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,6 +6740,7 @@ dependencies = [
  "proptest",
  "prost",
  "prost-types",
+ "proximadb-abac",
  "proximadb-admin-ui",
  "proximadb-api",
  "proximadb-block-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,6 +363,7 @@ proximadb-records = { path = "crates/foundation/proximadb-records" }
 proximadb-quantization-types = { path = "crates/foundation/proximadb-quantization-types" }
 proximadb-quantization-model = { path = "crates/foundation/proximadb-quantization-model" }
 proximadb-catalog = { path = "crates/control/proximadb-catalog" }
+proximadb-abac = { path = "crates/control/proximadb-abac", optional = true }
 proximadb-metrics = { path = "crates/control/proximadb-metrics" }
 proximadb-api = { path = "crates/platform/proximadb-api" }
 proximadb-admin-ui = { path = "crates/platform/proximadb-admin-ui" }
@@ -707,6 +708,11 @@ experimental-ledger = ["dep:proximadb-ledger", "proximadb-ledger/durable"]
 # path. Off by default → the existing check-then-act PK-uniqueness probe runs unchanged;
 # on, a LocalWalKeyStore is wired in and enforces composite-PK uniqueness atomically.
 oltp-integrity = ["dep:proximadb-cks-local"]
+# FA (TD-FOUNDATION-3): enable ABAC row-level enforcement. Off by default → the
+# read primitives run unchanged; on, the compile bridge + admits_with_security
+# filter rows by the subject's policy. The abac crate itself stays un-gated
+# (a security substrate that never compiles is never tested).
+abac-policy = ["dep:proximadb-abac"]
 # Experimental SIMD path; not enabled by default
 simd-experimental = ["proximadb-codec/simd-experimental"]
 # TD-160 / ADR-027 / ADR-030: gate the PERF-CLASS I/O-trace *emission* (the

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! The ABAC-to-scan-predicate adapter: turns compiled `ObjectId` refs into a
+//! per-row `Fn(&ProximaRecord) -> bool` that `scan_records_filtered` ANDs into
+//! its existing `RecordScanPredicate`.
+//!
+//! This is the **scan-path integration point** (FA-c Phase 2b). It compiles the
+//! `AuthorizedReadContext`'s `row_predicate_refs` once (at request-scope), then
+//! the returned closure evaluates each record under the strict 3-valued walker
+//! via [`admits_with_security`](super::filter_lattice::admits_with_security).
+
+#[cfg(feature = "abac-policy")]
+use crate::core::search::sql_value_filter::proxima_value_to_json;
+#[cfg(feature = "abac-policy")]
+use crate::security::rls::filter_lattice::admits_with_security;
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{PredicateObjectStore, compile_security_filter};
+#[cfg(feature = "abac-policy")]
+use proximadb_catalog::fc_metamodel::ObjectId;
+#[cfg(feature = "abac-policy")]
+use proximadb_records::{ProximaRecord, ProximaTreeNode};
+
+/// Compile `refs` into a per-row predicate for `scan_records_filtered`.
+///
+/// Returns `None` when the refs are empty (no row restriction) or when the
+/// compiled expression is `None`. Returns `Some(closure)` that evaluates each
+/// `ProximaRecord` under the strict security walker. A missing predicate ref
+/// (fail-closed in `compile_security_filter`) yields an unsatisfiable closure
+/// that denies every row.
+///
+/// The closure owns the compiled `FilterExpression`; it is `Send + Sync` and
+/// can be passed as a `RecordScanPredicate` to `scan_records_filtered`.
+/// FA-c Phase 2c wires this into `scan_records_filtered`'s predicate param; until
+/// then it has no production caller (the feature is default-OFF and the function is
+/// the integration point the wiring step consumes).
+#[cfg(feature = "abac-policy")]
+#[allow(dead_code)]
+pub fn abac_scan_predicate(
+    refs: &[ObjectId],
+    store: &dyn PredicateObjectStore,
+) -> Option<Box<dyn Fn(&ProximaRecord) -> bool + Send + Sync>> {
+    let security = compile_security_filter(refs, store)?;
+
+    Some(Box::new(move |record: &ProximaRecord| {
+        // Resolve each field the security expression references from the record's
+        // props. Using `proxima_value_to_json` (not the whole-tree map) avoids a
+        // per-row HashMap allocation — only the fields the expression actually
+        // touches are extracted, lazily.
+        let resolve = |field: &str| -> Option<serde_json::Value> {
+            record.props.get(field).and_then(|node| match node {
+                ProximaTreeNode::Value(pv) => Some(proxima_value_to_json(pv)),
+                _ => None,
+            })
+        };
+        admits_with_security(None, Some(&security), &resolve)
+    }))
+}
+
+#[cfg(all(test, feature = "abac-policy"))]
+mod tests {
+    use super::*;
+    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use proximadb_abac::InMemoryPredicateObjectStore;
+    use proximadb_data_model::ProximaValue;
+    use proximadb_records::{ProximaRecord, ProximaTreeNode};
+    use serde_json::json;
+
+    fn record_with(dept: &str) -> ProximaRecord {
+        let mut rec = ProximaRecord::default();
+        rec.props.insert(
+            "dept".to_string(),
+            ProximaTreeNode::Value(ProximaValue::String(dept.to_string())),
+        );
+        rec
+    }
+
+    #[test]
+    fn predicate_filters_rows_by_dept() {
+        let mut store = InMemoryPredicateObjectStore::new();
+        store.register(
+            42,
+            FilterExpression::Comparison {
+                field: "dept".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!("eng"),
+            },
+        );
+
+        let predicate = abac_scan_predicate(&[42], &store).expect("refs non-empty → predicate");
+
+        assert!(predicate(&record_with("eng")), "dept=eng must be admitted");
+        assert!(!predicate(&record_with("hr")), "dept=hr must be denied");
+    }
+
+    #[test]
+    fn empty_refs_produce_no_predicate() {
+        let store = InMemoryPredicateObjectStore::new();
+        assert!(abac_scan_predicate(&[], &store).is_none());
+    }
+
+    #[test]
+    fn missing_ref_denies_every_row() {
+        let store = InMemoryPredicateObjectStore::new();
+        let predicate =
+            abac_scan_predicate(&[999], &store).expect("non-empty refs → unsatisfiable predicate");
+        assert!(!predicate(&record_with("eng")), "missing ref denies all");
+    }
+}

--- a/src/security/rls/abac_enforcement_tests.rs
+++ b/src/security/rls/abac_enforcement_tests.rs
@@ -1,0 +1,269 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end ABAC enforcement: resolve → compile → `admits_with_security`.
+//!
+//! This test module proves the full chain Phase 1 (compile bridge) + Phase 2
+//! (evaluation) without wiring into the DML scan path. It is the TDD proof that
+//! a `dept=eng` subject sees only `dept=eng` rows — the canonical ABAC scenario.
+
+use crate::core::search::{ComparisonOperator, FilterExpression};
+use crate::security::rls::filter_lattice::admits_with_security;
+use proximadb_abac::{
+    AttributeAuthority, AttributeBinding, AuthorizedReadContext, InMemoryAttributeAuthority,
+    InMemoryPolicyEpochs, InMemoryPredicateObjectStore, PredicateObjectStore,
+    compile_security_filter,
+};
+use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope, SubjectId, Target};
+use serde_json::json;
+
+const TENANT: u64 = 7;
+const NS: u16 = 3;
+const TABLE: u32 = 200;
+
+/// The canonical end-to-end: a subject with `dept=eng` filtering to only
+/// `dept=eng` rows through the full resolve → compile → evaluate chain.
+#[test]
+fn dept_eng_subject_sees_only_dept_eng_rows() {
+    // --- Set up the substrate ---
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        AttributeBinding::new("alice", TENANT).with_attr("dept", AttrValue::Str("eng".into())),
+    );
+    authority.upsert(
+        AttributeBinding::new("bob", TENANT).with_attr("dept", AttrValue::Str("hr".into())),
+    );
+
+    let mut store = InMemoryPredicateObjectStore::new();
+    // Predicate object 42: the subject's dept must equal the row's dept.
+    // (Simplified: in a real system, this predicate is derived from the
+    //  policy rule; here we store the already-lowered FilterExpression.)
+    store.register(
+        42,
+        FilterExpression::Comparison {
+            field: "dept".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!("eng"), // alice's dept
+        },
+    );
+
+    let bindings = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Table(TABLE),
+        effect: Effect::Permit,
+        predicate_ref: Some(42),
+        field_mask: None,
+    }];
+    let epochs = InMemoryPolicyEpochs::new();
+    let target = Target {
+        namespace: NS,
+        table: TABLE,
+        column: None,
+    };
+
+    // --- Resolve alice ---
+    let ctx = AuthorizedReadContext::resolve(
+        &authority,
+        &epochs,
+        &bindings,
+        &SubjectId("alice".into()),
+        TENANT,
+        target,
+    )
+    .admitted()
+    .expect("alice is bound and permitted");
+
+    // --- Compile the security filter from the resolved refs ---
+    let security = compile_security_filter(ctx.row_predicate_refs(), &store);
+
+    // --- Evaluate: alice (dept=eng) should see only dept=eng rows ---
+    let rows = [
+        (json!({"dept": "eng", "name": "carol"}), true),
+        (json!({"dept": "hr", "name": "dave"}), false),
+        (json!({"dept": "eng", "name": "eve"}), true),
+        (json!({"dept": "legal", "name": "frank"}), false),
+    ];
+
+    for (row, expected_admit) in rows {
+        let resolve = |f: &str| row.get(f).cloned();
+        let admitted = admits_with_security(None, security.as_ref(), &resolve);
+        assert_eq!(
+            admitted, expected_admit,
+            "alice (dept=eng) vs row {:?}: expected admit={expected_admit}",
+            row
+        );
+    }
+}
+
+/// Fail-closed: a subject with no policy binding is denied (ReadDecision::Deny).
+#[test]
+fn unbound_subject_is_denied() {
+    let authority = InMemoryAttributeAuthority::new();
+    let epochs = InMemoryPolicyEpochs::new();
+    let bindings: Vec<PolicyBinding> = vec![]; // no bindings → no applicable policy
+
+    let decision = AuthorizedReadContext::resolve(
+        &authority,
+        &epochs,
+        &bindings,
+        &SubjectId("mallory".into()),
+        TENANT,
+        Target {
+            namespace: NS,
+            table: TABLE,
+            column: None,
+        },
+    );
+
+    // No applicable binding → deny (fail-closed default).
+    assert!(
+        decision.is_deny(),
+        "an unbound subject must be denied, not silently admitted"
+    );
+}
+
+/// Fail-closed: a policy referencing a missing predicate object denies.
+#[test]
+fn missing_predicate_ref_denies_all_rows() {
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        AttributeBinding::new("alice", TENANT).with_attr("dept", AttrValue::Str("eng".into())),
+    );
+
+    let store = InMemoryPredicateObjectStore::new(); // empty — ref 999 is missing
+
+    let bindings = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Table(TABLE),
+        effect: Effect::Permit,
+        predicate_ref: Some(999),
+        field_mask: None,
+    }];
+    let epochs = InMemoryPolicyEpochs::new();
+    let ctx = AuthorizedReadContext::resolve(
+        &authority,
+        &epochs,
+        &bindings,
+        &SubjectId("alice".into()),
+        TENANT,
+        Target {
+            namespace: NS,
+            table: TABLE,
+            column: None,
+        },
+    )
+    .admitted()
+    .expect("alice is bound");
+
+    // The compiled filter is unsatisfiable (missing ref → deny-all).
+    let security = compile_security_filter(ctx.row_predicate_refs(), &store);
+    let row = json!({"dept": "eng"});
+    let resolve = |f: &str| row.get(f).cloned();
+    assert!(
+        !admits_with_security(None, security.as_ref(), &resolve),
+        "a missing predicate ref must deny every row, not admit"
+    );
+}
+
+/// Different subjects with different attributes get different row sets.
+#[test]
+fn different_subjects_see_different_rows() {
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        AttributeBinding::new("alice", TENANT).with_attr("dept", AttrValue::Str("eng".into())),
+    );
+    authority.upsert(
+        AttributeBinding::new("bob", TENANT).with_attr("dept", AttrValue::Str("hr".into())),
+    );
+
+    let mut store = InMemoryPredicateObjectStore::new();
+    // Predicate for alice (dept=eng)
+    store.register(
+        42,
+        FilterExpression::Comparison {
+            field: "dept".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!("eng"),
+        },
+    );
+    // Predicate for bob (dept=hr)
+    store.register(
+        43,
+        FilterExpression::Comparison {
+            field: "dept".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!("hr"),
+        },
+    );
+
+    let bindings_alice = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Table(TABLE),
+        effect: Effect::Permit,
+        predicate_ref: Some(42),
+        field_mask: None,
+    }];
+    let bindings_bob = vec![PolicyBinding {
+        object_id: 2,
+        tenant_stable_id: TENANT,
+        scope: Scope::Table(TABLE),
+        effect: Effect::Permit,
+        predicate_ref: Some(43),
+        field_mask: None,
+    }];
+    let epochs = InMemoryPolicyEpochs::new();
+    let target = Target {
+        namespace: NS,
+        table: TABLE,
+        column: None,
+    };
+
+    let ctx_alice = AuthorizedReadContext::resolve(
+        &authority,
+        &epochs,
+        &bindings_alice,
+        &SubjectId("alice".into()),
+        TENANT,
+        target,
+    )
+    .admitted()
+    .expect("alice");
+    let ctx_bob = AuthorizedReadContext::resolve(
+        &authority,
+        &epochs,
+        &bindings_bob,
+        &SubjectId("bob".into()),
+        TENANT,
+        target,
+    )
+    .admitted()
+    .expect("bob");
+
+    let sec_alice = compile_security_filter(ctx_alice.row_predicate_refs(), &store);
+    let sec_bob = compile_security_filter(ctx_bob.row_predicate_refs(), &store);
+
+    let eng_row = json!({"dept": "eng"});
+    let hr_row = json!({"dept": "hr"});
+
+    // Alice sees eng, not hr.
+    assert!(admits_with_security(
+        None,
+        sec_alice.as_ref(),
+        &|f: &str| eng_row.get(f).cloned()
+    ));
+    assert!(!admits_with_security(
+        None,
+        sec_alice.as_ref(),
+        &|f: &str| hr_row.get(f).cloned()
+    ));
+
+    // Bob sees hr, not eng.
+    assert!(!admits_with_security(None, sec_bob.as_ref(), &|f: &str| {
+        eng_row.get(f).cloned()
+    }));
+    assert!(admits_with_security(None, sec_bob.as_ref(), &|f: &str| {
+        hr_row.get(f).cloned()
+    }));
+}

--- a/src/security/rls/mod.rs
+++ b/src/security/rls/mod.rs
@@ -24,3 +24,6 @@ pub use policy::{
     Operation, RLSPolicy, RLSPolicyBuilder, SecurityPredicate, SecurityPredicateBuilder,
 };
 pub use service::{CollectionRLS, RLSConfig, RLSFilterResult};
+
+#[cfg(all(test, feature = "abac-policy"))]
+mod abac_enforcement_tests;

--- a/src/security/rls/mod.rs
+++ b/src/security/rls/mod.rs
@@ -25,5 +25,8 @@ pub use policy::{
 };
 pub use service::{CollectionRLS, RLSConfig, RLSFilterResult};
 
+#[cfg(feature = "abac-policy")]
+mod abac_adapter;
+
 #[cfg(all(test, feature = "abac-policy"))]
 mod abac_enforcement_tests;


### PR DESCRIPTION
Creates the `abac-policy` feature gate (default-OFF) and proves the full ABAC chain: resolve → compile → admits_with_security. 4 tests: dept=eng filtering, unbound-subject denial, missing-ref denial, different-subjects isolation. Stacked on Phase 1 (#1289).