### PR TITLE
feat(security): FA-c Phase 2c — AbacEnforcer (service-facing one-call API)

### DIFF
--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -4,19 +4,22 @@
 //! per-row `Fn(&ProximaRecord) -> bool` that `scan_records_filtered` ANDs into
 //! its existing `RecordScanPredicate`.
 //!
-//! This is the **scan-path integration point** (FA-c Phase 2b). It compiles the
-//! `AuthorizedReadContext`'s `row_predicate_refs` once (at request-scope), then
-//! the returned closure evaluates each record under the strict 3-valued walker
-//! via [`admits_with_security`](super::filter_lattice::admits_with_security).
+//! This is the **scan-path integration point** (FA-c Phase 2b/2c). It compiles
+//! the `AuthorizedReadContext`'s `row_predicate_refs` once (at request-scope),
+//! then the returned closure evaluates each record under the strict 3-valued
+//! walker via [`admits_with_security`](super::filter_lattice::admits_with_security).
 
 #[cfg(feature = "abac-policy")]
 use crate::core::search::sql_value_filter::proxima_value_to_json;
 #[cfg(feature = "abac-policy")]
 use crate::security::rls::filter_lattice::admits_with_security;
 #[cfg(feature = "abac-policy")]
-use proximadb_abac::{PredicateObjectStore, compile_security_filter};
+use proximadb_abac::{
+    AttributeAuthority, AuthorizedReadContext, DenyReason, PolicyEpochSource, PredicateObjectStore,
+    compile_security_filter,
+};
 #[cfg(feature = "abac-policy")]
-use proximadb_catalog::fc_metamodel::ObjectId;
+use proximadb_catalog::fc_metamodel::{ObjectId, PolicyBinding, SubjectId, Target};
 #[cfg(feature = "abac-policy")]
 use proximadb_records::{ProximaRecord, ProximaTreeNode};
 
@@ -56,11 +59,88 @@ pub fn abac_scan_predicate(
     }))
 }
 
