### PR TITLE
fix(sst): D2 watermarks must not block WAL recovery/restart (TD-COMPACT-7)

### DIFF
--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -321,7 +321,14 @@ impl SstEngine {
         // Both default-OFF via 0; env-overridable. Only armed when a compaction
         // manager exists (no point bounding L0 for a collection that can't
         // compact it).
-        if self.compaction_manager().is_some() {
+        //
+        // SKIP during WAL recovery (`recovery_materialization.is_some()`):
+        // recovery flushes MUST complete regardless of L0 count — the watermark
+        // would deadlock (the flush can't proceed AND the compaction workers
+        // can't drain L0 because the server isn't fully started). Discovered by
+        // the Phase 2 cache sweep (server restart with l0_count=10 →
+        // stop_trigger=10 → D2 blocks → WAL recovery fails → server can't boot).
+        if self.compaction_manager().is_some() && recovery_materialization.is_none() {
             let cfg = self.config();
             let stop_trigger = std::env::var("PROXIMADB_L0_STOP_TRIGGER")
                 .ok()


### PR DESCRIPTION
CRITICAL fix: D2 L0 admission watermarks blocked server restart when l0_count >= stop_trigger (10).

**Bug:** during WAL recovery, the recovery flush hit the D2 STOP → returned Err → WAL recovery failed → **server couldn't boot**:
```
TD-COMPACT-7: L0 admission STOP — 10 L0 files >= stop_trigger 10
→ Failed to start storage engine: WAL recovery failed
```

**Root cause:** the D2 check didn't distinguish recovery flushes (mandatory — must complete) from live-ingest flushes (can be deferred for backpressure).

**Fix:** skip D2 when `recovery_materialization.is_some()` (the existing hint identifying recovery flushes):
```rust
if self.compaction_manager().is_some() && recovery_materialization.is_none() {
```

**Discovered by:** the Phase 2 cache sweep (hot-vs-cold measurement) — the cold sweep required a server restart to clear caches, which exposed the D2 restart deadlock.

**Impact:** any server restart with L0 at the ceiling (stop_trigger) would fail. This is a production blocker for any deployment with sustained ingest that leaves L0 at the watermark.