### PR TITLE
refactor(config): retire dead WalStorageConfig twin (TD-CONFIG-CONSOLIDATE-1 step 1)

### DIFF
--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -1055,92 +1055,14 @@ impl Default for AdvancedPruneConfig {
     }
 }
 
-/// WAL storage configuration supporting multiple directories and cloud storage.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WalStorageConfig {
-    /// Distribution strategy for collections across storage locations.
-    pub distribution_strategy: WalDistributionStrategy,
-
-    /// Whether to keep each collection on a single WAL directory.
-    pub collection_affinity: bool,
-
-    /// Memory flush threshold per collection (bytes).
-    pub memory_flush_size_bytes: usize,
-
-    /// Global WAL size threshold for forced flush (bytes).
-    pub global_flush_threshold: usize,
-
-    /// WAL strategy type (Avro vs Bincode).
-    pub strategy_type: Option<String>,
-
-    /// Memtable type for memory structure.
-    pub memtable_type: Option<String>,
-
-    /// Sync mode for durability vs performance tradeoff.
-    pub sync_mode: Option<String>,
-
-    /// Batch threshold for operations.
-    pub batch_threshold: Option<usize>,
-
-    /// Write buffer size in MB.
-    pub write_buffer_size_mb: Option<usize>,
-
-    /// Maximum concurrent flush operations.
-    pub concurrent_flushes: Option<usize>,
-
-    /// Shrink factor for global threshold management (percentage).
-    pub global_shrink_factor: Option<f64>,
-
-    /// Global manifest location (optional - explicit configuration).
-    pub global_manifest_url: Option<String>,
-
-    /// ADR-069 D2 — time-based WAL flush interval (seconds); absent = engine default.
-    pub flush_interval_secs: Option<u64>,
-
-    /// ADR-069 D6 — per-collection WAL size budget (bytes) for capacity watermarks; absent = disabled.
-    pub wal_max_bytes: Option<usize>,
-
-    /// ADR-069 D3 — fraction of `wal_max_bytes` to force a flush at; absent = engine default.
-    pub high_watermark_pct: Option<f64>,
-
-    /// ADR-069 D3 — fraction of `wal_max_bytes` to apply write backpressure at; absent = engine default.
-    pub critical_watermark_pct: Option<f64>,
-}
-
-/// Strategy for distributing WAL segments across multiple storage directories.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub enum WalDistributionStrategy {
-    /// Round-robin across WAL directories.
-    RoundRobin,
-    /// Hash-based distribution (consistent).
-    Hash,
-    /// Load-balanced distribution (dynamic).
-    #[default]
-    LoadBalanced,
-}
-
-impl Default for WalStorageConfig {
-    fn default() -> Self {
-        Self {
-            global_manifest_url: None,
-            distribution_strategy: WalDistributionStrategy::LoadBalanced,
-            collection_affinity: true,
-            memory_flush_size_bytes: 10 * 1024 * 1024,
-            global_flush_threshold: 4 * 1024 * 1024 * 1024,
-            strategy_type: None,
-            memtable_type: None,
-            sync_mode: None,
-            batch_threshold: None,
-            write_buffer_size_mb: None,
-            concurrent_flushes: None,
-            global_shrink_factor: Some(0.4),
-            flush_interval_secs: None,
-            wal_max_bytes: None,
-            high_watermark_pct: None,
-            critical_watermark_pct: None,
-        }
-    }
-}
+// NOTE: `WalStorageConfig` + `WalDistributionStrategy` were RETIRED
+// (TD-CONFIG-CONSOLIDATE-1, Core Directive #19). They were a stranded
+// decomposition duplicate of the LIVE `WriteBufferUserConfig` (src/core/config.rs)
+// — extracted into this foundation crate but never wired into the assembled
+// `CoreStorageConfig`, and consumed only by a test-only `From<&WalStorageConfig>
+// for WALConfig`. Keeping the dead twin caused drift (fields added to each in
+// parallel). The canonical WAL config is `WriteBufferUserConfig`; do NOT
+// re-add a foundation twin.
 
 // ---------------------------------------------------------------------------
 // Embedding-precision rollout (PR 3 of EMBEDDING_PRECISION_LLD_2026_05_22)
