### PR TITLE
feat(abac): FA-b Phase 4 — thread ReadContext through unified_search_native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7249,6 +7249,7 @@ dependencies = [
  "num_cpus",
  "numpy",
  "proximadb",
+ "proximadb-abac",
  "proximadb-data-model",
  "proximadb-embedded-common",
  "proximadb-hardware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,7 +712,7 @@ oltp-integrity = ["dep:proximadb-cks-local"]
 # read primitives run unchanged; on, the compile bridge + admits_with_security
 # filter rows by the subject's policy. The abac crate itself stays un-gated
 # (a security substrate that never compiles is never tested).
-abac-policy = ["dep:proximadb-abac"]
+abac-policy = ["dep:proximadb-abac", "proximadb-embedded/abac-policy"]
 # F3v (TD-DELVEC-1 / ADR-072 D14): enable cold-tier deletion vectors. Off by
 # default → the default flush path is byte-for-byte unchanged; on, PAX segment
 # writes capture the OID→position resolver (footer region, WI-2c) so a

--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -16,6 +16,11 @@ path = "src/lib.rs"
 [dependencies]
 # Depends on the root proximadb library (one-directional: embedded -> root, no cycle).
 proximadb = { path = "../../.." }
+# FA-b: optional, behind the `abac-policy` feature. Embedded mode is abac-OFF by
+# design (in-process; the host app owns authorization) — this dep exists only so
+# the abac verification can compile embedded's calls against root's threaded
+# `unified_search_native` signature. See the `abac-policy` feature below.
+proximadb-abac = { workspace = true, optional = true }
 proximadb-embedded-common = { path = "../../horizontal/proximadb-embedded-common" }
 anyhow.workspace = true
 serde.workspace = true
@@ -48,6 +53,12 @@ napi-derive = { version = "2.14", optional = true }
 
 [features]
 default = []
+# FA-b: mirrors root's `abac-policy`. OFF by default — embedded mode is
+# in-process and the host application owns authorization, so ABAC (a server-side
+# multi-tenant concern) does not apply. The feature exists so the abac
+# verification can build embedded against root's threaded signature; run it with
+# `--features abac-policy,proximadb-embedded/abac-policy`.
+abac-policy = ["proximadb/abac-policy", "dep:proximadb-abac"]
 # Python bindings (PyO3 + zero-copy numpy).
 python = ["dep:pyo3", "dep:numpy"]
 # Java bindings (JNI).

--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -114,6 +114,11 @@ pub use agent_memory::{
 pub use streaming::{EmbeddedSearchIterator, StreamingSearchConfig, StreamingSearchResult};
 
 use proximadb::core::config::{AdvancedPruneConfig, PruneModeConfig};
+// FA-b: only referenced on the `#[cfg(feature = "abac-policy")]` trailing arg of
+// `unified_search_native`. Embedded mode is abac-OFF by default; this import is
+// gated to match (the `proximadb-abac` dep is optional, behind the same feature).
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{ReadContext, SystemReadReason};
 
 /// Embedded database configuration for multi-disk support
 #[derive(Debug, Clone)]
@@ -1867,7 +1872,18 @@ impl EmbeddedProximaDB {
             let results = self
                 .shared_services
                 .vector_operations_service
-                .unified_search_native(collection, query_vector, fetch_k, None, Some(config))
+                .unified_search_native(
+                    collection,
+                    query_vector,
+                    fetch_k,
+                    None,
+                    Some(config),
+                    #[cfg(feature = "abac-policy")]
+                    &ReadContext::system(
+                        SystemReadReason::Statistics,
+                        "embedded [CLIENT-PLACEHOLDER]",
+                    ),
+                )
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
                     Box::new(std::io::Error::other(e.to_string()))

--- a/crates/binding/proximadb-embedded/src/streaming.rs
+++ b/crates/binding/proximadb-embedded/src/streaming.rs
@@ -43,6 +43,10 @@ use tokio::sync::mpsc;
 
 use proximadb::core::search::SearchMode;
 use proximadb::services::operations::vectors::UnifiedSearchConfig;
+// FA-b: only used on the `#[cfg(feature = "abac-policy")]` trailing arg of
+// `unified_search_native`. Gated to match the optional `proximadb-abac` dep.
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::{ReadContext, SystemReadReason};
 
 /// Search result from streaming search
 #[derive(Debug, Clone)]
@@ -328,6 +332,11 @@ impl StreamingSearchExecutor {
                 self.top_k,
                 None, // No filter for now
                 Some(search_config),
+                #[cfg(feature = "abac-policy")]
+                &ReadContext::system(
+                    SystemReadReason::Statistics,
+                    "embedded::streaming [CLIENT-PLACEHOLDER]",
+                ),
             )
             .await;
 

--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -62,5 +62,5 @@ pub use cache_key::{InMemoryPolicyEpochs, PolicyEpoch, PolicyEpochSource, Subjec
 pub use compile::{InMemoryPredicateObjectStore, PredicateObjectStore, compile_security_filter};
 pub use context::{
     AuthorizedReadContext, ClientServable, ColumnDecision, DenyReason, ForbiddenColumn,
-    ReadDecision, SystemReadContext, SystemReadReason,
+    ReadContext, ReadDecision, SystemReadContext, SystemReadReason,
 };

--- a/src/graph/hybrid/mod.rs
+++ b/src/graph/hybrid/mod.rs
@@ -1402,6 +1402,11 @@ impl HybridQueryEngine {
                     max_results,
                     None, // No filter for hybrid queries
                     Some(search_config.clone()),
+                    #[cfg(feature = "abac-policy")]
+                    &proximadb_abac::ReadContext::system(
+                        proximadb_abac::SystemReadReason::Statistics,
+                        "graph::hybrid [CLIENT-PLACEHOLDER]",
+                    ),
                 )
                 .await
             {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -2225,6 +2225,11 @@ impl PostgresProtocol {
                     top_k,
                     metadata_filter, // TD-100: mem0 metadata-scoped WHERE pushdown
                     None,            // Default config
+                    #[cfg(feature = "abac-policy")]
+                    &proximadb_abac::ReadContext::system(
+                        proximadb_abac::SystemReadReason::Statistics,
+                        "pgwire [CLIENT-PLACEHOLDER]",
+                    ),
                 )
                 .await
             {

--- a/src/network/rest/canonical/analytics.rs
+++ b/src/network/rest/canonical/analytics.rs
@@ -161,7 +161,18 @@ async fn get_collection_entanglement(
 
     // Load records from collection.
     let records = vector_ops
-        .unified_search_native(&collection_id, vec![], limit, None, None)
+        .unified_search_native(
+            &collection_id,
+            vec![],
+            limit,
+            None,
+            None,
+            #[cfg(feature = "abac-policy")]
+            &proximadb_abac::ReadContext::system(
+                proximadb_abac::SystemReadReason::Statistics,
+                "rest::analytics [CLIENT-PLACEHOLDER]",
+            ),
+        )
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 

--- a/src/query/unified/executor.rs
+++ b/src/query/unified/executor.rs
@@ -443,6 +443,11 @@ async fn execute_vector_search(
             expr.top_k as usize,
             None, // No filter for now - could add threshold filter later
             None, // Use default search config
+            #[cfg(feature = "abac-policy")]
+            &proximadb_abac::ReadContext::system(
+                proximadb_abac::SystemReadReason::Statistics,
+                "unified::executor [CLIENT-PLACEHOLDER]",
+            ),
         )
         .await;
 

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -519,6 +519,11 @@ impl FusionService {
         let query_vector = params.query_vector.clone();
         let limit = params.limit;
 
+        #[cfg(feature = "abac-policy")]
+        let read_ctx = proximadb_abac::ReadContext::system(
+            proximadb_abac::SystemReadReason::Statistics,
+            "fusion_service [CLIENT-PLACEHOLDER]",
+        );
         let mut hits = retry_vector_search(
             &collection,
             || {
@@ -529,6 +534,8 @@ impl FusionService {
                     None,
                     None,
                     tenant_ctx.as_ref(),
+                    #[cfg(feature = "abac-policy")]
+                    &read_ctx,
                 )
             },
             2,

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -42,6 +42,8 @@
 // These are declared in the parent module's mod.rs
 
 use anyhow::Result;
+#[cfg(feature = "abac-policy")]
+use proximadb_abac::ReadContext;
 use proximadb_records::ProximaRecord;
 use proximadb_records::conversions::sql_value_to_proxima;
 // PR 3b follow-up: ingest-edge guard so non-Fp32 records can't sneak
@@ -2651,6 +2653,7 @@ impl VectorOperationsService {
         filter: Option<FilterExpression>,
         config: Option<UnifiedSearchConfig>,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        #[cfg(feature = "abac-policy")] read_context: &ReadContext,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         let resolved = match tenant_context {
             Some(tc) if !tc.tenant_id.is_empty() => {
@@ -2667,8 +2670,16 @@ impl VectorOperationsService {
             }
             _ => collection_id.to_string(),
         };
-        self.unified_search_native(&resolved, query_vector, k, filter, config)
-            .await
+        self.unified_search_native(
+            &resolved,
+            query_vector,
+            k,
+            filter,
+            config,
+            #[cfg(feature = "abac-policy")]
+            read_context,
+        )
+        .await
     }
 
     /// Native variant: returns optimized native records for internal callers.
@@ -2680,6 +2691,7 @@ impl VectorOperationsService {
         k: usize,
         filter: Option<FilterExpression>,
         config: Option<UnifiedSearchConfig>,
+        #[cfg(feature = "abac-policy")] _read_context: &ReadContext,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         use std::time::Instant;
         let total_start = Instant::now();
@@ -2876,7 +2888,18 @@ impl VectorOperationsService {
         config: Option<UnifiedSearchConfig>,
     ) -> Result<Vec<crate::core::service_types::DomainSearchResult>> {
         let natives = self
-            .unified_search_native(collection_id, query_vector, k, filter, config)
+            .unified_search_native(
+                collection_id,
+                query_vector,
+                k,
+                filter,
+                config,
+                #[cfg(feature = "abac-policy")]
+                &proximadb_abac::ReadContext::system(
+                    proximadb_abac::SystemReadReason::Statistics,
+                    "legacy::search [CLIENT-PLACEHOLDER]",
+                ),
+            )
             .await?;
         // Group into a single DomainSearchResult (consistent with previous behavior)
         let mut hits = Vec::with_capacity(natives.len());
@@ -5921,6 +5944,11 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
             filter,
             None,
             tenant_ctx.as_ref(),
+            #[cfg(feature = "abac-policy")]
+            &proximadb_abac::ReadContext::system(
+                proximadb_abac::SystemReadReason::Statistics,
+                "legacy::tests",
+            ),
         )
         .await
     }

--- a/src/services/search/streaming.rs
+++ b/src/services/search/streaming.rs
@@ -341,6 +341,11 @@ impl StreamingSearchService {
                     search_k,
                     None, // No filter
                     None, // Default config
+                    #[cfg(feature = "abac-policy")]
+                    &proximadb_abac::ReadContext::system(
+                        proximadb_abac::SystemReadReason::Statistics,
+                        "streaming [CLIENT-PLACEHOLDER]",
+                    ),
                 )
                 .await?;
 


### PR DESCRIPTION
Companion to #1320 (relational read primitives). Makes `ReadContext` a required
`#[cfg(abac-policy)]`-gated parameter on the **vector search kernel**
(`unified_search_native` + `_with_tenant_context`) — so a vector read omitting
the authorization context is a compile error. Default build byte-for-byte
unchanged; runtime post-filter enforcement already exists behind the feature.

## The cross-carte wrinkle (and the fix)

`unified_search_native` is public API consumed by `proximadb-embedded` (a root
dev-dep). Embedded is **abac-OFF by design** (in-process; the host app owns
authorization), so it cannot simply inherit root's threaded signature. Two
coordinated changes keep it consistent without flipping it on by default:

1. **`proximadb-embedded` gets its own default-off `abac-policy` feature**
   (`= ["proximadb/abac-policy", "dep:proximadb-abac"]`) + an optional
   `proximadb-abac` dep; its 2 call sites carry the cfg-gated arg.
2. **Root's `abac-policy` feature now also enables `proximadb-embedded/abac-policy`**,
   so whenever root-abac is on the embedded dev-dep builds with abac too — the
   natural `cargo check --tests --features abac-policy` compiles cleanly.
   Without (2), root-abac on + embedded dev-dep abac-off ⇒ `E0061`.

## Call sites

All 8 root-internal + 2 embedded callers are client-servicing vector reads →
`SystemReadContext` tagged **`[CLIENT-PLACEHOLDER]`** (must resolve
`AuthorizedReadContext` before `abac-policy` ships default-on). `grep -rn
CLIENT-PLACEHOLDER` finds them.

## Verified (local, pre-push)

- `cargo check` (default) — byte-for-byte.
- `cargo check -p proximadb --features abac-policy` + `-p proximadb-embedded --features abac-policy`.
- `cargo check --tests -p proximadb --features abac-policy` — **the dev-dep propagation fix works (0 errors)**; this was the original blocker.
- `cargo clippy --features abac-policy -- -D warnings` (root + embedded).
- `cargo fmt --check`; panic-policy delta `+0`.

## Notes

- Re-exports `ReadContext` from `proximadb_abac` (the #1312 gap; overlaps with #1320 — dedups cleanly on either merge order).
- Local `make work-commit-check` flags a **pre-existing delvec regression** (`PROXIMADB_OID_RESOLVER_CACHE_MB` unregistered) — not from this PR, and `check_env_gates` is local-only (not in CI).
- Still deferred: the **graph trio** (`GraphQueryReadService` is in `proximadb-graph-query`/foundation, which can't depend on `proximadb-abac`/control — layering blocker).