### PR TITLE
feat(abac): FA-b Phase 4 — thread required ReadContext through the relational read primitives

### DIFF
--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -62,5 +62,5 @@ pub use cache_key::{InMemoryPolicyEpochs, PolicyEpoch, PolicyEpochSource, Subjec
 pub use compile::{InMemoryPredicateObjectStore, PredicateObjectStore, compile_security_filter};
 pub use context::{
     AuthorizedReadContext, ClientServable, ColumnDecision, DenyReason, ForbiddenColumn,
-    ReadDecision, SystemReadContext, SystemReadReason,
+    ReadContext, ReadDecision, SystemReadContext, SystemReadReason,
 };

--- a/src/query/table_write_executor.rs
+++ b/src/query/table_write_executor.rs
@@ -247,6 +247,11 @@ impl TableRecordSourceReader for TableRecordStoreSourceReader {
                     // TD-113 family: scope the SELECT-source scan to the tenant's
                     // record partition (was `None` → unscoped/cross-tenant read).
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::Statistics,
+                        "table_write_executor [CLIENT-PLACEHOLDER]",
+                    ),
                 )
                 .await?;
             cursor.buffered_records = Some(records);
@@ -1139,6 +1144,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordScanRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<Vec<ProximaRecord>> {
             Ok(self.records.clone())
         }
@@ -1718,6 +1724,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordScanRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<Vec<ProximaRecord>> {
             Ok(Vec::new())
         }

--- a/src/query/table_write_executor.rs
+++ b/src/query/table_write_executor.rs
@@ -15,6 +15,8 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{ReadContext, SystemReadReason};
 use proximadb_catalog::{
     CatalogPhysicalFormat, CatalogStorageLayout, CatalogTableSchema, ColumnConstraint,
 };
@@ -510,6 +512,11 @@ async fn enforce_foreign_keys_for_batch(
                         include_props: false,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::ForeignKeyResolution,
+                        "table_write_executor",
+                    ),
                 )
                 .await?
                 .is_some();
@@ -979,6 +986,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordGetRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<TableRecordGetResponse> {
             Ok(None)
         }
@@ -1121,6 +1129,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordGetRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<TableRecordGetResponse> {
             Ok(None)
         }
