### PR TITLE
feat(delvec): F3v WI-3a — cold-deletion-vectors gate + flush-path resolver capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,6 +833,9 @@ jobs:
           # than relying on a PR being correctly labelled as mechanical.
           - { label: "no-default-features",  pkg: proximadb,        args: "--no-default-features" }
           - { label: "experimental-engines", pkg: proximadb,        args: "--features experimental-engines" }
+          # F3v (TD-DELVEC-1): cold-tier deletion vectors — feature-gated PAX flush-path
+          # resolver capture. Check it compiles so cfg drift in that path is caught.
+          - { label: "cold-deletion-vectors", pkg: proximadb,      args: "--features cold-deletion-vectors" }
           # Embedded crate (default, no language bindings) — validates the extracted
           # crate compiles against root at every tier. Python-feature + wheel build
           # is a qa→main (FULL) concern (heavy pyo3/numpy deps).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -713,6 +713,13 @@ oltp-integrity = ["dep:proximadb-cks-local"]
 # filter rows by the subject's policy. The abac crate itself stays un-gated
 # (a security substrate that never compiles is never tested).
 abac-policy = ["dep:proximadb-abac"]
+# F3v (TD-DELVEC-1 / ADR-072 D14): enable cold-tier deletion vectors. Off by
+# default → the default flush path is byte-for-byte unchanged; on, PAX segment
+# writes capture the OID→position resolver (footer region, WI-2c) so a
+# cold-resident delete (WI-3b) can set a deletion-vector bit without rewriting
+# the segment. Pure gate (no dep) — the storage-common primitives
+# (VersionedDeletionVector, OidPositionResolver, footer region) are unconditional.
+cold-deletion-vectors = []
 # Experimental SIMD path; not enabled by default
 simd-experimental = ["proximadb-codec/simd-experimental"]
 # TD-160 / ADR-027 / ADR-030: gate the PERF-CLASS I/O-trace *emission* (the

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -372,6 +372,14 @@ fn write_pax_segment_ordered(
     // ADR-061 pre-GA in-place amendment; `PROXIMADB_PAX_COALESCED_RABITQ=0` opts
     // out to the legacy in-block RaBitQ layout for mixed-read / measurement).
     .with_coalesced_rabitq(quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled());
+    // TD-DELVEC-1 WI-3a: capture the OID→position resolver (footer region, WI-2c)
+    // so a cold-resident delete (WI-3b) can set a deletion-vector bit without
+    // rewriting the segment. Feature-gated; default builds are byte-for-byte
+    // unchanged (the resolver is emitted only when this feature is on).
+    #[cfg(feature = "cold-deletion-vectors")]
+    {
+        writer = writer.with_oid_resolver(true);
+    }
     // TD-RDSTRAT-8 rev 3: the persisted IVF probe directory (v3 layout) — the
     // plan's runs are its IOP-derived cells, so the writer pads blocks at the
     // same boundaries the model's cell_rows describe (a cell = whole D-blocks).


### PR DESCRIPTION
WI-3a **plumbing** (no behavior change; default flush path byte-for-byte unchanged). Declares the `cold-deletion-vectors` cargo feature (off by default) and, under it, enables OID→position resolver capture on the PAX flush path (`write_pax_segment_ordered`) — so production segments carry the footer resolver region (WI-2c, #1290), the precondition for a cold-resident delete (WI-3b) to set a deletion-vector bit without rewriting the segment.

**Changes:** `Cargo.toml` — `cold-deletion-vectors = []` (pure gate, no dep; storage-common primitives unconditional). `segment_format.rs` — `#[cfg(feature="cold-deletion-vectors")] writer.with_oid_resolver(true)`. `ci.yml` — adds `cold-deletion-vectors` to the feature-matrix so CI catches cfg drift in the gated path.

**Defers (WI-3a follow-ups):** WAL-LSN plumbing (the delete `gen`), the CAS'd per-segment DV manifest store, the gRPC-v2 write path, and the delete-path wiring (WI-3b — blocked on the oid→segment resolution strategy: bloom-scan vs reverse index). The resolver is emitted here but not yet read.

Design context: rev-5 (#1286 footer-region) + rev-6 (#1291 compaction model). WI-3 recon found 3 missing prerequisites (LSN plumbing, oid→segment index, DV store) → WI-3 splits 3a/3b/3c; this is 3a's gate+toggle sub-slice.