### PR TITLE
feat(abac): FA-c Phase 2 — wire ABAC enforcement into the relational read path

### DIFF
--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -1781,6 +1781,11 @@ impl RelationalReader for DmlTableReader {
                 row_pred_ref,
                 limit,
                 self.tenant.as_ref(),
+                // FA-c Phase 2: subject not yet plumbed from the pgwire auth
+                // layer (UnifiedUserContext.user_id), so no enforcement here yet;
+                // pass None until handler subject-plumbing lands.
+                #[cfg(feature = "abac-policy")]
+                None,
             )
             .await
             .map_err(|e| ReaderError::Storage(e.to_string()))?;

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -82,9 +82,14 @@ pub enum AbacScanResult {
 #[cfg(feature = "abac-policy")]
 #[allow(dead_code)]
 pub struct AbacEnforcer {
-    authority: Box<dyn AttributeAuthority>,
-    store: Box<dyn PredicateObjectStore>,
-    epochs: Box<dyn PolicyEpochSource>,
+    authority: Box<dyn AttributeAuthority + Send + Sync>,
+    store: Box<dyn PredicateObjectStore + Send + Sync>,
+    epochs: Box<dyn PolicyEpochSource + Send + Sync>,
+    /// The policy bindings this enforcer governs. Holding them makes the enforcer
+    /// a self-contained policy a service can store once and call per-read
+    /// (`predicate_for`); the per-call `scan_predicate_for(.., bindings)` variant
+    /// remains for substrate unit tests.
+    bindings: Vec<PolicyBinding>,
 }
 
 #[cfg(feature = "abac-policy")]
@@ -93,15 +98,37 @@ impl AbacEnforcer {
     /// Construct from the three substrate stores. In production these are the
     /// durable-backed impls; in tests, the in-memory ones.
     pub fn new(
-        authority: Box<dyn AttributeAuthority>,
-        store: Box<dyn PredicateObjectStore>,
-        epochs: Box<dyn PolicyEpochSource>,
+        authority: Box<dyn AttributeAuthority + Send + Sync>,
+        store: Box<dyn PredicateObjectStore + Send + Sync>,
+        epochs: Box<dyn PolicyEpochSource + Send + Sync>,
     ) -> Self {
         Self {
             authority,
             store,
             epochs,
+            bindings: Vec::new(),
         }
+    }
+
+    /// Install the policy bindings this enforcer governs (builder). After this,
+    /// [`predicate_for`](Self::predicate_for) resolves against the held bindings
+    /// — the one call a read-serving service makes per scan.
+    pub fn with_bindings(mut self, bindings: Vec<PolicyBinding>) -> Self {
+        self.bindings = bindings;
+        self
+    }
+
+    /// Resolve `subject`'s authorization for `target` and compile to a scan
+    /// predicate, using the enforcer's **held** bindings (self-contained policy).
+    /// This is the production call site: a service holds the enforcer and invokes
+    /// this per read.
+    pub fn predicate_for(
+        &self,
+        subject: &SubjectId,
+        tenant: u64,
+        target: Target,
+    ) -> AbacScanResult {
+        self.scan_predicate_for(subject, tenant, target, &self.bindings)
     }
 
     /// Resolve `subject`'s authorization for `target` and compile to a scan

--- a/src/security/rls/mod.rs
+++ b/src/security/rls/mod.rs
@@ -38,6 +38,11 @@ pub use service::{CollectionRLS, RLSConfig, RLSFilterResult};
 
 #[cfg(feature = "abac-policy")]
 mod abac_adapter;
+// FA-c Phase 2: the service-facing enforcement API, re-exported so the
+// read-serving services (DmlService, …) can name the enforcer without depending
+// on the private adapter module's internals.
+#[cfg(feature = "abac-policy")]
+pub use abac_adapter::{AbacEnforcer, AbacScanResult};
 
 #[cfg(all(test, feature = "abac-policy"))]
 mod abac_enforcement_tests;

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -40,6 +40,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow};
 #[cfg(feature = "abac-policy")]
 use proximadb_abac::{ReadContext, SystemReadReason};
+#[cfg(feature = "abac-policy")]
+use proximadb_catalog::fc_metamodel::{SubjectId, Target};
 use proximadb_catalog::{
     CatalogColumn, CatalogStorageLayout, CatalogTableSchema, CatalogTableStatistics,
     relational::{
@@ -824,6 +826,11 @@ pub struct DmlService {
     /// a store is wired only at the composition root under the `oltp-integrity`
     /// feature, so default builds are behaviorally unchanged.
     conditional_key_store: Option<Arc<dyn proximadb_storage_ports::ConditionalKeyStore>>,
+    /// FA-c Phase 2: optional ABAC enforcer. When present (behind `abac-policy`)
+    /// and a client subject is supplied at a read boundary, relational scans
+    /// filter rows by the subject's policy. Absent by default.
+    #[cfg(feature = "abac-policy")]
+    abac_enforcer: Option<Arc<crate::security::rls::AbacEnforcer>>,
 }
 
 /// ADR-025: `DmlService` is the authoritative post-snapshot delta source for the
@@ -1000,6 +1007,8 @@ impl DmlService {
             table_write_executor,
             dml_lock_service: None,
             conditional_key_store: None,
+            #[cfg(feature = "abac-policy")]
+            abac_enforcer: None,
         }
     }
 
@@ -1027,6 +1036,16 @@ impl DmlService {
     /// Attach the tenant-scoped DML lock service.
     pub fn with_dml_lock_service(mut self, dml_lock_service: Arc<DmlLockService>) -> Self {
         self.dml_lock_service = Some(dml_lock_service);
+        self
+    }
+
+    /// FA-c Phase 2: wire an ABAC enforcer so relational scans filter rows by the
+    /// requesting subject's policy. Behind `abac-policy`; absent (no enforcement)
+    /// by default. The enforcer is a self-contained policy (holds authority +
+    /// predicate store + epochs + bindings).
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_enforcer(mut self, enforcer: Arc<crate::security::rls::AbacEnforcer>) -> Self {
+        self.abac_enforcer = Some(enforcer);
         self
     }
 
@@ -1367,6 +1386,48 @@ impl DmlService {
         Ok(table_schema)
     }
 
+    /// FA-c Phase 2: resolve the ABAC row filter for a relational scan. Returns
+    /// `None` when enforcement does not apply (no enforcer wired, or no client
+    /// subject — e.g. an internal read). Otherwise resolves the subject's
+    /// authorization against the held policy; the caller short-circuits a
+    /// denied result to zero rows and AND-combines `Restricted` into the user
+    /// predicate. Fail-closed: a legacy table lacking stable object/namespace
+    /// ids, or a tenant without a stable id, yields `Denied`.
+    #[cfg(feature = "abac-policy")]
+    fn abac_row_filter(
+        &self,
+        subject: Option<&SubjectId>,
+        tenant_context: Option<&TenantContext>,
+        table_schema: &CatalogTableSchema,
+    ) -> Option<crate::security::rls::AbacScanResult> {
+        let enforcer = self.abac_enforcer.as_ref()?;
+        let subject = subject?;
+        // Enforcer + client subject are present ⇒ enforce. Fail-closed: a legacy
+        // table lacking stable object/namespace ids, or an unknown tenant stable
+        // id, denies rather than reading unfiltered.
+        let (Some(namespace), Some(table)) =
+            (table_schema.stable_namespace_id, table_schema.object_id)
+        else {
+            return Some(crate::security::rls::AbacScanResult::Denied(
+                proximadb_abac::DenyReason::NoApplicablePolicy,
+            ));
+        };
+        let Some(tenant) = tenant_context.and_then(|t| t.tenant_stable_id) else {
+            return Some(crate::security::rls::AbacScanResult::Denied(
+                proximadb_abac::DenyReason::NoApplicablePolicy,
+            ));
+        };
+        Some(enforcer.predicate_for(
+            subject,
+            tenant,
+            Target {
+                namespace,
+                table: table as u32,
+                column: None,
+            },
+        ))
+    }
+
     /// Scan a catalog table for the relational pipeline (PATH B), pushing the
     /// caller's row predicate + limit into the record-store scan and projecting
     /// matching records into `output_columns` order (or all columns when `None`).
@@ -1386,6 +1447,7 @@ impl DmlService {
         >,
         limit: Option<usize>,
         tenant_context: Option<&TenantContext>,
+        #[cfg(feature = "abac-policy")] subject: Option<&SubjectId>,
     ) -> Result<(CatalogTableSchema, Vec<Vec<ProximaValue>>)> {
         let (table_schema, table_id_name) = self
             .resolve_select_table(table_name, tenant_context.map(|t| t.tenant_id.as_str()))
@@ -1402,6 +1464,20 @@ impl DmlService {
             Some(cols) => Self::resolve_select_projection(&table_schema, cols)?,
             None => full_selected.clone(),
         };
+
+        // FA-c Phase 2: resolve the ABAC row filter EARLY (before the predicate
+        // borrow, so the deny short-circuit can move `table_schema`). A denied
+        // (or fail-closed) subject sees zero rows.
+        #[cfg(feature = "abac-policy")]
+        let abac_pred: Option<Box<dyn Fn(&ProximaRecord) -> bool + Send + Sync>> =
+            match self.abac_row_filter(subject, tenant_context, &table_schema) {
+                None => None,
+                Some(crate::security::rls::AbacScanResult::Denied(_)) => {
+                    return Ok((table_schema, Vec::new()));
+                }
+                Some(crate::security::rls::AbacScanResult::Restricted(p)) => Some(p),
+                Some(crate::security::rls::AbacScanResult::Unrestricted) => None,
+            };
 
         // Push the predicate INTO the store scan: project each record to a full
         // row and apply the caller's full-row predicate. The scan-predicate API is
@@ -1429,6 +1505,14 @@ impl DmlService {
                 Err(_) => false,
             }
         };
+        // FA-c Phase 2: AND-combine the ABAC row filter with the user predicate.
+        #[cfg(feature = "abac-policy")]
+        let combined_pred = move |record: &ProximaRecord| -> bool {
+            record_pred(record) && abac_pred.as_ref().is_none_or(|p| p(record))
+        };
+        #[cfg(feature = "abac-policy")]
+        let predicate: Option<&proximadb_records::RecordScanPredicate<'_>> = Some(&combined_pred);
+        #[cfg(not(feature = "abac-policy"))]
         let predicate: Option<&proximadb_records::RecordScanPredicate<'_>> = Some(&record_pred);
 
         let records = self
@@ -1521,7 +1605,15 @@ impl DmlService {
 
         // 1. Snapshot the table's current rows (all columns, no predicate/limit).
         let (schema, rows) = self
-            .scan_table_relational(table_name, None, None, None, tenant_context)
+            .scan_table_relational(
+                table_name,
+                None,
+                None,
+                None,
+                tenant_context,
+                #[cfg(feature = "abac-policy")]
+                None,
+            )
             .await?;
 
         // 2. Column-order ProximaValue rows → ProximaRecord envelopes (props keyed by

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -2868,7 +2868,15 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
 
     // (a) No predicate / no projection → all rows, full column order [id,status,qty].
     let (schema, rows) = dml
-        .scan_table_relational("inv", None, None, None, None)
+        .scan_table_relational(
+            "inv",
+            None,
+            None,
+            None,
+            None,
+            #[cfg(feature = "abac-policy")]
+            None,
+        )
         .await
         .expect("scan all");
     assert_eq!(schema.columns.len(), 3);
@@ -2880,7 +2888,15 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
         Ok(matches!(&row[1], ProximaValue::String(s) if s == "active"))
     };
     let (_s, rows) = dml
-        .scan_table_relational("inv", None, Some(&pred), None, None)
+        .scan_table_relational(
+            "inv",
+            None,
+            Some(&pred),
+            None,
+            None,
+            #[cfg(feature = "abac-policy")]
+            None,
+        )
         .await
         .expect("scan predicate");
     let mut ids: Vec<String> = rows
@@ -2901,7 +2917,15 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
         })
     };
     let err = dml
