### PR TITLE
feat(storage): admit flushes before materialization

### DIFF
--- a/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
+++ b/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
@@ -19,6 +19,11 @@
 //!   * `proximadb_wal_last_flush_timestamp_seconds{collection}`   — gauge, unixtime of last OK flush (age = `time()-metric`)
 //!   * `proximadb_wal_backpressure_active{collection}`            — gauge, 1 while a write is being throttled
 //!   * `proximadb_wal_backpressure_total{collection}`             — counter, backpressure engagements
+//!   * `proximadb_wal_flush_admission_total{collection,result}`    — counter, admission verdicts
+//!   * `proximadb_wal_flush_admitted_in_flight`                    — gauge, globally admitted jobs
+//!   * `proximadb_wal_flush_admission_wait_seconds`                — histogram, global permit wait
+//!   * `proximadb_wal_flush_claimed_batches{collection}`           — gauge, exact source batches owned
+//!   * `proximadb_wal_flush_claim_rollback_batches_total{collection}` — counter, batches returned
 //!   * `proximadb_wal_truncation_segments_reclaimed_total`        — counter, WAL segments reclaimed below the canonical marker (TD-WAL-1 S6)
 //!   * `proximadb_wal_replay_duration_seconds`                    — gauge, last boot's WAL replay wall-clock (TD-WAL-1 S6)
 //!
@@ -95,6 +100,31 @@ lazy_static! {
     static ref BACKPRESSURE_TOTAL: IntCounterVec = build_counter(
         "proximadb_wal_backpressure_total",
         "Count of write-backpressure engagements at the critical watermark, per collection (ADR-069 D3)",
+        &["collection"],
+    );
+    static ref FLUSH_ADMISSION_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_flush_admission_total",
+        "Flush pre-materialization admission verdicts (ADR-081)",
+        &["collection", "result"],
+    );
+    static ref FLUSH_ADMITTED_IN_FLIGHT: IntGaugeVec = build_gauge(
+        "proximadb_wal_flush_admitted_in_flight",
+        "Globally admitted flush jobs currently holding a resource permit (ADR-081)",
+        &[],
+    );
+    static ref FLUSH_ADMISSION_WAIT: HistogramVec = build_histogram(
+        "proximadb_wal_flush_admission_wait_seconds",
+        "Time a collection-admitted flush waits for a global resource permit (ADR-081)",
+        &[],
+    );
+    static ref FLUSH_CLAIMED_BATCHES: IntGaugeVec = build_gauge(
+        "proximadb_wal_flush_claimed_batches",
+        "Exact WAL source batches currently claimed by a flush job (ADR-081)",
+        &["collection"],
+    );
+    static ref FLUSH_CLAIM_ROLLBACK_BATCHES: IntCounterVec = build_counter(
+        "proximadb_wal_flush_claim_rollback_batches_total",
+        "WAL source batches returned after flush error, cancellation, or keep-WAL completion (ADR-081)",
         &["collection"],
     );
     // TD-WAL-1 S6 residuals. Both are boot/compaction-wide aggregates (no