+/// The outcome of an ABAC resolution for a scan: how to handle the rows.
+#[cfg(feature = "abac-policy")]
+#[allow(dead_code)]
+pub enum AbacScanResult {
+    /// No row restriction (the subject is permitted with no row predicates).
+    Unrestricted,
+    /// A per-row predicate that `scan_records_filtered` ANDs into its hook.
+    Restricted(Box<dyn Fn(&ProximaRecord) -> bool + Send + Sync>),
+    /// The subject is denied entirely — return zero rows.
+    Denied(DenyReason),
+}
+
+/// The service-facing ABAC enforcement API. Holds the three substrate stores
+/// and provides one method a scan call site calls: resolve the subject's
+/// authorization, compile it, and return a scan predicate (or a deny).
+///
+/// FA-c Phase 2c constructs this at the scan boundary; Phase 4 (FA-b) threads
+/// it (or its `AuthorizedReadContext`) as a required parameter.
+#[cfg(feature = "abac-policy")]
+#[allow(dead_code)]
+pub struct AbacEnforcer {
+    authority: Box<dyn AttributeAuthority>,
+    store: Box<dyn PredicateObjectStore>,
+    epochs: Box<dyn PolicyEpochSource>,
+}
+
+#[cfg(feature = "abac-policy")]
+impl AbacEnforcer {
+    /// Construct from the three substrate stores. In production these are the
+    /// durable-backed impls; in tests, the in-memory ones.
+    pub fn new(
+        authority: Box<dyn AttributeAuthority>,
+        store: Box<dyn PredicateObjectStore>,
+        epochs: Box<dyn PolicyEpochSource>,
+    ) -> Self {
+        Self {
+            authority,
+            store,
+            epochs,
+        }
+    }
+
+    /// Resolve `subject`'s authorization for `target` and compile to a scan
+    /// predicate. The caller provides the `bindings` (loaded from the policy
+    /// store — Phase 5 makes that durable; today they are supplied directly).
+    ///
+    /// This is the one call a scan call site makes: it ties resolve → compile
+    /// → `abac_scan_predicate` into a single `AbacScanResult`.
+    pub fn scan_predicate_for(
+        &self,
+        subject: &SubjectId,
+        tenant: u64,
+        target: Target,
+        bindings: &[PolicyBinding],
+    ) -> AbacScanResult {
+        match AuthorizedReadContext::resolve(
+            self.authority.as_ref(),
+            self.epochs.as_ref(),
+            bindings,
+            subject,
+            tenant,
+            target,
+        ) {
+            proximadb_abac::ReadDecision::Deny(reason) => AbacScanResult::Denied(reason),
+            proximadb_abac::ReadDecision::Admit(ctx) => {
+                match abac_scan_predicate(ctx.row_predicate_refs(), self.store.as_ref()) {
+                    Some(predicate) => AbacScanResult::Restricted(predicate),
+                    None => AbacScanResult::Unrestricted,
+                }
+            }
+        }
+    }
+}
+
 #[cfg(all(test, feature = "abac-policy"))]
 mod tests {
     use super::*;
     use crate::core::search::{ComparisonOperator, FilterExpression};
-    use proximadb_abac::InMemoryPredicateObjectStore;
+    use proximadb_abac::{
+        InMemoryAttributeAuthority, InMemoryPolicyEpochs, InMemoryPredicateObjectStore,
+    };
+    use proximadb_catalog::fc_metamodel::{AttrValue, Effect, Scope};
     use proximadb_data_model::ProximaValue;
     use proximadb_records::{ProximaRecord, ProximaTreeNode};
     use serde_json::json;
@@ -104,5 +184,76 @@ mod tests {
         let predicate =
             abac_scan_predicate(&[999], &store).expect("non-empty refs → unsatisfiable predicate");
         assert!(!predicate(&record_with("eng")), "missing ref denies all");
+    }
+
+    // --- AbacEnforcer: the service-facing one-call API ---
+
+    fn enforcer_with_alice(dept: &str) -> (AbacEnforcer, Vec<PolicyBinding>) {
+        let mut authority = InMemoryAttributeAuthority::new();
+        authority.upsert(
+            proximadb_abac::AttributeBinding::new("alice", 7)
+                .with_attr("dept", AttrValue::Str(dept.into())),
+        );
+        let mut store = InMemoryPredicateObjectStore::new();
+        store.register(
+            42,
+            FilterExpression::Comparison {
+                field: "dept".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!(dept),
+            },
+        );
+        let bindings = vec![PolicyBinding {
+            object_id: 1,
+            tenant_stable_id: 7,
+            scope: Scope::Table(200),
+            effect: Effect::Permit,
+            predicate_ref: Some(42),
+            field_mask: None,
+        }];
+        let enforcer = AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(store),
+            Box::new(InMemoryPolicyEpochs::new()),
+        );
+        (enforcer, bindings)
+    }
+
+    #[test]
+    fn enforcer_returns_restricted_predicate_for_dept_eng() {
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let result = enforcer.scan_predicate_for(
+            &SubjectId("alice".into()),
+            7,
+            Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+            &bindings,
+        );
+        match result {
+            AbacScanResult::Restricted(pred) => {
+                assert!(pred(&record_with("eng")));
+                assert!(!pred(&record_with("hr")));
+            }
+            _ => panic!("alice (dept=eng, binding present) must be Restricted"),
+        }
+    }
+
+    #[test]
+    fn enforcer_denies_an_unbound_subject() {
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let result = enforcer.scan_predicate_for(
+            &SubjectId("mallory".into()),
+            7,
+            Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+            &bindings,
+        );
+        assert!(matches!(result, AbacScanResult::Denied(_)));
     }
 }


### PR DESCRIPTION
Stacked on #1293 (merged). The AbacEnforcer ties resolve → compile → abac_scan_predicate into one call: `scan_predicate_for(subject, tenant, target, bindings) -> AbacScanResult { Unrestricted | Restricted(predicate) | Denied }`. 5 tests (3 abac_scan_predicate + 2 AbacEnforcer). All OSS mechanism (ADR-060).