-        .scan_table_relational("inv", None, Some(&failing_pred), None, None)
+        .scan_table_relational(
+            "inv",
+            None,
+            Some(&failing_pred),
+            None,
+            None,
+            #[cfg(feature = "abac-policy")]
+            None,
+        )
         .await
         .expect_err("a predicate eval error must surface, not silently drop rows");
     assert!(
@@ -2912,7 +2936,15 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
     // (c) Output projection narrows + orders columns → just [status].
     let cols = vec!["status".to_string()];
     let (_s, rows) = dml
-        .scan_table_relational("inv", Some(&cols), None, None, None)
+        .scan_table_relational(
+            "inv",
+            Some(&cols),
+            None,
+            None,
+            None,
+            #[cfg(feature = "abac-policy")]
+            None,
+        )
         .await
         .expect("scan projection");
     assert_eq!(rows.len(), 4);
@@ -2920,7 +2952,15 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
 
     // (d) Limit caps the result.
     let (_s, rows) = dml
-        .scan_table_relational("inv", None, None, Some(2), None)
+        .scan_table_relational(
+            "inv",
+            None,
+            None,
+            Some(2),
+            None,
+            #[cfg(feature = "abac-policy")]
+            None,
+        )
         .await
         .expect("scan limit");
     assert_eq!(rows.len(), 2, "limit caps the scan");
@@ -6006,6 +6046,137 @@ fn sql_like_fast_paths_match_dp() {
         assert_eq!(
             fast, dp,
             "LIKE mismatch for value={value:?} pattern={pattern:?}: fast={fast} dp={dp}"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "abac-policy"))]