@@ -228,6 +258,45 @@ pub fn set_backpressure_active(collection: &str, active: bool) {
 /// Count a backpressure engagement (paired with `set_backpressure_active(.., true)`).
 pub fn inc_backpressure(collection: &str) {
     BACKPRESSURE_TOTAL.with_label_values(&[collection]).inc();
+}
+
+/// Record an engine admission verdict before source records are materialized.
+pub fn record_admission(collection: &str, admitted: bool) {
+    FLUSH_ADMISSION_TOTAL
+        .with_label_values(&[collection, if admitted { "admitted" } else { "rejected" }])
+        .inc();
+}
+
+pub fn inc_admitted_in_flight() {
+    FLUSH_ADMITTED_IN_FLIGHT
+        .with_label_values::<&str>(&[])
+        .inc();
+}
+
+pub fn dec_admitted_in_flight() {
+    FLUSH_ADMITTED_IN_FLIGHT
+        .with_label_values::<&str>(&[])
+        .dec();
+}
+
+pub fn record_admission_wait(seconds: f64) {
+    FLUSH_ADMISSION_WAIT
+        .with_label_values::<&str>(&[])
+        .observe(seconds.max(0.0));
+}
+
+pub fn set_claimed_batches(collection: &str, batches: i64) {
+    FLUSH_CLAIMED_BATCHES
+        .with_label_values(&[collection])
+        .set(batches.max(0));
+}
+
+pub fn record_claim_rollback(collection: &str, batches: u64) {
+    if batches > 0 {
+        FLUSH_CLAIM_ROLLBACK_BATCHES
+            .with_label_values(&[collection])
+            .inc_by(batches);
+    }
 }
 
 /// Count WAL segments reclaimed by canonical-marker truncation (TD-WAL-1 S6).

--- a/crates/storage/proximadb-storage-traits/src/lib.rs
+++ b/crates/storage/proximadb-storage-traits/src/lib.rs
@@ -535,6 +535,16 @@ pub trait UnifiedStorageFormat: Send + Sync {
     /// Core flush operation - engine-specific implementation (required)
     async fn do_flush(&self, params: &FlushParameters) -> Result<FlushResult>;
 
+    /// Lightweight admission check performed before a caller materializes or
+    /// clones a flush's record payload.
+    ///
+    /// Engines without backlog admission return `Ok(())`. LSM engines override
+    /// this to inspect bounded metadata (for example, L0 watermarks) and reject
+    /// work before sorting, clustering, encoding, or uploading records.
+    async fn preflight_flush(&self, _params: &FlushParameters) -> Result<()> {
+        Ok(())
+    }
+
     /// Core compaction operation - engine-specific implementation (required)
     async fn do_compact(&self, params: &CompactionParameters) -> Result<CompactionResult>;
 

--- a/docs/10-quality/td/TD-FLUSH-7-admission-before-sort-exact-batch-claims.adoc
+++ b/docs/10-quality/td/TD-FLUSH-7-admission-before-sort-exact-batch-claims.adoc
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FLUSH-7: Flush admission occurs after full-record clone/sort and source batches are unclaimed
+:status: Fixed (2026-07-29)
+:filed: 2026-07-29
+:priority: P0
+
+[cols="1,3", options="header"]
+|===
+|Field |Value
+|Status
+|**Fixed (2026-07-29).** ADR-081 is implemented with one canonical
+format-engine domain, collection-local single flight, bounded
+cross-collection admission, metadata-only engine preflight, and exact
+cancellation-safe WAL batch claims.
+|Priority |**P0 correctness and resource control.**
+|Component
+|`src/storage/flush_materializer.rs`,
+`src/storage/memtable/specialized/wal_behavior.rs`,
+`src/storage/engines/sst/flush/mod.rs`,
+`src/storage/auto_flush_driver.rs`
+|Evidence
+|SIFT1M reproduction on develop at
+`c4062103da5d65553a295aeef2f8da84f2b5617b`: approximately 592,000
+unmaterialized records were repeatedly cloned/sorted before each L0 STOP
+rejection. Every attempt constructed a fresh SST engine/worker domain. Restart
+recovery then changed the measured bed to 11 segments.
+|===
+
+== Defect
+
+The inline trigger has a private per-collection semaphore, but the periodic and
+shutdown paths do not share it. `get_unflushed_batches` returns every
+unflushed batch without an ownership transition. The materializer clones the
+records and constructs an engine before SST evaluates the L0 watermark.
+
+This permits duplicate optimistic work, makes cancellation ownership
+ambiguous, and can clear batches that arrived after the source snapshot.
+
+== Accepted fix
+
+Implement ADR-081:
+
+. canonical process-wide engine ownership per storage format;
+. one operation gate per collection plus bounded cross-collection admission;
+. exact cancellation-safe WAL batch claims;
+. engine preflight before record materialization;
+. exact source retirement that preserves new arrivals;
+. concurrent periodic flush submission; and
+. no-index AXIS suppression.
+
+== Acceptance
+
+* L0 STOP rejection performs zero sort calls and zero record clones.
+* Two same-collection materializers produce at most one segment from a source
+  set.
+* Two collections can execute concurrently up to the global permit limit.
+* Error and cancellation release every claimed batch.
+* A batch appended while a flush is in flight remains unflushed afterward.
+* Repeated flushes reuse one engine instance for the configured format.
+* Empty `index_configs` without the explicit RawF32 compatibility tag never
+  feed AXIS.
+* Targeted tests, `make work-commit-check`, and required CI are green.
+
+== Resolution
+
+The materializer now obtains the collection gate and global resource permit,
+resolves the canonical storage engine, and invokes metadata-only
+`preflight_flush` before it claims or clones any WAL batch. SST preflight counts
+only live `L0_` segments and rejects at the stop watermark before sort,
+clustering, training, encoding, or upload.
+
+An exact `WALFlushBatchClaim` owns the deterministic source batch-ID set for the
+duration of an admitted job. `Drop` rolls the claim back on error or future
+cancellation. Successful publication retires only those IDs, so batches
+appended during encoding remain for the next epoch.
+
+Inline, periodic, and shutdown triggers share the same coordinator. Periodic
+work is submitted concurrently across collections, while one collection
+publishes one segment at a time and uses the existing deterministic PAX morsels
+within that admitted segment job. Normal PAX collections with no configured
+AXIS index no longer populate or train the unused AXIS projection.
+
+== Verification
+
+`cargo test -p proximadb --lib adr081 --no-fail-fast`:
+
+* 12 passed, 0 failed;
+* rejection before claim/flush and zero SST sort invocations;
+* same-collection single publication and different-collection concurrency;
+* error, unsuccessful-result, and cancellation rollback;
+* exact retirement with a concurrent new batch;
+* zero-byte source-batch handling; and
+* canonical engine reuse.
+
+`cargo test -p proximadb --lib axis_insert_gate_tests --no-fail-fast`:
+
+* 3 passed, 0 failed;
+* no-index PAX is suppressed; configured and RawF32 compatibility consumers
+  remain enabled.
+
+Repository gates:
+
+* `make work-commit-check` — passed;
+* `make build-server` — optimized server binary built successfully;
+* `scripts/check_td_adr_unique.py --strict` — 81 ADR files and 305 TD IDs,
+  0 errors and 0 warnings; and
+* `scripts/check_no_agent_attribution.py --range origin/develop...HEAD` —
+  passed.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -55,6 +55,10 @@ Read these in order for future-shaping architecture work:
 5. `VECTOR_OBJECT_ECONOMY_ROUTE_HLD_LLD_2026_05_27.adoc` +
    Active HLD/LLD for object-storage vector economics, SST/HELIX centroid block pruning, cache
    affinity, WAL freshness, EXPLAIN visibility, and cataloged vector access-method projections.
+   Companion implementation blueprint:
+   link:SIFT1M_ADMISSION_FIRST_GET_REDUCTION_BLUEPRINT_2026_07_29.adoc[SIFT1M admission-first flush,
+   compaction, clustering, and GET reduction] — establishes source ownership and quiescent evidence
+   before consolidating segments, coalescing reads, or applying rate-card economics.
 6. `TD_064_PREDICATE_AWARE_VECTOR_SEARCH_DESIGN_2026_05_27.adoc` +
    Active TD-064 blueprint for predicate-aware vector search correctness, ADR-011 route selection,
    tenant/RLS predicate pushdown, record-aware ANN predicates, and fallback/shortfall disclosure.

--- a/docs/12-design/SIFT1M_ADMISSION_FIRST_GET_REDUCTION_BLUEPRINT_2026_07_29.adoc
+++ b/docs/12-design/SIFT1M_ADMISSION_FIRST_GET_REDUCTION_BLUEPRINT_2026_07_29.adoc
@@ -1,0 +1,754 @@
+= SIFT1M Admission-First Flush, Compaction, and GET-Reduction Blueprint
+:toc:
+:toclevels: 3
+:icons: font
+
+[cols="1,3"]
+|===
+|Status |Proposed active implementation blueprint
+|Owner |Storage / SST maintainers
+|Last updated |2026-07-29
+|Scope |SST/PAX flush, compaction, clustering, cold-read amplification, and SIFT1M evidence
+|Related decisions |link:adr/ADR-076-async-compaction-admission-control.adoc[ADR-076],
+link:adr/ADR-078-flush-compact-to-axis-single-mechanism.adoc[ADR-078]
+|Existing trackers
+|link:../10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc[TD-COMPACT-4],
+link:../10-quality/td/TD-COMPACT-7-l0-admission-control-watermarks.adoc[TD-COMPACT-7],
+link:../10-quality/td/TD-COMPACT-8-training-arm-debounce.adoc[TD-COMPACT-8],
+link:../10-quality/td/TD-FLUSH-5-flush-encode-single-threaded.adoc[TD-FLUSH-5],
+link:../10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc[TD-IVF-2],
+link:../10-quality/td/TD-RDSTRAT-9-collection-read-cost-envelope.adoc[TD-RDSTRAT-9],
+link:../10-quality/td/TD-RDSTRAT-11-probe-locality-cell-placement.adoc[TD-RDSTRAT-11]
+|===
+
+== Executive decision
+
+The SIFT1M result is first a write-pipeline ownership and physical-layout problem,
+then a read-amplification problem, and only after both are measured correctly an
+economics problem.
+
+No flush or compaction job may perform a full-vector clone, sort, clustering-model
+training, encoding, or object write until it has:
+
+. atomically claimed the exact immutable WAL batches or segment inputs it owns;
+. acquired the collection's mutation lease;
+. reserved the intended L0 slot or manifest generation;
+. acquired bounded memory and CPU permits; and
+. selected an admitted physical-layout plan.
+
+The expensive work belongs *inside* the admitted job. It must not be optimistic
+work performed before the system knows that the result can be published.
+
+Across collections, admitted jobs should execute concurrently. Within one
+collection, the first safe implementation admits one segment-producing mutation
+at a time and combines all claimed flush batches into one output. The already
+shipped TD-FLUSH-5 pass-2 PAX encoding parallelism remains the within-job morsel
+mechanism. Independent same-collection flush outputs are deferred because they
+increase segment count, object GETs, and manifest races even when their WAL batch
+sets do not overlap.
+
+This blueprint therefore orders the work as follows:
+
+. restore one canonical owner for flush and compaction state;
+. move admission before expensive work and add exact source reservations;
+. make compaction publication source-set-safe;
+. remove unnecessary or duplicate sorting/training;
+. establish a quiescent, auditable benchmark protocol;
+. consolidate to one or two healthy segments;
+. reduce per-segment probe GETs through locality placement and range coalescing;
+. calculate pricing only from the resulting valid trace.
+
+== Why the supplied benchmark is diagnostic, not promotable evidence
+
+The supplied `/tmp/sift1m_full_bench.py` was executed against a clean
+`file://` bed using the release-server binary built from
+`c4062103da5d65553a295aeef2f8da84f2b5617b`.
+
+The run reproduced the reported performance and GET-amplification order of
+magnitude, but it did not prove a stable one-million-row physical state.
+
+[cols="2,2,2,3", options="header"]
+|===
+|Measure |Handoff |Independent run |Verdict
+
+|Ingest
+|29.5 s; 33,888 vectors/s
+|29.1 s; 34,402 vectors/s
+|Reproduced
+
+|Physical state when ingest call returned
+|Implied complete
+|Approximately 408,000 rows materialized; approximately 592,000 rows still in
+WAL/write buffers
+|Not quiescent
+
+|Background behavior
+|23 non-blocking compactions
+|The auto-flush path repeatedly cloned/sorted the remaining approximately
+592,000 rows, then failed the late L0 STOP check
+|Admission occurs too late
+
+|Restart behavior
+|Restart used for cold cache
+|Recovery bypassed the L0 watermark and published the remaining rows as an
+additional 158 MB L0 segment
+|Restart changed the segment geometry under test
+
+|Segments after recovery
+|Approximately 4 L0 + 6 L1
+|4 L0 + 7 L1 = 11 PAX objects
+|Same amplification class, not an identical bed
+
+|Cold diverse-query latency
+|p50 149.6 ms; p95 177.4 ms
+|p50 145.0 ms; p95 159.6 ms
+|Reproduced order of magnitude
+
+|Recall@10
+|0.9780, described as passing a 0.98 floor
+|0.9820
+|The handoff's 0.9780 does not satisfy `>= 0.98`
+
+|Physical object reads
+|205 GET/query
+|193 GET/query
+|Problem reproduced; exact number is bed-dependent
+
+|Fetched bytes
+|172.1 MB/query
+|123.1 MB/query
+|Materially different; must be reported with exact geometry
+
+|Survivor cache
+|22.4% hit
+|28.3% hit
+|Bed and query-order dependent
+
+|Segment invariants cache
+|33.2% hit
+|36.2% hit
+|Bed and query-order dependent
+|===
+
+For the independent run, the raw counters over 200 queries were:
+
+* 38,594 object reads and 24,612,843,211 fetched bytes;
+* 12,135 survivor hits and 30,782 survivor misses;
+* 796 invariants hits and 1,404 invariants misses;
+* 5,400 logical IVF cells, 4,200 probed cells, and 1,913 probe fetch rounds.
+
+Those counters are useful diagnostic evidence. They are not rate-card evidence
+until the physical-state gates in <<benchmark-contract>> pass.
+
+=== Script correctness findings
+
+The benchmark driver must be corrected before it is used for a pricing claim:
+
+* it hard-codes collection ID `1` during the sweep rather than persisting the ID
+  returned by collection creation;
+* it does not record the server binary hash, commit, effective configuration,
+  registered environment gates, or data-bed identity;
+* it does not prove that all one million rows are materialized and visible before
+  restarting or measuring;
+* it does not prove that segment count and row ownership are unchanged across
+  restart;
+* its "cold" series begins empty but progressively warms shared caches over 200
+  unique queries; it is not an empty-cache measurement for every query;
+* its "hot" series primarily measures the query-result cache, not PAX range-cache
+  behavior;
+* its `sweep` entry point invokes the complete cold/hot sweep twice in the same
+  process, so the second result is already warmed by both earlier series and is
+  not an independent replicate;
+* its Prometheus parser overwrites labeled time-series instead of summing them;
+* if the physical GET counter is absent, it substitutes selected cache misses,
+  which are not equivalent to all object-store operations;
+* its percentile indexing is approximate and does not declare the convention;
+* it estimates engine storage as `raw / 5` instead of summing the exact live
+  manifest objects;
+* it declares egress but does not apply a documented egress scenario;
+* it treats ProximaDB's customer byte-scan charge as provider COGS rather than
+  retrieval revenue;
+* it hard-codes competitor prices without an evidence date or source; and
+* one output variable is overwritten with the Turbopuffer total and then labeled
+  as the ProximaDB total.
+
+The arithmetic must also be labeled precisely. The handoff's stated retrieval
+total does not equal physical GET count multiplied by the stated Azure
+per-operation price alone. A separate byte-scan term can explain the difference,
+but a customer scan charge is not an Azure operation cost. Its stated
+margin-preserving ProximaDB price also does not undercut its stated Turbopuffer
+price.
+
+== Current failure chain
+
+[source,text]
+----
+periodic / inline / shutdown flush triggers
+        |
+        v
+snapshot all "unflushed" batches (no atomic claim)
+        |
+        v
+construct a fresh storage engine and fresh worker/guard state
+        |
+        v
+clone + sort the complete vector set
+        |
+        v
+check the L0 STOP watermark
+        |
+        +-- rejected: WAL retained, next tick repeats clone + sort
+        |
+        v
+publish another L0 and independently arm compaction
+        |
+        v
+tasks reserve unique output names, not their shared input set
+        |
+        v
+overlapping compactions can publish multiple live outputs and race input deletion
+        |
+        v
+extra segments multiply probe ranges and physical GETs
+----
+
+This chain is visible in the current source:
+
+* `src/storage/engines/sst/flush/mod.rs::flush_implementation` clones and calls
+  `sort_vectors_for_sstable_encoding` before
+  `perform_atomic_flush`;
+* the L0 STOP/SLOWDOWN check is inside `perform_atomic_flush`;
+* `src/storage/flush_materializer.rs::materialize_collection` calls
+  `get_unflushed_batches`, clones their records, and creates a storage engine
+  through `StorageFormatFactory` for the attempt;
+* source batches are marked flushed only after the segment write;
+* `src/storage/engines/sst/compaction.rs::schedule_compaction` keys
+  `active_compactions` by the unique output path, so it does not reserve a
+  collection or input set; and
+* `src/storage/common/compaction_utils.rs::should_trigger_compaction` accepts a
+  `level` argument but checks level `0` for its count and pending-file arms.
+
+In the diagnostic run, the late-admission loop repeatedly sorted approximately
+592,000 records before rejection. A separate AXIS clustering trainer also started
+for the one-million-vector collection even though the collection was created
+without an ANN index configuration. Search correctly skipped AXIS for that
+collection, so insert-side training is unnecessary work and indicates that the
+TD-IVF-2 gate is not effective on this path.
+
+== Required invariants
+
+The implementation is complete only when the following are structural rather
+than timing assumptions:
+
+. *Canonical engine ownership.* A collection resolves to one long-lived engine
+  and one flush/compaction coordinator. Periodic, inline, shutdown, and recovery
+  triggers submit to it; they do not construct private scheduling domains.
+. *Admission precedes work.* An admission rejection consumes only bounded
+  metadata work. It cannot have cloned, sorted, clustered, trained, encoded, or
+  uploaded the job's vectors.
+. *Exclusive source ownership.* Every WAL batch and every input segment is
+  unclaimed, claimed by exactly one epoch, or durably retired.
+. *Fenced publication.* A job may publish only if its collection lease,
+  manifest generation, and source claims are still valid.
+. *One live generation.* Readers never observe two successful outputs derived
+  from the same source generation.
+. *Bounded resources.* Admitted jobs hold explicit memory, CPU, and object-store
+  concurrency permits. A Rayon pool is not itself admission control.
+. *Useful clustering only.* No model is trained unless a configured projection
+  consumes it and the predicted lifetime benefit exceeds its cost.
+. *Deterministic layout.* Parallel morsels may encode independently, but assembly
+  is stable and byte-identical for the same admitted plan.
+. *Recovery equivalence.* Recovery uses the same ownership/publication protocol;
+  bypassing a backlog threshold must not bypass source or manifest fencing.
+
+== Target ownership model
+
+=== Canonical coordinator
+
+Introduce one `CollectionStorageCoordinator` per canonical collection/storage
+assignment. The existing query-side engine cache is not sufficient if the flush
+materializer cannot resolve the same instance.
+
+The registry key must include the canonical tenant, collection identity, engine,
+and storage assignment. All flush triggers and compaction scheduling resolve
+through this registry.
+
+The coordinator owns:
+
+* the long-lived `UnifiedStorageFormat` engine;
+* the collection mutation lease;
+* flush and compaction queues;
+* source-claim tables;
+* manifest generation/fencing;
+* compaction `training_in_flight` and active-source state;
+* collection-local backlog and quiescence state; and
+* references to global resource admission.
+
+Engine construction belongs at catalog/storage-assignment activation, not inside
+each materialization attempt. Idle eviction is allowed only when the queues are
+empty, no claims remain, and reconstructing the instance cannot split ownership.
+
+=== Source state
+
+WAL batches require an atomic state transition:
+
+[source,text]
+----
+Unflushed
+   |
+   | claim(collection_epoch, flush_job_id)
+   v
+Claimed --------------------------+
+   |                              |
+   | publish + durable manifest   | abort / lease loss / expired claim
+   v                              |
+Flushed                           +--> Unflushed
+   |
+   | WAL-retention policy permits
+   v
+Retired
+----
+
+The claim operation returns exact batch IDs and immutable handles. Cleanup marks
+only those IDs flushed; it must not clear newly arrived batches. Expired claims
+are recovered by epoch/fence validation, not by assuming that the previous
+process failed before publication.
+
+Segments need the analogous state:
+
+`Live(generation) -> Claimed(compaction_job) -> Retired`, with an atomic manifest
+CAS that replaces the exact input IDs with one output ID.
+
+=== Admission order
+
+For a normal flush:
+
+. read only bounded metadata: backlog, candidate batch IDs, row/byte estimates,
+  current manifest generation, and collection policy;
+. acquire the collection mutation lease;
+. reserve one L0/output token against that manifest generation;
+. atomically claim the exact candidate batch IDs;
+. acquire global memory, CPU, and object-store permits using the estimate;
+. derive the admitted layout plan;
+. materialize records from the claimed immutable handles;
+. sort/cluster only as required by that plan;
+. encode in bounded parallel morsels;
+. assemble and upload deterministically;
+. publish with manifest CAS;
+. mark the exact batches flushed and apply the WAL-retention policy;
+. release resources and schedule compaction against the new manifest generation.
+
+If a step before publication fails, the job aborts and releases its source claim.
+If publication succeeds but cleanup is interrupted, recovery recognizes the
+published job ID and completes retirement idempotently.
+
+== Flush granularity and parallelism
+
+[cols="3,2,4", options="header"]
+|===
+|Scope |Policy |Reason
+
+|Different collections
+|Parallel
+|They have independent source sets and manifests. Global permits bound aggregate
+CPU, memory, and object-store pressure.
+
+|Different batches in one collection as independent output jobs
+|Serial initially
+|Disjoint WAL IDs avoid one race but do not avoid manifest races or the direct
+read-amplification cost of producing extra L0 objects.
+
+|Different batches in one collection as one admitted flush epoch
+|Combine
+|Claim an exact list of batches and emit one physical segment. New arrivals stay
+unclaimed for a later epoch.
+
+|Record preparation inside one admitted epoch
+|Parallel when bounded
+|Partition immutable claimed records into morsels; retain a deterministic final
+order and account for peak intermediate memory.
+
+|PAX pass-2 RaBitQ/SQ8 encoding
+|Parallel
+|TD-FLUSH-5 already uses ordered Rayon `par_iter` passes with a registered thread
+gate. Reuse it behind job-level resource admission.
+
+|Compaction in different collections
+|Parallel
+|Source sets and manifests are independent; global admission still applies.
+
+|Two compactions in one collection
+|Serial initially
+|The current scheduler cannot prove disjoint source sets or fence publication.
+Source-aware parallelism is a later optimization after manifest CAS exists.
+
+|Queries versus background work
+|Queries receive priority
+|Flush/compaction workers must yield CPU, memory, and object-store permits at
+configured foreground pressure thresholds.
+|===
+
+The unit of admission is the *segment-producing job*, not an encoding morsel.
+Morsels borrow capacity from an already admitted job. Otherwise a job can hold
+hundreds of source batches while waiting indefinitely for enough independent
+morsels to finish, recreating unbounded work-in-progress.
+
+== Sorting and clustering policy
+
+Clustering is not intrinsically required for every L0 flush. It is justified only
+when it creates a layout that the configured read path can exploit for enough of
+the segment's expected lifetime.
+
+The current flush first sorts canonical records for SST encoding, while the PAX
+writer can later choose sign/SQ8 Morton clustering order. Two whole-dataset order
+decisions are redundant when the second substantially replaces the first.
+
+Use one admitted `PhysicalLayoutPlan`:
+
+[cols="2,3,3", options="header"]
+|===
+|Plan |When used |Allowed work
+
+|`Append`
+|Small or short-lived L0; no useful persisted model; compaction expected soon
+|OID-stable deterministic order only. No model training.
+
+|`ReuseModel`
+|A compatible persisted collection model already exists
+|Assign records to existing cells and order for probe locality. No retraining.
+
+|`CheapL0Locality`
+|The L0 is expected to receive enough reads before compaction to repay assignment
+and ordering
+|Use bounded sampling or existing centroids; cell/locality key primary,
+metadata key within cell, OID as deterministic tie-break.
+
+|`TrainStable`
+|A major admitted compaction creates a long-lived L1/L2 projection and the
+collection has a configured consumer
+|Fit PCA/IVF/k-means once, persist model identity/version, cluster, and encode.
+|===
+
+Model training must require all of:
+
+* a configured ANN/projection consumer;
+* no compatible persisted model available for reuse;
+* an admitted stable-output job rather than an L0 retry;
+* sufficient sample size and expected output lifetime;
+* resource permits; and
+* a model version embedded in the segment/manifest for mixed-read safety.
+
+This preserves the valid observation behind the question: a clustered L0 can
+reduce bytes and improve co-located range reads. It rejects the stronger and
+costlier assumption that every flush should train a new model. The system should
+measure `training_cpu_ms`, `sort_cpu_ms`, output bytes, segment lifetime, range
+count, and reads served so that the clustering payback is falsifiable.
+
+== Compaction corrections
+
+ADR-076 made compaction asynchronous, but asynchronous execution is safe only
+when scheduling owns its sources.
+
+The first implementation should enforce one collection mutation/compaction job
+at a time. `active_compactions` must be indexed by collection plus claimed input
+segment IDs, not by a unique output filename.
+
+A compaction admission performs:
+
+. discover from one manifest generation;
+. choose an exact non-empty source set and target level;
+. acquire the collection mutation lease and global resource permits;
+. atomically claim every source segment;
+. build, cluster, train, and encode only after admission;
+. upload a staged output;
+. CAS the manifest from the discovered generation, replacing exactly the claimed
+  sources with the output;
+. retire source objects after the new manifest is durable; and
+. release source claims on every exit path.
+
+The count trigger in
+`src/storage/common/compaction_utils.rs::should_trigger_compaction` must use the
+requested `level` rather than hard-coded level `0`. Higher-level consolidation
+policy must then target:
+
+* bulk-load settle state: one stable segment when its rewrite cost is justified;
+* normal steady state at one-million-vector scale: at most two stable searchable
+  segments, plus a bounded freshness delta; and
+* no overlapping outputs or missing-input deletion warnings.
+
+Universal L1-to-L2 consolidation must be driven by both segment-count/read-cost
+envelopes and rewrite budget. A blind count-only merge loop can trade GET savings
+for uncontrolled write amplification.
+
+[[benchmark-contract]]
+== Correct benchmark contract
+
+The benchmark harness must fail closed rather than print apparently successful
+economics from a partially materialized bed.
+
+=== Immutable run identity
+
+Record in one machine-readable artifact:
+
+* Git commit and dirty state;
+* exact server binary path, SHA-256, build profile, and target;
+* dataset and ground-truth hashes;
+* full server configuration;
+* every explicitly used `PROXIMADB_*` gate after checking
+  `ENV_GATE_REGISTRY.adoc`;
+* cache budgets and query-result-cache policy;
+* tenant and returned collection ID;
+* storage-bed path and backend; and
+* benchmark script hash.
+
+=== Quiescence gate
+
+Before restart or search, require all of:
+
+* accepted rows = one million;
+* durable WAL rows + claimed rows + live-segment rows reconcile without overlap;
+* no unflushed or claimed batch remains;
+* no queued, running, or claimed compaction remains;
+* manifest generation is stable over a declared settle interval;
+* live segment objects and levels are recorded with exact bytes and row counts;
+* no two live segments descend from the same source generation; and
+* restart produces the same live manifest and row coverage.
+
+A fixed sleep is not a quiescence protocol.
+
+=== Search measurements
+
+Run and label distinct experiments:
+
+. *Empty-cache cold:* restart, disable/bypass query-result caching, clear or
+  epoch the PAX caches, issue one measured query, repeat per query or report
+  first-query-only samples.
+. *Progressively warm diverse:* one restart, deterministic unique query order,
+  report per-position and aggregate cache behavior.
+. *Hot result-cache:* repeat exact queries and explicitly label the result-cache
+  contribution.
+
+The harness must sum all matching Prometheus label series and fail if the physical
+I/O counter is absent or does not increase. Report exact percentile convention,
+query count, exclusions, and confidence intervals.
+
+Add physical per-tier counters for:
+
+* manifest/control/footer;
+* invariant Region A;
+* IVF probe-cell Region A;
+* SQ8 survivor Region B;
+* OID Region D; and
+* fallback/exact-scan reads.
+
+Logical cell and cache counters do not replace backend operation counts.
+
+== GET reduction after P0 correctness
+
+Once the bed passes the benchmark contract, GET reduction has two multiplicative
+terms:
+
+`physical GET/query = live segment fanout × coalesced reads/segment + shared control reads`.
+
+=== Stage 1: healthy consolidation
+
+Fix source ownership and higher-level scheduling, then settle a bulk-loaded
+one-million-vector collection to one or two stable searchable segments. This
+removes the approximately 10x segment multiplier without changing recall.
+
+Consolidation alone is unlikely to prove the `<= 20` target if the remaining
+segment still performs one object read per probed cell.
+
+=== Stage 2: probe-locality layout
+
+Implement TD-RDSTRAT-11 so cells likely to be probed together occupy nearby
+physical ranges. Make cell/locality the primary physical-order key; preserve
+metadata locality within cells and OID determinism as lower-order keys.
+
+The model and cell-directory version are persisted with the segment. Old layouts
+remain readable. The new layout is default-OFF until mixed-read and recall gates
+pass.
+
+=== Stage 3: miss-path range planning
+
+Before issuing Region-A/SQ8/OID reads:
+
+. translate selected logical ranges to physical offsets;
+. sort and merge overlapping or nearby ranges using a backend-aware maximum gap
+  and maximum span;
+. align fetches to canonical chunk boundaries when the extra bytes fit the
+  byte-amplification budget;
+. issue bounded parallel reads; and
+. slice the returned chunks to logical ranges.
+
+Region B and OID paths already have range-coalescing policy. The audit must first
+extend equivalent planning to IVF probe-cell Region A, which remains a major
+fanout source.
+
+Cache keys must use the same canonical physical chunk identity on hit and miss.
+Otherwise adjacent logical cells fetch the same bytes under different keys.
+
+=== Stage 4: cache and optional local tier
+
+The survivor cache is already LRU-like, and the measured budget sweep has a knee
+near 1,024 MB. Merely doubling it is not the primary fix.
+
+After canonical range planning:
+
+* separate cache accounting for probe Region A, SQ8, and OID;
+* weight admission by miss cost, reuse probability, and bytes rather than a
+  generic region class;
+* retain frequently probed cell bundles rather than arbitrary logical slices;
+* protect foreground-hot chunks from bulk compaction pollution; and
+* evaluate an SSD/local-object tier as a separate warm-service target.
+
+An SSD tier may reduce provider operations for warm workloads, but it cannot be
+used to claim the empty-cache cold acceptance criterion.
+
+=== Target GET envelope
+
+For a one-segment quiescent bed:
+
+[cols="2,1,3", options="header"]
+|===
+|Read class |GET/query budget |Mechanism
+
+|Shared control/footer
+|0-2
+|Invariant cache plus one coalesced control read on miss
+
+|IVF probe Region A
+|4-7
+|Cell-locality placement plus miss-path range coalescing
+
+|SQ8 survivor Region B
+|4-6
+|Canonical chunks and adjacent-range merging
+
+|OID Region D
+|2-3
+|Late materialization and coalesced OID ranges
+
+|Fallback/other
+|0-2
+|No per-cell control-plane reads
+
+|Total
+|10-20
+|Physical backend counter, not inferred cache misses
+|===
+
+For two segments, each segment must stay near 8-9 variable reads or share cached
+control reads. If that cannot be demonstrated, the stable bulk-load target must
+be one segment.
+
+== Implementation slices and exit gates
+
+=== P0-A: observability and benchmark repair
+
+* Add per-tier physical GET/byte counters and flush/compaction state counters.
+* Add a quiescence/manifest diagnostic consumed by the benchmark.
+* Repair collection-ID handling, metric aggregation, cache experiment labels,
+  engine-byte accounting, and fail-closed assertions.
+
+Exit: the benchmark refuses the reproduced partial-WAL state and explains why.
+
+=== P0-B: canonical ownership and admission-first flush
+
+* Route all flush triggers through the canonical collection coordinator.
+* Add exact WAL batch claim/rollback/retire transitions.
+* Move the L0 and resource admission decision before record materialization,
+  clone, sort, clustering, training, and encode.
+* Preserve and govern TD-FLUSH-5 parallel pass-2 encoding.
+* Enforce the TD-IVF-2 no-index training gate.
+
+Exit:
+
+* `post_rejection_sort_records = 0`;
+* `post_rejection_training_jobs = 0`;
+* one engine/coordinator scheduling domain per active collection;
+* no batch belongs to two jobs; and
+* cross-collection flush concurrency is bounded and demonstrated.
+
+=== P0-C: source-safe compaction
+
+* Claim exact input segments and publish with manifest CAS.
+* Enforce one mutation job per collection initially.
+* Fix level-aware count triggers.
+* Add explicit universal higher-level consolidation policy.
+
+Exit:
+
+* no overlapping source tasks;
+* no "input file not found" deletion races;
+* no duplicate live output generations; and
+* one-million-row bulk load settles to at most two searchable segments.
+
+=== P1: one admitted physical ordering
+
+* Remove the redundant whole-dataset order pass when PAX layout supersedes it.
+* Introduce `PhysicalLayoutPlan`.
+* Reuse models for L0 when profitable; train only admitted stable outputs.
+
+Exit: recall does not regress, ingest throughput is at least the valid baseline,
+and CPU/peak-memory decline or are justified by measured read savings.
+
+=== P2: GET-reduction layout and range planning
+
+* Land mixed-read-safe cell-locality layout behind a default-OFF collection
+  format/version gate.
+* Add Region-A miss-path coalescing and canonical cache keys.
+* Tune byte-versus-operation amplification from per-tier traces.
+
+Exit on quiescent SIFT1M:
+
+* recall@10 `>= 0.98`;
+* physical GET/query `<= 20` for the declared cold-diverse protocol;
+* cold p50 `<= 50 ms`;
+* exact live bytes, read bytes, and segment count reported; and
+* results repeat across restart without changing the manifest.
+
+=== P3: economics
+
+Only after P2 passes:
+
+* apply dated provider operation, storage, data-transfer, and local-tier prices
+  to the measured physical trace;
+* keep provider COGS separate from ProximaDB customer-meter revenue;
+* state whether data transfer is same-region, cross-zone, cross-region, or
+  internet egress;
+* recompute the KRU price and margin; and
+* compare competitors using dated, sourced, like-for-like assumptions.
+
+No pricing claim should be used to choose a write/read optimization before these
+gates. The optimization target is first the minimum resource trace that preserves
+correctness and recall; pricing is a transparent projection of that trace.
+
+== Acceptance criteria
+
+The end-to-end work is accepted when all of the following hold:
+
+* rejected flushes perform no vector-proportional compute;
+* each source batch/segment has exactly one owner and one live successor;
+* AXIS/PCA/IVF training is absent when no configured projection consumes it;
+* flush jobs for independent collections run concurrently within global bounds;
+* one collection combines admitted batches into one output while exploiting
+  bounded within-segment encoding parallelism;
+* quiescent physical row coverage is exactly one million before measurement;
+* the bulk-loaded collection settles to one or two searchable segments;
+* restart leaves the manifest and segment geometry unchanged;
+* recall@10 is at least 0.98;
+* cold-diverse physical GET/query is at most 20;
+* cold p50 is at most 50 ms; and
+* economics are computed only from the accepted run artifact.
+
+== Non-goals
+
+This blueprint does not:
+
+* promise that all same-collection mutations must remain serial forever;
+* require clustering on every flush;
+* use a larger DRAM cache to conceal bad physical layout;
+* count logical cache misses as provider GETs;
+* use recovery watermark bypass as normal backlog control; or
+* set or approve a production rate card from the current diagnostic run.

--- a/docs/12-design/adr/ADR-081-admission-first-flush-ownership.adoc
+++ b/docs/12-design/adr/ADR-081-admission-first-flush-ownership.adoc
@@ -1,0 +1,139 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-081: Admission-first flush ownership and exact WAL batch claims
+:status: Accepted
+:date: 2026-07-29
+
+[cols="1,3"]
+|===
+|Status |**Accepted** — implementation tracked by TD-FLUSH-7
+|Date |2026-07-29
+|Decider |Vijaykumar Singh
+|Amends |ADR-069 D2 flush triggering; ADR-076 D2 L0 admission placement
+|Relates to |ADR-070 no-AXIS co-design collections; ADR-078 one flush-to-AXIS mechanism
+|Detailed blueprint
+|link:../SIFT1M_ADMISSION_FIRST_GET_REDUCTION_BLUEPRINT_2026_07_29.adoc[SIFT1M admission-first flush, compaction, and GET-reduction blueprint]
+|===
+
+== Context
+
+The SIFT1M verification exposed three interacting defects in the live
+memtable-to-segment path:
+
+. `materialize_collection` snapshots all unflushed batches without reserving
+  them, while the inline, periodic, and shutdown triggers have independent
+  scheduling state.
+. Each materialization attempt constructs a new storage-engine instance. For
+  SST this also constructs a new compaction queue, worker pool, and
+  `training_in_flight` state.
+. The SST L0 STOP check runs inside `perform_atomic_flush`, after the complete
+  record set has been cloned and sorted.
+
+In the reproduced one-million-vector run, approximately 592,000 records were
+cloned and sorted on each retry before the late L0 STOP check rejected the
+flush. The retry did not own its source batches, and the fresh engine meant the
+guard state was not canonical across attempts.
+
+The existing TD-FLUSH-5 Rayon pass-2 encoder is useful within an admitted job,
+but encoding morsels are not admission control: they neither own WAL batches
+nor serialize collection publication.
+
+== Decision
+
+=== D1 — One canonical flush scheduling domain
+
+All materialization triggers resolve through one process-wide flush
+coordinator:
+
+* one long-lived engine instance per configured storage format;
+* one operation gate per canonical collection; and
+* one bounded global permit pool for cross-collection flush jobs.
+
+Different collections may flush concurrently up to the configured background
+worker limit. A collection admits one segment-producing flush at a time.
+
+This is deliberately one engine per *format*, not one engine per collection:
+SST is collection-agnostic and owns a worker pool, so per-collection instances
+would multiply workers and caches.
+
+=== D2 — Exact cancellation-safe WAL batch claims
+
+Before cloning any records, the admitted job atomically claims an exact,
+deterministically ordered list of immutable WAL batch IDs.
+
+Claimed batches:
+
+* remain visible to unflushed reads until the segment is durable;
+* cannot be claimed by another flush;
+* are released automatically if the future is cancelled or returns an error;
+* are retired by exact ID after successful publication; and
+* do not cause batches appended during the flush to be cleared.
+
+The claim is an in-process ownership primitive. Durable crash-idempotent
+publication remains a separate follow-up because normal flush filenames are
+not yet derived from a persisted materialization epoch.
+
+=== D3 — Admission before vector-proportional work
+
+The engine contract gains a lightweight `preflight_flush` method. The
+materializer performs this preflight before claiming or cloning records.
+
+For SST, preflight:
+
+* resolves the target storage path;
+* counts only live L0 segment filenames, not all levels;
+* applies the configured slowdown/stop watermarks; and
+* bypasses backlog watermarks only for WAL recovery, preserving the existing
+  boot-deadlock protection.
+
+`do_flush` repeats the same preflight at its boundary so direct SST callers are
+also safe. A rejected SST flush cannot reach sorting, clustering, training,
+encoding, staging, or upload.
+
+=== D4 — Parallelism is collection-scoped, morsels are job-scoped
+
+The periodic driver evaluates collections and submits due materializations
+concurrently. The global permit pool bounds aggregate work.
+
+Within one collection, all batches claimed by the epoch feed one segment.
+TD-FLUSH-5's deterministic PAX encoding morsels remain the within-segment
+parallelism mechanism. Independent same-collection segment outputs are rejected
+for this slice because they increase manifest races and read amplification.
+
+=== D5 — AXIS work requires a configured consumer
+
+The recovery/direct-insert path may feed AXIS only when the collection carries
+at least one index configuration or the existing `pax_vector_format:off`
+RawF32 compatibility tag. A normal collection with an empty index list uses its
+PAX segment as the index and must not buffer or train an unused AXIS IVF
+projection.
+
+== Consequences
+
+* An L0 rejection costs bounded metadata work rather than O(number of vectors)
+  CPU and memory.
+* Inline, periodic, and shutdown flushes cannot create overlapping segments
+  from the same WAL batches.
+* New writes may continue while an admitted flush encodes immutable claimed
+  batches; they remain for the next epoch.
+* Independent collections use available concurrency without multiplying SST
+  engines or compaction worker pools.
+* A failed or cancelled flush returns its exact source claim.
+* Claim ownership is process-local. Crash-idempotent normal-flush publication,
+  manifest generation CAS, and compaction source-set claims remain explicit
+  follow-ups.
+
+== Verification
+
+TD-FLUSH-7 must provide deterministic tests for:
+
+* preflight rejection before SST sorting;
+* same-collection single-flight behavior;
+* different-collection bounded concurrency;
+* claim rollback after error and future cancellation;
+* exact retirement while a new batch arrives during the flush;
+* canonical engine reuse; and
+* no AXIS insertion for a collection with no configured index.
+
+Operational counters must expose admission results, in-flight jobs, claimed
+batches, and claim rollbacks.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -399,6 +399,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Vector-search compaction tuning — segment count is the GET multiplier
 | Proposed (2026-07-29)
 | The SIFT1M benchmark measured 205 GETs/query (9 segments × ~8 reads each) — 10× the competitive threshold. The compaction framework's `level_multiplier=2.0` (RocksDB-style scaling for write-amplification) sets the L2 threshold to 20 files — unreachable for a 1M collection with 5 L2 segments. For vector search, the dominant cloud cost is GET round-trips (not write amplification). Decision: `level_multiplier=1.0` (every level compacts at the same threshold; 5 L2 files → merge into 1-2), plus a post-ingest settle pass + production flush_floor (128MB). Target: ≤30 GETs/query cold (2-3 segments), retrieval margin >50% at $50/M KRU. Tracked: TD-COMPACT-10.
+| link:ADR-081-admission-first-flush-ownership.adoc[ADR-081]
+| Admission-first flush ownership and exact WAL batch claims
+| Accepted (2026-07-29)
+| Makes all materialization triggers share one process-wide engine per format, one operation gate per collection, and bounded cross-collection admission. Exact cancellation-safe WAL batch claims remain readable until publication and retire by ID, preserving writes that arrive during a flush. SST L0 admission moves before clone/sort/train/encode and counts only L0 segments. TD-FLUSH-5 encoding morsels remain within one admitted segment; empty-index collections do not feed AXIS. Tracked: TD-FLUSH-7.
 |===
 
 The index is complete and is enforced by `scripts/check_design_status_index.py`.

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -77,6 +77,19 @@ use super::write::{
     insert_existing_record_conflict_result, insert_only_lock_key, tombstone_records_for_ids,
 };
 
+/// ADR-070 / ADR-081: AXIS is a configured projection, not an automatic cost
+/// paid by every vector collection. PAX-only collections carry no index config;
+/// the explicit RawF32 compatibility tag retains the established AXIS path.
+fn collection_uses_axis_indexes(collection: &Collection) -> bool {
+    collection.config.as_ref().is_some_and(|config| {
+        !config.index_configs.is_empty()
+            || config
+                .tags
+                .iter()
+                .any(|tag| tag.trim().eq_ignore_ascii_case("pax_vector_format:off"))
+    })
+}
+
 // Import vector query service contract (Phase 2.1)
 use proximadb_vector_query::{VectorQueryRequest, VectorQueryService, VectorSearchResult};
 
@@ -3584,10 +3597,7 @@ impl VectorOperationsService {
         // A0 coarse-probe) in the SST engine handles the search — the segment IS
         // the index. This avoids the 8.6GB RSS + minutes of IVF training for
         // cost-optimized, object-storage-backed collections.
-        let collection_has_axis_indexes = collection
-            .config
-            .as_ref()
-            .is_some_and(|c| !c.index_configs.is_empty());
+        let collection_has_axis_indexes = collection_uses_axis_indexes(&collection);
         let axis_optimized_results = if !collection_has_axis_indexes {
             info!(
                 "🔍 Co-design: skipping AXIS for collection {} (no index_configs) — \
@@ -4111,28 +4121,39 @@ impl VectorOperationsService {
             .write_vector_batch_native_arc(collection_id, Arc::new(vectors.clone()))
             .await?;
 
-        let axis_start = std::time::Instant::now();
-        for record in vectors.iter() {
-            if let Err(e) = self
-                .axis_index_manager
-                .insert_record(collection_id, record)
-                .await
-            {
-                tracing::warn!(
-                    "Failed to index vector {} in AXIS: {} (search will use linear scan)",
-                    record.oid,
-                    e
+        let collection = self.get_or_load_collection(collection_id).await?;
+        let axis_duration = if collection_uses_axis_indexes(&collection) {
+            let axis_start = std::time::Instant::now();
+            for record in vectors.iter() {
+                if let Err(e) = self
+                    .axis_index_manager
+                    .insert_record(collection_id, record)
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to index vector {} in AXIS: {} (search will use storage)",
+                        record.oid,
+                        e
+                    );
+                }
+            }
+            let axis_duration = axis_start.elapsed();
+            if axis_duration.as_millis() > 10 {
+                tracing::debug!(
+                    "AXIS indexing for {} vectors took {:?}",
+                    vectors.len(),
+                    axis_duration
                 );
             }
-        }
-        let axis_duration = axis_start.elapsed();
-        if axis_duration.as_millis() > 10 {
+            axis_duration
+        } else {
             tracing::debug!(
-                "AXIS indexing for {} vectors took {:?}",
-                vectors.len(),
-                axis_duration
+                collection_id,
+                records = vectors.len(),
+                "ADR-081: skipping AXIS insert feed because collection has no index_configs"
             );
-        }
+            std::time::Duration::ZERO
+        };
 
         let duration_micros = start.elapsed().as_micros() as i64;
         let bytes_written = vectors
@@ -6198,5 +6219,47 @@ mod recompute_merged_shortfall_tests {
         assert!(recompute_merged_shortfall(10, 10, true, Some(&ctx)).is_none());
         // also: more than requested (cap) is not a shortfall
         assert!(recompute_merged_shortfall(10, 12, true, Some(&ctx)).is_none());
+    }
+}
+
+#[cfg(test)]
+mod axis_insert_gate_tests {
+    use super::collection_uses_axis_indexes;
+    use crate::proto::proximadb_v1::{Collection, CollectionConfig, IndexConfig};
+
+    #[test]
+    fn empty_index_configs_do_not_feed_axis() {
+        let collection = Collection {
+            config: Some(CollectionConfig {
+                index_configs: Vec::new(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!collection_uses_axis_indexes(&collection));
+    }
+
+    #[test]
+    fn configured_index_feeds_axis() {
+        let collection = Collection {
+            config: Some(CollectionConfig {
+                index_configs: vec![IndexConfig::default()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(collection_uses_axis_indexes(&collection));
+    }
+
+    #[test]
+    fn raw_f32_compatibility_tag_feeds_axis() {
+        let collection = Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_vector_format:off".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(collection_uses_axis_indexes(&collection));
     }
 }

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -124,12 +124,10 @@ impl AutoFlushDriver {
         // Catalog is the metadata authority (engine / dimension / path / tenant) —
         // the same source flush_memtable_to_storage resolves each plan from.
         let catalog = list_collections_from_catalog().await;
+        let mut pending = tokio::task::JoinSet::new();
 
         for collection_id in &collections {
-            let mem_bytes: u64 = match write_buffer.get_unflushed_batches(collection_id).await {
-                Ok(batches) => batches.iter().map(|b| b.total_size_bytes as u64).sum(),
-                Err(_) => 0,
-            };
+            let mem_bytes = write_buffer.unflushed_bytes(collection_id).await;
             // Observation is emitted at the decision boundary: what /metrics shows
             // is exactly what the policy acted on.
             wal_flush_metrics::set_wal_size(collection_id, mem_bytes as i64);
@@ -180,38 +178,59 @@ impl AutoFlushDriver {
                 tenant_id,
             };
 
-            // free_wal=true: once the SST segment is written, free the covered WAL
-            // so the materialized segment (not a WAL replay) is the durable restart
-            // source — the same posture as the shutdown flush (engine.rs), gated by
-            // the insert→flush→search recall round-trip.
-            let start = Instant::now();
-            let res = materialize_collection(
-                &write_buffer,
-                &plan,
-                self.storage_write_fence.as_ref(),
-                None,
-                true,
-                Some(&self.axis_index_manager),
-            )
-            .await;
-            let dur = start.elapsed().as_secs_f64();
+            // ADR-081 D4: submit independent collections concurrently. The
+            // process-wide materializer permit pool bounds the actual work, and
+            // its per-collection gate collapses overlap with inline/shutdown
+            // triggers.
+            let task_write_buffer = write_buffer.clone();
+            let task_axis = self.axis_index_manager.clone();
+            let task_fence = self.storage_write_fence.clone();
+            let reason_label = reason.as_str().to_string();
+            pending.spawn(async move {
+                let start = Instant::now();
+                let result = materialize_collection(
+                    &task_write_buffer,
+                    &plan,
+                    task_fence.as_ref(),
+                    None,
+                    true,
+                    Some(&task_axis),
+                )
+                .await;
+                (
+                    plan.wal_key,
+                    reason_label,
+                    start.elapsed().as_secs_f64(),
+                    result,
+                )
+            });
+        }
 
-            match res {
+        while let Some(joined) = pending.join_next().await {
+            let (collection_id, reason, dur, result) = match joined {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::error!("ADR-081 auto-flush task failed to join: {}", error);
+                    continue;
+                }
+            };
+            match result {
                 Ok(Some(outcome)) => {
                     wal_flush_metrics::record_flush(
-                        collection_id,
-                        reason.as_str(),
+                        &collection_id,
+                        &reason,
                         true,
                         outcome.bytes as i64,
                         outcome.entries_flushed as i64,
                         dur,
                         Self::now_unixtime(),
                     );
-                    self.note_flushed(collection_id).await;
-                    wal_flush_metrics::set_wal_size(collection_id, 0);
+                    self.note_flushed(&collection_id).await;
+                    let remaining = write_buffer.unflushed_bytes(&collection_id).await;
+                    wal_flush_metrics::set_wal_size(&collection_id, remaining as i64);
                     tracing::info!(
-                        "✅ ADR-069 auto-flush [{}] '{}': {} vectors, {} bytes in {:.3}s",
-                        reason.as_str(),
+                        "✅ ADR-081 auto-flush [{}] '{}': {} vectors, {} bytes in {:.3}s",
+                        reason,
                         collection_id,
                         outcome.entries_flushed,
                         outcome.bytes,
@@ -220,25 +239,17 @@ impl AutoFlushDriver {
                 }
                 Ok(None) => {
                     // Raced to empty; reset the window so we don't re-decide every tick.
-                    self.note_flushed(collection_id).await;
+                    self.note_flushed(&collection_id).await;
                 }
                 Err(e) => {
-                    wal_flush_metrics::record_flush(
-                        collection_id,
-                        reason.as_str(),
-                        false,
-                        0,
-                        0,
-                        dur,
-                        0,
-                    );
+                    wal_flush_metrics::record_flush(&collection_id, &reason, false, 0, 0, dur, 0);
                     // TD-FLUSH-6: `{:#}` prints the full anyhow source chain, not
                     // just the outer "Failed to commit atomic flush operation"
                     // wrapper — the proximate object-store cause lives 1-2 .context
                     // layers down and was previously dropped.
                     tracing::warn!(
-                        "❌ ADR-069 auto-flush [{}] '{}' failed: {:#}",
-                        reason.as_str(),
+                        "❌ ADR-081 auto-flush [{}] '{}' failed: {:#}",
+                        reason,
                         collection_id,
                         e
                     );

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, warn};
 pub struct StorageEngine {
     config: StorageConfig,
     sst_storages: Arc<DashMap<String, Arc<SstEngine>>>,
+    canonical_sst_storage: Arc<SstEngine>,
     #[allow(dead_code)]
     disk_manager: Arc<DiskManager>,
     write_ahead_log_manager: Arc<WriteAheadLogManager>,
@@ -143,30 +144,42 @@ impl StorageEngine {
         crate::index::set_global_axis_manager(axis_index_manager.clone());
         info!("✅ AXIS manager registered with SST engine for HNSW/IVF search");
 
-        // Initialize compaction manager with default config if not provided
+        // Build the one configured SST instance used by every flush and its
+        // background compaction. Keeping this Arc prevents the worker-owning
+        // instance from being discarded and a second default engine from being
+        // constructed by the materializer.
         let sst_config = config.sst_config.clone().unwrap_or_default();
-        let compaction_manager = Arc::new(Compaction::new(sst_config).await?);
-
-        // Create singleton SST storage instance
-        let _sst_config_for_storage = config.sst_config.clone().unwrap_or_default();
-        let _sst_storage = Arc::new(SstEngine::new().await.map_err(|e| {
-            proximadb_kernel::error::StorageError::SstEngine(format!(
-                "Failed to create SST storage: {}",
-                e
-            ))
-        })?);
+        let distance_compute =
+            Arc::new(proximadb_distance_kernel::engine::UnifiedDistanceCompute::default());
+        let canonical_sst_storage = Arc::new(
+            SstEngine::new_with_config(sst_config, filesystem.clone(), distance_compute.clone())
+                .await
+                .map_err(|e| {
+                    proximadb_kernel::error::StorageError::SstEngine(format!(
+                        "Failed to create SST storage: {}",
+                        e
+                    ))
+                })?,
+        );
+        let compaction_manager = canonical_sst_storage
+            .compaction_manager()
+            .cloned()
+            .ok_or_else(|| {
+                proximadb_kernel::error::StorageError::SstEngine(
+                    "canonical SST storage did not initialize compaction".to_string(),
+                )
+            })?;
 
         Ok(Self {
             config,
             sst_storages: Arc::new(DashMap::new()), // Now uses DashMap for per-collection storages
+            canonical_sst_storage,
             disk_manager,
             write_ahead_log_manager,
             axis_index_manager,
             compaction_manager,
             filesystem,
-            distance_compute: Arc::new(
-                proximadb_distance_kernel::engine::UnifiedDistanceCompute::default(),
-            ),
+            distance_compute,
             storage_write_fence: None,
         })
     }
@@ -189,6 +202,21 @@ impl StorageEngine {
     pub async fn start(&mut self) -> crate::storage::Result<()> {
         tracing::info!("🚀 STORAGE_ENGINE: Starting storage engine");
 
+        // ADR-081: establish the one process-wide flush admission domain before
+        // recovery or any live trigger can resolve a materializer.
+        crate::storage::flush_materializer::configure_flush_admission(
+            self.config
+                .sst_config
+                .as_ref()
+                .map(|config| config.background_thread_count as usize)
+                .unwrap_or_else(crate::storage::flush_materializer::default_parallel_flushes),
+        );
+        crate::storage::flush_materializer::register_flush_engine(
+            crate::proto::proximadb_v1::StorageEngine::Sst,
+            self.canonical_sst_storage.clone(),
+        )
+        .await;
+
         // Load the durable catalog before WAL replay. Recovery flushes each WAL
         // batch through the collection's assigned storage engine, so those
         // engines must be registered first (especially after a cold restart,
@@ -205,17 +233,9 @@ impl StorageEngine {
         self.recover_from_wal().await?;
         tracing::info!("✅ STORAGE_ENGINE: WAL recovery completed, starting compaction workers");
 
-        // The StorageEngine holds a Compaction handle ONLY for
-        // `set_precision_resolver` (database.rs) + shutdown — it is NEVER
-        // enqueued to (the flush path uses the SstEngine's own Compaction,
-        // started with workers in core.rs). So this instance starts NO workers
-        // (the former `start_workers` here spawned 4 idle, never-fed workers —
-        // pure proliferation). The precision-resolver wiring is a separate
-        // follow-up (it currently targets this idle instance, not the one that
-        // compacts).
-        let sst_config = self.config.sst_config.clone().unwrap_or_default();
-        let temp_manager = Arc::new(Compaction::new(sst_config).await?);
-        self.compaction_manager = temp_manager;
+        // `compaction_manager` is the handle owned by canonical_sst_storage.
+        // Flush scheduling and bootstrap resolver wiring therefore target the
+        // same queue/workers rather than an idle look-alike instance.
 
         // ADR-069/TD-WAL-1: spawn the live auto-flush driver. The default config arms the
         // 300s time floor so the driver spawns and segments materialize while the server

--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -374,6 +374,11 @@ pub struct SstEngine {
     freshness_lsn_source: Option<
         Arc<dyn crate::storage::engines::sst::object_economy_directory::FreshnessLsnSource>,
     >,
+
+    /// ADR-081 regression hook: rejected preflights must not reach the
+    /// vector-proportional sort boundary.
+    #[cfg(test)]
+    pub(crate) flush_sort_invocations: std::sync::atomic::AtomicU64,
 }
 
 impl SstEngine {
@@ -615,6 +620,8 @@ impl SstEngine {
             survivor_cache,
             tiering_integration: None,
             freshness_lsn_source: None,
+            #[cfg(test)]
+            flush_sort_invocations: std::sync::atomic::AtomicU64::new(0),
         })
     }
 

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -119,7 +119,15 @@ impl SstEngine {
             collection_storage_url, collection_id
         );
 
+        // ADR-081 D3: admission is the first vector-path boundary. Direct
+        // `do_flush` callers reach this check here; the WAL materializer also
+        // invokes the same preflight before it claims/clones source records.
+        self.preflight_flush_implementation(params).await?;
+
         // Sort canonical records for optimal SSTable encoding.
+        #[cfg(test)]
+        self.flush_sort_invocations
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let (sorted_vectors, sort_stats) = self
             .sort_vectors_for_sstable_encoding(params.vector_records.clone())
             .await?;
@@ -199,7 +207,8 @@ impl SstEngine {
         // already have the persisted PCA/IVF model in the A0 region, and re-training loads
         // the entire dataset into RAM (5.7 GB for 1M vectors, 100% CPU for minutes).
         // The cascade reader loads centroids lazily from A0 at search time.
-        if params.vector_records.len() >= 100 && params.collection_config.is_some() {
+        let needs_flush_pca = crate::storage::common::axis_flush_hook::axis_needed(params);
+        if params.vector_records.len() >= 100 && needs_flush_pca {
             // Only train with enough samples
             match self
                 .train_and_cache_pca_model(
@@ -279,6 +288,85 @@ impl SstEngine {
 
     // Removed duplicate sort_vectors_for_sstable_encoding method - using the one from utils.rs
 
+    /// ADR-081 D3: bounded metadata-only admission for an SST flush.
+    ///
+    /// This method must remain independent of `vector_records`: the WAL
+    /// materializer calls it before claiming or cloning record payloads.
+    pub(crate) async fn preflight_flush_implementation(
+        &self,
+        params: &FlushParameters,
+    ) -> Result<()> {
+        let recovery_materialization = params
+            .hints
+            .get("recovery_materialization_id")
+            .and_then(|value| value.as_str());
+
+        // Recovery must complete even while the normal live L0 backlog is at
+        // STOP, otherwise boot can deadlock before compaction workers run.
+        if self.compaction_manager().is_none() || recovery_materialization.is_some() {
+            return Ok(());
+        }
+
+        let cfg = self.config();
+        let stop_trigger = std::env::var("PROXIMADB_L0_STOP_TRIGGER")
+            .ok()
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or(cfg.l0_stop_trigger);
+        let slowdown_trigger = std::env::var("PROXIMADB_L0_SLOWDOWN_TRIGGER")
+            .ok()
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or(cfg.l0_slowdown_trigger);
+        if stop_trigger == 0 && slowdown_trigger == 0 {
+            return Ok(());
+        }
+
+        let storage_url = Self::get_collection_storage_url_from_params(params)?;
+        let files = self
+            .discover_sstable_files(&storage_url)
+            .await
+            .map_err(|error| {
+                SstError::Flush(format!(
+                    "ADR-081: cannot evaluate L0 admission for '{}': {}",
+                    storage_url, error
+                ))
+            })?;
+        // ADR-081 corrects TD-COMPACT-7's all-level count. The admission
+        // backlog is L0 only; stable L1/L2 objects must not stall new flushes.
+        let l0_count = files
+            .iter()
+            .filter(|path| {
+                path.rsplit('/')
+                    .next()
+                    .is_some_and(|name| name.starts_with("L0_"))
+            })
+            .count() as u32;
+
+        if stop_trigger > 0 && l0_count >= stop_trigger {
+            tracing::warn!(
+                collection = %storage_url,
+                l0_count,
+                stop_trigger,
+                "ADR-081: L0 admission STOP before record materialization"
+            );
+            return Err(SstError::Flush(format!(
+                "ADR-081: L0 admission stop — {l0_count} L0 files >= stop_trigger \
+                 {stop_trigger}; flush rejected before record materialization"
+            ))
+            .into());
+        }
+
+        if slowdown_trigger > 0 && l0_count >= slowdown_trigger {
+            tracing::debug!(
+                collection = %storage_url,
+                l0_count,
+                slowdown_trigger,
+                "ADR-081: L0 admission SLOWDOWN before record materialization"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        Ok(())
+    }
+
     /// Perform atomic flush operation with staging
     async fn perform_atomic_flush(
         &self,
@@ -305,69 +393,6 @@ impl SstEngine {
         };
 
         tracing::debug!(storage_url = %storage_url, filename = %filename, "Starting flush operation");
-
-        // TD-COMPACT-7 (ADR-076 D2): L0 admission watermarks — the CONSUMER
-        // half of the producer/consumer rate-control loop. TD-COMPACT-6 D1 made
-        // compaction async, so flush can outrun compaction during sustained
-        // ingest; these watermarks feed backpressure from the L0 backlog into
-        // the flush rate. Checked before writing a new L0, using the same file
-        // count `should_trigger_compaction` reasons over:
-        //  - STOP (hard):    l0_count >= stop_trigger    → defer the flush
-        //    (return Err). `materialize_collection`'s `?` returns before its
-        //    `free_wal` block, so the data stays durable in the WAL and the
-        //    auto-flush driver retries next tick. Bounds unbounded L0 growth.
-        //  - SLOWDOWN (soft): l0_count >= slowdown_trigger → yield ~1ms so the
-        //    background compaction workers get headroom to drain L0.
-        // Both default-OFF via 0; env-overridable. Only armed when a compaction
-        // manager exists (no point bounding L0 for a collection that can't
-        // compact it).
-        //
-        // SKIP during WAL recovery (`recovery_materialization.is_some()`):
-        // recovery flushes MUST complete regardless of L0 count — the watermark
-        // would deadlock (the flush can't proceed AND the compaction workers
-        // can't drain L0 because the server isn't fully started). Discovered by
-        // the Phase 2 cache sweep (server restart with l0_count=10 →
-        // stop_trigger=10 → D2 blocks → WAL recovery fails → server can't boot).
-        if self.compaction_manager().is_some() && recovery_materialization.is_none() {
-            let cfg = self.config();
-            let stop_trigger = std::env::var("PROXIMADB_L0_STOP_TRIGGER")
-                .ok()
-                .and_then(|v| v.parse::<u32>().ok())
-                .unwrap_or(cfg.l0_stop_trigger);
-            let slowdown_trigger = std::env::var("PROXIMADB_L0_SLOWDOWN_TRIGGER")
-                .ok()
-                .and_then(|v| v.parse::<u32>().ok())
-                .unwrap_or(cfg.l0_slowdown_trigger);
-            if stop_trigger > 0 || slowdown_trigger > 0 {
-                let l0_count = self
-                    .discover_sstable_files(storage_url)
-                    .await
-                    .unwrap_or_default()
-                    .len() as u32;
-                if stop_trigger > 0 && l0_count >= stop_trigger {
-                    tracing::warn!(
-                        collection = %storage_url,
-                        l0_count, stop_trigger,
-                        "TD-COMPACT-7: L0 admission STOP — deferring flush (WAL retained); \
-                         background compaction must drain L0 first"
-                    );
-                    return Err(SstError::Flush(format!(
-                        "TD-COMPACT-7: L0 admission stop — {l0_count} L0 files >= stop_trigger \
-                         {stop_trigger}; deferring flush so background compaction can drain L0 \
-                         (data is durable in the WAL)"
-                    ))
-                    .into());
-                }
-                if slowdown_trigger > 0 && l0_count >= slowdown_trigger {
-                    tracing::debug!(
-                        collection = %storage_url,
-                        l0_count, slowdown_trigger,
-                        "TD-COMPACT-7: L0 admission SLOWDOWN — yielding ~1ms for compaction"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-                }
-            }
-        }
 
         let atomic_op = if recovery_materialization.is_some() {
             // Recovery publishes directly to the deterministic final object via
@@ -1501,6 +1526,10 @@ mod tests {
 
     async fn create_test_engine() -> SstEngine {
         let config = SstConfig::default();
+        create_test_engine_with_config(config).await
+    }
+
+    async fn create_test_engine_with_config(config: SstConfig) -> SstEngine {
         let filesystem_config =
             crate::storage::persistence::filesystem::FilesystemConfig::default();
         let filesystem = Arc::new(FilesystemFactory::create(filesystem_config).await.unwrap());
@@ -1526,6 +1555,85 @@ mod tests {
             }],
             ..ProximaRecord::default()
         }
+    }
+
+    #[tokio::test]
+    async fn adr081_l0_stop_rejects_before_sort_and_ignores_stable_levels() {
+        use crate::proto::proximadb_v1::{
+            Collection, CollectionConfig, StorageAssignment, StorageEngine,
+        };
+        use crate::storage::traits::UnifiedStorageFormat;
+
+        let mut config = SstConfig::default();
+        config.l0_stop_trigger = 1;
+        config.l0_slowdown_trigger = 0;
+        config.background_thread_count = 1;
+        let engine = create_test_engine_with_config(config).await;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let collection_id = "adr081_preflight";
+        let data_dir = StoragePath::collection_data_path(
+            temp_dir.path().to_string_lossy().as_ref(),
+            collection_id,
+        );
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(
+            std::path::Path::new(&data_dir).join("L1_20260729T000000_stable.pax"),
+            b"stable",
+        )
+        .unwrap();
+
+        let collection = Collection {
+            id: collection_id.to_string(),
+            config: Some(CollectionConfig {
+                name: collection_id.to_string(),
+                dimension: 2,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: temp_dir.path().to_string_lossy().into_owned(),
+                engine: StorageEngine::Sst as i32,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let params = FlushParameters {
+            collection_id: Some(collection_id.to_string()),
+            vector_records: vec![create_test_vector("v0", vec![1.0, 0.0])],
+            force: true,
+            synchronous: true,
+            collection_config: Some(collection),
+            ..Default::default()
+        };
+
+        engine
+            .preflight_flush(&params)
+            .await
+            .expect("a stable L1 segment must not consume the L0 admission budget");
+        std::fs::write(
+            std::path::Path::new(&data_dir).join("L0_20260729T000001_blocked.pax"),
+            b"l0",
+        )
+        .unwrap();
+
+        let before = engine
+            .flush_sort_invocations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let error = engine
+            .do_flush(&params)
+            .await
+            .expect_err("L0 stop watermark must reject the flush");
+        let after = engine
+            .flush_sort_invocations
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            error.to_string().contains("L0 admission stop"),
+            "unexpected rejection: {error:#}"
+        );
+        assert_eq!(
+            after, before,
+            "admission rejection must occur before vector sorting"
+        );
     }
 
     /// TD-112: the LIVE flush path (`do_flush` -> `flush_implementation`) must

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -45,6 +45,10 @@ impl UnifiedStorageFormat for SstEngine {
         StorageFormatStrategy::Sst
     }
 
+    async fn preflight_flush(&self, params: &FlushParameters) -> Result<()> {
+        self.preflight_flush_implementation(params).await
+    }
+
     async fn do_flush(&self, params: &FlushParameters) -> Result<FlushResult> {
         info!("🚀 SST: Starting flush operation");
         // Use the flush module implementation directly

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -20,9 +20,11 @@
 //! server reads the catalog; embedded uses its collection port) and, optionally, a
 //! fallback engine to reuse.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock, Weak};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use dashmap::DashMap;
+use tokio::sync::{Mutex, OnceCell, Semaphore};
 
 use crate::index::AxisManager;
 use crate::proto::proximadb_v1::{
@@ -80,6 +82,7 @@ pub fn flush_plan_from_collection_meta(
 }
 
 /// What a single collection's materialization produced.
+#[derive(Debug)]
 pub struct CollectionFlushOutcome {
     /// Records submitted to the engine (post tombstone-filter) — the count used
     /// for collection stats / optimizer row estimates.
@@ -88,6 +91,191 @@ pub struct CollectionFlushOutcome {
     /// count used for flush summaries.
     pub entries_flushed: u64,
     pub bytes: u64,
+}
+
+/// Process-wide owner of flush engines, per-collection serialization, and
+/// bounded cross-collection admission (ADR-081).
+struct FlushExecutionCoordinator {
+    collection_gates: DashMap<String, Weak<Mutex<()>>>,
+    engines: DashMap<i32, Arc<OnceCell<Arc<dyn UnifiedStorageFormat>>>>,
+    permits: Arc<Semaphore>,
+}
+
+impl FlushExecutionCoordinator {
+    fn new(max_parallel_flushes: usize) -> Self {
+        Self {
+            collection_gates: DashMap::new(),
+            engines: DashMap::new(),
+            permits: Arc::new(Semaphore::new(max_parallel_flushes.max(1))),
+        }
+    }
+
+    fn collection_gate(&self, plan: &CollectionFlushPlan) -> Arc<Mutex<()>> {
+        let key = format!(
+            "{}:{}",
+            plan.tenant_id.as_deref().unwrap_or(""),
+            plan.canonical_id
+        );
+        if self.collection_gates.len() > 4_096 {
+            self.collection_gates
+                .retain(|_, gate| gate.strong_count() > 0);
+        }
+        match self.collection_gates.entry(key) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if let Some(gate) = entry.get().upgrade() {
+                    gate
+                } else {
+                    let gate = Arc::new(Mutex::new(()));
+                    entry.insert(Arc::downgrade(&gate));
+                    gate
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let gate = Arc::new(Mutex::new(()));
+                entry.insert(Arc::downgrade(&gate));
+                gate
+            }
+        }
+    }
+
+    async fn engine_for(
+        &self,
+        engine_type: ProtoStorageEngine,
+        fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
+    ) -> Result<Arc<dyn UnifiedStorageFormat>> {
+        let key = engine_type as i32;
+        let cell = self
+            .engines
+            .entry(key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
+        let engine = cell
+            .get_or_try_init(|| async move {
+                if let Some(engine) = fallback_engine {
+                    return Ok(engine);
+                }
+                crate::storage::engines::factory::StorageFormatFactory::create_from_proto_async(
+                    engine_type,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to construct canonical {} flush engine",
+                        engine_type.as_str_name()
+                    )
+                })
+            })
+            .await?;
+        Ok(engine.clone())
+    }
+}
+
+static FLUSH_EXECUTION_COORDINATOR: OnceLock<FlushExecutionCoordinator> = OnceLock::new();
+
+pub(crate) fn default_parallel_flushes() -> usize {
+    crate::core::config::SstConfig::default()
+        .background_thread_count
+        .max(1) as usize
+}
+
+fn flush_execution_coordinator() -> &'static FlushExecutionCoordinator {
+    FLUSH_EXECUTION_COORDINATOR
+        .get_or_init(|| FlushExecutionCoordinator::new(default_parallel_flushes()))
+}
+
+/// Configure the process-wide flush concurrency before the first materializer
+/// runs. Production calls this from `StorageEngine::start` using the existing
+/// SST background worker setting; tests may rely on the bounded default.
+pub fn configure_flush_admission(max_parallel_flushes: usize) {
+    if FLUSH_EXECUTION_COORDINATOR
+        .set(FlushExecutionCoordinator::new(max_parallel_flushes))
+        .is_err()
+    {
+        tracing::debug!(
+            requested = max_parallel_flushes,
+            "flush admission coordinator already initialized; retaining its original limit"
+        );
+    }
+}
+
+/// Seed the canonical engine instance for a storage format.
+///
+/// The composition root uses this for SST so flush and compaction share the
+/// configured worker pool. Other formats are constructed lazily once by the
+/// coordinator until their composition roots provide an instance.
+pub async fn register_flush_engine(
+    engine_type: ProtoStorageEngine,
+    engine: Arc<dyn UnifiedStorageFormat>,
+) {
+    let coordinator = flush_execution_coordinator();
+    let cell = coordinator
+        .engines
+        .entry(engine_type as i32)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+    let requested = engine.clone();
+    let resolved = cell.get_or_init(|| async move { engine }).await;
+    if !Arc::ptr_eq(resolved, &requested) {
+        tracing::warn!(
+            engine = engine_type.as_str_name(),
+            "flush engine was resolved before composition-root registration; retaining the existing canonical instance"
+        );
+    }
+}
+
+struct FlushAdmissionTicket;
+
+impl FlushAdmissionTicket {
+    fn new(wait: std::time::Duration) -> Self {
+        crate::metrics::wal_flush_metrics::record_admission_wait(wait.as_secs_f64());
+        crate::metrics::wal_flush_metrics::inc_admitted_in_flight();
+        Self
+    }
+}
+
+impl Drop for FlushAdmissionTicket {
+    fn drop(&mut self) {
+        crate::metrics::wal_flush_metrics::dec_admitted_in_flight();
+    }
+}
+
+/// Cancellation-safe metrics ownership for an exact source claim.
+///
+/// The WAL claim itself owns correctness. This companion keeps the observable
+/// gauge/counter consistent when a task is aborted at any await point.
+struct FlushClaimTicket {
+    collection_id: String,
+    batch_count: u64,
+    completed: bool,
+}
+
+impl FlushClaimTicket {
+    fn new(collection_id: &str, batch_count: usize) -> Self {
+        crate::metrics::wal_flush_metrics::set_claimed_batches(collection_id, batch_count as i64);
+        Self {
+            collection_id: collection_id.to_string(),
+            batch_count: batch_count as u64,
+            completed: false,
+        }
+    }
+
+    fn complete(&mut self) {
+        crate::metrics::wal_flush_metrics::set_claimed_batches(&self.collection_id, 0);
+        self.completed = true;
+    }
+}
+
+impl Drop for FlushClaimTicket {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        crate::metrics::wal_flush_metrics::record_claim_rollback(
+            &self.collection_id,
+            self.batch_count,
+        );
+        crate::metrics::wal_flush_metrics::set_claimed_batches(&self.collection_id, 0);
+    }
 }
 
 /// Materialize one collection's unflushed WAL batches to its configured storage
@@ -124,6 +312,83 @@ pub async fn materialize_collection(
     free_wal: bool,
     axis_index_manager: Option<&AxisManager>,
 ) -> Result<Option<CollectionFlushOutcome>> {
+    materialize_collection_with_coordinator_mode(
+        flush_execution_coordinator(),
+        write_buffer,
+        plan,
+        fence,
+        fallback_engine,
+        free_wal,
+        axis_index_manager,
+        CollectionAdmission::Wait,
+    )
+    .await
+}
+
+/// Inline-trigger variant that collapses a burst when this collection already
+/// has a materialization in progress. The same canonical coordinator owns the
+/// decision; no trigger-local semaphore or scheduling registry is involved.
+pub async fn materialize_collection_if_idle(
+    write_buffer: &Arc<WALBehaviorWrapper>,
+    plan: &CollectionFlushPlan,
+    fence: Option<&Arc<dyn StorageWriteFence>>,
+    fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
+    free_wal: bool,
+    axis_index_manager: Option<&AxisManager>,
+) -> Result<Option<CollectionFlushOutcome>> {
+    materialize_collection_with_coordinator_mode(
+        flush_execution_coordinator(),
+        write_buffer,
+        plan,
+        fence,
+        fallback_engine,
+        free_wal,
+        axis_index_manager,
+        CollectionAdmission::SkipIfBusy,
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum CollectionAdmission {
+    Wait,
+    SkipIfBusy,
+}
+
+#[cfg(test)]
+async fn materialize_collection_with_coordinator(
+    coordinator: &FlushExecutionCoordinator,
+    write_buffer: &Arc<WALBehaviorWrapper>,
+    plan: &CollectionFlushPlan,
+    fence: Option<&Arc<dyn StorageWriteFence>>,
+    fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
+    free_wal: bool,
+    axis_index_manager: Option<&AxisManager>,
+) -> Result<Option<CollectionFlushOutcome>> {
+    materialize_collection_with_coordinator_mode(
+        coordinator,
+        write_buffer,
+        plan,
+        fence,
+        fallback_engine,
+        free_wal,
+        axis_index_manager,
+        CollectionAdmission::Wait,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn materialize_collection_with_coordinator_mode(
+    coordinator: &FlushExecutionCoordinator,
+    write_buffer: &Arc<WALBehaviorWrapper>,
+    plan: &CollectionFlushPlan,
+    fence: Option<&Arc<dyn StorageWriteFence>>,
+    fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
+    free_wal: bool,
+    axis_index_manager: Option<&AxisManager>,
+    collection_admission: CollectionAdmission,
+) -> Result<Option<CollectionFlushOutcome>> {
     // A6 storage-write fence — reject a displaced pod before touching storage.
     if write_fencing_enabled() {
         let now_ms = chrono::Utc::now().timestamp_millis();
@@ -151,27 +416,39 @@ pub async fn materialize_collection(
         }
     }
 
-    let batches = write_buffer.get_unflushed_batches(&plan.wal_key).await?;
-    if batches.is_empty() {
+    // ADR-081 D1: serialize only this collection. Contenders wait without
+    // consuming a global worker permit, so a hot collection cannot starve
+    // independent collections.
+    let collection_gate = coordinator.collection_gate(plan);
+    let _collection_guard = match collection_admission {
+        CollectionAdmission::Wait => collection_gate.lock_owned().await,
+        CollectionAdmission::SkipIfBusy => match collection_gate.try_lock_owned() {
+            Ok(guard) => guard,
+            Err(_) => {
+                tracing::trace!(
+                    collection_id = %plan.wal_key,
+                    "inline flush collapsed into the collection's admitted materialization"
+                );
+                return Ok(None);
+            }
+        },
+    };
+    if write_buffer.unflushed_batch_count(&plan.wal_key).await == 0 {
         return Ok(None);
     }
 
-    // Combine canonical records from all unflushed batches. Tombstones (no
-    // embeddings) are dropped: the SST writer's centroid/clustering pipeline
-    // cannot handle empty vectors, and the deleted ids are simply absent from the
-    // resulting segment (correct for this single-level flush — no older segment
-    // holds a stale copy).
-    let vector_records: Vec<proximadb_records::ProximaRecord> = batches
-        .iter()
-        .flat_map(|batch| batch.vector_records.iter().cloned())
-        .filter(|r| r.embeddings.first().is_some_and(|e| !e.values.is_empty()))
-        .collect();
-    let vector_count = vector_records.len() as u64;
+    let permit_wait = std::time::Instant::now();
+    let _permit = coordinator
+        .permits
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| anyhow::anyhow!("flush admission coordinator is closed"))?;
+    let _admission_ticket = FlushAdmissionTicket::new(permit_wait.elapsed());
 
-    // Resolve the collection's configured engine (proven factory path). An
-    // unrecognized engine id is a misconfiguration — fail loudly rather than
-    // silently substituting SST, which would write the collection's data in a
-    // different on-disk format than it was configured for.
+    // Resolve one canonical engine per configured storage format. An
+    // unrecognized engine id or construction failure is fail-closed; silently
+    // substituting SST would write bytes in the wrong format.
     let proto_engine = ProtoStorageEngine::try_from(plan.engine_type).map_err(|_| {
         anyhow::anyhow!(
             "flush: collection '{}' declares an unrecognized storage engine id {} — \
@@ -180,29 +457,9 @@ pub async fn materialize_collection(
             plan.engine_type
         )
     })?;
-    let engine =
-        match crate::storage::engines::factory::StorageFormatFactory::create_from_proto_async(
-            proto_engine,
-        )
-        .await
-        {
-            Ok(engine) => engine,
-            Err(e) => {
-                tracing::warn!(
-                    "flush: failed to create {:?} engine for '{}': {}; falling back to SST",
-                    proto_engine,
-                    plan.wal_key,
-                    e
-                );
-                match fallback_engine {
-                    Some(engine) => engine,
-                    None => {
-                        crate::storage::engines::factory::StorageFormatFactory::create_sst_async()
-                            .await?
-                    }
-                }
-            }
-        };
+    let engine = coordinator
+        .engine_for(proto_engine, fallback_engine)
+        .await?;
 
     // Collection config carries engine + dimension + the on-disk layout path so the
     // flush writes into the same directory recovery reads from.
@@ -222,18 +479,65 @@ pub async fn materialize_collection(
         ..Default::default()
     };
 
+    // ADR-081 D3: engine admission occurs before a source claim and before
+    // cloning any ProximaRecord. The preflight payload is metadata-only.
+    let preflight_params = FlushParameters {
+        collection_id: Some(plan.canonical_id.clone()),
+        force: true,
+        synchronous: true,
+        collection_config: Some(collection_config.clone()),
+        ..Default::default()
+    };
+    if let Err(error) = engine.preflight_flush(&preflight_params).await {
+        crate::metrics::wal_flush_metrics::record_admission(&plan.wal_key, false);
+        return Err(error);
+    }
+    crate::metrics::wal_flush_metrics::record_admission(&plan.wal_key, true);
+
+    // Exact source ownership is acquired only after engine admission. The
+    // claim's Drop releases every batch on error or future cancellation.
+    let Some(mut claim) = write_buffer.claim_unflushed_batches(&plan.wal_key).await? else {
+        return Ok(None);
+    };
+    let mut claim_ticket = FlushClaimTicket::new(&plan.wal_key, claim.batch_ids().len());
+
+    // Vector-proportional work starts here, inside the admitted job. Tombstones
+    // remain a WAL concern because the current segment writer requires a
+    // non-empty embedding.
+    let vector_records: Vec<proximadb_records::ProximaRecord> = claim
+        .batches()
+        .iter()
+        .flat_map(|batch| batch.vector_records.iter().cloned())
+        .filter(|record| {
+            record
+                .embeddings
+                .first()
+                .is_some_and(|embedding| !embedding.values.is_empty())
+        })
+        .collect();
+    let vector_count = vector_records.len() as u64;
     let flush_params = FlushParameters {
         collection_id: Some(plan.canonical_id.clone()),
         force: true,
         synchronous: true,
         vector_records,
-        batch_ids: batches.iter().map(|batch| batch.batch_id).collect(),
+        batch_ids: claim.batches().iter().map(|batch| batch.batch_id).collect(),
         collection_config: Some(collection_config),
         ..Default::default()
     };
 
     // The single trait `flush()` funnel (validation + post-processing + do_flush).
-    let result = engine.flush(flush_params).await?;
+    let result = match engine.flush(flush_params).await {
+        Ok(result) => result,
+        Err(error) => return Err(error),
+    };
+    if !result.success {
+        anyhow::bail!(
+            "{} flush returned an unsuccessful publication result for '{}'; exact WAL claim retained for retry",
+            engine.engine_name(),
+            plan.wal_key
+        );
+    }
     let bytes = result.bytes_written.unwrap_or(0);
     let entries_flushed = result.entries_flushed.unwrap_or(0);
 
@@ -260,48 +564,19 @@ pub async fn materialize_collection(
         );
     }
 
-    // WAL cleanup after a successful flush: clear the memtable batches and delete
-    // the now-redundant WAL files (avoids 2× WAL+segment storage overhead). Gated
-    // by `free_wal`: the server keeps the WAL until the cold SST read path serves
-    // exact recall, so recovery's WAL replay remains the recall source post-restart.
+    // WAL cleanup after successful publication retires only the exact claim.
+    // Batches appended while the segment encoded remain unflushed.
     if free_wal {
-        if let Err(e) = write_buffer.clear_flushed(&plan.wal_key).await {
-            tracing::warn!(
-                "flush: failed to clear flushed batches for '{}': {}",
-                plan.wal_key,
-                e
-            );
+        let batch_id_strings = claim.batch_ids().to_vec();
+        if let Err(error) = write_buffer.complete_flush_claim(&mut claim).await {
+            return Err(error).with_context(|| {
+                format!(
+                    "flush segment published but exact WAL retirement failed for '{}'",
+                    plan.wal_key
+                )
+            });
         }
-        let batch_id_strings: Vec<String> = batches
-            .iter()
-            .map(|batch| batch.batch_id.to_base62())
-            .collect();
-        // ADR-069: ALSO retire the batches in the BATCH COORDINATOR — the store
-        // `get_unflushed_batches` / `list_collections_with_unflushed_data` read
-        // from. `clear_flushed` above only clears the inner memtable, so without
-        // this the just-flushed batches are re-served as "unflushed" forever —
-        // harmless on the terminal shutdown flush, but an infinite re-flush loop
-        // for any periodic caller (the auto-flush driver exposed this).
-        for batch_id in &batch_id_strings {
-            if let Err(e) = write_buffer
-                .mark_batch_flushed(&plan.wal_key, batch_id)
-                .await
-            {
-                tracing::warn!(
-                    "flush: failed to mark batch {} flushed for '{}': {}",
-                    batch_id,
-                    plan.wal_key,
-                    e
-                );
-            }
-        }
-        if let Err(e) = write_buffer.clear_flushed_batches(&plan.wal_key).await {
-            tracing::warn!(
-                "flush: failed to clear coordinator batches for '{}': {}",
-                plan.wal_key,
-                e
-            );
-        }
+        claim_ticket.complete();
         if !batch_id_strings.is_empty()
             && let Err(e) = crate::storage::persistence::write_ahead_log::manifest::mark_flushed_and_delete_files(
                 &batch_id_strings,
@@ -328,7 +603,16 @@ pub async fn materialize_collection(
     // leaving it resident caused unbounded memory growth (OOM) and masked cold-read
     // bugs (warm GETs served from the stale copy). Non-fatal: the segment is the
     // source of truth post-flush, so a reap failure is logged, not fatal.
-    if let Some(axis) = axis_index_manager
+    // Do not clear AXIS records belonging to batches that arrived while this
+    // flush encoded. Once the WAL delta reaches empty, the whole projection is
+    // safe to reap.
+    let collection_wal_empty = write_buffer
+        .get_unflushed_batches(&plan.wal_key)
+        .await
+        .map(|batches| batches.is_empty())
+        .unwrap_or(false);
+    if collection_wal_empty
+        && let Some(axis) = axis_index_manager
         && let Err(e) = axis.clear_collection_vectors(&plan.canonical_id).await
     {
         tracing::warn!(
@@ -343,4 +627,544 @@ pub async fn materialize_collection(
         entries_flushed,
         bytes,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::memtable::core::MemtableConfig;
+    use crate::storage::memtable::specialized::wal_behavior::WALVectorBatch;
+    use crate::storage::persistence::write_ahead_log::BatchId;
+    use crate::storage::traits::{
+        CompactionParameters, CompactionResult, FlushResult, StorageEngineStrategy,
+        StorageQueryContext,
+    };
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::sync::{Barrier, Notify};
+
+    struct ActiveFlush<'a>(&'a AtomicUsize);
+
+    impl Drop for ActiveFlush<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    struct RecordingEngine {
+        preflight_allowed: AtomicBool,
+        fail_flush: AtomicBool,
+        successful_result: AtomicBool,
+        preflight_calls: AtomicUsize,
+        flush_calls: AtomicUsize,
+        active_flushes: AtomicUsize,
+        max_active_flushes: AtomicUsize,
+        rendezvous: Option<Arc<Barrier>>,
+        wait_for_release: bool,
+        entered_flush: Notify,
+        release_flush: Notify,
+    }
+
+    impl RecordingEngine {
+        fn new() -> Self {
+            Self {
+                preflight_allowed: AtomicBool::new(true),
+                fail_flush: AtomicBool::new(false),
+                successful_result: AtomicBool::new(true),
+                preflight_calls: AtomicUsize::new(0),
+                flush_calls: AtomicUsize::new(0),
+                active_flushes: AtomicUsize::new(0),
+                max_active_flushes: AtomicUsize::new(0),
+                rendezvous: None,
+                wait_for_release: false,
+                entered_flush: Notify::new(),
+                release_flush: Notify::new(),
+            }
+        }
+
+        fn with_rendezvous(parties: usize) -> Self {
+            Self {
+                rendezvous: Some(Arc::new(Barrier::new(parties))),
+                ..Self::new()
+            }
+        }
+
+        fn blocking() -> Self {
+            Self {
+                wait_for_release: true,
+                ..Self::new()
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl UnifiedStorageFormat for RecordingEngine {
+        fn engine_name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn engine_version(&self) -> &'static str {
+            "test"
+        }
+
+        fn strategy(&self) -> StorageEngineStrategy {
+            StorageEngineStrategy::Sst
+        }
+
+        async fn preflight_flush(&self, _params: &FlushParameters) -> Result<()> {
+            self.preflight_calls.fetch_add(1, Ordering::SeqCst);
+            if self.preflight_allowed.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                anyhow::bail!("test admission rejection")
+            }
+        }
+
+        async fn do_flush(&self, params: &FlushParameters) -> Result<FlushResult> {
+            self.flush_calls.fetch_add(1, Ordering::SeqCst);
+            let active = self.active_flushes.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active_flushes.fetch_max(active, Ordering::SeqCst);
+            let _active_guard = ActiveFlush(&self.active_flushes);
+
+            if let Some(rendezvous) = &self.rendezvous {
+                rendezvous.wait().await;
+            }
+            if self.wait_for_release {
+                self.entered_flush.notify_one();
+                self.release_flush.notified().await;
+            }
+            if self.fail_flush.load(Ordering::SeqCst) {
+                anyhow::bail!("test flush failure")
+            }
+
+            Ok(FlushResult {
+                success: self.successful_result.load(Ordering::SeqCst),
+                entries_flushed: Some(params.vector_records.len() as u64),
+                bytes_written: Some(params.vector_records.len() as u64 * 32),
+                ..Default::default()
+            })
+        }
+
+        async fn do_compact(&self, _params: &CompactionParameters) -> Result<CompactionResult> {
+            Ok(CompactionResult::default())
+        }
+
+        async fn collect_engine_metrics(&self) -> Result<HashMap<String, serde_json::Value>> {
+            Ok(HashMap::new())
+        }
+
+        async fn vector_by_id(
+            &self,
+            _collection_id: &str,
+            _base_path: &str,
+            _vector_id: &str,
+        ) -> Result<Option<proximadb_records::ProximaRecord>> {
+            Ok(None)
+        }
+
+        async fn search_vectors_unified(
+            &self,
+            _ctx: &StorageQueryContext,
+        ) -> Result<Vec<proximadb_search_types::results::OptimizedSearchRecord>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn plan(collection_id: &str) -> CollectionFlushPlan {
+        CollectionFlushPlan {
+            wal_key: collection_id.to_string(),
+            canonical_id: collection_id.to_string(),
+            base_location: "file:///tmp/adr081-tests".to_string(),
+            engine_type: ProtoStorageEngine::Sst as i32,
+            dimension: 2,
+            tenant_id: Some("test-tenant".to_string()),
+        }
+    }
+
+    fn record(oid: &str) -> proximadb_records::ProximaRecord {
+        proximadb_records::ProximaRecord {
+            oid: oid.to_string(),
+            embeddings: vec![proximadb_records::EmbeddingCell {
+                model_id: "test".to_string(),
+                modality: "dense_vector".to_string(),
+                dim: 2,
+                values: proximadb_records::EmbeddingValues::Fp32(vec![1.0, 2.0]),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    async fn add_batch(write_buffer: &WALBehaviorWrapper, collection_id: &str, oid: &str) {
+        let records = vec![record(oid)];
+        write_buffer
+            .add_vector_batch(
+                collection_id,
+                WALVectorBatch {
+                    batch_id: BatchId::new(),
+                    total_size_bytes: WALVectorBatch::estimate_records_size(&records),
+                    vector_records: Arc::new(records),
+                    timestamp: std::time::SystemTime::now(),
+                    is_flushed: false,
+                    metadata_bloom_filter: None,
+                },
+            )
+            .await
+            .expect("test batch must enter the WAL");
+    }
+
+    #[tokio::test]
+    async fn adr081_rejection_happens_before_batch_claim_or_flush() {
+        let coordinator = FlushExecutionCoordinator::new(1);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "rejected", "v0").await;
+        let engine = Arc::new(RecordingEngine::new());
+        engine.preflight_allowed.store(false, Ordering::SeqCst);
+
+        let error = materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("rejected"),
+            None,
+            Some(engine.clone()),
+            true,
+            None,
+        )
+        .await
+        .expect_err("preflight must reject the job");
+
+        assert!(error.to_string().contains("admission rejection"));
+        assert_eq!(engine.preflight_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.flush_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            write_buffer.claimed_flush_batch_count("rejected").unwrap(),
+            0
+        );
+        assert_eq!(
+            write_buffer
+                .get_unflushed_batches("rejected")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn adr081_zero_byte_source_batch_is_not_mistaken_for_empty() {
+        let coordinator = FlushExecutionCoordinator::new(1);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        let records = vec![record("legacy-zero")];
+        write_buffer
+            .add_vector_batch(
+                "zero",
+                WALVectorBatch {
+                    batch_id: BatchId::new(),
+                    vector_records: Arc::new(records),
+                    timestamp: std::time::SystemTime::now(),
+                    total_size_bytes: 0,
+                    is_flushed: false,
+                    metadata_bloom_filter: None,
+                },
+            )
+            .await
+            .expect("legacy zero-byte batch must enter the WAL");
+        let engine = Arc::new(RecordingEngine::new());
+
+        let outcome = materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("zero"),
+            None,
+            Some(engine.clone()),
+            true,
+            None,
+        )
+        .await
+        .expect("zero-byte source still contains a record");
+
+        assert!(outcome.is_some());
+        assert_eq!(engine.flush_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn adr081_same_collection_contenders_publish_one_source_set_once() {
+        let coordinator = FlushExecutionCoordinator::new(2);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "same", "v0").await;
+        let engine = Arc::new(RecordingEngine::new());
+        let plan = plan("same");
+
+        let (first, second) = tokio::join!(
+            materialize_collection_with_coordinator(
+                &coordinator,
+                &write_buffer,
+                &plan,
+                None,
+                Some(engine.clone()),
+                true,
+                None,
+            ),
+            materialize_collection_with_coordinator(
+                &coordinator,
+                &write_buffer,
+                &plan,
+                None,
+                Some(engine.clone()),
+                true,
+                None,
+            )
+        );
+
+        let published = [first.unwrap(), second.unwrap()]
+            .into_iter()
+            .filter(Option::is_some)
+            .count();
+        assert_eq!(published, 1);
+        assert_eq!(engine.flush_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            write_buffer
+                .get_unflushed_batches("same")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn adr081_different_collections_flush_in_parallel_within_global_bound() {
+        let coordinator = FlushExecutionCoordinator::new(2);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "left", "left-v0").await;
+        add_batch(&write_buffer, "right", "right-v0").await;
+        let engine = Arc::new(RecordingEngine::with_rendezvous(2));
+        let left = plan("left");
+        let right = plan("right");
+
+        let (left_result, right_result) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                tokio::join!(
+                    materialize_collection_with_coordinator(
+                        &coordinator,
+                        &write_buffer,
+                        &left,
+                        None,
+                        Some(engine.clone()),
+                        false,
+                        None,
+                    ),
+                    materialize_collection_with_coordinator(
+                        &coordinator,
+                        &write_buffer,
+                        &right,
+                        None,
+                        Some(engine.clone()),
+                        false,
+                        None,
+                    )
+                )
+            })
+            .await
+            .expect("independent collections must both reach the engine");
+        left_result.expect("left flush must succeed");
+        right_result.expect("right flush must succeed");
+
+        assert_eq!(engine.flush_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(engine.max_active_flushes.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn adr081_failed_flush_releases_claim_for_retry() {
+        let coordinator = FlushExecutionCoordinator::new(1);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "retry", "v0").await;
+        let engine = Arc::new(RecordingEngine::new());
+        engine.fail_flush.store(true, Ordering::SeqCst);
+
+        materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("retry"),
+            None,
+            Some(engine.clone()),
+            true,
+            None,
+        )
+        .await
+        .expect_err("first publication must fail");
+        assert_eq!(write_buffer.claimed_flush_batch_count("retry").unwrap(), 0);
+
+        engine.fail_flush.store(false, Ordering::SeqCst);
+        let retry = materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("retry"),
+            None,
+            Some(engine.clone()),
+            true,
+            None,
+        )
+        .await
+        .expect("released source must be retryable");
+        assert!(retry.is_some());
+        assert_eq!(engine.flush_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn adr081_unsuccessful_result_does_not_retire_source() {
+        let coordinator = FlushExecutionCoordinator::new(1);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "unsuccessful", "v0").await;
+        let engine = Arc::new(RecordingEngine::new());
+        engine.successful_result.store(false, Ordering::SeqCst);
+
+        materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("unsuccessful"),
+            None,
+            Some(engine),
+            true,
+            None,
+        )
+        .await
+        .expect_err("an unsuccessful result is not a durable publication");
+
+        assert_eq!(
+            write_buffer
+                .claimed_flush_batch_count("unsuccessful")
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            write_buffer
+                .get_unflushed_batches("unsuccessful")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn adr081_cancellation_releases_claim_for_retry() {
+        let coordinator = Arc::new(FlushExecutionCoordinator::new(1));
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "cancel", "v0").await;
+        let engine = Arc::new(RecordingEngine::blocking());
+        let task_coordinator = coordinator.clone();
+        let task_buffer = write_buffer.clone();
+        let task_engine = engine.clone();
+
+        let task = tokio::spawn(async move {
+            materialize_collection_with_coordinator(
+                &task_coordinator,
+                &task_buffer,
+                &plan("cancel"),
+                None,
+                Some(task_engine),
+                true,
+                None,
+            )
+            .await
+        });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine.entered_flush.notified(),
+        )
+        .await
+        .expect("flush must enter the engine");
+        assert_eq!(write_buffer.claimed_flush_batch_count("cancel").unwrap(), 1);
+
+        task.abort();
+        let join_error = task.await.expect_err("aborted flush must be cancelled");
+        assert!(join_error.is_cancelled());
+        assert_eq!(write_buffer.claimed_flush_batch_count("cancel").unwrap(), 0);
+        assert_eq!(
+            write_buffer
+                .get_unflushed_batches("cancel")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn adr081_batch_appended_during_flush_remains_for_next_epoch() {
+        let coordinator = Arc::new(FlushExecutionCoordinator::new(1));
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "append", "old").await;
+        let engine = Arc::new(RecordingEngine::blocking());
+        let task_coordinator = coordinator.clone();
+        let task_buffer = write_buffer.clone();
+        let task_engine = engine.clone();
+
+        let task = tokio::spawn(async move {
+            materialize_collection_with_coordinator(
+                &task_coordinator,
+                &task_buffer,
+                &plan("append"),
+                None,
+                Some(task_engine),
+                true,
+                None,
+            )
+            .await
+        });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine.entered_flush.notified(),
+        )
+        .await
+        .expect("first source epoch must enter the engine");
+        add_batch(&write_buffer, "append", "new").await;
+        engine.release_flush.notify_one();
+        task.await
+            .expect("flush task must join")
+            .expect("flush must succeed");
+
+        let remaining = write_buffer
+            .get_unflushed_batches("append")
+            .await
+            .expect("new source epoch must remain readable");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].vector_records[0].oid, "new");
+    }
+
+    #[tokio::test]
+    async fn adr081_engine_instance_is_canonical_per_format() {
+        let coordinator = FlushExecutionCoordinator::new(2);
+        let write_buffer = Arc::new(WALBehaviorWrapper::new(MemtableConfig::default()));
+        add_batch(&write_buffer, "first", "v0").await;
+        add_batch(&write_buffer, "second", "v1").await;
+        let canonical = Arc::new(RecordingEngine::new());
+        let discarded = Arc::new(RecordingEngine::new());
+
+        materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("first"),
+            None,
+            Some(canonical.clone()),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        materialize_collection_with_coordinator(
+            &coordinator,
+            &write_buffer,
+            &plan("second"),
+            None,
+            Some(discarded.clone()),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(canonical.flush_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(discarded.flush_calls.load(Ordering::SeqCst), 0);
+    }
 }

--- a/src/storage/memtable/implementations/global_partitioned.rs
+++ b/src/storage/memtable/implementations/global_partitioned.rs
@@ -1453,7 +1453,12 @@ impl GlobalPartitionedMemtable {
 
             // Remove from vector index
             for vector_record in removed_batch.vector_records.iter() {
-                if !vector_record.oid.is_empty() {
+                if !vector_record.oid.is_empty()
+                    && partition
+                        .vector_id_index
+                        .get(&vector_record.oid)
+                        .is_some_and(|indexed_batch| indexed_batch == batch_id)
+                {
                     partition.vector_id_index.remove(&vector_record.oid);
                 }
             }
@@ -1482,6 +1487,74 @@ impl GlobalPartitionedMemtable {
             batch_id,
             collection_id
         ))
+    }
+
+    /// Remove an exact set of batches after a flush has durably published.
+    ///
+    /// The complete set is validated before mutation, so a stale or foreign
+    /// claim cannot partially clear a collection. Concurrently appended batches
+    /// have different IDs and are preserved.
+    pub async fn remove_batches_exact(
+        &self,
+        collection_id: &str,
+        batch_ids: &[String],
+    ) -> Result<usize> {
+        let mut collections = self.collections.write().await;
+        let Some(partition) = collections.get_mut(collection_id) else {
+            anyhow::bail!("collection '{}' has no WAL partition", collection_id);
+        };
+        if let Some(missing) = batch_ids
+            .iter()
+            .find(|batch_id| !partition.wal_batches.contains_key(*batch_id))
+        {
+            anyhow::bail!(
+                "claimed batch '{}:{}' is absent from the WAL partition",
+                collection_id,
+                missing
+            );
+        }
+
+        let mut removed_records = 0usize;
+        for batch_id in batch_ids {
+            let removed_batch = partition.wal_batches.remove(batch_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "claimed batch '{}:{}' disappeared during exact retirement",
+                    collection_id,
+                    batch_id
+                )
+            })?;
+            removed_records += removed_batch.vector_records.len();
+            partition.vector_count = partition
+                .vector_count
+                .saturating_sub(removed_batch.vector_records.len());
+            partition.total_size = partition
+                .total_size
+                .saturating_sub(removed_batch.total_size_bytes);
+            partition.batch_count = partition.batch_count.saturating_sub(1);
+
+            for record in removed_batch.vector_records.iter() {
+                if !record.oid.is_empty()
+                    && partition
+                        .vector_id_index
+                        .get(&record.oid)
+                        .is_some_and(|indexed_batch| indexed_batch == batch_id)
+                {
+                    partition.vector_id_index.remove(&record.oid);
+                }
+            }
+        }
+        partition.scan_index = None;
+        drop(collections);
+
+        let mut metrics = self.metrics.write().await;
+        metrics.entry_count = metrics.entry_count.saturating_sub(removed_records);
+        tracing::debug!(
+            collection_id,
+            batches = batch_ids.len(),
+            removed_records,
+            "retired exact WAL batch set after flush"
+        );
+        Ok(removed_records)
     }
 
     /// Clear all vectors and batches

--- a/src/storage/memtable/specialized/wal_behavior.rs
+++ b/src/storage/memtable/specialized/wal_behavior.rs
@@ -9,8 +9,8 @@
 
 use anyhow::Result;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use tokio::sync::RwLock;
 
 use crate::core::bloom::strategies::composite::CompositeBloomFilter;
@@ -150,6 +150,116 @@ impl WALVectorBatch {
     }
 }
 
+/// Exact, cancellation-safe ownership of immutable WAL batches for one flush.
+///
+/// Dropping an unfinished claim releases its batch IDs synchronously, including
+/// when the owning future is cancelled. Claimed batches remain visible to WAL
+/// reads until [`WALBehaviorWrapper::complete_flush_claim`] retires them after a
+/// successful segment publication.
+#[derive(Debug)]
+pub struct WALFlushBatchClaim {
+    collection_id: String,
+    claim_id: u64,
+    batch_ids: Vec<String>,
+    batches: Vec<WALVectorBatch>,
+    registry: Arc<StdMutex<FlushClaimRegistry>>,
+    finalized: bool,
+}
+
+impl WALFlushBatchClaim {
+    pub fn collection_id(&self) -> &str {
+        &self.collection_id
+    }
+
+    pub fn claim_id(&self) -> u64 {
+        self.claim_id
+    }
+
+    pub fn batch_ids(&self) -> &[String] {
+        &self.batch_ids
+    }
+
+    pub fn batches(&self) -> &[WALVectorBatch] {
+        &self.batches
+    }
+
+    fn finalize(&mut self) -> Result<()> {
+        let mut registry = self.registry.lock().map_err(|_| {
+            anyhow::anyhow!(
+                "flush claim registry poisoned while finalizing collection '{}'",
+                self.collection_id
+            )
+        })?;
+        registry.release(&self.collection_id, self.claim_id, &self.batch_ids);
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+impl Drop for WALFlushBatchClaim {
+    fn drop(&mut self) {
+        if self.finalized {
+            return;
+        }
+        match self.registry.lock() {
+            Ok(mut registry) => {
+                registry.release(&self.collection_id, self.claim_id, &self.batch_ids);
+            }
+            Err(_) => {
+                tracing::error!(
+                    collection_id = %self.collection_id,
+                    claim_id = self.claim_id,
+                    "flush claim registry poisoned; cancellation rollback could not run"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct FlushClaimRegistry {
+    /// collection -> batch id -> claim id
+    claimed: HashMap<String, HashMap<String, u64>>,
+}
+
+impl FlushClaimRegistry {
+    fn is_claimed(&self, collection_id: &str, batch_id: &str) -> bool {
+        self.claimed
+            .get(collection_id)
+            .is_some_and(|claims| claims.contains_key(batch_id))
+    }
+
+    fn insert(&mut self, collection_id: &str, batch_id: String, claim_id: u64) {
+        self.claimed
+            .entry(collection_id.to_string())
+            .or_default()
+            .insert(batch_id, claim_id);
+    }
+
+    fn owns_all(&self, collection_id: &str, claim_id: u64, batch_ids: &[String]) -> bool {
+        self.claimed.get(collection_id).is_some_and(|claims| {
+            batch_ids
+                .iter()
+                .all(|batch_id| claims.get(batch_id) == Some(&claim_id))
+        })
+    }
+
+    fn release(&mut self, collection_id: &str, claim_id: u64, batch_ids: &[String]) {
+        let mut remove_collection = false;
+        if let Some(claims) = self.claimed.get_mut(collection_id) {
+            for batch_id in batch_ids {
+                if claims.get(batch_id) == Some(&claim_id) {
+                    claims.remove(batch_id);
+                }
+            }
+            remove_collection = claims.is_empty();
+        }
+        if remove_collection {
+            self.claimed.remove(collection_id);
+        }
+    }
+}
+
 /// Write Buffer-specific batch coordinator
 #[derive(Debug)]
 struct BatchCoordinator {
@@ -249,6 +359,62 @@ impl BatchCoordinator {
         } else {
             Vec::new()
         }
+    }
+
+    fn unflushed_batch_count(&self, collection_id: &str) -> usize {
+        self.batches
+            .get(collection_id)
+            .map(|batches| batches.values().filter(|batch| !batch.is_flushed).count())
+            .unwrap_or(0)
+    }
+
+    fn validate_batches_exact(&self, collection_id: &str, batch_ids: &[String]) -> Result<()> {
+        let Some(collection_batches) = self.batches.get(collection_id) else {
+            anyhow::bail!("collection '{}' has no WAL batches", collection_id);
+        };
+        if let Some(missing) = batch_ids
+            .iter()
+            .find(|batch_id| !collection_batches.contains_key(*batch_id))
+        {
+            anyhow::bail!(
+                "claimed batch '{}:{}' disappeared before flush retirement",
+                collection_id,
+                missing
+            );
+        }
+        Ok(())
+    }
+
+    /// Remove an exact, pre-validated set of batches as one coordinator update.
+    fn remove_batches_exact(&mut self, collection_id: &str, batch_ids: &[String]) -> Result<usize> {
+        self.validate_batches_exact(collection_id, batch_ids)?;
+
+        let mut removed_records = 0usize;
+        for batch_id in batch_ids {
+            let removed = self
+                .batches
+                .get_mut(collection_id)
+                .and_then(|batches| batches.remove(batch_id))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "claimed batch '{}:{}' disappeared during flush retirement",
+                        collection_id,
+                        batch_id
+                    )
+                })?;
+            removed_records += removed.vector_records.len();
+            for record in removed.vector_records.iter() {
+                let owned_by_removed_batch = self
+                    .vector_index
+                    .get(&record.oid)
+                    .is_some_and(|(_, indexed_batch, _)| indexed_batch == batch_id);
+                if owned_by_removed_batch {
+                    self.vector_index.remove(&record.oid);
+                }
+            }
+            self.credit_predicted(collection_id, batch_id);
+        }
+        Ok(removed_records)
     }
 
     /// Sum the unflushed bytes for a collection WITHOUT cloning the batches. The
@@ -389,6 +555,13 @@ pub struct WALBehaviorWrapper {
     #[allow(dead_code)]
     flush_state: Arc<RwLock<FlushState>>,
 
+    /// ADR-081: exact source ownership for in-flight materializations. This is
+    /// a synchronous mutex so a cancelled future's claim can roll back in Drop.
+    flush_claims: Arc<StdMutex<FlushClaimRegistry>>,
+
+    /// Monotonic process-local claim epoch.
+    flush_claim_sequence: Arc<AtomicU64>,
+
     /// Distributed mode: idempotency tokens per collection
     idempotency_tokens:
         Arc<RwLock<std::collections::HashMap<String, std::collections::HashSet<String>>>>,
@@ -408,6 +581,8 @@ impl WALBehaviorWrapper {
             mvcc_versions: Arc::new(RwLock::new(std::collections::HashMap::new())),
             wal_metrics: Arc::new(RwLock::new(WriteBufferMetrics::default())),
             flush_state: Arc::new(RwLock::new(FlushState::default())),
+            flush_claims: Arc::new(StdMutex::new(FlushClaimRegistry::default())),
+            flush_claim_sequence: Arc::new(AtomicU64::new(1)),
             idempotency_tokens: Arc::new(RwLock::new(std::collections::HashMap::new())),
             partition_sequences: Arc::new(RwLock::new(std::collections::HashMap::new())),
         }
@@ -703,6 +878,148 @@ impl WALBehaviorWrapper {
             .collect();
 
         Ok(unflushed_batches)
+    }
+
+    /// Atomically claim every currently unclaimed WAL batch in one collection.
+    ///
+    /// The returned batches are ordered by `(timestamp, batch_id)` so one source
+    /// set has a deterministic materialization order. New batches appended after
+    /// the snapshot remain unclaimed for the next flush epoch.
+    pub async fn claim_unflushed_batches(
+        &self,
+        collection_id: &str,
+    ) -> Result<Option<WALFlushBatchClaim>> {
+        // Hold the coordinator read guard through the process-local ownership
+        // transition. Otherwise a legacy retirement/drop path could remove a
+        // batch between the snapshot and registry insertion, producing a claim
+        // for a source that no longer exists. Cloning a WALVectorBatch is cheap
+        // because the record payload is Arc-backed; the synchronous claim lock
+        // is held only for map lookups/inserts and never across an await.
+        let coordinator = self.batch_coordinator.read().await;
+        let mut candidates: Vec<WALVectorBatch> = coordinator
+            .get_unflushed_batches(collection_id)
+            .into_iter()
+            .cloned()
+            .collect();
+        candidates.sort_by(|left, right| {
+            left.timestamp
+                .cmp(&right.timestamp)
+                .then_with(|| left.batch_id.to_base62().cmp(&right.batch_id.to_base62()))
+        });
+
+        let claim_id = self.flush_claim_sequence.fetch_add(1, Ordering::Relaxed);
+        let mut registry = self.flush_claims.lock().map_err(|_| {
+            anyhow::anyhow!(
+                "flush claim registry poisoned while claiming collection '{}'",
+                collection_id
+            )
+        })?;
+
+        let mut batches = Vec::new();
+        let mut batch_ids = Vec::new();
+        for batch in candidates {
+            let batch_id = batch.batch_id.to_base62();
+            if registry.is_claimed(collection_id, &batch_id) {
+                continue;
+            }
+            registry.insert(collection_id, batch_id.clone(), claim_id);
+            batch_ids.push(batch_id);
+            batches.push(batch);
+        }
+        drop(registry);
+        drop(coordinator);
+
+        if batches.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(WALFlushBatchClaim {
+            collection_id: collection_id.to_string(),
+            claim_id,
+            batch_ids,
+            batches,
+            registry: self.flush_claims.clone(),
+            finalized: false,
+        }))
+    }
+
+    /// Retire exactly the source batches owned by a successfully published
+    /// flush. Batches appended while encoding was in flight are untouched.
+    pub async fn complete_flush_claim(&self, claim: &mut WALFlushBatchClaim) -> Result<usize> {
+        if !Arc::ptr_eq(&self.flush_claims, &claim.registry) {
+            anyhow::bail!(
+                "flush claim for '{}' belongs to a different WAL behavior",
+                claim.collection_id
+            );
+        }
+        {
+            let registry = self.flush_claims.lock().map_err(|_| {
+                anyhow::anyhow!(
+                    "flush claim registry poisoned while completing collection '{}'",
+                    claim.collection_id
+                )
+            })?;
+            if !registry.owns_all(&claim.collection_id, claim.claim_id, &claim.batch_ids) {
+                anyhow::bail!(
+                    "flush claim {} no longer owns every source batch for '{}'",
+                    claim.claim_id,
+                    claim.collection_id
+                );
+            }
+        }
+
+        // Lock and validate the coordinator before mutating the inner store.
+        // Holding this guard across the inner retirement ensures the second
+        // mirror cannot change between validation and removal. If inner
+        // retirement rejects, neither mirror is changed; if it succeeds, the
+        // already-validated coordinator removal cannot fail due to a race.
+        let mut coordinator = self.batch_coordinator.write().await;
+        coordinator.validate_batches_exact(&claim.collection_id, &claim.batch_ids)?;
+        let removed = self
+            .inner
+            .remove_batches_exact(&claim.collection_id, &claim.batch_ids)
+            .await?;
+        let coordinator_removed =
+            coordinator.remove_batches_exact(&claim.collection_id, &claim.batch_ids)?;
+        if coordinator_removed != removed {
+            tracing::warn!(
+                collection_id = %claim.collection_id,
+                claim_id = claim.claim_id,
+                inner_records = removed,
+                coordinator_records = coordinator_removed,
+                "flush retirement stores reported different record counts"
+            );
+        }
+        drop(coordinator);
+        claim.finalize()?;
+        Ok(removed)
+    }
+
+    /// Number of source batches currently owned by in-flight flush jobs.
+    pub fn claimed_flush_batch_count(&self, collection_id: &str) -> Result<usize> {
+        let registry = self.flush_claims.lock().map_err(|_| {
+            anyhow::anyhow!(
+                "flush claim registry poisoned while reading collection '{}'",
+                collection_id
+            )
+        })?;
+        Ok(registry
+            .claimed
+            .get(collection_id)
+            .map(HashMap::len)
+            .unwrap_or(0))
+    }
+
+    /// Count unflushed source batches without cloning their record payloads.
+    ///
+    /// This is the admission fast path. A count is used instead of byte sum
+    /// because tombstone/legacy batches may legitimately report zero bytes and
+    /// still require durable retirement.
+    pub async fn unflushed_batch_count(&self, collection_id: &str) -> usize {
+        self.batch_coordinator
+            .read()
+            .await
+            .unflushed_batch_count(collection_id)
     }
 
     /// Sum unflushed bytes for a collection without cloning batches (hot-path
@@ -1002,7 +1319,12 @@ impl WALBehaviorWrapper {
         {
             // Remove vector index entries for this batch
             for vector_record in removed_batch.vector_records.iter() {
-                if !vector_record.oid.is_empty() {
+                if !vector_record.oid.is_empty()
+                    && coordinator
+                        .vector_index
+                        .get(&vector_record.oid)
+                        .is_some_and(|(_, indexed_batch, _)| indexed_batch == batch_id)
+                {
                     coordinator.vector_index.remove(&vector_record.oid);
                 }
             }
@@ -1457,5 +1779,85 @@ mod tests {
             .filter(|(_, record)| record.oid == vector_id)
             .collect();
         assert!(!found_vectors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn adr081_flush_claim_drop_releases_exact_source_batches() {
+        let wal = WALBehaviorWrapper::new(MemtableConfig::default());
+        wal.add_vector_batch(
+            "claim_drop",
+            test_wal_batch(vec![test_vector_record("v1", vec![1.0, 0.0])]),
+        )
+        .await
+        .unwrap();
+
+        let claim = wal
+            .claim_unflushed_batches("claim_drop")
+            .await
+            .unwrap()
+            .expect("first claim");
+        assert_eq!(claim.batch_ids().len(), 1);
+        assert_eq!(wal.claimed_flush_batch_count("claim_drop").unwrap(), 1);
+        assert!(
+            wal.claim_unflushed_batches("claim_drop")
+                .await
+                .unwrap()
+                .is_none(),
+            "a claimed source must not be served to another flush"
+        );
+
+        drop(claim);
+        assert_eq!(wal.claimed_flush_batch_count("claim_drop").unwrap(), 0);
+        assert!(
+            wal.claim_unflushed_batches("claim_drop")
+                .await
+                .unwrap()
+                .is_some(),
+            "drop/cancellation must return the exact source claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn adr081_exact_flush_retirement_preserves_batch_appended_after_claim() {
+        let wal = WALBehaviorWrapper::new(MemtableConfig::default());
+        wal.add_vector_batch(
+            "claim_exact",
+            test_wal_batch(vec![test_vector_record("old", vec![1.0, 0.0])]),
+        )
+        .await
+        .unwrap();
+        let mut claim = wal
+            .claim_unflushed_batches("claim_exact")
+            .await
+            .unwrap()
+            .expect("source claim");
+
+        wal.add_vector_batch(
+            "claim_exact",
+            test_wal_batch(vec![test_vector_record("new", vec![0.0, 1.0])]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            wal.complete_flush_claim(&mut claim).await.unwrap(),
+            1,
+            "only the claimed record is retired"
+        );
+        let remaining = wal.get_unflushed_batches("claim_exact").await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].vector_records[0].oid, "new");
+        assert!(
+            wal.vector_by_id("claim_exact", "old")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            wal.vector_by_id("claim_exact", "new")
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1140,23 +1140,12 @@ pub fn get_global_write_buffer_behavior()
         .cloned()
 }
 
-/// Per-collection in-flight flush guard for the inline size-trigger. A `Semaphore(1)`
-/// per collection: [`spawn_inline_flush`] try-acquires and skips if a flush is already
-/// running for that collection, so a burst of size-threshold-crossing writes collapses
-/// into a single in-flight materialization (avoiding duplicate segments). The periodic
-/// `AutoFlushDriver` is independently rate-limited by its tick; a concurrent driver
-/// flush of the same collection is harmless — `materialize_collection` no-ops via its
-/// `Ok(None)` empty-batches early-return once the inline flush has cleared them.
-static INLINE_FLUSH_GUARDS: std::sync::LazyLock<
-    dashmap::DashMap<String, std::sync::Arc<tokio::sync::Semaphore>>,
-> = std::sync::LazyLock::new(dashmap::DashMap::new);
-
 /// ADR-069 D2 inline size-trigger: fire-and-forget a `materialize_collection` for the
-/// collection. Per-collection guarded (see [`INLINE_FLUSH_GUARDS`]). Reuses the exact
-/// `AutoFlushDriver` recipe (same globals, same plan shape via
-/// `flush_plan_from_collection_meta`) — ONE materialization path; the inline trigger
-/// only adds *when* to fire (a size crossing on the live write path, vs. the driver's
-/// periodic tick).
+/// collection. ADR-081's canonical materializer gate collapses a burst for this
+/// collection. Reuses the exact `AutoFlushDriver` recipe (same globals, same plan
+/// shape via `flush_plan_from_collection_meta`) — ONE materialization path; the
+/// inline trigger only adds *when* to fire (a size crossing on the live write path,
+/// vs. the driver's periodic tick).
 /// TD-FLUSH-4: count of inline size-flush materializations currently in
 /// flight. Shutdown MUST await these — a large-memtable materialize takes
 /// tens of seconds (measured 43.9s for 884k entries) and killing it at
@@ -1204,26 +1193,11 @@ impl Drop for InlineFlushTicket {
 
 fn spawn_inline_flush(collection_id: String) {
     use crate::storage::flush_materializer::{
-        flush_plan_from_collection_meta, materialize_collection,
+        flush_plan_from_collection_meta, materialize_collection_if_idle,
     };
 
     tokio::spawn(async move {
         let _ticket = InlineFlushTicket::new();
-        // per-collection guard: skip if a flush is already in flight for this collection
-        let guard = INLINE_FLUSH_GUARDS
-            .entry(collection_id.clone())
-            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Semaphore::new(1)))
-            .clone();
-        let _permit = match guard.try_acquire() {
-            Ok(p) => p,
-            Err(_) => {
-                tracing::trace!(
-                    "inline size-flush: already in flight for '{}', skipping",
-                    collection_id
-                );
-                return;
-            }
-        };
 
         let Some(write_buffer) = get_global_write_buffer_behavior() else {
             return;
@@ -1248,7 +1222,15 @@ fn spawn_inline_flush(collection_id: String) {
             "🚿 inline size-flush starting (segments appear on completion)"
         );
         let start = std::time::Instant::now();
-        match materialize_collection(&write_buffer, &plan, None, None, true, axis.as_deref()).await
+        match materialize_collection_if_idle(
+            &write_buffer,
+            &plan,
+            None,
+            None,
+            true,
+            axis.as_deref(),
+        )
+        .await
         {
             Ok(Some(outcome)) => tracing::info!(
                 "✅ inline size-flush '{}': {} entries, {} bytes in {:.3}s",


### PR DESCRIPTION
## Summary

Moves SST L0 admission ahead of WAL record cloning, sorting, clustering,
training, and encoding. All inline, periodic, and shutdown materializations now
share canonical engine ownership, per-collection single flight, bounded
cross-collection concurrency, and exact cancellation-safe WAL batch claims.

The accompanying first-principles SIFT1M audit records why the existing
benchmark is defect-reproduction evidence rather than valid rate-card evidence.

### Type of Change

- [x] Bug fix
- [x] Performance improvement
- [x] Test coverage improvement
- [x] Documentation update

### Move / Decomposition Inventory

- [x] No files/modules moved

### Changes

- Add metadata-only `preflight_flush`; SST counts only live L0 files and rejects
  before vector-proportional work.
- Claim deterministic WAL batch-ID sets after admission; rollback on error or
  cancellation and retire only the published source set.
- Reuse one configured SST engine/compaction worker domain.
- Serialize segment publication per collection while allowing bounded
  concurrency across collections and retaining within-segment PAX morsels.
- Skip AXIS/PCA work when no configured consumer needs it.
- Add admission, in-flight, claim, and rollback metrics.
- File ADR-081 and resolve TD-FLUSH-7.

## Test Plan

- [x] `cargo test -p proximadb --lib adr081 --no-fail-fast` — 12 passed
- [x] `cargo test -p proximadb --lib axis_insert_gate_tests --no-fail-fast` — 3 passed
- [x] `make work-commit-check`
- [x] `scripts/check_td_adr_unique.py --strict`
- [x] `scripts/check_no_agent_attribution.py --range origin/develop...HEAD`
- [x] `make build-server`

The deterministic tests cover preflight-before-sort, same-collection single
publication, cross-collection concurrency, zero-byte batches, error/
unsuccessful-result/cancellation rollback, concurrent new-batch preservation,
exact retirement, canonical engine reuse, and AXIS gating.

## Performance Impact

Rejected L0 flushes perform metadata discovery only: zero record clone, sort,
clustering, training, encoding, or upload. Independent collections can flush
concurrently up to the configured background-worker bound.

## Breaking Changes

None.

## Security Considerations

- [x] No new dependencies
- [x] No secrets or credentials
- [x] Storage-engine identifiers fail closed instead of falling back to SST

## Documentation

- [x] ADR-081 filed and indexed
- [x] TD-FLUSH-7 marked fixed with verification
- [x] SIFT1M audit and implementation blueprint indexed
