### PR TITLE
docs(evidence): Phase 2 cache hot-vs-cold (1M post-compaction) + D2 bug note

### DIFF
--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -739,3 +739,19 @@ hardware = "Local macOS arm64 (Apple Silicon, 64GB), serialized release run"
 date = "2026-07-28"
 version = "develop @ 99b84be1a (post-merge of #1253 + #1265 + #1271)"
 notes = "Post-merge of the async-compaction arc (D3 #1241, D0 #1242, D1+D2 #1253, follow-ups #1265, CI fix #1271). The prior compaction entries (training_compaction_cold_ladder_1m, flush_encode_parallel_1m) measured the PRE-ASYNC inline path; this entry measures the ASYNC path. Recall/GET numbers from the pre-async entries are still valid for that code state; the async change eliminated the ~35s inline flush block (D1) and added bounded L0 backpressure (D2)."
+
+[[claims]]
+id = "cache_hot_vs_cold_1m_post_compaction"
+claim = "Phase 2 cache measurement (hot vs cold) on merged develop's trained v3/A0 segment layout, SIFT 1M REST e2e: COLD first-access p50=131.6ms / p95=142.2ms (segment scan, caches empty after restart); HOT repeat p50=0.4ms / p95=0.7ms (result cache, 323x speedup). Segment invariants cache 99.96% hit rate during cold sweep (segment-level — loaded once per segment, shared across queries). Survivor range cache 38.2% hit rate (query-level — cell overlap across diverse queries, consistent with TD-CACHE-8's ~33%). The trained v3/A0 layout (post-async-compaction) has similar cache dynamics to the pre-compaction layout — the A0 coarse directory adds a cached region but overall hit patterns are unchanged. Discovered the D2 restart-recovery deadlock (fixed in #1294)."
+metric = "cold/hot p50/p95 latency + cache hit% (survivor + invariants)"
+status = "measured"
+asserted_in = [
+  "docs/_internal/status/CACHE_HOT_VS_COLD_1M_EVIDENCE_2026_07_28.adoc",
+]
+bench_source = "scripts/bench/cache_hot_vs_cold_1m.py"
+bench_command = "python3 scripts/bench/cache_hot_vs_cold_1m.py  # restart server first to clear caches; PROXIMADB_L0_STOP_TRIGGER=0 if l0>=10 (D2 bug, #1294)"
+artifact = "docs/_internal/status/CACHE_HOT_VS_COLD_1M_EVIDENCE_2026_07_28.adoc"
+hardware = "Local macOS arm64 (Apple Silicon, 64GB), serialized release run, server restarted to clear caches"
+date = "2026-07-28"
+version = "develop @ 79209453a (merged #1253)"
+notes = "The HOT 0.4ms is the result cache (vector-hash-keyed), not the segment caches — the same known TD-CACHE-8 behavior. The segment cache value is in the COLD sweep: invariants ~100% (eliminates per-query segment-metadata re-reads) + survivor ~38% (reduces per-query SQ8 range GETs via cell overlap). Phase 3 (budget sweep) follows once the D2 restart-recovery fix (#1294) enables multi-config restarts."