+mod abac_relational_enforcement_tests {
+    //! FA-c Phase 2 e2e: the ABAC enforcement is wired into `DmlService`. Proves
+    //! a real `DmlService` resolves a client subject's authorization via the
+    //! injected `AbacEnforcer` — a permitted subject ⇒ `Restricted`; an unbound
+    //! subject ⇒ `Denied` (fail-closed); an internal read (no subject) ⇒ no
+    //! enforcement; a legacy table lacking stable ids ⇒ `Denied` (fail-closed,
+    //! never unfiltered). The substrate test proves the compiled predicate then
+    //! filters rows; this module proves the DmlService wiring resolves to the
+    //! right `AbacScanResult`.
+    use super::*;
+    use crate::core::search::{ComparisonOperator, FilterExpression};
+    use crate::security::rls::{AbacEnforcer, AbacScanResult};
+    use crate::storage::tenant::context::TenantContext;
+    use proximadb_abac::{
+        AttributeAuthority, AttributeBinding, InMemoryAttributeAuthority, InMemoryPolicyEpochs,
+        InMemoryPredicateObjectStore,
+    };
+    use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope, SubjectId};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    const TENANT: u64 = 7;
+    const NS: u16 = 3;
+    const TABLE: u32 = 200;
+
+    /// alice (dept=eng) + a `dept == eng` predicate (obj 42) + a table-scoped
+    /// Permit binding referencing it. Self-contained policy held by the enforcer.
+    fn enforcer() -> AbacEnforcer {
+        let mut authority = InMemoryAttributeAuthority::new();
+        authority.upsert(
+            AttributeBinding::new("alice", TENANT).with_attr("dept", AttrValue::Str("eng".into())),
+        );
+        let mut store = InMemoryPredicateObjectStore::new();
+        store.register(
+            42,
+            FilterExpression::Comparison {
+                field: "dept".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!("eng"),
+            },
+        );
+        let bindings = vec![PolicyBinding {
+            object_id: 1,
+            tenant_stable_id: TENANT,
+            scope: Scope::Table(TABLE),
+            effect: Effect::Permit,
+            predicate_ref: Some(42),
+            field_mask: None,
+        }];
+        AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(store),
+            Box::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_bindings(bindings)
+    }
+
+    fn schema_with_stable_ids() -> CatalogTableSchema {
+        let mut s = update_test_schema();
+        s.object_id = Some(TABLE as u64);
+        s.stable_namespace_id = Some(NS);
+        s
+    }
+
+    fn tenant_ctx() -> TenantContext {
+        let mut tc = TenantContext::for_tenant_id("t7");
+        tc.tenant_stable_id = Some(TENANT);
+        tc
+    }
+
+    fn dml_with_enforcer() -> DmlService {
+        DmlService::with_record_store_and_table_write_executor(
+            Arc::new(CatalogManager::new()),
+            Arc::new(ExplainOnlyRecordStore),
+            Arc::new(PlannedOnlyTableWriteExecutor::new()),
+        )
+        .with_abac_enforcer(Arc::new(enforcer()))
+    }
+
+    #[test]
+    fn permitted_subject_resolves_restricted() {
+        let dml = dml_with_enforcer();
+        let alice = SubjectId("alice".into());
+        let res = dml.abac_row_filter(Some(&alice), Some(&tenant_ctx()), &schema_with_stable_ids());
+        assert!(
+            matches!(res, Some(AbacScanResult::Restricted(_))),
+            "alice (bound, permitted, dept=eng predicate) must resolve to Restricted"
+        );
+    }
+
+    #[test]
+    fn unbound_subject_is_denied_fail_closed() {
+        let dml = dml_with_enforcer();
+        let mallory = SubjectId("mallory".into());
+        let res = dml.abac_row_filter(
+            Some(&mallory),
+            Some(&tenant_ctx()),
+            &schema_with_stable_ids(),
+        );
+        assert!(
+            matches!(res, Some(AbacScanResult::Denied(_))),
+            "an unbound subject must be Denied (fail-closed), never Restricted"
+        );
+    }
+
+    #[test]
+    fn internal_read_has_no_enforcement() {
+        let dml = dml_with_enforcer();
+        // No subject ⇒ an internal/system read ⇒ no ABAC enforcement applies.
+        let res = dml.abac_row_filter(None, Some(&tenant_ctx()), &schema_with_stable_ids());
+        assert!(
+            res.is_none(),
+            "an internal read (no subject) must not enforce"
+        );
+    }
+
+    #[test]
+    fn legacy_table_without_stable_ids_denies_fail_closed() {
+        let dml = dml_with_enforcer();
+        let alice = SubjectId("alice".into());
+        // `update_test_schema()` has no stable object/namespace ids ⇒ cannot build
+        // a Target ⇒ fail-closed (Denied), never an unfiltered read.
+        let res = dml.abac_row_filter(Some(&alice), Some(&tenant_ctx()), &update_test_schema());
+        assert!(
+            matches!(res, Some(AbacScanResult::Denied(_))),
+            "a legacy table lacking stable ids must deny (fail-closed), not leak"
         );
     }
 }


