### PR TITLE
ci(qa-gate): run coverage ratchet under nextest (process isolation)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -315,11 +315,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
-      - name: Install system deps + cargo-llvm-cov
+      - name: Install system deps + cargo-llvm-cov + cargo-nextest
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
           cargo install cargo-llvm-cov --locked
+          cargo install cargo-nextest --locked
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-qa-llvmcov"
@@ -327,7 +328,16 @@ jobs:
         env:
           CARGO_BUILD_JOBS: "1"
         run: |
-          cargo llvm-cov --lib --no-report -p proximadb
+          # Run under nextest (process-per-test isolation), NOT libtest's shared
+          # process. Four lib tests that touch process-global singletons
+          # (axis_flush_hook boot-global, eventlog restart/recovery, datafusion
+          # document-pax ranged-pushdown) flake under shared-process
+          # `cargo test --lib` — verified locally: 7424 pass / 4 fail under
+          # `cargo test --lib`; the SAME 4 PASS under `cargo nextest`. Matching
+          # every other CI job (which already uses nextest, mandate #11) removes
+          # the intermittent gate failure and is the prerequisite to flipping
+          # this job from continue-on-error to required.
+          cargo llvm-cov nextest --lib --no-report -p proximadb
           cargo llvm-cov report --json --output-path /tmp/llvm-cov.json
           python3 scripts/coverage_ratchet.py normalize --rust /tmp/llvm-cov.json -o /tmp/rust-current.json
           # Seed the baseline if absent (first run), else ratchet-check.


### PR DESCRIPTION
Fixes the intermittent **Rust Coverage Ratchet** qa-gate failure (the 4 shared-process lib-test flakes). CI-only; no code change.

## Root cause

The ratchet job ran `cargo llvm-cov --lib` = libtest's **shared process** — the one CI runner that doesn't use nextest. Four lib tests that touch process-global singletons flake under shared-process contamination (mandate #11):

- `axis_flush_hook::boot_registered_global_is_used_when_engine_passes_none`
- `eventlog::open_rebuilds_index_so_reads_survive_restart`
- `eventlog::recovery_handles_flat_object_store_listing_shape`
- `datafusion::document_pax_provider::ranged_pushdown_prunes_bytes_and_matches`

## Local verification (develop @ 9483bb56d)

| Command | Result |
|---|---|
| `cargo test --lib -p proximadb` (shared) | **7424 pass / 4 FAIL** — reproduces the CI gate failure exactly |
| `cargo nextest run --lib <the 4>` (isolated) | **4 PASS** — each in its own process |

The only difference between the failing `cargo llvm-cov --lib` and the fix `cargo llvm-cov nextest --lib` is shared-vs-isolated process.

## Change

- Install `cargo-nextest` alongside `cargo-llvm-cov` in the job.
- `cargo llvm-cov --lib --no-report -p proximadb` → `cargo llvm-cov nextest --lib --no-report -p proximadb` (cargo-llvm-cov's nextest subcommand = process-per-test isolation under coverage).

Matches every other CI job (nextest). Removes the intermittent gate failure and is the prerequisite to flipping the job from `continue-on-error` to required (its own stated condition). The job stays non-blocking for now; the next qa-gate run is the end-to-end confirmation.