@@ -1232,25 +1154,6 @@ fn parse_bool_flag(raw: &str, env_name: &str) -> anyhow::Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn wal_storage_defaults_match_root_runtime_expectations() {
-        let config = WalStorageConfig::default();
-
-        assert!(matches!(
-            config.distribution_strategy,
-            WalDistributionStrategy::LoadBalanced
-        ));
-        assert!(config.collection_affinity);
-        assert_eq!(config.memory_flush_size_bytes, 10 * 1024 * 1024);
-        assert_eq!(config.global_flush_threshold, 4 * 1024 * 1024 * 1024);
-        assert_eq!(config.global_shrink_factor, Some(0.4));
-        // ADR-069 / TD-WAL-1 S1: new flush-control fields default to None (engine defaults apply).
-        assert_eq!(config.flush_interval_secs, None);
-        assert_eq!(config.wal_max_bytes, None);
-        assert_eq!(config.high_watermark_pct, None);
-        assert_eq!(config.critical_watermark_pct, None);
-    }
 
     #[test]
     fn hardware_defaults_match_root_runtime_expectations() {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1658,7 +1658,7 @@ impl SstConfig {
 
 pub use proximadb_config::ApiConfig;
 
-pub use proximadb_config::{WalDistributionStrategy, WalStorageConfig};
+// RETIRED (TD-CONFIG-CONSOLIDATE-1): WalStorageConfig + WalDistributionStrategy — dead twin of WriteBufferUserConfig; do not re-add.
 
 // Helper functions for serde defaults
 #[allow(dead_code)]

--- a/src/storage/persistence/write_ahead_log/config.rs
+++ b/src/storage/persistence/write_ahead_log/config.rs
@@ -427,106 +427,6 @@ pub struct CollectionWalConfig {
     pub default_ttl_days: Option<u32>,
 }
 
-// Conversion from core config to WAL config
-impl From<&crate::core::config::WalStorageConfig> for WALConfig {
-    fn from(core_config: &crate::core::config::WalStorageConfig) -> Self {
-        // WAL uses storage_locations - will be populated by caller
-        // Default to a safe fallback
-        let distribution_strategy = match core_config.distribution_strategy {
-            crate::core::config::WalDistributionStrategy::RoundRobin => {
-                DiskDistributionStrategy::RoundRobin
-            }
-            crate::core::config::WalDistributionStrategy::Hash => DiskDistributionStrategy::Hash,
-            crate::core::config::WalDistributionStrategy::LoadBalanced => {
-                DiskDistributionStrategy::LoadBalanced
-            }
-        };
-        let mut wal_config = WALConfig {
-            multi_disk: MultiDiskConfig {
-                data_directories: vec!["file://./data".to_string()],
-                distribution_strategy,
-                collection_affinity: core_config.collection_affinity,
-            },
-            performance: WalPerformanceConfig {
-                memory_flush_size_bytes: core_config.memory_flush_size_bytes,
-                global_flush_threshold: core_config.global_flush_threshold,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        // Apply optional configuration overrides from config.toml
-        if let Some(strategy_type) = &core_config.strategy_type {
-            wal_config.strategy_type = match strategy_type.as_str() {
-                "Avro" => WriteBufferStrategyType::AvroBatch,
-                "Bincode" => WriteBufferStrategyType::BincodeBatch,
-                "AvroBatch" => WriteBufferStrategyType::AvroBatch,
-                "BincodeBatch" => WriteBufferStrategyType::BincodeBatch,
-                "Proto" => WriteBufferStrategyType::ProtoBatch,
-                "ProtoBatch" => WriteBufferStrategyType::ProtoBatch,
-                _ => WriteBufferStrategyType::default(),
-            };
-        }
-
-        if let Some(memtable_type) = &core_config.memtable_type {
-            wal_config.memtable.memtable_type = match memtable_type.as_str() {
-                "BTree" => MemTableType::BTree,
-                "HashMap" => MemTableType::HashMap,
-                "SkipList" => MemTableType::SkipList,
-                "Art" => MemTableType::Art,
-                _ => MemTableType::default(),
-            };
-        }
-
-        if let Some(sync_mode) = &core_config.sync_mode {
-            wal_config.performance.sync_mode = match sync_mode.as_str() {
-                "Always" => SyncMode::Always,
-                "PerBatch" => SyncMode::PerBatch,
-                "Periodic" => SyncMode::Periodic,
-                "Never" => SyncMode::Never,
-                "MemoryOnly" => SyncMode::MemoryOnly,
-                _ => SyncMode::PerBatch, // Default to balanced mode
-            };
-        }
-
-        if let Some(batch_threshold) = core_config.batch_threshold {
-            wal_config.performance.batch_threshold = batch_threshold;
-        }
-
-        if let Some(write_buffer_mb) = core_config.write_buffer_size_mb {
-            wal_config.performance.write_buffer_size = write_buffer_mb * 1024 * 1024;
-            // Convert MB to bytes
-        }
-
-        if let Some(concurrent_flushes) = core_config.concurrent_flushes {
-            wal_config.performance.concurrent_flushes = concurrent_flushes;
-        }
-
-        if let Some(global_shrink_factor) = core_config.global_shrink_factor {
-            wal_config.performance.global_shrink_factor = global_shrink_factor;
-        }
-
-        // ADR-069 / TD-WAL-1 S1: WAL flush-control overrides (inert until S2/S3).
-        wal_config.performance.flush_interval_secs = core_config
-            .flush_interval_secs
-            .unwrap_or(wal_config.performance.flush_interval_secs);
-        wal_config.performance.wal_max_bytes = core_config
-            .wal_max_bytes
-            .unwrap_or(wal_config.performance.wal_max_bytes);
-        if let Some(pct) = core_config.high_watermark_pct {
-            wal_config.performance.high_watermark_pct = pct;
-        }
-        if let Some(pct) = core_config.critical_watermark_pct {
-            wal_config.performance.critical_watermark_pct = pct;
-        }
-
-        // Set global manifest URL from TOML config
-        wal_config.global_manifest_url = core_config.global_manifest_url.clone();
-
-        wal_config
-    }
-}
-
 impl WALConfig {
     /// Create configuration optimized for high-throughput writes
     pub fn high_throughput() -> Self {
@@ -945,32 +845,6 @@ mod tests {
         assert_eq!(p.wal_max_bytes, 0, "capacity budget off by default");
         assert_eq!(p.high_watermark_pct, 0.80);
         assert_eq!(p.critical_watermark_pct, 0.95);
-    }
-
-    #[test]
-    fn wal_storage_config_overrides_flush_triggers() {
-        use crate::core::config::WalStorageConfig;
-        // Absent overrides (None) leave the runtime performance defaults intact
-        // (the 300s time floor — ADR-069 D2).
-        let base = WALConfig::from(&WalStorageConfig::default());
-        assert_eq!(base.performance.flush_interval_secs, 300);
-        assert_eq!(base.performance.wal_max_bytes, 0);
-        assert_eq!(base.performance.high_watermark_pct, 0.80);
-        assert_eq!(base.performance.critical_watermark_pct, 0.95);
-
-        // Present overrides (ADR-069 D2/D3/D6) flow through to WalPerformanceConfig.
-        let core = WalStorageConfig {
-            flush_interval_secs: Some(300),
-            wal_max_bytes: Some(25 * 1024 * 1024 * 1024),
-            high_watermark_pct: Some(0.75),
-            critical_watermark_pct: Some(0.9),
-            ..WalStorageConfig::default()
-        };
-        let cfg = WALConfig::from(&core);
-        assert_eq!(cfg.performance.flush_interval_secs, 300);
-        assert_eq!(cfg.performance.wal_max_bytes, 25 * 1024 * 1024 * 1024);
-        assert_eq!(cfg.performance.high_watermark_pct, 0.75);
-        assert_eq!(cfg.performance.critical_watermark_pct, 0.9);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Step 1 of [TD-CONFIG-CONSOLIDATE-1](docs/10-quality/td/TD-CONFIG-CONSOLIDATE-1-duplicate-config-structs.adoc) + Core Directive #19. **Retire a dead duplicate config struct** — shrink the build, kill drift.

## What
`WalStorageConfig` (foundation `proximadb-config`) was a **stranded decomposition duplicate** of the LIVE `WriteBufferUserConfig` (`src/core/config.rs`): extracted into the foundation crate by *"Extract config contract crate"*, but **never wired into the assembled `CoreStorageConfig`**. Its only consumer was a **test-only** `impl From<&WalStorageConfig> for WALConfig` (itself called only by unit tests). The canonical WAL config is `WriteBufferUserConfig` (+ its two live converters).

Keeping the dead twin caused **drift** — fields added to each in parallel (the `wal_local_dir` near-miss during ADR-069 S1).

## Removed (all test-only; traced TOML → `CoreStorageConfig` → engine — the foundation struct was never the deserialization target)
- `crates/foundation/proximadb-config`: `WalStorageConfig` struct + `WalDistributionStrategy` enum + `Default` + the `wal_storage_defaults` test.
- `src/storage/persistence/write_ahead_log/config.rs`: the test-only `From<&WalStorageConfig> for WALConfig` impl + its `wal_storage_config_overrides_flush_triggers` test.
- `src/core/config.rs`: the `pub use` re-export.

Each site keeps a `RETIRED` note so the twin isn't re-added.

## Verified
7427/7427 lib tests pass, fmt, clippy (`-D warnings`), work-commit-check (env-gates 224), td-adr-unique.

## Follow-ups (in the TD)
- Fold the two drifted WAL converters (`to_engine_config()` + `convert_toml_to_wal_config()`).
- Add a `make work-commit-check` tripwire that fails when a `pub struct`/`pub enum` name is defined in BOTH `src/core/config.rs` and `crates/foundation/proximadb-config/` (a duplicate, not a re-export).