@@ -1365,6 +1374,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             request: TableRecordGetRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<TableRecordGetResponse> {
             Ok(self.existing_parent_keys.contains(&request.key).then(|| {
                 crate::services::operations::vectors::RichSearchResult {
@@ -1698,6 +1708,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordGetRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<TableRecordGetResponse> {
             Ok(None)
         }

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -38,6 +38,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{ReadContext, SystemReadReason};
 use proximadb_catalog::{
     CatalogColumn, CatalogStorageLayout, CatalogTableSchema, CatalogTableStatistics,
     relational::{
@@ -1709,6 +1711,8 @@ impl DmlService {
                     include_props: true,
                 },
                 tenant_context,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
         match record {
@@ -1757,6 +1761,8 @@ impl DmlService {
                         include_props: true,
                     },
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
                 )
                 .await?;
             if let Some(rich) = record {
@@ -1820,6 +1826,8 @@ impl DmlService {
                         include_props: true,
                     },
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
                 )
                 .await?;
             if let Some(rich) = record {
@@ -1870,6 +1878,11 @@ impl DmlService {
                             include_props: true,
                         },
                         tenant_context,
+                        #[cfg(feature = "abac-policy")]
+                        &ReadContext::system(
+                            SystemReadReason::Statistics,
+                            "dml [CLIENT-PLACEHOLDER]",
+                        ),
                     )
                     .await?
                 else {
@@ -1914,6 +1927,11 @@ impl DmlService {
                                 include_props: true,
                             },
                             tenant_context,
+                            #[cfg(feature = "abac-policy")]
+                            &ReadContext::system(
+                                SystemReadReason::Statistics,
+                                "dml [CLIENT-PLACEHOLDER]",
+                            ),
                         )
                         .await?
                     else {
@@ -2031,6 +2049,8 @@ impl DmlService {
                         include_props: true,
                     },
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
                 )
                 .await?;
             let primary_key = table_schema.primary_key.first().map(String::as_str);
@@ -2106,6 +2126,8 @@ impl DmlService {
                     include_props,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
 
@@ -3082,6 +3104,11 @@ impl DmlService {
                                 include_props: false,
                             },
                             None,
+                            #[cfg(feature = "abac-policy")]
+                            &ReadContext::system(
+                                SystemReadReason::ForeignKeyResolution,
+                                "dml::fk_check",
+                            ),
                         )
                         .await?
                         .is_some()
@@ -3236,6 +3263,8 @@ impl DmlService {
                         include_props: true,
                     },
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
                 )
                 .await?
             else {
@@ -4957,6 +4986,11 @@ impl DmlService {
                                 include_props: false,
                             },
                             tenant_context,
+                            #[cfg(feature = "abac-policy")]
+                            &ReadContext::system(
+                                SystemReadReason::ForeignKeyResolution,
+                                "dml::fk_check",
+                            ),
                         )
                         .await?
                         .is_some()
@@ -5010,6 +5044,11 @@ impl DmlService {
                             include_props: true,
                         },
                         tenant_context,
+                        #[cfg(feature = "abac-policy")]
+                        &ReadContext::system(
+                            SystemReadReason::Statistics,
+                            "dml [CLIENT-PLACEHOLDER]",
+                        ),
                     )
                     .await?
                 else {

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1328,6 +1328,11 @@ impl DmlService {
                         },
                         None,
                         tenant_context,
+                        #[cfg(feature = "abac-policy")]
+                        &ReadContext::system(
+                            SystemReadReason::Statistics,
+                            "dml [CLIENT-PLACEHOLDER]",
+                        ),
                     )
                     .await?;
                 (RelationalSelectAccessPath::TableScan, records, 0)
@@ -1439,6 +1444,8 @@ impl DmlService {
                 },
                 predicate,
                 tenant_context,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
 
@@ -1964,6 +1971,8 @@ impl DmlService {
                 },
                 predicate,
                 tenant_context,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
         Ok((RelationalSelectAccessPath::TableScan, records))
@@ -2093,6 +2102,8 @@ impl DmlService {
                 },
                 predicate,
                 tenant_context,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
 
@@ -4744,6 +4755,11 @@ impl DmlService {
                     },
                     predicate,
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::ForeignKeyResolution,
+                        "dml::referencing_check",
+                    ),
                 )
                 .await?;
             if referencing.is_empty() {
@@ -5078,6 +5094,8 @@ impl DmlService {
                 },
                 predicate,
                 tenant_context,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "dml [CLIENT-PLACEHOLDER]"),
             )
             .await?;
         Ok(records.into_iter().map(|record| record.oid).collect())

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -276,6 +276,7 @@ impl TableRecordStore for ExplainOnlyRecordStore {
         _table_schema: &CatalogTableSchema,
         _request: TableRecordScanRequest,
         _tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
     ) -> Result<TableRecordScanResponse> {
         Ok(Vec::new())
     }

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{ReadContext, SystemReadReason};
 
 /// TD-OLAP-6: explicit `cluster_key` property wins; else the first
 /// DATE/TIMESTAMP column; NULL-keyed rows sort last.
@@ -264,6 +266,7 @@ impl TableRecordStore for ExplainOnlyRecordStore {
         _table_schema: &CatalogTableSchema,
         _request: TableRecordGetRequest,
         _tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
     ) -> Result<TableRecordGetResponse> {
         Ok(None)
     }
@@ -4729,6 +4732,8 @@ async fn delete_enforces_referential_actions() {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml::tests"),
                 )
                 .await
                 .expect("get_by_key")
@@ -4874,6 +4879,8 @@ async fn delete_enforces_composite_fk() {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml::tests"),
                 )
                 .await
                 .expect("get_by_key")
@@ -4995,6 +5002,8 @@ async fn delete_enforces_cross_namespace_fk() {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml::tests"),
                 )
                 .await
                 .expect("get_by_key")
@@ -5099,6 +5108,8 @@ async fn delete_cascade_recurses_and_rejects_cycles_and_depth() {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "dml::tests"),
                 )
                 .await
                 .expect("get_by_key")

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -16,7 +16,17 @@ use anyhow::{Result, anyhow};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
+// FA-b (Phase 4): the required read context. Only referenced on read
+// primitives' `#[cfg(feature = "abac-policy")]` trailing parameter, so the
+// import is gated to match — the default build never touches the type.
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::ReadContext;
+// `SystemReadReason` is only constructed at record-store *test* call sites (the
+// impls thread the param through unchanged), so it is test-gated to avoid an
+// unused-import warning in the non-test lib build.
 use futures::StreamExt;
+#[cfg(all(test, feature = "abac-policy"))]
+use proximadb_abac::SystemReadReason;
 use proximadb_block_format::{BlockCompression, BlockMode};
 use proximadb_catalog::{
     CatalogPhysicalFormat, CatalogStorageLayout, CatalogStorageSpecialization, CatalogTableSchema,
@@ -507,6 +517,29 @@ fn change_row_from_entry(
     }
 }
 
+#[cfg(feature = "abac-policy")]
+pub mod fa_b_bypass_does_not_compile {
+    //! FA-b compile-time guard (Phase 4).
+    //!
+    //! Asserts that a client read which omits the required `ReadContext`
+    //! argument does not compile. The carrier module is cfg-gated, so the
+    //! `compile_fail` doctest runs **only** when the `read_context` parameter
+    //! exists; under the default (feature-off) build the parameter is absent and
+    //! a 3-argument call would compile, which would make a bare `compile_fail`
+    //! doctest pass *vacuously*. Gating the carrier makes the assertion
+    //! meaningful.
+    //!
+    //! ```compile_fail
+    //! use proximadb::services::record_store::TableRecordStore;
+    //!
+    //! // FA-b: omitting the 4th `read_context` argument → E0061. Bypass is a
+    //! // compile error, not a code-review convention.
+    //! fn no_read_context<S: TableRecordStore>(store: &S) {
+    //!     let _ = store.get_by_key(todo!(), todo!(), todo!());
+    //! }
+    //! ```
+}
+
 #[async_trait]
 pub trait TableRecordStore: Send + Sync {
     /// Write catalog-validated record mutations.
@@ -518,11 +551,18 @@ pub trait TableRecordStore: Send + Sync {
     ) -> Result<TableRecordWriteResult>;
 
     /// Get the current visible record for a key.
+    ///
+    /// `read_context` (present only under `abac-policy`) is the FA-b required
+    /// authorization context: a client read resolves `AuthorizedReadContext`;
+    /// an internal read (FK resolution, index build, recovery) supplies
+    /// `ReadContext::system(reason, origin)`. A call that omits it does not
+    /// compile when the feature is on — ABAC bypass is a compile error.
     async fn get_by_key(
         &self,
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse>;
 
     /// Scan current visible records for a cataloged table.
@@ -1050,9 +1090,16 @@ impl TableRecordStore for CatalogRoutingTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         self.store_for_schema(table_schema)
-            .get_by_key(table_schema, request, tenant_context)
+            .get_by_key(
+                table_schema,
+                request,
+                tenant_context,
+                #[cfg(feature = "abac-policy")]
+                read_context,
+            )
             .await
     }
 
@@ -1149,6 +1196,7 @@ impl TableRecordStore for VectorOpsTableRecordStore {
         _table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         self.vector_ops
             .get_record_with_tenant_context(
@@ -1257,6 +1305,7 @@ impl TableRecordStore for RecordStorageTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         _tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         let record = self
             .storage
@@ -2046,6 +2095,7 @@ impl TableRecordStore for DirectWalTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         // Pass `None`: the partition already scopes the tenant structurally, so
         // no per-record tenant filter is needed (TD-064).
@@ -2053,19 +2103,37 @@ impl TableRecordStore for DirectWalTableRecordStore {
         let (primary, legacy) = self.partitions_for(&tenant, table_schema);
         let Some(legacy) = legacy else {
             return RecordStorageTableRecordStore::new(primary)
-                .get_by_key(table_schema, request, None)
+                .get_by_key(
+                    table_schema,
+                    request,
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    read_context,
+                )
                 .await;
         };
         // O3 cutover window: the primary (post-flip) partition wins; fall back to
         // the legacy name-keyed partition for records not yet migrated-on-write.
         let primary_res = RecordStorageTableRecordStore::new(primary)
-            .get_by_key(table_schema, request.clone(), None)
+            .get_by_key(
+                table_schema,
+                request.clone(),
+                None,
+                #[cfg(feature = "abac-policy")]
+                read_context,
+            )
             .await?;
         if primary_res.is_some() {
             return Ok(primary_res);
         }
         RecordStorageTableRecordStore::new(legacy)
-            .get_by_key(table_schema, request, None)
+            .get_by_key(
+                table_schema,
+                request,
+                None,
+                #[cfg(feature = "abac-policy")]
+                read_context,
+            )
             .await
     }
 
@@ -2400,7 +2468,13 @@ mod tests {
         // Dual-read: under the oid gate, get + scan still see the legacy record.
         assert!(
             store
-                .get_by_key(&schema, get("r1"), None)
+                .get_by_key(
+                    &schema,
+                    get("r1"),
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
+                )
                 .await
                 .unwrap()
                 .is_some(),
@@ -2456,7 +2530,13 @@ mod tests {
             .unwrap();
         assert!(
             store
-                .get_by_key(&schema, get("r1"), None)
+                .get_by_key(
+                    &schema,
+                    get("r1"),
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
+                )
                 .await
                 .unwrap()
                 .is_none(),
@@ -2793,6 +2873,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -2838,6 +2920,8 @@ mod tests {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
                 )
                 .await
                 .unwrap()
@@ -3340,6 +3424,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -3433,6 +3519,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -3520,6 +3608,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -3782,6 +3872,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -3889,6 +3981,8 @@ mod tests {
                     include_props: false,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap()
@@ -3998,6 +4092,8 @@ mod tests {
                         include_props: true,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
                 )
                 .await
                 .expect("get_by_key");
@@ -4223,6 +4319,7 @@ impl TableRecordStore for ObjectStoreIcebergRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         _tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         let records = self.read_all_records(table_schema, _tenant_context).await?;
         let found = records.into_iter().find(|record| record.oid == request.key);
@@ -4561,6 +4658,7 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordGetRequest,
         _tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordGetResponse> {
         let records = self.read_all_records(table_schema, _tenant_context).await?;
         let found = records.into_iter().find(|record| record.oid == request.key);

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -21,11 +21,10 @@ use async_trait::async_trait;
 // import is gated to match — the default build never touches the type.
 #[cfg(feature = "abac-policy")]
 use proximadb_abac::ReadContext;
-// `SystemReadReason` is only constructed at record-store *test* call sites (the
-// impls thread the param through unchanged), so it is test-gated to avoid an
-// unused-import warning in the non-test lib build.
+// `SystemReadReason` is constructed at internal call sites (index-build scans)
+// and record-store test call sites; feature-gated like `ReadContext`.
 use futures::StreamExt;
-#[cfg(all(test, feature = "abac-policy"))]
+#[cfg(feature = "abac-policy")]
 use proximadb_abac::SystemReadReason;
 use proximadb_block_format::{BlockCompression, BlockMode};
 use proximadb_catalog::{
@@ -575,7 +574,10 @@ pub trait TableRecordStore: Send + Sync {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
+        #[cfg(feature = "abac-policy")]
+        let _ = read_context;
         let _ = (request, tenant_context);
         Err(anyhow!(
             "TableRecordStore for '{}' does not support catalog-table scans yet",
@@ -597,11 +599,20 @@ pub trait TableRecordStore: Send + Sync {
         request: TableRecordScanRequest,
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let limit = request.limit.unwrap_or(usize::MAX);
         let mut req = request;
         req.limit = None;
-        let mut all = self.scan_records(table_schema, req, tenant_context).await?;
+        let mut all = self
+            .scan_records(
+                table_schema,
+                req,
+                tenant_context,
+                #[cfg(feature = "abac-policy")]
+                read_context,
+            )
+            .await?;
         let mut kept = 0usize;
         all.retain(|record| {
             if kept >= limit {
@@ -660,6 +671,11 @@ pub trait TableRecordStore: Send + Sync {
                     },
                     predicate,
                     tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::ForeignKeyResolution,
+                        "check_unique_conflict",
+                    ),
                 )
                 .await?;
             if let Some(existing) = hits.first() {
@@ -1108,9 +1124,16 @@ impl TableRecordStore for CatalogRoutingTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         self.store_for_schema(table_schema)
-            .scan_records(table_schema, request, tenant_context)
+            .scan_records(
+                table_schema,
+                request,
+                tenant_context,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await
     }
 
@@ -1120,9 +1143,17 @@ impl TableRecordStore for CatalogRoutingTableRecordStore {
         request: TableRecordScanRequest,
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         self.store_for_schema(table_schema)
-            .scan_records_filtered(table_schema, request, predicate, tenant_context)
+            .scan_records_filtered(
+                table_schema,
+                request,
+                predicate,
+                tenant_context,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await
     }
 
@@ -1216,6 +1247,7 @@ impl TableRecordStore for VectorOpsTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         self.vector_ops
             .scan_records_with_tenant_context(
@@ -1326,6 +1358,7 @@ impl TableRecordStore for RecordStorageTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let mut options = request
             .limit
@@ -1362,6 +1395,7 @@ impl TableRecordStore for RecordStorageTableRecordStore {
         request: TableRecordScanRequest,
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let mut options = request
             .limit
@@ -1775,13 +1809,28 @@ impl DirectWalTableRecordStore {
         };
         let mut existing =
             RecordStorageTableRecordStore::new(self.partition(tenant_id, &collection_id))
-                .scan_records(table_schema, scan_request.clone(), None)
+                .scan_records(
+                    table_schema,
+                    scan_request.clone(),
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::IndexBuild,
+                        "record_store::build_unique_index",
+                    ),
+                )
                 .await?;
         // O3: include any pre-flip records still in the legacy name-keyed partition
         // so the index reflects current visible state across the cutover window.
         if let Some(legacy) = &legacy_key {
             let legacy_recs = RecordStorageTableRecordStore::new(self.partition(tenant_id, legacy))
-                .scan_records(table_schema, scan_request, None)
+                .scan_records(
+                    table_schema,
+                    scan_request,
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::IndexBuild, "record_store::build_index"),
+                )
                 .await?;
             existing = merge_scan_primary_wins(existing, legacy_recs, None);
         }
@@ -1824,12 +1873,27 @@ impl DirectWalTableRecordStore {
         };
         let mut existing =
             RecordStorageTableRecordStore::new(self.partition(tenant_id, &collection_id))
-                .scan_records(table_schema, scan_request.clone(), None)
+                .scan_records(
+                    table_schema,
+                    scan_request.clone(),
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::IndexBuild,
+                        "record_store::build_unique_index",
+                    ),
+                )
                 .await?;
         // O3: include any pre-flip records still in the legacy name-keyed partition.
         if let Some(legacy) = &legacy_key {
             let legacy_recs = RecordStorageTableRecordStore::new(self.partition(tenant_id, legacy))
-                .scan_records(table_schema, scan_request, None)
+                .scan_records(
+                    table_schema,
+                    scan_request,
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::IndexBuild, "record_store::build_index"),
+                )
                 .await?;
             existing = merge_scan_primary_wins(existing, legacy_recs, None);
         }
@@ -2142,20 +2206,39 @@ impl TableRecordStore for DirectWalTableRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let tenant = Self::tenant_key(tenant_context);
         let (primary, legacy) = self.partitions_for(&tenant, table_schema);
         let Some(legacy) = legacy else {
             return RecordStorageTableRecordStore::new(primary)
-                .scan_records(table_schema, request, None)
+                .scan_records(
+                    table_schema,
+                    request,
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    _read_context,
+                )
                 .await;
         };
         let limit = request.limit;
         let primary_recs = RecordStorageTableRecordStore::new(primary)
-            .scan_records(table_schema, request.clone(), None)
+            .scan_records(
+                table_schema,
+                request.clone(),
+                None,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await?;
         let legacy_recs = RecordStorageTableRecordStore::new(legacy)
-            .scan_records(table_schema, request, None)
+            .scan_records(
+                table_schema,
+                request,
+                None,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await?;
         Ok(merge_scan_primary_wins(primary_recs, legacy_recs, limit))
     }
@@ -2166,20 +2249,42 @@ impl TableRecordStore for DirectWalTableRecordStore {
         request: TableRecordScanRequest,
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let tenant = Self::tenant_key(tenant_context);
         let (primary, legacy) = self.partitions_for(&tenant, table_schema);
         let Some(legacy) = legacy else {
             return RecordStorageTableRecordStore::new(primary)
-                .scan_records_filtered(table_schema, request, predicate, None)
+                .scan_records_filtered(
+                    table_schema,
+                    request,
+                    predicate,
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    _read_context,
+                )
                 .await;
         };
         let limit = request.limit;
         let primary_recs = RecordStorageTableRecordStore::new(primary)
-            .scan_records_filtered(table_schema, request.clone(), predicate, None)
+            .scan_records_filtered(
+                table_schema,
+                request.clone(),
+                predicate,
+                None,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await?;
         let legacy_recs = RecordStorageTableRecordStore::new(legacy)
-            .scan_records_filtered(table_schema, request, predicate, None)
+            .scan_records_filtered(
+                table_schema,
+                request,
+                predicate,
+                None,
+                #[cfg(feature = "abac-policy")]
+                _read_context,
+            )
             .await?;
         Ok(merge_scan_primary_wins(primary_recs, legacy_recs, limit))
     }
@@ -2482,7 +2587,13 @@ mod tests {
         );
         assert_eq!(
             store
-                .scan_records(&schema, scan(), None)
+                .scan_records(
+                    &schema,
+                    scan(),
+                    None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests",),
+                )
                 .await
                 .unwrap()
                 .len(),
@@ -2508,7 +2619,16 @@ mod tests {
             )
             .await
             .unwrap();
-        let after = store.scan_records(&schema, scan(), None).await.unwrap();
+        let after = store
+            .scan_records(
+                &schema,
+                scan(),
+                None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
+            )
+            .await
+            .unwrap();
         assert_eq!(
             after.len(),
             1,
@@ -2810,6 +2930,8 @@ mod tests {
                 },
                 Some(&pred),
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap();
@@ -2892,6 +3014,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap();
@@ -3345,6 +3469,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap();
@@ -3842,6 +3968,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap();
@@ -3940,6 +4068,8 @@ mod tests {
                     include_props: true,
                 },
                 None,
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
             )
             .await
             .unwrap();
@@ -4116,6 +4246,8 @@ mod tests {
                         filter: None,
                     },
                     None,
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(SystemReadReason::Statistics, "record_store::tests"),
                 )
                 .await
                 .expect("scan_records");
@@ -4338,6 +4470,7 @@ impl TableRecordStore for ObjectStoreIcebergRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         _tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let mut records = self.read_all_records(table_schema, _tenant_context).await?;
         if let Some(limit) = request.limit {
@@ -4677,6 +4810,7 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
         table_schema: &CatalogTableSchema,
         request: TableRecordScanRequest,
         _tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let mut records = self.read_all_records(table_schema, _tenant_context).await?;
         if let Some(limit) = request.limit {
@@ -4706,12 +4840,21 @@ impl TableRecordStore for ObjectStoreVectorRecordStore {
         request: TableRecordScanRequest,
         predicate: Option<&RecordScanPredicate<'_>>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<TableRecordScanResponse> {
         let Some(filter) = request.filter.clone() else {
             let limit = request.limit.unwrap_or(usize::MAX);
             let mut req = request;
             req.limit = None;
-            let mut all = self.scan_records(table_schema, req, tenant_context).await?;
+            let mut all = self
+                .scan_records(
+                    table_schema,
+                    req,
+                    tenant_context,
+                    #[cfg(feature = "abac-policy")]
+                    _read_context,
+                )
+                .await?;
             let mut kept = 0usize;
             all.retain(|record| {
                 if kept >= limit {

--- a/src/services/transaction/cross_model_coordinator.rs
+++ b/src/services/transaction/cross_model_coordinator.rs
@@ -574,6 +574,7 @@ mod tests {
             _table_schema: &CatalogTableSchema,
             _request: TableRecordGetRequest,
             _tenant_context: Option<&TenantContext>,
+            #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
         ) -> Result<TableRecordGetResponse> {
             Ok(None)
         }

--- a/tests/cross_model_transaction_e2e.rs
+++ b/tests/cross_model_transaction_e2e.rs
@@ -158,6 +158,7 @@ impl TableRecordStore for MockTableRecordStore {
         _table_schema: &CatalogTableSchema,
         _request: TableRecordGetRequest,
         _tenant_context: Option<&StorageTenantContext>,
+        #[cfg(feature = "abac-policy")] _read_context: &proximadb_abac::ReadContext,
     ) -> Result<TableRecordGetResponse> {
         Ok(None)
     }


### PR DESCRIPTION
## Summary

Phase 4 (FA-b) of the ABAC-enforcement track: make `ReadContext` a **required,
non-`Option` parameter** of the relational read primitives so that an ABAC
bypass is a **compile error**, not a code-review convention. Stacked on #1312
(the `ReadContext` type), which has merged.

`ReadContext` is now a required trailing parameter on `TableRecordStore`:
- `get_by_key` (point lookup)
- `scan_records` + `scan_records_filtered` (incl. the permissive default bodies —
  `scan_records_filtered`'s default and `check_unique_conflict`'s probe — all 6
  impls, all mocks, and every call site)

## The mechanism

A `#[cfg(feature = "abac-policy")]`-gated trailing parameter
(`#[cfg(feature = "abac-policy")] read_context: &ReadContext`), plus a
`#[cfg]`-gated call argument at each site. Two facts make it work:
1. `#[cfg]` on a single function **parameter** survives the `#[async_trait]` macro.
2. `#[cfg]` on a **call argument** collapses correctly in both modes.

Net effect: the **default build is byte-for-byte unchanged** (the arg is cfg'd
out everywhere); with the feature on, a call that omits the context is `E0061`.
A `compile_fail` doctest (`fa_b_bypass_does_not_compile`, carried by a
cfg-gated module so it can't pass vacuously off-feature) pins this.

## Call-site classification

Bodies ignore the context for now (applying the compiled predicate via the
existing `AbacEnforcer` is the runtime-enforcement step, already built behind
this feature). Each site carries an audited `SystemReadContext`:
- internal FK / unique-conflict / existence checks → `ForeignKeyResolution`
- index-build scans → `IndexBuild`
- client-servicing reads (DML `get_record` / scan paths) → `Statistics` with
  origin tagged **`[CLIENT-PLACEHOLDER]`** — these must resolve
  `AuthorizedReadContext` (needs `AbacEnforcer` wired into DML) before
  `abac-policy` ships default-on. `grep -rn CLIENT-PLACEHOLDER` finds them.
- test/internal reads → `Statistics`

## Side-fix

#1312 added the `ReadContext` enum to `context.rs` but did not re-export it from
`proximadb_abac`'s `lib.rs`, leaving it unreachable from the root crate. This PR
adds the export.

## Verification (local, pre-push)

`cargo check` (default, byte-for-byte) · `cargo check --tests --features abac-policy`
· `cargo clippy -p proximadb --features abac-policy -- -D warnings` (both configs)
· abac substrate `44/44` · enforcement `13/13` · `make work-commit-check`
(panic-policy delta `+0`) · `cargo fmt --check`.

## Out of scope (deferred, with reasons)

- **`unified_search_native` (vector):** it is public API consumed cross-crate by
  `proximadb-embedded` (a root dev-dep, built under `--tests`). The cfg-gated
  param breaks because embedded is abac-OFF by design (in-process lib; host app
  owns auth) yet is built alongside root-with-abac, with no clean
  feature-propagation path (root can't depend back on embedded → cycle). Resolution:
  give `proximadb-embedded` its own default-off `abac-policy` feature + optional
  `proximadb-abac` dep — a focused follow-up. Runtime enforcement (post-filter)
  already exists behind this feature.
- **graph trio (`query_nodes`/`query_edges`/`traverse`):** the
  `GraphQueryReadService` trait lives in `proximadb-graph-query` (foundation),
  which cannot depend on `proximadb-abac` (control) — a backward dependency the
  workspace-boundaries CI guard rejects. Layering blocker.