### PR TITLE
fix: close red-team gaps — Finding 5 (float epsilon), discoverability, vector-path API

### DIFF
--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -42,6 +42,8 @@
 //!    them reaching a client sink — at compile time, not by review.
 //!
 //! Design of record: `docs/10-quality/td/TD-FOUNDATION-3-abac-enforcement-subsystem.adoc`
+//! (search for 'TD-FOUNDATION-3' or 'ABAC enforcement' to find the full track).
+//! The enforcement wiring plan: `docs/12-design/` + the 5-phase plan.
 //! (build track) and `TD-FOUNDATION-2` §3.4 / §8 (architecture + S1–S10).
 
 #![forbid(unsafe_code)]

--- a/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
+++ b/crates/foundation/proximadb-search-types/src/sql_value_filter.rs
@@ -1196,8 +1196,44 @@ pub fn compare_json_op_type_strict(
             _ => None,
         },
 
-        // Equals, NotEquals, and the ordered operators all require the same class.
+        // Equals/NotEquals use EXACT numeric equality, not json_eq's epsilon.
+        // (Red-team Finding 5: json_eq uses a relative epsilon for floats, so a
+        // predicate `clearance == 3` would admit `clearance = 3.0000001` within
+        // epsilon — a false admit in a security context. The ordered operators
+        // already use exact `partial_cmp`; this makes Equals consistent with
+        // them under the strict path.)
+        ComparisonOperator::Equals => require_same().map(|_| exact_json_eq(json_val, value)),
+        ComparisonOperator::NotEquals => require_same().map(|_| !exact_json_eq(json_val, value)),
+
+        // The ordered operators require the same class.
         _ => require_same().map(|_| compare_json_op(operator, json_val, value)),
+    }
+}
+
+/// Exact JSON equality — like `json_eq` but WITHOUT the float epsilon.
+///
+/// `json_eq` uses a relative-epsilon comparison for floats (`compare_json_numbers`),
+/// which is defensible for user-facing metadata search but **wrong for a security
+/// predicate**: a policy `clearance == 3` should not admit `3.0000001`. This
+/// function is the strict-path alternative — exact for numbers, structural for
+/// everything else.
+fn exact_json_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    match (a, b) {
+        (serde_json::Value::Number(n1), serde_json::Value::Number(n2)) => {
+            // Exact integer first (preserves precision), then exact float.
+            match (n1.as_i64(), n2.as_i64()) {
+                (Some(i1), Some(i2)) => i1 == i2,
+                _ => match (n1.as_u64(), n2.as_u64()) {
+                    (Some(u1), Some(u2)) => u1 == u2,
+                    _ => n1
+                        .as_f64()
+                        .zip(n2.as_f64())
+                        .is_some_and(|(f1, f2)| f1 == f2),
+                },
+            }
+        }
+        // Non-numbers: structural equality, same as json_eq.
+        _ => a == b,
     }
 }
 #[cfg(test)]
@@ -1358,6 +1394,38 @@ mod type_strict_tests {
                 "strict mode changed an already-exact operator: {op:?} {field} {lit}"
             );
         }
+    }
+
+    #[test]
+    fn strict_equals_uses_exact_numeric_comparison_not_epsilon() {
+        // Finding 5: json_eq uses relative epsilon for floats, so a security
+        // predicate clearance == 3 would admit 3.0000001 within epsilon.
+        // The strict path must use exact equality.
+        let near = json!(1.0_f64 + f64::EPSILON); // within json_eq's epsilon of 1.0
+        let one = json!(1.0);
+        assert!(
+            compare_json_op(&ComparisonOperator::Equals, &near, &one),
+            "precondition: the permissive json_eq admits (epsilon absorbs the diff)"
+        );
+        assert!(
+            !compare_json_op_type_strict(&ComparisonOperator::Equals, &near, &one).unwrap_or(false),
+            "strict Equals must NOT admit a near-but-not-equal float (no epsilon)"
+        );
+        // And exact equality still works.
+        assert!(
+            compare_json_op_type_strict(&ComparisonOperator::Equals, &json!(3), &json!(3))
+                .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn strict_not_equals_uses_exact_numeric_comparison() {
+        let near = json!(1.0_f64 + f64::EPSILON);
+        assert!(
+            compare_json_op_type_strict(&ComparisonOperator::NotEquals, &near, &json!(1.0))
+                .unwrap_or(false),
+            "strict NotEquals must deny a near-but-not-equal float (they are NOT equal exactly)"
+        );
     }
 
     #[test]

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -10,7 +10,7 @@
 //! walker via [`admits_with_security`](super::filter_lattice::admits_with_security).
 
 #[cfg(feature = "abac-policy")]
-use crate::core::search::sql_value_filter::proxima_value_to_json;
+use crate::core::search::{FilterExpression, sql_value_filter::proxima_value_to_json};
 #[cfg(feature = "abac-policy")]
 use crate::security::rls::filter_lattice::admits_with_security;
 #[cfg(feature = "abac-policy")]
@@ -129,6 +129,37 @@ impl AbacEnforcer {
                     None => AbacScanResult::Unrestricted,
                 }
             }
+        }
+    }
+
+    /// Resolve `subject`'s authorization and return the compiled security
+    /// `FilterExpression` directly — for read paths that take a `FilterExpression`
+    /// natively (e.g. `unified_search_native`'s `filter` param), rather than a
+    /// per-record closure.
+    ///
+    /// Returns `Ok(None)` when the subject is permitted with no row predicates;
+    /// `Ok(Some(expr))` when a security filter applies; `Err(reason)` when denied.
+    /// The caller ANDs `expr` with the user's own filter before the search.
+    pub fn security_expression_for(
+        &self,
+        subject: &SubjectId,
+        tenant: u64,
+        target: Target,
+        bindings: &[PolicyBinding],
+    ) -> Result<Option<FilterExpression>, DenyReason> {
+        match AuthorizedReadContext::resolve(
+            self.authority.as_ref(),
+            self.epochs.as_ref(),
+            bindings,
+            subject,
+            tenant,
+            target,
+        ) {
+            proximadb_abac::ReadDecision::Deny(reason) => Err(reason),
+            proximadb_abac::ReadDecision::Admit(ctx) => Ok(compile_security_filter(
+                ctx.row_predicate_refs(),
+                self.store.as_ref(),
+            )),
         }
     }
 }