--- a/docs/_internal/status/CACHE_HOT_VS_COLD_1M_EVIDENCE_2026_07_28.adoc
+++ b/docs/_internal/status/CACHE_HOT_VS_COLD_1M_EVIDENCE_2026_07_28.adoc
@@ -1,0 +1,83 @@
+= Cache Hot-vs-Cold (Phase 2) — SIFT 1M Post-Compaction
+:date: 2026-07-28
+:version: develop @ 79209453a (merged #1253 async-compaction arc)
+:hardware: Local macOS arm64 (Apple Silicon, 64GB), serialized release run
+:bench: scripts/bench/cache_hot_vs_cold_1m.py
+
+== Summary
+
+Phase 2 cache performance measurement on merged develop's trained v3/A0 segment
+layout. Measures the cache effectiveness delta between a COLD first-access
+(caches empty after restart) and a HOT repeat (result cache warm) on the
+post-async-compaction code. Also discovered the D2 restart-recovery bug (#1294).
+
+== Setup
+
+- Server: `release-server` binary from develop.
+- Data: SIFT 1M ingested (28k vec/s), async compaction settled (6 L1 segments,
+  4 L0 remain), recall@10 = 0.9880.
+- Config: `flush_interval_secs=12`, default cache budgets:
+  `segment_invariants_cache_mb=256`, `survivor_cache_mb=1024`.
+- Procedure: restart server (clears in-memory caches), immediately run 200
+  novel SIFT queries (cold), then repeat the same 200 (hot).
+
+== Results
+
+[cols="1,2,2,1"]
+|===
+| Metric | COLD (first access) | HOT (repeat) | Speedup
+
+| p50 latency
+| **131.6ms**
+| **0.4ms**
+| **323×**
+
+| p95 latency
+| 142.2ms
+| 0.7ms
+| 197×
+
+| Segment invariants hit%
+| 99.96% (2,199 hits / 1 miss)
+| n/a (already fully cached)
+| Segment-level: loaded once per segment, shared across all queries
+
+| Survivor range hit%
+| 38.2% (14,222 hits / 23,001 misses)
+| n/a (hot served from result cache)
+| Query-level: cell overlap across diverse queries (consistent with TD-CACHE-8's ~33%)
+|===
+
+== Interpretation
+
+**The HOT sweep's 0.4ms** is the **result cache** (vector-hash-keyed) — the same
+200 queries return cached results without touching the segment scan path (zero
+survivor/invariants deltas). This is the known TD-CACHE-8 behavior ("the hot
+~0 GET headline is a result-cache artifact").
+
+**The COLD sweep's 131.6ms** exercises the full PAX segment scan with both warm-
+tier caches active:
+
+- **Segment invariants (99.96% hit):** caches per-segment header/footer/A0
+  metadata. The first query to each segment misses (loads invariants); all
+  subsequent queries to the same segment hit. With ~10 segments and 200 queries,
+  ~100% amortized hit rate. This eliminates re-reading segment control metadata
+  per query.
+
+- **Survivor range (38.2% hit):** caches per-query SQ8 survivor + OID ranges.
+  Diverse queries overlap where they probe the same IVF cells (the coarse probe
+  routes to ~sqrt(k_c) cells; ~38% are shared across the query set). The
+  remaining 62% are query-specific misses (unique cell ranges per novel query).
+
+**Post-compaction insight:** the trained v3/A0 layout (from async compaction)
+has **similar cache dynamics** to the pre-compaction layout. The A0 coarse
+directory adds a cached region the old layout didn't have, but the overall hit
+patterns (invariants ~100% segment-level, survivor ~38% query-level) are
+consistent with the prior `warmtier_flushfloor_1m_e2e` measurement (2026-07-24).
+
+== Bug discovered
+
+The cold sweep required a server restart (to clear caches), which exposed the
+**D2 restart-recovery deadlock**: when `l0_count >= stop_trigger (10)`, the WAL
+recovery flush hits the D2 STOP → returns Err → server can't boot. Fixed in
+#1294 (skip D2 during `recovery_materialization`).

--- a/scripts/bench/cache_hot_vs_cold_1m.py
+++ b/scripts/bench/cache_hot_vs_cold_1m.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Cache hot-vs-cold measurement (Phase 2) — SIFT 1M, post-compaction.
+
+Measures the cache effectiveness delta between a COLD first-access (caches empty
+after server restart) and a HOT repeat (result cache warm). Scrapes Prometheus
+cache metrics (survivor hits/misses, segment invariants hits/misses) to capture
+the per-sweep cache-hit delta.
+
+Prerequisites:
+  - proximadb-server running on :5678 (release binary from develop).
+  - SIFT1M ingested + compaction settled.
+  - Restart the server immediately before running (to clear in-memory caches).
+  - Set PROXIMADB_L0_STOP_TRIGGER=0 on restart if l0_count >= stop_trigger
+    (D2 restart-recovery bug, fixed in #1294).
+
+Usage:
+  # 1. Restart server (clears caches):
+  #    pkill proximadb-server; sleep 3; <boot with same data_dir>
+  # 2. Immediately run:
+  python3 scripts/bench/cache_hot_vs_cold_1m.py
+"""
+import json, os, struct, time, urllib.request
+
+SERVER = os.environ.get("PROXIMA_VERIFY_SERVER", "http://127.0.0.1:5678")
+CID    = os.environ.get("PROXIMA_COLLECTION_ID", "1")
+NQUERY = 200
+TOPK   = 10
+
+def post(p, b, t=120):
+    r = urllib.request.urlopen(urllib.request.Request(
+        SERVER + p, data=json.dumps(b).encode(),
+        headers={"Content-Type": "application/json"}, method="POST"), timeout=t)
+    return json.loads(r.read())
+
+def read_fvecs(path, lim):
+    with open(path, "rb") as f:
+        raw = f.read()
+    o = []; i = 0
+    while len(o) < lim:
+        if i + 4 > len(raw): break
+        d = struct.unpack("<i", raw[i:i+4])[0]; i += 4
+        o.append(list(struct.unpack("<%df" % d, raw[i:i+4*d]))); i += 4 * d
+    return o
+
+def scrape_metrics():
+    """Scrape cache hit/miss counters from /metrics/prometheus."""
+    try:
+        text = urllib.request.urlopen(
+            SERVER + "/metrics/prometheus", timeout=10).read().decode()
+    except Exception:
+        return {}
+    keys = [
+        "proximadb_survivor_cache_hits",
+        "proximadb_survivor_cache_misses",
+        "proximadb_segment_invariants_cache_hits_total",
+        "proximadb_segment_invariants_cache_misses_total",
+    ]
+    out = {}
+    for line in text.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        for key in keys:
+            if line.startswith(key + " ") or line.startswith(key + "{"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        out[key] = float(parts[-1])
+                    except ValueError:
+                        pass
+    return out
+
+def run_sweep(queries, label):
+    """Run a sweep of queries, return latency stats."""
+    lats = []
+    for q in queries:
+        ts = time.time()
+        post(f"/api/v2/collections/{CID}/search",
+             {"vector": q, "top_k": TOPK}, t=120)
+        lats.append((time.time() - ts) * 1000)
+    lats.sort()
+    return {
+        "p50": lats[len(lats) // 2],
+        "p95": lats[int(len(lats) * 0.95)],
+        "mean": sum(lats) / len(lats),
+    }
+
+def fmt_delta(m_before, m_after, key):
+    d = m_after.get(key, 0) - m_before.get(key, 0)
+    return f"{d:+,.0f}"
+
+def main():
+    base_path = os.environ.get(
+        "SIFT_QUERY", "/Users/vijaysingh/sift1m/sift_query.fvecs")
+    queries = read_fvecs(base_path, NQUERY)
+    print(f"loaded {len(queries)} queries", flush=True)
+
+    m0 = scrape_metrics()
+    print(f"\nbaseline: {m0}", flush=True)
+
+    # COLD sweep
+    print(f"\nCOLD sweep ({NQUERY} queries, caches empty)...", flush=True)
+    cold = run_sweep(queries, "COLD")
+    m1 = scrape_metrics()
+    print(f"COLD: p50={cold['p50']:.1f}ms p95={cold['p95']:.1f}ms", flush=True)
+    for k in ["proximadb_survivor_cache_hits", "proximadb_survivor_cache_misses",
+              "proximadb_segment_invariants_cache_hits_total",
+              "proximadb_segment_invariants_cache_misses_total"]:
+        print(f"  Δ {k}: {fmt_delta(m0, m1, k)}", flush=True)
+
+    # HOT sweep (same queries)
+    print(f"\nHOT sweep (repeat {NQUERY} queries)...", flush=True)
+    hot = run_sweep(queries, "HOT")
+    m2 = scrape_metrics()
+    print(f"HOT:  p50={hot['p50']:.1f}ms p95={hot['p95']:.1f}ms", flush=True)
+    for k in ["proximadb_survivor_cache_hits", "proximadb_survivor_cache_misses",
+              "proximadb_segment_invariants_cache_hits_total",
+              "proximadb_segment_invariants_cache_misses_total"]:
+        print(f"  Δ {k}: {fmt_delta(m1, m2, k)}", flush=True)
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"RESULT: cold p50={cold['p50']:.1f}ms vs hot p50={hot['p50']:.1f}ms"
+          f" = {cold['p50']/hot['p50']:.1f}x speedup" if hot['p50'] > 0 else "")
+    sh = m1.get("proximadb_survivor_cache_hits", 0) - m0.get("proximadb_survivor_cache_hits", 0)
+    sm = m1.get("proximadb_survivor_cache_misses", 0) - m0.get("proximadb_survivor_cache_misses", 0)
+    if sh + sm > 0:
+        print(f"COLD survivor hit%: {sh/(sh+sm)*100:.1f}%")
+    ih = (m1.get("proximadb_segment_invariants_cache_hits_total", 0)
+          - m0.get("proximadb_segment_invariants_cache_hits_total", 0))
+    im = (m1.get("proximadb_segment_invariants_cache_misses_total", 0)
+          - m0.get("proximadb_segment_invariants_cache_misses_total", 0))
+    if ih + im > 0:
+        print(f"COLD invariants hit%: {ih/(ih+im)*100:.1f}%")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phase 2 cache effectiveness measurement on merged develop's trained v3/A0 layout.

**New entry `cache_hot_vs_cold_1m_post_compaction` (measured):**
- Cold: p50=131.6ms (segment scan, caches empty after restart)
- Hot: p50=0.4ms (result cache, **323× speedup**)
- Invariants: 99.96% hit (segment-level)
- Survivor: 38.2% hit (query-level, cell overlap — consistent with TD-CACHE-8)
- Post-compaction layout has similar cache dynamics to pre-compaction

Includes checked-in bench script + dated evidence artifact. Also notes the D2 restart-recovery bug discovery (fixed in #1294).