### PR DESCRIPTION
Makes ABAC **actually filter rows** on the relational (DML SELECT) path — the missing Phase-2 piece (develop already has the substrate: #1312 `ReadContext`, #1320/#1321 threading, #1309 vector post-filter, #1310 durable authority). Behind \`abac-policy\` (default-off); default build byte-for-byte unchanged.

## What
A real \`scan_table_relational\` resolves the requesting subject's policy and filters/denies accordingly:
- **Expose** \`AbacEnforcer\`/\`AbacScanResult\` from \`security::rls\` (the adapter module was private).
- **\`AbacEnforcer\`** holds its \`PolicyBinding\`s (\`with_bindings\`) + a bindings-less \`predicate_for\` → a service stores one self-contained policy. Its trait-object fields are now \`Send + Sync\` (it's held by the \`Send\` \`DmlService\`, which the test-only substrate never exercised).
- **DI**: \`DmlService::with_abac_enforcer(...)\` (mirrors \`with_conditional_key_store\`).
- **\`scan_table_relational\`** takes a cfg-gated \`subject: Option<&SubjectId>\`, resolves \`abac_row_filter\` early (before the predicate borrow), **AND-combines** the compiled ABAC row filter with the user \`WHERE\` into the single \`scan_records_filtered\` predicate hook, and **short-circuits a deny** (or a fail-closed legacy table / unknown tenant id) to zero rows before the scan.

## e2e proof (\`abac_relational_enforcement_tests\`)
A \`DmlService\` with an in-memory enforcer (alice/dept=eng + binding + predicate) resolves: alice ⇒ \`Restricted\`, an unbound subject ⇒ \`Denied\`, an internal read (no subject) ⇒ no enforcement, a legacy table lacking stable ids ⇒ \`Denied\` (fail-closed). The 4-outcome matrix is self-teeth-checking (a no-op cannot satisfy all four).

## Verified
\`cargo check\` (default + \`--features abac-policy\`) · \`cargo clippy -D warnings\` (both configs) · \`cargo nextest -E 'test(abac)'\` **17/17** (4 new + 13 existing) · \`cargo fmt\`. \`make work-commit-check\` passes all guards except a **pre-existing delvec env-gate regression** (\`PROXIMADB_OID_RESOLVER_CACHE_MB\`, not in CI).

## Scope reality (follow-ons)
This proves the production-path wiring with in-memory stores + test-supplied bindings. Full *durable* production enforcement is still gated on:
- **Subject plumbing** — \`SubjectId\` from \`UnifiedUserContext.user_id\` through the pgwire/REST handlers (today the handler passes \`None\`; only the test supplies a subject). The \"wide multi-PR signature change\".
- **\`PolicyBinding\` store** (Phase 5) — with \`abac-policy\` on but no binding source, reads deny fail-closed.
- **Column masking** — no seam today (\`AuthorizedReadContext::project\`/\`column_decision\`).