@@ -255,5 +286,54 @@ mod tests {
             &bindings,
         );
         assert!(matches!(result, AbacScanResult::Denied(_)));
+    }
+
+    #[test]
+    fn enforcer_returns_security_expression_for_vector_path() {
+        // The vector search path (unified_search_native) takes a FilterExpression,
+        // not a closure. security_expression_for returns it directly.
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let result = enforcer
+            .security_expression_for(
+                &SubjectId("alice".into()),
+                7,
+                Target {
+                    namespace: 3,
+                    table: 200,
+                    column: None,
+                },
+                &bindings,
+            )
+            .expect("alice is admitted");
+
+        let expr = result.expect("alice has a predicate ref → Some(expr)");
+        // The expression should be the dept=eng filter.
+        match expr {
+            FilterExpression::Comparison {
+                field,
+                operator: ComparisonOperator::Equals,
+                value,
+            } => {
+                assert_eq!(field, "dept");
+                assert_eq!(value, json!("eng"));
+            }
+            _ => panic!("expected a single Eq(dept, eng) comparison"),
+        }
+    }
+
+    #[test]
+    fn enforcer_expression_denies_unbound_subject() {
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let result = enforcer.security_expression_for(
+            &SubjectId("mallory".into()),
+            7,
+            Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+            &bindings,
+        );
+        assert!(result.is_err(), "unbound subject must be denied");
     }
 }

--- a/src/security/rls/mod.rs
+++ b/src/security/rls/mod.rs
@@ -1,4 +1,15 @@
-//! Row-Level Security (RLS) for ProximaDB
+//! Row-Level Security (RLS) and ABAC row-level enforcement for ProximaDB.
+//!
+//! ## ABAC enforcement substrate (TD-FOUNDATION-3, behind `abac-policy`)
+//!
+//! The [`abac_adapter`] module provides the `AbacEnforcer` — the service-facing
+//! API that resolves a subject's authorization, compiles it to a
+//! `FilterExpression` or a per-row predicate, and feeds it to the read
+//! primitives (`scan_records_filtered`, `unified_search_native`). The substrate
+//! (crates/control/proximadb-abac) provides the attribute authority, policy-epoch
+//! cache keying, and the non-optional `AuthorizedReadContext`.
+//!
+//! ## Legacy RLS (inert on the read path)
 //!
 //! Implements collection-level data isolation through security predicates
 //! that filter records based on user context. RLS policies are evaluated


### PR DESCRIPTION
Closes all in-lane gaps from the cross-model evaluations and tests.

**Finding 5 (float epsilon):** the strict-path Equals/NotEquals now uses exact numeric comparison (exact_json_eq), not json_eq's relative epsilon. A security predicate clearance == 3 no longer admits 3.0000001 within epsilon. The permissive path is untouched. 2 new tests.

**Discoverability:** the rls module doc now leads with 'ABAC enforcement' + AbacEnforcer reference (fixes the DeepSeek false-negative).

**Doc cross-refs:** abac crate references TD-FOUNDATION-3 by name.

**security_expression_for:** AbacEnforcer now serves both consumption shapes — scan_predicate_for (closure, relational) + security_expression_for (FilterExpression, vector).

Verified: 70 search-types tests + P1 equivalence property green. clippy/fmt clean.