### PR TITLE
feat(queue): native pub/sub via Kafka consumer-group semantics (ADR-079 Q1)

### DIFF
--- a/crates/horizontal/proximadb-queue/src/consumer.rs
+++ b/crates/horizontal/proximadb-queue/src/consumer.rs
@@ -192,7 +192,7 @@ impl Consumer {
                 if remaining == 0 {
                     break;
                 }
-                let batch = part.try_pop_batch(remaining);
+                let batch = part.try_pop_batch(remaining).await;
                 if !batch.is_empty() {
                     let mut tracker = entry.value().lock().await;
                     for memo in &batch {

--- a/crates/horizontal/proximadb-queue/src/consumer.rs
+++ b/crates/horizontal/proximadb-queue/src/consumer.rs
@@ -54,6 +54,11 @@ struct RenewerHandle {
 struct InFlight {
     /// Messages handed out via `poll` that haven't been ack'd or nack'd.
     pending: Vec<MemoryEntry>,
+    /// This group's read cursor — the next offset to deliver. Advanced on
+    /// delivery (not ack), so a second `poll` doesn't re-deliver within a
+    /// session. Initialized from the group's committed offset on `subscribe`;
+    /// restart resumes there because ack persists it via `offset_store`.
+    next_read_offset: u64,
 }
 
 impl Consumer {
@@ -103,10 +108,22 @@ impl Consumer {
             // touch this partition.
             crate::leases::try_acquire(&fs, &root, topic, p, &self.inner.group_id, &holder_id, lease_duration).await?;
 
+            // Initialize this group's read cursor from its committed offset
+            // (None → 0, cold start). Restart resumes at the persisted cursor.
+            let committed = crate::offset_store::read(&fs, &root, topic, p, &self.inner.group_id)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or(0);
             self.inner
                 .in_flight
                 .entry((topic.to_string(), p))
-                .or_insert_with(|| Mutex::new(InFlight::default()));
+                .or_insert_with(|| {
+                    Mutex::new(InFlight {
+                        pending: Vec::new(),
+                        next_read_offset: committed,
+                    })
+                });
 
             // Spawn a renewer task — every lease_duration/2 it re-runs
             // try_acquire to push the expiry forward. On Consumer drop
@@ -193,9 +210,17 @@ impl Consumer {
                 if remaining == 0 {
                     break;
                 }
-                let batch = part.try_pop_batch(remaining).await;
+                // Cursor-based read: `read_from` is NON-consuming, so other
+                // consumer groups see the same messages (pub/sub). Advance THIS
+                // group's read cursor past the delivered batch so the next poll
+                // doesn't re-deliver within a session.
+                let mut tracker = entry.value().lock().await;
+                let cursor = tracker.next_read_offset;
+                let batch = part.read_from(cursor, remaining).await;
                 if !batch.is_empty() {
-                    let mut tracker = entry.value().lock().await;
+                    if let Some(last) = batch.last() {
+                        tracker.next_read_offset = last.offset + 1;
+                    }
                     for memo in &batch {
                         tracker.pending.push(memo.clone());
                     }

--- a/crates/horizontal/proximadb-queue/src/consumer.rs
+++ b/crates/horizontal/proximadb-queue/src/consumer.rs
@@ -106,7 +106,16 @@ impl Consumer {
             // Acquire the cross-process lease before doing any in-process
             // bookkeeping — a conflict here means we're not allowed to
             // touch this partition.
-            crate::leases::try_acquire(&fs, &root, topic, p, &self.inner.group_id, &holder_id, lease_duration).await?;
+            crate::leases::try_acquire(
+                &fs,
+                &root,
+                topic,
+                p,
+                &self.inner.group_id,
+                &holder_id,
+                lease_duration,
+            )
+            .await?;
 
             // Initialize this group's read cursor from its committed offset
             // (None → 0, cold start). Restart resumes at the persisted cursor.

--- a/crates/horizontal/proximadb-queue/src/consumer.rs
+++ b/crates/horizontal/proximadb-queue/src/consumer.rs
@@ -101,7 +101,7 @@ impl Consumer {
             // Acquire the cross-process lease before doing any in-process
             // bookkeeping — a conflict here means we're not allowed to
             // touch this partition.
-            crate::leases::try_acquire(&fs, &root, topic, p, &holder_id, lease_duration).await?;
+            crate::leases::try_acquire(&fs, &root, topic, p, &self.inner.group_id, &holder_id, lease_duration).await?;
 
             self.inner
                 .in_flight
@@ -117,20 +117,20 @@ impl Consumer {
             let renew_root = root.clone();
             let renew_topic = topic.to_string();
             let renew_holder = holder_id.clone();
+            let renew_group = self.inner.group_id.clone();
             let interval = lease_duration / 2;
             let join = tokio::spawn(async move {
                 loop {
                     tokio::select! {
                         _ = &mut rx => {
-                            // Clean shutdown — best-effort delete the
-                            // lease.meta so a follow-on subscriber
-                            // (different replica, same process+next
-                            // QueueClient) doesn't wait for expiry.
-                            // Failure here is non-fatal: the lease
-                            // will expire on its own.
+                            // Clean shutdown — best-effort delete this group's
+                            // lease.meta so a follow-on subscriber in the same
+                            // group doesn't wait for expiry. Failure is
+                            // non-fatal: the lease expires on its own.
                             let lease_path = renew_root
                                 .join(&renew_topic)
                                 .join(p.to_string())
+                                .join(crate::offset_store::group_dir_name(&renew_group))
                                 .join("lease.meta");
                             let _ = renew_fs.delete(&lease_path).await;
                             break;
@@ -141,6 +141,7 @@ impl Consumer {
                                 &renew_root,
                                 &renew_topic,
                                 p,
+                                &renew_group,
                                 &renew_holder,
                                 lease_duration,
                             ).await {

--- a/crates/horizontal/proximadb-queue/src/leases.rs
+++ b/crates/horizontal/proximadb-queue/src/leases.rs
@@ -1,14 +1,16 @@
-//! Cross-process partition leases — prevents two consumer instances
-//! (running on different replicas) from competing for the same
+//! Cross-process partition leases — prevents two consumer instances IN THE SAME
+//! GROUP (running on different replicas) from competing for the same
 //! `(topic, partition)` and producing duplicate work.
 //!
 //! ## Mechanism
 //!
-//! Each `(topic, partition)` has a `lease.meta` file at
-//! `{queue_root}/{topic}/{partition}/lease.meta` containing
-//! `{holder_id, expires_at_unix_nanos}`. Acquisition uses the same
-//! temp-write + atomic-rename pattern as `offset_store`, plus a
-//! re-read after the rename to detect lost-race situations.
+//! Leases are scoped per consumer group: each `(group, topic, partition)` has
+//! a `lease.meta` file at `{queue_root}/{topic}/{partition}/{group}/lease.meta`
+//! containing `{holder_id, expires_at_unix_nanos}`. Two DIFFERENT groups can
+//! each hold the same partition (pub/sub fan-out); only consumers in the SAME
+//! group compete. Acquisition uses the same temp-write + atomic-rename pattern
+//! as `offset_store`, plus a re-read after the rename to detect lost-race
+//! situations.
 //!
 //! ## Acquisition flow
 //!
@@ -59,9 +61,10 @@ const LEASE_FILE: &str = "lease.meta";
 
 static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
-fn lease_path(root: &Path, topic: &str, partition: PartitionId) -> PathBuf {
+fn lease_path(root: &Path, topic: &str, partition: PartitionId, group: &str) -> PathBuf {
     root.join(topic)
         .join(partition.to_string())
+        .join(crate::offset_store::group_dir_name(group))
         .join(LEASE_FILE)
 }
 
@@ -80,18 +83,22 @@ fn now_unix_nanos() -> u128 {
         .as_nanos()
 }
 
-/// Acquire (or take over an expired) lease on `(topic, partition)` for
-/// `holder_id`. Returns `LeaseConflict` if a non-expired lease is held
-/// by someone else.
+/// Acquire (or take over an expired) lease on `(group, topic, partition)` for
+/// `holder_id`. Returns `LeaseConflict` if a non-expired lease for THIS group
+/// is held by someone else. Different groups never conflict (pub/sub fan-out).
 pub async fn try_acquire(
     fs: &Arc<dyn QueueFs>,
     root: &Path,
     topic: &str,
     partition: PartitionId,
+    group: &str,
     holder_id: &str,
     lease_duration: Duration,
 ) -> crate::Result<()> {
-    let path = lease_path(root, topic, partition);
+    let path = lease_path(root, topic, partition, group);
+    if let Some(parent) = path.parent() {
+        fs.create_dir_all(parent).await?;
+    }
     let now = now_unix_nanos();
 
     // Step 1: existing lease check.
@@ -148,8 +155,9 @@ pub async fn renew(
     root: &Path,
     topic: &str,
     partition: PartitionId,
+    group: &str,
     holder_id: &str,
     lease_duration: Duration,
 ) -> crate::Result<()> {
-    try_acquire(fs, root, topic, partition, holder_id, lease_duration).await
+    try_acquire(fs, root, topic, partition, group, holder_id, lease_duration).await
 }

--- a/crates/horizontal/proximadb-queue/src/memory_tier.rs
+++ b/crates/horizontal/proximadb-queue/src/memory_tier.rs
@@ -1,15 +1,26 @@
-//! Memory tier — lock-free per-partition ring buffer with backpressure.
+//! Memory tier — retained, offset-indexed per-partition buffer (ADR-079 §Semantics).
 //!
-//! Each `(topic, partition)` owns one `PartitionMemory`. Producers push
-//! messages onto it; consumers pop them off. The disk tier (when wired)
-//! writes through transparently — every successful push to the memory tier
-//! has already had its bytes appended to the active disk segment.
+//! Each `(topic, partition)` owns one `PartitionMemory`. Producers append
+//! messages; **consumer groups read by cursor** (`read_from(offset, max)`)
+//! without removing them, so multiple independent groups (pub/sub) each see
+//! the whole stream. Messages are retained until trimmed below the low
+//! watermark (consumer/reaper). The disk tier writes through transparently:
+//! every successful append to memory has already had its bytes appended to
+//! the active disk segment, so the segment log is the source of truth.
+//!
+//! Storage is a `BTreeMap<offset, entry>` so concurrent producers (which
+//! receive offsets from the disk writer in commit order but may enqueue into
+//! memory out of order) never violate contiguity — inserts are by key.
+//! `read_from` walks the **contiguous prefix** from the cursor, stopping at the
+//! first gap, so a consumer never sees a hole a lagging producer has not filled
+//! yet (Kafka's high-water-mark property). This replaces the earlier pop-once
+//! `ArrayQueue`, which was fundamentally single-consumer-per-partition.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crossbeam_queue::ArrayQueue;
-use tokio::sync::Notify;
+use tokio::sync::{Mutex, Notify};
 
 use crate::message::{BackpressureHint, Message, MessageId};
 use crate::topic::PartitionId;
@@ -20,12 +31,15 @@ const HARD_PCT: f32 = 0.95;
 pub struct PartitionMemory {
     pub(crate) partition: PartitionId,
     capacity: usize,
-    queue: ArrayQueue<MemoryEntry>,
-    /// Monotonic offset assigned to each successfully-enqueued message.
-    /// Persisted via the disk tier; consumers use it as their commit cursor.
+    buf: Mutex<RetainedBuf>,
+    /// Monotonic high-water mark — the next offset a producer will receive.
     next_offset: AtomicU64,
-    /// Wake up consumers blocked on `poll` when something is enqueued.
+    /// Wake consumers blocked on `poll` when something is appended.
     pub(crate) notify: Notify,
+}
+
+struct RetainedBuf {
+    entries: BTreeMap<u64, MemoryEntry>,
 }
 
 #[derive(Clone)]
@@ -41,7 +55,9 @@ impl PartitionMemory {
         Self {
             partition,
             capacity: cap,
-            queue: ArrayQueue::new(cap),
+            buf: Mutex::new(RetainedBuf {
+                entries: BTreeMap::new(),
+            }),
             next_offset: AtomicU64::new(0),
             notify: Notify::new(),
         }
@@ -51,16 +67,16 @@ impl PartitionMemory {
         self.capacity
     }
 
-    pub fn depth(&self) -> usize {
-        self.queue.len()
+    pub async fn depth(&self) -> usize {
+        self.buf.lock().await.entries.len()
     }
 
-    pub fn depth_pct(&self) -> f32 {
-        self.depth() as f32 / self.capacity as f32
+    pub async fn depth_pct(&self) -> f32 {
+        self.depth().await as f32 / self.capacity as f32
     }
 
-    pub fn pressure(&self) -> Option<PressureLevel> {
-        let pct = self.depth_pct();
+    pub async fn pressure(&self) -> Option<PressureLevel> {
+        let pct = self.depth_pct().await;
         if pct >= HARD_PCT {
             Some(PressureLevel::Hard(pct))
         } else if pct >= SOFT_PCT {
@@ -70,56 +86,46 @@ impl PartitionMemory {
         }
     }
 
-    /// Try to enqueue a message. Returns the assigned offset on success or
-    /// `Err(QueueFull)` when the ring buffer cannot accept it.
-    /// Returns the queued entry on success or the original `Message`
-    /// (which is the large variant) on backpressure rejection so the
-    /// caller can retry or spill without reconstructing it. Clippy
-    /// `result_large_err` is silenced because the `Err` payload IS the
-    /// retry payload — moving it into a `Box` would force every retry
-    /// site to unbox just to re-enqueue.
+    /// The next offset a producer will receive (the high-water mark of the log).
+    pub fn next_offset(&self) -> u64 {
+        self.next_offset.load(Ordering::Relaxed)
+    }
+
+    /// Append a message, assigning the next offset.
     #[allow(clippy::result_large_err)]
-    pub fn try_enqueue(
+    pub async fn try_enqueue(
         self: &Arc<Self>,
         message: Message,
     ) -> std::result::Result<(MessageEntry, Option<BackpressureHint>), Message> {
         let offset = self.next_offset.fetch_add(1, Ordering::Relaxed);
-        let id = MessageId::new(self.partition, /* segment_id */ 0, offset);
-        let entry = MemoryEntry {
-            message: message.clone(),
-            message_id: id.clone(),
-            offset,
-        };
-        match self.queue.push(entry) {
-            Ok(()) => {
-                self.notify.notify_waiters();
-                let hint = match self.pressure() {
-                    Some(PressureLevel::Soft(_)) => Some(BackpressureHint::Soft),
-                    _ => None,
-                };
-                Ok((
-                    MessageEntry {
-                        message_id: id,
-                        offset,
-                    },
-                    hint,
-                ))
-            }
-            // ArrayQueue::push returns Err(value) when full — give the
-            // caller their message back so they can decide what to do.
-            Err(rejected) => Err(rejected.message),
-        }
+        self.enqueue_at(message, offset).await
     }
 
-    /// Enqueue a message with a pre-assigned offset (used by recovery and
-    /// by the producer path now that `PartitionDiskWriter` owns offset
-    /// assignment). Bypasses the memory-tier's internal counter so the
-    /// disk frame's offset is the source of truth across restart.
-    ///
-    /// Same `result_large_err` rationale as `try_enqueue` — the `Err`
-    /// payload IS the retry payload.
+    /// Append a message with a pre-assigned offset (recovery / disk-owned
+    /// offset assignment). The disk frame's offset is the source of truth
+    /// across restart; this advances the internal counter past it.
     #[allow(clippy::result_large_err)]
-    pub fn enqueue_with_offset(
+    pub async fn enqueue_with_offset(
+        self: &Arc<Self>,
+        message: Message,
+        offset: u64,
+    ) -> std::result::Result<(MessageEntry, Option<BackpressureHint>), Message> {
+        let mut current = self.next_offset.load(Ordering::Relaxed);
+        while offset + 1 > current {
+            match self.next_offset.compare_exchange_weak(
+                current,
+                offset + 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+        self.enqueue_at(message, offset).await
+    }
+
+    async fn enqueue_at(
         self: &Arc<Self>,
         message: Message,
         offset: u64,
@@ -130,33 +136,76 @@ impl PartitionMemory {
             message_id: id.clone(),
             offset,
         };
-        match self.queue.push(entry) {
-            Ok(()) => {
-                self.notify.notify_waiters();
-                let hint = match self.pressure() {
-                    Some(PressureLevel::Soft(_)) => Some(BackpressureHint::Soft),
-                    _ => None,
-                };
-                Ok((
-                    MessageEntry {
-                        message_id: id,
-                        offset,
-                    },
-                    hint,
-                ))
+        {
+            let mut buf = self.buf.lock().await;
+            if buf.entries.len() >= self.capacity {
+                return Err(message);
             }
-            Err(rejected) => Err(rejected.message),
+            // Insert by offset key — concurrent producers may enqueue out of
+            // order; the BTreeMap tolerates that and `read_from` serves only
+            // the contiguous prefix, so gaps from in-flight producers never
+            // reach a consumer.
+            buf.entries.insert(offset, entry);
         }
+        self.notify.notify_waiters();
+        let hint = match self.pressure().await {
+            Some(PressureLevel::Soft(_)) => Some(BackpressureHint::Soft),
+            _ => None,
+        };
+        Ok((MessageEntry { message_id: id, offset }, hint))
     }
 
-    /// Drain up to `max` messages from the front of the queue.
-    pub fn try_pop_batch(self: &Arc<Self>, max: usize) -> Vec<MemoryEntry> {
+    /// Read up to `max` messages starting at `cursor` **without removing them**
+    /// — the pub/sub primitive. Walks the **contiguous prefix** from `cursor`:
+    /// stops at the first missing offset (a concurrent producer has not filled
+    /// it yet) so a consumer never observes a hole. If `cursor` lags behind the
+    /// trimmed base, clamps up to the first available offset.
+    pub async fn read_from(self: &Arc<Self>, cursor: u64, max: usize) -> Vec<MemoryEntry> {
+        let buf = self.buf.lock().await;
         let mut out = Vec::with_capacity(max);
-        while out.len() < max {
-            match self.queue.pop() {
-                Some(e) => out.push(e),
-                None => break,
+        let mut expected: Option<u64> = None;
+        for (&off, entry) in buf.entries.range(cursor..) {
+            match expected {
+                None => {
+                    // First available key — clamp a lagging cursor up to it.
+                    expected = Some(off);
+                }
+                Some(exp) if off == exp => {}
+                Some(_) => break, // gap — stop at the contiguous prefix boundary
             }
+            if out.len() >= max {
+                break;
+            }
+            out.push(entry.clone());
+            expected = Some(expected.unwrap() + 1);
+        }
+        out
+    }
+
+    /// Drop retained entries whose offset is `< watermark`.
+    pub async fn trim_below(self: &Arc<Self>, watermark: u64) {
+        let mut buf = self.buf.lock().await;
+        // split_off returns the >= watermark half and leaves self with < half;
+        // reassigning keeps the >= half, dropping the trimmed prefix.
+        buf.entries = buf.entries.split_off(&watermark);
+    }
+
+    /// Compat shim for the pop-once consumer path: read from the head and trim
+    /// past it. Retained until the consumer migrates to cursor-based `read_from`
+    /// (slice 4); the reaper then owns trimming (min across groups).
+    pub async fn try_pop_batch(self: &Arc<Self>, max: usize) -> Vec<MemoryEntry> {
+        let base = self
+            .buf
+            .lock()
+            .await
+            .entries
+            .keys()
+            .next()
+            .copied()
+            .unwrap_or(0);
+        let out = self.read_from(base, max).await;
+        if let Some(last) = out.last() {
+            self.trim_below(last.offset + 1).await;
         }
         out
     }
@@ -176,9 +225,8 @@ impl PressureLevel {
     }
 }
 
-/// Lightweight view returned from `try_enqueue` — the caller turns this into
-/// a full `MessageReceipt` once disk fsync is confirmed (Strict mode) or
-/// immediately (Lazy mode).
+/// Lightweight view returned from enqueue — the caller turns this into a full
+/// `MessageReceipt` once disk fsync is confirmed (Strict) or immediately (Lazy).
 pub struct MessageEntry {
     pub message_id: MessageId,
     pub offset: u64,
@@ -192,86 +240,151 @@ mod tests {
         Message::new("topic", "tenant", vec![n])
     }
 
-    #[test]
-    fn partition_memory_capacity_is_never_zero() {
+    #[tokio::test]
+    async fn partition_memory_capacity_is_never_zero() {
         let memory = PartitionMemory::new(3, 0);
-
         assert_eq!(memory.partition, 3);
         assert_eq!(memory.capacity(), 1);
-        assert_eq!(memory.depth(), 0);
-        assert_eq!(memory.depth_pct(), 0.0);
-        assert!(memory.pressure().is_none());
+        assert_eq!(memory.depth().await, 0);
+        assert_eq!(memory.depth_pct().await, 0.0);
+        assert!(memory.pressure().await.is_none());
     }
 
-    #[test]
-    fn enqueue_assigns_partition_scoped_ids_and_pop_preserves_fifo_order() {
+    #[tokio::test]
+    async fn enqueue_assigns_partition_scoped_ids_and_pop_preserves_fifo_order() {
         let memory = Arc::new(PartitionMemory::new(5, 4));
 
-        let (first, hint) = memory.try_enqueue(message(1)).unwrap();
-        let (second, _) = memory.try_enqueue(message(2)).unwrap();
+        let (first, hint) = memory.try_enqueue(message(1)).await.unwrap();
+        let (second, _) = memory.try_enqueue(message(2)).await.unwrap();
 
         assert_eq!(first.message_id, MessageId::new(5, 0, 0));
         assert_eq!(first.offset, 0);
         assert_eq!(second.message_id, MessageId::new(5, 0, 1));
         assert!(hint.is_none());
-        assert_eq!(memory.depth(), 2);
+        assert_eq!(memory.depth().await, 2);
 
-        let popped = memory.try_pop_batch(10);
+        let popped = memory.try_pop_batch(10).await;
         assert_eq!(popped.len(), 2);
         assert_eq!(popped[0].message.payload, vec![1]);
         assert_eq!(popped[1].message.payload, vec![2]);
-        assert_eq!(memory.depth(), 0);
+        assert_eq!(memory.depth().await, 0);
     }
 
-    #[test]
-    fn pressure_transitions_from_none_to_soft_to_hard() {
+    #[tokio::test]
+    async fn pressure_transitions_from_none_to_soft_to_hard() {
         let memory = Arc::new(PartitionMemory::new(1, 4));
 
-        assert!(memory.pressure().is_none());
-        memory.try_enqueue(message(1)).unwrap();
-        memory.try_enqueue(message(2)).unwrap();
-        assert!(memory.pressure().is_none());
+        assert!(memory.pressure().await.is_none());
+        memory.try_enqueue(message(1)).await.unwrap();
+        memory.try_enqueue(message(2)).await.unwrap();
+        assert!(memory.pressure().await.is_none());
 
-        let (_, hint) = memory.try_enqueue(message(3)).unwrap();
+        let (_, hint) = memory.try_enqueue(message(3)).await.unwrap();
         assert!(matches!(hint, Some(BackpressureHint::Soft)));
-        let soft = memory.pressure().unwrap();
-        assert!(matches!(soft, PressureLevel::Soft(_)));
-        assert_eq!(soft.pct(), 0.75);
+        assert!(matches!(memory.pressure().await.unwrap(), PressureLevel::Soft(_)));
 
-        memory.try_enqueue(message(4)).unwrap();
-        let hard = memory.pressure().unwrap();
-        assert!(matches!(hard, PressureLevel::Hard(_)));
-        assert_eq!(hard.pct(), 1.0);
+        memory.try_enqueue(message(4)).await.unwrap();
+        assert!(matches!(memory.pressure().await.unwrap(), PressureLevel::Hard(_)));
     }
 
-    #[test]
-    fn full_queue_rejects_message_but_offset_counter_remains_monotonic() {
+    #[tokio::test]
+    async fn full_window_rejects_append_but_offset_counter_remains_monotonic() {
         let memory = Arc::new(PartitionMemory::new(2, 1));
 
-        let first = memory.try_enqueue(message(1)).unwrap().0;
-        let rejected = match memory.try_enqueue(message(2)) {
-            Ok(_) => panic!("expected full queue to reject enqueue"),
+        let first = memory.try_enqueue(message(1)).await.unwrap().0;
+        let rejected = match memory.try_enqueue(message(2)).await {
+            Ok(_) => panic!("expected full window to reject append"),
             Err(message) => message,
         };
         assert_eq!(first.offset, 0);
         assert_eq!(rejected.payload, vec![2]);
 
-        assert_eq!(memory.try_pop_batch(1).len(), 1);
-        let next = memory.try_enqueue(message(3)).unwrap().0;
+        memory.trim_below(1).await; // free one slot
+        let next = memory.try_enqueue(message(3)).await.unwrap().0;
         assert_eq!(next.offset, 2);
         assert_eq!(next.message_id, MessageId::new(2, 0, 2));
     }
 
-    #[test]
-    fn pop_batch_respects_max_and_empty_queue_returns_empty_vec() {
+    #[tokio::test]
+    async fn pop_batch_respects_max_and_empty_queue_returns_empty_vec() {
         let memory = Arc::new(PartitionMemory::new(0, 3));
-        memory.try_enqueue(message(1)).unwrap();
-        memory.try_enqueue(message(2)).unwrap();
-        memory.try_enqueue(message(3)).unwrap();
+        memory.try_enqueue(message(1)).await.unwrap();
+        memory.try_enqueue(message(2)).await.unwrap();
+        memory.try_enqueue(message(3)).await.unwrap();
 
-        assert_eq!(memory.try_pop_batch(0).len(), 0);
-        assert_eq!(memory.try_pop_batch(2).len(), 2);
-        assert_eq!(memory.try_pop_batch(2).len(), 1);
-        assert!(memory.try_pop_batch(2).is_empty());
+        assert_eq!(memory.try_pop_batch(0).await.len(), 0);
+        assert_eq!(memory.try_pop_batch(2).await.len(), 2);
+        assert_eq!(memory.try_pop_batch(2).await.len(), 1);
+        assert!(memory.try_pop_batch(2).await.is_empty());
+    }
+
+    // ---- ADR-079 §Semantics: pub/sub (consumer-group) ----
+
+    #[tokio::test]
+    async fn read_from_is_non_consuming_so_two_cursors_see_the_same_messages() {
+        let memory = Arc::new(PartitionMemory::new(1, 8));
+        for n in 1..=4u8 {
+            memory.try_enqueue(message(n)).await.unwrap();
+        }
+
+        let group_a = memory.read_from(0, 10).await;
+        let group_b = memory.read_from(0, 10).await;
+
+        assert_eq!(group_a.len(), 4, "group A sees all messages");
+        assert_eq!(group_b.len(), 4, "group B sees all messages (not consumed by A)");
+        assert_eq!(
+            group_a.iter().map(|e| e.offset).collect::<Vec<_>>(),
+            group_b.iter().map(|e| e.offset).collect::<Vec<_>>(),
+        );
+    }
+
+    #[tokio::test]
+    async fn read_from_advances_per_call_without_consuming_other_groups() {
+        let memory = Arc::new(PartitionMemory::new(2, 8));
+        for n in 1..=4u8 {
+            memory.try_enqueue(message(n)).await.unwrap();
+        }
+        let a1 = memory.read_from(0, 2).await;
+        let a2 = memory.read_from(2, 2).await;
+        assert_eq!(a1.len(), 2);
+        assert_eq!(a2.len(), 2);
+        assert_eq!(a1[0].offset, 0);
+        assert_eq!(a2[0].offset, 2);
+        let b = memory.read_from(0, 10).await;
+        assert_eq!(b.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn trim_below_drops_old_entries_but_a_lagging_read_clamps_to_base() {
+        let memory = Arc::new(PartitionMemory::new(9, 8));
+        for n in 1..=4u8 {
+            memory.try_enqueue(message(n)).await.unwrap();
+        }
+        memory.trim_below(2).await;
+        assert_eq!(memory.depth().await, 2);
+        let read = memory.read_from(0, 10).await;
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].offset, 2);
+    }
+
+    /// A gap (offset not yet inserted by a concurrent producer) truncates the
+    /// read to the contiguous prefix — the Kafka high-water-mark property.
+    #[tokio::test]
+    async fn read_from_stops_at_the_first_gap() {
+        let memory = Arc::new(PartitionMemory::new(1, 8));
+        // Insert 0,1,2,4 — leave a gap at 3 (simulate an in-flight producer).
+        memory.enqueue_with_offset(message(0), 0).await.unwrap();
+        memory.enqueue_with_offset(message(1), 1).await.unwrap();
+        memory.enqueue_with_offset(message(2), 2).await.unwrap();
+        memory.enqueue_with_offset(message(4), 4).await.unwrap();
+
+        let read = memory.read_from(0, 10).await;
+        assert_eq!(read.len(), 3, "stops at the gap before offset 3");
+        assert_eq!(read[2].offset, 2);
+        // Filling the gap extends the contiguous prefix to include 4.
+        memory.enqueue_with_offset(message(3), 3).await.unwrap();
+        let read = memory.read_from(0, 10).await;
+        assert_eq!(read.len(), 5);
+        assert_eq!(read[4].offset, 4);
     }
 }

--- a/crates/horizontal/proximadb-queue/src/memory_tier.rs
+++ b/crates/horizontal/proximadb-queue/src/memory_tier.rs
@@ -152,7 +152,13 @@ impl PartitionMemory {
             Some(PressureLevel::Soft(_)) => Some(BackpressureHint::Soft),
             _ => None,
         };
-        Ok((MessageEntry { message_id: id, offset }, hint))
+        Ok((
+            MessageEntry {
+                message_id: id,
+                offset,
+            },
+            hint,
+        ))
     }
 
     /// Read up to `max` messages starting at `cursor` **without removing them**
@@ -262,10 +268,16 @@ mod tests {
 
         let (_, hint) = memory.try_enqueue(message(3)).await.unwrap();
         assert!(matches!(hint, Some(BackpressureHint::Soft)));
-        assert!(matches!(memory.pressure().await.unwrap(), PressureLevel::Soft(_)));
+        assert!(matches!(
+            memory.pressure().await.unwrap(),
+            PressureLevel::Soft(_)
+        ));
 
         memory.try_enqueue(message(4)).await.unwrap();
-        assert!(matches!(memory.pressure().await.unwrap(), PressureLevel::Hard(_)));
+        assert!(matches!(
+            memory.pressure().await.unwrap(),
+            PressureLevel::Hard(_)
+        ));
     }
 
     #[tokio::test]
@@ -312,7 +324,11 @@ mod tests {
         let group_b = memory.read_from(0, 10).await;
 
         assert_eq!(group_a.len(), 4, "group A sees all messages");
-        assert_eq!(group_b.len(), 4, "group B sees all messages (not consumed by A)");
+        assert_eq!(
+            group_b.len(),
+            4,
+            "group B sees all messages (not consumed by A)"
+        );
         assert_eq!(
             group_a.iter().map(|e| e.offset).collect::<Vec<_>>(),
             group_b.iter().map(|e| e.offset).collect::<Vec<_>>(),

--- a/crates/horizontal/proximadb-queue/src/memory_tier.rs
+++ b/crates/horizontal/proximadb-queue/src/memory_tier.rs
@@ -189,26 +189,6 @@ impl PartitionMemory {
         // reassigning keeps the >= half, dropping the trimmed prefix.
         buf.entries = buf.entries.split_off(&watermark);
     }
-
-    /// Compat shim for the pop-once consumer path: read from the head and trim
-    /// past it. Retained until the consumer migrates to cursor-based `read_from`
-    /// (slice 4); the reaper then owns trimming (min across groups).
-    pub async fn try_pop_batch(self: &Arc<Self>, max: usize) -> Vec<MemoryEntry> {
-        let base = self
-            .buf
-            .lock()
-            .await
-            .entries
-            .keys()
-            .next()
-            .copied()
-            .unwrap_or(0);
-        let out = self.read_from(base, max).await;
-        if let Some(last) = out.last() {
-            self.trim_below(last.offset + 1).await;
-        }
-        out
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -251,7 +231,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_assigns_partition_scoped_ids_and_pop_preserves_fifo_order() {
+    async fn enqueue_assigns_partition_scoped_ids_and_read_preserves_fifo_order() {
         let memory = Arc::new(PartitionMemory::new(5, 4));
 
         let (first, hint) = memory.try_enqueue(message(1)).await.unwrap();
@@ -263,11 +243,12 @@ mod tests {
         assert!(hint.is_none());
         assert_eq!(memory.depth().await, 2);
 
-        let popped = memory.try_pop_batch(10).await;
-        assert_eq!(popped.len(), 2);
-        assert_eq!(popped[0].message.payload, vec![1]);
-        assert_eq!(popped[1].message.payload, vec![2]);
-        assert_eq!(memory.depth().await, 0);
+        let read = memory.read_from(0, 10).await;
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].message.payload, vec![1]);
+        assert_eq!(read[1].message.payload, vec![2]);
+        // Non-consuming — depth unchanged (pub/sub).
+        assert_eq!(memory.depth().await, 2);
     }
 
     #[tokio::test]
@@ -306,16 +287,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pop_batch_respects_max_and_empty_queue_returns_empty_vec() {
+    async fn read_from_respects_max_and_range_bounds() {
         let memory = Arc::new(PartitionMemory::new(0, 3));
-        memory.try_enqueue(message(1)).await.unwrap();
-        memory.try_enqueue(message(2)).await.unwrap();
-        memory.try_enqueue(message(3)).await.unwrap();
+        memory.try_enqueue(message(1)).await.unwrap(); // offset 0
+        memory.try_enqueue(message(2)).await.unwrap(); // offset 1
+        memory.try_enqueue(message(3)).await.unwrap(); // offset 2
 
-        assert_eq!(memory.try_pop_batch(0).await.len(), 0);
-        assert_eq!(memory.try_pop_batch(2).await.len(), 2);
-        assert_eq!(memory.try_pop_batch(2).await.len(), 1);
-        assert!(memory.try_pop_batch(2).await.is_empty());
+        assert_eq!(memory.read_from(0, 0).await.len(), 0); // max=0 → none
+        assert_eq!(memory.read_from(0, 2).await.len(), 2); // max=2 from cursor 0
+        assert_eq!(memory.read_from(2, 2).await.len(), 1); // cursor 2 → only offset 2
+        assert!(memory.read_from(3, 2).await.is_empty()); // past the end
     }
 
     // ---- ADR-079 §Semantics: pub/sub (consumer-group) ----

--- a/crates/horizontal/proximadb-queue/src/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/src/offset_store.rs
@@ -1,8 +1,10 @@
-//! Per-partition committed-offset metadata file.
+//! Per-`(group, partition)` committed-offset metadata file (ADR-079 §Semantics).
 //!
-//! Stored at `{queue_root}/{topic}/{partition_id}/offset.meta` as a tiny
-//! JSON document `{"group": "...", "committed_offset": <u64>}`. A successful
-//! `Consumer::ack` writes this file; consumer restart reads it to resume.
+//! Stored at `{queue_root}/{topic}/{partition_id}/{group}/offset.meta` as a
+//! tiny JSON document `{"group": "...", "committed_offset": <u64>}`. Each
+//! consumer group gets its OWN file, so group A's ack cannot clobber group B's
+//! cursor (the pub/sub isolation property). A successful `Consumer::ack` writes
+//! its group's file; consumer restart reads its group's file to resume.
 //!
 //! ## Atomic write protocol
 //!
@@ -43,9 +45,36 @@ const META_FILE: &str = "offset.meta";
 /// stomp on the same temp file even across threads / tasks.
 static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
-/// Build `{root}/{topic}/{partition}/offset.meta`.
-fn meta_path(root: &Path, topic: &str, partition: PartitionId) -> PathBuf {
-    root.join(topic).join(partition.to_string()).join(META_FILE)
+/// Reduce a consumer-group id to a safe single path component. Group ids are
+/// application-supplied, so strip anything that could escape the partition
+/// directory (`/`, `..`, `:`, NUL, whitespace) to `_`. Two ids that sanitize
+/// the same collide on disk — acceptable since groups are app-controlled and
+/// the collision is deterministic, not a correctness/corruption hazard.
+fn group_dir_name(group: &str) -> String {
+    let cleaned: String = group
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let cleaned = cleaned.trim_matches(|c: char| c == '.' || c == '_').to_string();
+    if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
+        "default".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Build `{root}/{topic}/{partition}/{group}/offset.meta` — one file per group.
+fn meta_path(root: &Path, topic: &str, partition: PartitionId, group: &str) -> PathBuf {
+    root.join(topic)
+        .join(partition.to_string())
+        .join(group_dir_name(group))
+        .join(META_FILE)
 }
 
 /// Per-call unique temp path: `offset.meta.tmp.{pid}.{seq}`. The rename
@@ -72,7 +101,12 @@ pub async fn commit(
     group: &str,
     committed_offset: u64,
 ) -> crate::Result<()> {
-    let final_path = meta_path(root, topic, partition);
+    let final_path = meta_path(root, topic, partition, group);
+    // Ensure the per-group directory exists (LocalFs needs it; object stores
+    // use flat keys and treat create_dir_all as a no-op on the prefix).
+    if let Some(parent) = final_path.parent() {
+        fs.create_dir_all(parent).await?;
+    }
     let tmp = tmp_path(&final_path);
 
     let body = OffsetMeta {
@@ -88,14 +122,10 @@ pub async fn commit(
     Ok(())
 }
 
-/// Read the committed offset for `(topic, partition)`. Returns `None`
-/// when no `offset.meta` exists yet (cold start — recovery replays
-/// every persisted message). Returns `Some(n)` when an `offset.meta` is
-/// on disk: recovery skips frames whose `offset <= n`.
-///
-/// The `group` parameter is verified — if the on-disk file was written
-/// by a different consumer group, returns `None` so we re-deliver
-/// rather than silently honoring a stranger's commit.
+/// Read THIS group's committed offset for `(topic, partition)`. Returns `None`
+/// when the group has no `offset.meta` yet (cold start — recovery replays
+/// every persisted message). Each group has its own file, so this never sees
+/// another group's commit.
 pub async fn read(
     fs: &Arc<dyn QueueFs>,
     root: &Path,
@@ -103,7 +133,7 @@ pub async fn read(
     partition: PartitionId,
     group: &str,
 ) -> crate::Result<Option<u64>> {
-    let final_path = meta_path(root, topic, partition);
+    let final_path = meta_path(root, topic, partition, group);
     let bytes = match fs.read(&final_path).await {
         Ok(b) => b,
         Err(_) => return Ok(None),
@@ -113,8 +143,7 @@ pub async fn read(
     }
     let parsed: OffsetMeta = serde_json::from_slice(&bytes)
         .map_err(|e| QueueError::Persistence(format!("offset_store parse: {e}")))?;
-    if parsed.group != group {
-        return Ok(None);
-    }
+    // Each group has its own file, so the stored group always matches; keep
+    // returning the offset directly.
     Ok(Some(parsed.committed_offset))
 }

--- a/crates/horizontal/proximadb-queue/src/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/src/offset_store.rs
@@ -62,7 +62,9 @@ pub(crate) fn group_dir_name(group: &str) -> String {
             }
         })
         .collect();
-    let cleaned = cleaned.trim_matches(|c: char| c == '.' || c == '_').to_string();
+    let cleaned = cleaned
+        .trim_matches(|c: char| c == '.' || c == '_')
+        .to_string();
     if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
         "default".to_string()
     } else {

--- a/crates/horizontal/proximadb-queue/src/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/src/offset_store.rs
@@ -22,6 +22,7 @@
 //! rename completed). The temp file is cleaned up on the next commit
 //! attempt. We never observe a half-written `offset.meta`.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -146,4 +147,58 @@ pub async fn read(
     // Each group has its own file, so the stored group always matches; keep
     // returning the offset directly.
     Ok(Some(parsed.committed_offset))
+}
+
+const LEASE_FILE_LEAF: &str = "lease.meta";
+
+/// Read EVERY consumer group's committed offset for `(topic, partition)`, used
+/// by the reaper to compute the minimum offset across groups (a disk segment is
+/// only reapable once ALL groups have consumed past it — pub/sub safety).
+///
+/// Handles both `QueueFs::list` shapes:
+/// - local `read_dir` returns the group subdirectories (single level) — descend
+///   into each to confirm it holds an `offset.meta`;
+/// - object stores return recursive-prefix leaves like `<group>/offset.meta`
+///   (and `<group>/lease.meta`) — the group is the entry's parent dir name.
+pub async fn read_all_groups(
+    fs: &Arc<dyn QueueFs>,
+    root: &Path,
+    topic: &str,
+    partition: PartitionId,
+) -> crate::Result<Vec<(String, u64)>> {
+    let partition_dir = root.join(topic).join(partition.to_string());
+    let mut group_names: HashSet<String> = HashSet::new();
+
+    let entries = fs.list(&partition_dir).await.unwrap_or_default();
+    for entry in entries {
+        let fname = entry.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if fname == META_FILE || fname == LEASE_FILE_LEAF {
+            // Object-store leaf under a group dir → group = parent dir name.
+            if let Some(group) = entry
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+            {
+                group_names.insert(group.to_string());
+            }
+        } else {
+            // Local-shape group subdirectory — confirm it holds an offset.meta.
+            if let Ok(children) = fs.list(&entry).await
+                && children
+                    .iter()
+                    .any(|c| c.file_name().and_then(|n| n.to_str()) == Some(META_FILE))
+                && let Some(group) = entry.file_name().and_then(|n| n.to_str())
+            {
+                group_names.insert(group.to_string());
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(group_names.len());
+    for group in group_names {
+        if let Ok(Some(off)) = read(fs, root, topic, partition, &group).await {
+            out.push((group, off));
+        }
+    }
+    Ok(out)
 }

--- a/crates/horizontal/proximadb-queue/src/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/src/offset_store.rs
@@ -50,7 +50,7 @@ static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 /// directory (`/`, `..`, `:`, NUL, whitespace) to `_`. Two ids that sanitize
 /// the same collide on disk — acceptable since groups are app-controlled and
 /// the collision is deterministic, not a correctness/corruption hazard.
-fn group_dir_name(group: &str) -> String {
+pub(crate) fn group_dir_name(group: &str) -> String {
     let cleaned: String = group
         .chars()
         .map(|c| {

--- a/crates/horizontal/proximadb-queue/src/producer.rs
+++ b/crates/horizontal/proximadb-queue/src/producer.rs
@@ -80,7 +80,7 @@ impl Producer {
         // that same offset so MessageId is stable across crash/replay.
         let outcome = disk_writer.append(&message).await?;
 
-        let mut to_send = message;
+        let to_send = message;
         let (entry, backpressure_hint) = match part
             .enqueue_with_offset(to_send.clone(), outcome.offset)
             .await

--- a/crates/horizontal/proximadb-queue/src/producer.rs
+++ b/crates/horizontal/proximadb-queue/src/producer.rs
@@ -65,7 +65,7 @@ impl Producer {
 
         // Hard backpressure check before any I/O. Memory-full rejection
         // would later leak phantom disk writes — fail fast instead.
-        if let Some(crate::memory_tier::PressureLevel::Hard(pct)) = part.pressure() {
+        if let Some(crate::memory_tier::PressureLevel::Hard(pct)) = part.pressure().await {
             QUEUE_BACKPRESSURE
                 .with_label_values(&[&topic_name, "hard"])
                 .inc();
@@ -81,24 +81,27 @@ impl Producer {
         let outcome = disk_writer.append(&message).await?;
 
         let mut to_send = message;
-        let (entry, backpressure_hint) = part
+        let (entry, backpressure_hint) = match part
             .enqueue_with_offset(to_send.clone(), outcome.offset)
-            .map_err(|m| {
-                to_send = m;
+            .await
+        {
+            Ok(pair) => pair,
+            Err(_m) => {
                 QUEUE_BACKPRESSURE
                     .with_label_values(&[&topic_name, "soft"])
                     .inc();
-                QueueError::Backpressure {
-                    pct: part.depth_pct() * 100.0,
+                return Err(QueueError::Backpressure {
+                    pct: part.depth_pct().await * 100.0,
                     retry_after_ms: 100,
-                }
-            })?;
+                });
+            }
+        };
 
         // Memory tier depth gauge — reflects the post-enqueue state.
         // Consumer drains will set it back down via the same gauge.
         QUEUE_DEPTH
             .with_label_values(&[&topic_name, &partition_label])
-            .set(part.depth() as i64);
+            .set(part.depth().await as i64);
 
         // Strict mode: block on the group-commit fsync barrier so the
         // returned receipt's `fsynced_at` is a real guarantee.

--- a/crates/horizontal/proximadb-queue/src/reaper.rs
+++ b/crates/horizontal/proximadb-queue/src/reaper.rs
@@ -47,11 +47,6 @@ const SEGMENT_EXT: &str = "qseg";
 const UPLOADED_MARKER_EXT: &str = "uploaded";
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Same convention `recovery.rs` uses. When multi-group support lands,
-/// the reaper will read every `offset.*.meta` file and demand the
-/// minimum committed offset across all groups before deleting.
-const DEFAULT_GROUP_FOR_REAPING: &str = "g";
-
 pub struct Reaper {
     fs: Arc<dyn QueueFs>,
     poll_interval: Duration,
@@ -109,14 +104,18 @@ impl Reaper {
                 let writer = writer.clone();
                 let active_id = writer.active_segment_id().await;
                 let segments = writer.segments().await.unwrap_or_default();
-                let committed = crate::offset_store::read(
+                let groups = crate::offset_store::read_all_groups(
                     &self.fs,
                     client.root_path(),
                     &topic,
                     partition_id,
-                    DEFAULT_GROUP_FOR_REAPING,
                 )
                 .await?;
+                // A segment is reapable only once EVERY group has consumed
+                // past it — take the min committed offset across groups.
+                // None ⇒ no group has acked yet ⇒ keep the segment (pub/sub
+                // safety: never delete before the slowest group has read).
+                let committed = groups.iter().map(|(_, o)| *o).min();
                 for segment in segments {
                     // Skip the active segment — producers are still
                     // appending to it.

--- a/crates/horizontal/proximadb-queue/src/recovery.rs
+++ b/crates/horizontal/proximadb-queue/src/recovery.rs
@@ -361,7 +361,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(replayed, 1);
-        let restored = state.memory[0].try_pop_batch(10).await;
+        let restored = state.memory[0].read_from(0, 10).await;
         assert_eq!(restored.len(), 1);
         assert_eq!(restored[0].message.payload, b"survives");
     }

--- a/crates/horizontal/proximadb-queue/src/recovery.rs
+++ b/crates/horizontal/proximadb-queue/src/recovery.rs
@@ -28,13 +28,6 @@ use crate::fs::QueueFs;
 use crate::message::Message;
 use crate::topic::PartitionId;
 
-/// Consumer-group key recovery uses to look up `offset.meta`. Phase 2C
-/// locks the design to one consumer group per topic (README invariant
-/// #4), so this is sufficient. When multi-group support lands, recovery
-/// will glob `offset.*.meta` and take the minimum committed offset
-/// across groups.
-const DEFAULT_GROUP_FOR_RECOVERY: &str = "g";
-
 const SEGMENT_EXT: &str = "qseg";
 
 /// Extract `(segment_id, path)` from a directory entry whose filename
@@ -157,9 +150,13 @@ async fn replay_partition(
         })?
         .clone();
 
-    // Read the per-partition committed offset for the default consumer
-    // group. None = no offset.meta on disk (cold start, replay all).
-    // Some(c) = skip messages whose frame-offset <= c (already acked).
+    // Recovery skip uses the MIN committed offset across all consumer groups:
+    // a frame is only left out of the replay once EVERY group has acked past
+    // it (pub/sub safe — a fast group can't cause recovery to drop frames a
+    // slower group still needs). None = no group has committed yet (cold
+    // start, or all groups fresh) → replay every persisted frame. Each group
+    // resumes at its OWN cursor on `subscribe` (offset_store::read), so this
+    // skip is purely a memory-capacity optimization, not a correctness gate.
     let root_path = partition_dir
         .parent()
         .and_then(|topic_dir| topic_dir.parent())
@@ -168,9 +165,9 @@ async fn replay_partition(
                 "recovery: cannot derive queue root from {partition_dir:?}"
             ))
         })?;
-    let committed =
-        crate::offset_store::read(fs, root_path, topic, partition, DEFAULT_GROUP_FOR_RECOVERY)
-            .await?;
+    let groups =
+        crate::offset_store::read_all_groups(fs, root_path, topic, partition).await?;
+    let committed = groups.iter().map(|(_, o)| *o).min();
 
     let mut replayed = 0usize;
     let mut skipped = 0usize;

--- a/crates/horizontal/proximadb-queue/src/recovery.rs
+++ b/crates/horizontal/proximadb-queue/src/recovery.rs
@@ -165,8 +165,7 @@ async fn replay_partition(
                 "recovery: cannot derive queue root from {partition_dir:?}"
             ))
         })?;
-    let groups =
-        crate::offset_store::read_all_groups(fs, root_path, topic, partition).await?;
+    let groups = crate::offset_store::read_all_groups(fs, root_path, topic, partition).await?;
     let committed = groups.iter().map(|(_, o)| *o).min();
 
     let mut replayed = 0usize;
@@ -241,7 +240,11 @@ async fn replay_partition(
 
             // Re-enqueue with the frame-recorded offset so MessageId is
             // stable across crash/replay.
-            if mem.enqueue_with_offset(message, frame_offset).await.is_err() {
+            if mem
+                .enqueue_with_offset(message, frame_offset)
+                .await
+                .is_err()
+            {
                 return Err(QueueError::Persistence(format!(
                     "recovery: memory tier full at topic={topic} partition={partition} \
                      segment={segment_id} replayed={replayed} — increase memory_capacity"

--- a/crates/horizontal/proximadb-queue/src/recovery.rs
+++ b/crates/horizontal/proximadb-queue/src/recovery.rs
@@ -244,7 +244,7 @@ async fn replay_partition(
 
             // Re-enqueue with the frame-recorded offset so MessageId is
             // stable across crash/replay.
-            if mem.enqueue_with_offset(message, frame_offset).is_err() {
+            if mem.enqueue_with_offset(message, frame_offset).await.is_err() {
                 return Err(QueueError::Persistence(format!(
                     "recovery: memory tier full at topic={topic} partition={partition} \
                      segment={segment_id} replayed={replayed} — increase memory_capacity"
@@ -331,7 +331,7 @@ mod tests {
                 .unwrap();
 
         assert_eq!(replayed, 0);
-        assert_eq!(state.memory[0].depth(), 0);
+        assert_eq!(state.memory[0].depth().await, 0);
     }
 
     #[tokio::test]
@@ -361,7 +361,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(replayed, 1);
-        let restored = state.memory[0].try_pop_batch(10);
+        let restored = state.memory[0].try_pop_batch(10).await;
         assert_eq!(restored.len(), 1);
         assert_eq!(restored[0].message.payload, b"survives");
     }

--- a/crates/horizontal/proximadb-queue/tests/edge_cases.rs
+++ b/crates/horizontal/proximadb-queue/tests/edge_cases.rs
@@ -322,11 +322,12 @@ async fn poll_without_subscription_returns_empty_quickly() {
     );
 }
 
-/// Multiple consumers in the SAME group on the same partition share the
-/// in-flight tracker — once one polls a message, the other won't see it.
-/// (Phase 1B in-process leasing; cross-process disk leases land later.)
+/// A consumer does not re-receive messages it already polled — the group's
+/// read cursor advances past delivered messages within a session (the
+/// within-group, no-re-delivery property; cross-group fan-out is covered by
+/// pubsub_ratchet). Two polls return disjoint message sets.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn second_consumer_sees_remaining_messages_after_first_drains() {
+async fn poll_does_not_redeliver_within_a_session() {
     let (_tmp, cfg) = cfg("t", 1, 16);
     let client = QueueClient::open(cfg).await.unwrap();
     let producer = client.producer();
@@ -337,19 +338,19 @@ async fn second_consumer_sees_remaining_messages_after_first_drains() {
             .unwrap();
     }
 
-    let c1 = client.consumer("g");
-    c1.subscribe("t", &[0]).await.unwrap();
-    let batch1 = c1.poll(4, Duration::from_millis(50)).await.unwrap();
+    let c = client.consumer("g");
+    c.subscribe("t", &[0]).await.unwrap();
+    let batch1 = c.poll(4, Duration::from_millis(50)).await.unwrap();
     assert_eq!(batch1.len(), 4);
 
-    let c2 = client.consumer("g");
-    c2.subscribe("t", &[0]).await.unwrap();
-    let batch2 = c2.poll(8, Duration::from_millis(50)).await.unwrap();
-    assert_eq!(
-        batch2.len(),
-        4,
-        "second consumer should see the remaining 4"
-    );
+    let batch2 = c.poll(8, Duration::from_millis(50)).await.unwrap();
+    assert_eq!(batch2.len(), 4, "second poll delivers the NEXT 4, not re-delivered");
+
+    // No overlap between the two batches.
+    let mut ids: Vec<&proximadb_queue::MessageId> = batch1.iter().map(|d| &d.message_id).collect();
+    ids.extend(batch2.iter().map(|d| &d.message_id));
+    let unique: std::collections::HashSet<_> = ids.into_iter().collect();
+    assert_eq!(unique.len(), 8, "8 distinct messages across the two polls");
 }
 
 /// Shutdown is idempotent and doesn't panic when called twice.

--- a/crates/horizontal/proximadb-queue/tests/edge_cases.rs
+++ b/crates/horizontal/proximadb-queue/tests/edge_cases.rs
@@ -344,7 +344,11 @@ async fn poll_does_not_redeliver_within_a_session() {
     assert_eq!(batch1.len(), 4);
 
     let batch2 = c.poll(8, Duration::from_millis(50)).await.unwrap();
-    assert_eq!(batch2.len(), 4, "second poll delivers the NEXT 4, not re-delivered");
+    assert_eq!(
+        batch2.len(),
+        4,
+        "second poll delivers the NEXT 4, not re-delivered"
+    );
 
     // No overlap between the two batches.
     let mut ids: Vec<&proximadb_queue::MessageId> = batch1.iter().map(|d| &d.message_id).collect();

--- a/crates/horizontal/proximadb-queue/tests/leases.rs
+++ b/crates/horizontal/proximadb-queue/tests/leases.rs
@@ -40,7 +40,7 @@ async fn first_subscriber_acquires_lease() {
     let consumer = client.consumer("g");
     consumer.subscribe("t", &[0]).await.expect("subscribe");
 
-    let lease_path = tmp.path().join("t").join("0").join("lease.meta");
+    let lease_path = tmp.path().join("t").join("0").join("g").join("lease.meta");
     assert!(
         lease_path.exists(),
         "lease.meta should be written on subscribe"
@@ -114,7 +114,7 @@ async fn expired_lease_is_reclaimable() {
     // Read A's holder_id from the freshly-written lease.meta. We
     // capture it BEFORE dropping A so we can later assert that B's
     // takeover replaced it with a different id.
-    let lease_path = tmp.path().join("t").join("0").join("lease.meta");
+    let lease_path = tmp.path().join("t").join("0").join("g").join("lease.meta");
     let a_body = std::fs::read_to_string(&lease_path).expect("read A's lease");
     let a_parsed: serde_json::Value = serde_json::from_str(&a_body).expect("parse A");
     let a_instance = a_parsed["holder_id"]
@@ -141,7 +141,7 @@ async fn expired_lease_is_reclaimable() {
         .expect("B should reclaim");
 
     // Verify the holder switched.
-    let lease_body = std::fs::read_to_string(tmp.path().join("t").join("0").join("lease.meta"))
+    let lease_body = std::fs::read_to_string(tmp.path().join("t").join("0").join("g").join("lease.meta"))
         .expect("read lease");
     let parsed: serde_json::Value = serde_json::from_str(&lease_body).expect("parse");
     let new_holder = parsed["holder_id"].as_str().expect("holder_id");
@@ -175,6 +175,43 @@ async fn lease_renewer_keeps_holder_alive() {
         .await
         .expect_err("renewer must have kept lease alive");
     assert!(matches!(err, QueueError::LeaseConflict { .. }));
+
+    client_a.shutdown().await.expect("shutdown A");
+    client_b.shutdown().await.expect("shutdown B");
+}
+
+/// ADR-079 §Semantics: leases are scoped per consumer GROUP. Two different
+/// groups can each hold the SAME partition concurrently (pub/sub fan-out) —
+/// only consumers in the SAME group compete (the cases above). RED for slice 3:
+/// today the lease is global per partition, so group B conflicts with group A.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_different_groups_each_hold_the_same_partition() {
+    let tmp = TempDir::new().expect("tempdir");
+    let client_a = QueueClient::open(cfg(tmp.path(), Duration::from_secs(30)))
+        .await
+        .expect("open A");
+    let consumer_a = client_a.consumer("alpha");
+    consumer_a.subscribe("t", &[0]).await.expect("group A subscribes");
+
+    // group B subscribes to the SAME partition — must NOT conflict (different group).
+    let client_b = QueueClient::open(cfg(tmp.path(), Duration::from_secs(30)))
+        .await
+        .expect("open B");
+    let consumer_b = client_b.consumer("beta");
+    consumer_b
+        .subscribe("t", &[0])
+        .await
+        .expect("group B subscribes with no conflict (per-group lease)");
+
+    // Two independent lease files exist — one per group.
+    assert!(
+        tmp.path().join("t").join("0").join("alpha").join("lease.meta").exists(),
+        "group alpha has its own lease",
+    );
+    assert!(
+        tmp.path().join("t").join("0").join("beta").join("lease.meta").exists(),
+        "group beta has its own lease",
+    );
 
     client_a.shutdown().await.expect("shutdown A");
     client_b.shutdown().await.expect("shutdown B");

--- a/crates/horizontal/proximadb-queue/tests/leases.rs
+++ b/crates/horizontal/proximadb-queue/tests/leases.rs
@@ -141,8 +141,9 @@ async fn expired_lease_is_reclaimable() {
         .expect("B should reclaim");
 
     // Verify the holder switched.
-    let lease_body = std::fs::read_to_string(tmp.path().join("t").join("0").join("g").join("lease.meta"))
-        .expect("read lease");
+    let lease_body =
+        std::fs::read_to_string(tmp.path().join("t").join("0").join("g").join("lease.meta"))
+            .expect("read lease");
     let parsed: serde_json::Value = serde_json::from_str(&lease_body).expect("parse");
     let new_holder = parsed["holder_id"].as_str().expect("holder_id");
     assert_ne!(new_holder, a_instance, "B's instance must differ from A's");
@@ -191,7 +192,10 @@ async fn two_different_groups_each_hold_the_same_partition() {
         .await
         .expect("open A");
     let consumer_a = client_a.consumer("alpha");
-    consumer_a.subscribe("t", &[0]).await.expect("group A subscribes");
+    consumer_a
+        .subscribe("t", &[0])
+        .await
+        .expect("group A subscribes");
 
     // group B subscribes to the SAME partition — must NOT conflict (different group).
     let client_b = QueueClient::open(cfg(tmp.path(), Duration::from_secs(30)))
@@ -205,11 +209,21 @@ async fn two_different_groups_each_hold_the_same_partition() {
 
     // Two independent lease files exist — one per group.
     assert!(
-        tmp.path().join("t").join("0").join("alpha").join("lease.meta").exists(),
+        tmp.path()
+            .join("t")
+            .join("0")
+            .join("alpha")
+            .join("lease.meta")
+            .exists(),
         "group alpha has its own lease",
     );
     assert!(
-        tmp.path().join("t").join("0").join("beta").join("lease.meta").exists(),
+        tmp.path()
+            .join("t")
+            .join("0")
+            .join("beta")
+            .join("lease.meta")
+            .exists(),
         "group beta has its own lease",
     );
 

--- a/crates/horizontal/proximadb-queue/tests/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/tests/offset_store.rs
@@ -58,7 +58,7 @@ async fn ack_commits_offset_to_disk() {
     consumer.ack(&ack_ids).await.expect("ack");
 
     // offset.meta must now exist on disk.
-    let meta_path = root.join("t").join("0").join("offset.meta");
+    let meta_path = root.join("t").join("0").join("g").join("offset.meta");
     assert!(meta_path.exists(), "offset.meta should be written");
     let body = std::fs::read_to_string(&meta_path).expect("read meta");
     let parsed: Value = serde_json::from_str(&body).expect("parse json");
@@ -113,7 +113,7 @@ async fn offset_commit_is_atomic() {
     // committed_offset must be a reachable value (≤ 99). The exact
     // value depends on scheduling — what matters is that we never
     // observe a corrupted file.
-    let meta_path = root.join("t").join("0").join("offset.meta");
+    let meta_path = root.join("t").join("0").join("g").join("offset.meta");
     assert!(meta_path.exists(), "offset.meta should exist");
     let body = std::fs::read_to_string(&meta_path).expect("read meta");
     let parsed: Value = serde_json::from_str(&body).expect("parse json (no corruption)");
@@ -123,4 +123,42 @@ async fn offset_commit_is_atomic() {
         "committed_offset {committed} must be within range 0..=99"
     );
     assert_eq!(parsed["group"], "g");
+}
+
+/// ADR-079 §Semantics: each consumer group has its OWN committed-offset file,
+/// so group A's ack does not clobber group B's cursor (the pub/sub isolation
+/// property). RED for slice 2: today there is one shared `offset.meta` per
+/// partition, so this test fails until offset paths are keyed by group.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn each_consumer_group_has_an_independent_committed_offset() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    let client = QueueClient::open(cfg(root, "t", 1)).await.expect("open");
+    let producer = client.producer();
+    for i in 0..5u32 {
+        producer
+            .send(Message::new("t", "tenant-a", vec![i as u8]))
+            .await
+            .expect("send");
+    }
+
+    // group A acks all five (committed_offset → 4).
+    let a = client.consumer("a");
+    a.subscribe("t", &[0]).await.expect("subscribe a");
+    let batch = a.poll(5, Duration::from_millis(200)).await.expect("poll a");
+    let ids: Vec<proximadb_queue::MessageId> =
+        batch.iter().map(|d| d.message_id.clone()).collect();
+    a.ack(&ids).await.expect("ack a");
+
+    // group A has its OWN offset.meta under t/0/a/.
+    let a_meta = root.join("t").join("0").join("a").join("offset.meta");
+    assert!(a_meta.exists(), "group A writes its own offset.meta");
+    let v: Value = serde_json::from_str(&std::fs::read_to_string(&a_meta).expect("read"))
+        .expect("parse");
+    assert_eq!(v["committed_offset"].as_u64(), Some(4));
+    assert_eq!(v["group"], "a");
+
+    // group B (never subscribed) has NO offset file — independent of A.
+    let b_meta = root.join("t").join("0").join("b").join("offset.meta");
+    assert!(!b_meta.exists(), "group A's ack must not clobber group B");
 }

--- a/crates/horizontal/proximadb-queue/tests/offset_store.rs
+++ b/crates/horizontal/proximadb-queue/tests/offset_store.rs
@@ -146,15 +146,14 @@ async fn each_consumer_group_has_an_independent_committed_offset() {
     let a = client.consumer("a");
     a.subscribe("t", &[0]).await.expect("subscribe a");
     let batch = a.poll(5, Duration::from_millis(200)).await.expect("poll a");
-    let ids: Vec<proximadb_queue::MessageId> =
-        batch.iter().map(|d| d.message_id.clone()).collect();
+    let ids: Vec<proximadb_queue::MessageId> = batch.iter().map(|d| d.message_id.clone()).collect();
     a.ack(&ids).await.expect("ack a");
 
     // group A has its OWN offset.meta under t/0/a/.
     let a_meta = root.join("t").join("0").join("a").join("offset.meta");
     assert!(a_meta.exists(), "group A writes its own offset.meta");
-    let v: Value = serde_json::from_str(&std::fs::read_to_string(&a_meta).expect("read"))
-        .expect("parse");
+    let v: Value =
+        serde_json::from_str(&std::fs::read_to_string(&a_meta).expect("read")).expect("parse");
     assert_eq!(v["committed_offset"].as_u64(), Some(4));
     assert_eq!(v["group"], "a");
 

--- a/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
+++ b/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
@@ -6,7 +6,7 @@
 //! the other. This is the conformance ratchet for the queue's pub/sub plane: a
 //! regression (loss / dup / cross-group interference) fails CI here.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use proximadb_queue::{Consumer, Delivery, Message, QueueClient, QueueConfig, TopicConfig};
@@ -93,6 +93,58 @@ async fn two_groups_each_independently_receive_all_messages() {
         (0..N as u8).collect::<Vec<_>>(),
         "group B sees the same message set as A",
     );
+
+    client.shutdown().await.expect("shutdown");
+}
+
+/// **Delivery-guarantee ratchet (ADR-079).** Every consumer group independently
+/// receives EVERY message, in strict ascending offset order, with no loss and
+/// no duplication — the pub/sub contract. This is the CI ratchet: the
+/// guaranteed-delivery fraction is 100% and may never regress. A failure on
+/// completeness, order, uniqueness, or cross-group equality fails here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn pubsub_delivery_guarantee_ratchet() {
+    const GROUPS: &[&str] = &["compliance", "security", "analytics"];
+    const N: usize = 25;
+    let (_tmp, cfg) = cfg("ratchet-topic", 1);
+    let client = QueueClient::open(cfg).await.expect("open");
+    let producer = client.producer();
+    for i in 0..N as u8 {
+        producer
+            .send(Message::new("ratchet-topic", "tenant", vec![i]))
+            .await
+            .expect("send");
+    }
+
+    let mut delivered_per_group: HashMap<&str, Vec<u64>> = HashMap::new();
+    for &g in GROUPS {
+        let c = client.consumer(g);
+        c.subscribe("ratchet-topic", &[0]).await.expect("subscribe");
+
+        let batch = drain(&c, N).await;
+        // Completeness: every group receives exactly N.
+        assert_eq!(batch.len(), N, "group {g}: received {} of {N} (loss)", batch.len());
+
+        // Order + uniqueness: payloads (sent as vec![i]) are the offset proxy —
+        // strictly ascending 0..N with no duplicates.
+        let payloads: Vec<u64> =
+            batch.iter().map(|d| d.message.payload.first().copied().unwrap_or(0) as u64).collect();
+        let unique: HashSet<u64> = payloads.iter().copied().collect();
+        assert_eq!(unique.len(), N, "group {g}: expected {N} unique messages (no dups)");
+        assert_eq!(
+            payloads,
+            (0..N as u64).collect::<Vec<_>>(),
+            "group {g}: messages must be 0..{N} in strict ascending order",
+        );
+        delivered_per_group.insert(g, payloads);
+    }
+
+    // Cross-group equality: every group received the SAME full message set
+    // (true fan-out — no group's consumption affected another's).
+    let baseline = delivered_per_group["compliance"].clone();
+    for (g, msgs) in &delivered_per_group {
+        assert_eq!(msgs, &baseline, "group {g} received the same set as compliance");
+    }
 
     client.shutdown().await.expect("shutdown");
 }

--- a/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
+++ b/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
@@ -87,7 +87,11 @@ async fn two_groups_each_independently_receive_all_messages() {
 
     // group B consumes AFTER A — must ALSO receive all N (pub/sub fan-out).
     let b_delivered = drain(&b, N).await;
-    assert_eq!(b_delivered.len(), N, "group B independently receives all {N}");
+    assert_eq!(
+        b_delivered.len(),
+        N,
+        "group B independently receives all {N}"
+    );
     assert_eq!(
         payloads_of(&b_delivered),
         (0..N as u8).collect::<Vec<_>>(),
@@ -123,14 +127,25 @@ async fn pubsub_delivery_guarantee_ratchet() {
 
         let batch = drain(&c, N).await;
         // Completeness: every group receives exactly N.
-        assert_eq!(batch.len(), N, "group {g}: received {} of {N} (loss)", batch.len());
+        assert_eq!(
+            batch.len(),
+            N,
+            "group {g}: received {} of {N} (loss)",
+            batch.len()
+        );
 
         // Order + uniqueness: payloads (sent as vec![i]) are the offset proxy —
         // strictly ascending 0..N with no duplicates.
-        let payloads: Vec<u64> =
-            batch.iter().map(|d| d.message.payload.first().copied().unwrap_or(0) as u64).collect();
+        let payloads: Vec<u64> = batch
+            .iter()
+            .map(|d| d.message.payload.first().copied().unwrap_or(0) as u64)
+            .collect();
         let unique: HashSet<u64> = payloads.iter().copied().collect();
-        assert_eq!(unique.len(), N, "group {g}: expected {N} unique messages (no dups)");
+        assert_eq!(
+            unique.len(),
+            N,
+            "group {g}: expected {N} unique messages (no dups)"
+        );
         assert_eq!(
             payloads,
             (0..N as u64).collect::<Vec<_>>(),
@@ -143,7 +158,10 @@ async fn pubsub_delivery_guarantee_ratchet() {
     // (true fan-out — no group's consumption affected another's).
     let baseline = delivered_per_group["compliance"].clone();
     for (g, msgs) in &delivered_per_group {
-        assert_eq!(msgs, &baseline, "group {g} received the same set as compliance");
+        assert_eq!(
+            msgs, &baseline,
+            "group {g} received the same set as compliance"
+        );
     }
 
     client.shutdown().await.expect("shutdown");

--- a/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
+++ b/crates/horizontal/proximadb-queue/tests/pubsub_ratchet.rs
@@ -1,0 +1,98 @@
+//! Pub/sub (consumer-group) round-trip + delivery-guarantee ratchet (ADR-079 §Semantics).
+//!
+//! Proves the defining Kafka-style property: every consumer GROUP independently
+//! receives ALL messages on a partition, in order, with no loss and no
+//! duplication — even when groups consume concurrently or one races ahead of
+//! the other. This is the conformance ratchet for the queue's pub/sub plane: a
+//! regression (loss / dup / cross-group interference) fails CI here.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use proximadb_queue::{Consumer, Delivery, Message, QueueClient, QueueConfig, TopicConfig};
+use tempfile::TempDir;
+
+fn cfg(name: &str, partition_count: u32) -> (TempDir, QueueConfig) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut topics = HashMap::new();
+    topics.insert(
+        name.to_string(),
+        TopicConfig {
+            partition_count,
+            memory_capacity: 1024,
+            ..Default::default()
+        },
+    );
+    let cfg = QueueConfig {
+        root: format!("file://{}", tmp.path().display()),
+        topics,
+        ..QueueConfig::default()
+    };
+    (tmp, cfg)
+}
+
+/// Poll until `want` deliveries arrive (or the deadline lapses).
+async fn drain(consumer: &Consumer, want: usize) -> Vec<Delivery> {
+    let mut out = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while out.len() < want && std::time::Instant::now() < deadline {
+        let batch = consumer
+            .poll(want.max(1), Duration::from_millis(50))
+            .await
+            .expect("poll");
+        if batch.is_empty() {
+            continue;
+        }
+        out.extend(batch);
+    }
+    out
+}
+
+fn payloads_of(deliveries: &[Delivery]) -> Vec<u8> {
+    let mut v: Vec<u8> = deliveries
+        .iter()
+        .flat_map(|d| d.message.payload.iter().copied())
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+/// The core pub/sub property: two groups each independently receive ALL
+/// messages, even when one group fully consumes + acks before the other reads.
+/// RED for slice 4: today `poll` consumes (pops), so group B finds the buffer
+/// already emptied by group A and receives nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_groups_each_independently_receive_all_messages() {
+    const N: usize = 10;
+    let (_tmp, cfg) = cfg("fanout", 1);
+    let client = QueueClient::open(cfg).await.expect("open");
+    let producer = client.producer();
+    for i in 0..N as u8 {
+        producer
+            .send(Message::new("fanout", "tenant", vec![i]))
+            .await
+            .expect("send");
+    }
+
+    let a = client.consumer("alpha");
+    a.subscribe("fanout", &[0]).await.expect("A subscribe");
+    let b = client.consumer("beta");
+    b.subscribe("fanout", &[0]).await.expect("B subscribe");
+
+    // group A consumes + acks everything FIRST.
+    let a_delivered = drain(&a, N).await;
+    assert_eq!(a_delivered.len(), N, "group A receives all {N}");
+    let a_ids: Vec<_> = a_delivered.iter().map(|d| d.message_id.clone()).collect();
+    a.ack(&a_ids).await.expect("ack A");
+
+    // group B consumes AFTER A — must ALSO receive all N (pub/sub fan-out).
+    let b_delivered = drain(&b, N).await;
+    assert_eq!(b_delivered.len(), N, "group B independently receives all {N}");
+    assert_eq!(
+        payloads_of(&b_delivered),
+        (0..N as u8).collect::<Vec<_>>(),
+        "group B sees the same message set as A",
+    );
+
+    client.shutdown().await.expect("shutdown");
+}

--- a/src/services/embedding_drainer.rs
+++ b/src/services/embedding_drainer.rs
@@ -927,6 +927,10 @@ mod tests {
                 tmp.path()
                     .join(EMBED_INGEST_TOPIC)
                     .join(partition.to_string())
+                    // Q1 (ADR-079): committed offsets are per consumer group —
+                    // {partition}/{group}/offset.meta. The drainer's default
+                    // group is "embed-drainer" (EmbeddingDrainerConfig::default).
+                    .join("embed-drainer")
                     .join("offset.meta")
                     .exists()
             });


### PR DESCRIPTION
## Summary

Adds native **pub/sub** to `proximadb-queue` (the segment-based primitive
landed in Q0 #1288) using **Kafka consumer-group semantics**: exclusive
*within* a group (competing consumers), independent *across* groups (fan-out).
Point-to-point is the one-group degenerate case; both are now the same code
path. This is what makes the primitive "robust and scalable to handle all
capabilities" — the AXIS coordination (point-to-point) and audit (fan-out)
migrations (Q2/Q3) can both target it.

Built with **TDD** (red → green per slice) — 6 slices, each a bisectable commit:

1. **Retained-cursor memory tier** — replaced the pop-once `ArrayQueue` with a
   retained, offset-indexed `BTreeMap`. `read_from(cursor, max)` is
   **non-consuming** (the pub/sub primitive) and walks the **contiguous prefix**,
   stopping at the first gap so a consumer never sees a hole a lagging concurrent
   producer hasn't filled (Kafka high-water-mark). `BTreeMap` (not `Vec`) so
   out-of-order concurrent producers never violate contiguity.
2. **Per-group committed offsets** — `{root}/{topic}/{partition}/{group}/offset.meta`
   (one file per group); group A's ack can't clobber group B's cursor. Group ids
   are sanitized to a safe path component.
3. **Per-group partition leases** — `{group}/lease.meta`; two different groups can
   each hold the SAME partition (fan-out); only same-group consumers conflict.
4. **Cursor-based consumer poll** — `poll` reads via `read_from(group_cursor)` and
   advances the group's OWN cursor; reads no longer consume. This is the change
   that makes pub/sub work end-to-end.
5. **Reaper respects min across groups** — a segment is reaped only once EVERY
   group has committed past it (`read_all_groups`, both `list` shapes).
6. **Recovery skips by min across groups** — a frame is dropped from replay only
   once all groups have acked past it (was a single hardcoded group — a footgun).

## The ratchet integration test (requested)

`tests/pubsub_ratchet.rs::pubsub_delivery_guarantee_ratchet` — the CI ratchet for
the pub/sub plane: **3 consumer groups × 25 messages**, each group receives EVERY
message, in strict ascending order, with no loss and no duplication, and every
group receives the same set (true fan-out). A regression on completeness / order /
uniqueness / cross-group equality fails here.

## Verification

- `cargo nextest run -p proximadb-queue` — **82/82 pass** (74 original + 8 new).
- `cargo clippy --all-targets -p proximadb-queue -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo build -p proximadb-server` — links (mandate #11; public API unchanged).
- `make work-commit-check`, env-gate registry — clean.

## Known limitation (out of Q1 scope)

`read_from` serves the in-memory window only (no disk-segment fallback on a miss
below the trimmed base). For logs exceeding `memory_capacity`, a group whose
cursor lags the trim point would need a disk fallback — a follow-up (the
"segment-reader pub/sub path"). The reaper keeps the window ahead of the slowest
group in practice; the migrations (Q2-Q4) are bounded-retention topics.