### PR TITLE
refactor(config): retire dead MetadataBackendConfig cluster (TD-CONFIG-CONSOLIDATE-1 S3)

### DIFF
--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -579,95 +579,6 @@ impl Default for HardwareConfig {
     }
 }
 
-/// Metadata backend configuration for cloud and local storage.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MetadataBackendConfig {
-    /// Backend type (filestore, memory).
-    pub backend_type: String,
-
-    /// Storage URL (file://, s3://, adls://, gcs://).
-    pub storage_url: String,
-
-    /// Cloud-specific configuration.
-    pub cloud_config: Option<CloudStorageConfig>,
-
-    /// In-memory cache size in megabytes for metadata.
-    pub cache_size_mb: Option<u64>,
-
-    /// Interval in seconds between metadata flush operations.
-    pub flush_interval_secs: Option<u64>,
-}
-
-impl Default for MetadataBackendConfig {
-    fn default() -> Self {
-        Self {
-            backend_type: "filestore".to_string(),
-            storage_url: "file://./metadata".to_string(),
-            cloud_config: None,
-            cache_size_mb: Some(256),
-            flush_interval_secs: Some(60),
-        }
-    }
-}
-
-/// Cloud storage configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CloudStorageConfig {
-    /// AWS S3 configuration.
-    pub s3_config: Option<S3Config>,
-
-    /// Azure Blob Storage configuration.
-    pub azure_config: Option<AzureConfig>,
-
-    /// Google Cloud Storage configuration.
-    pub gcs_config: Option<GcsConfig>,
-}
-
-/// AWS S3 configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct S3Config {
-    /// AWS region (e.g., "us-east-1").
-    pub region: String,
-    /// S3 bucket name.
-    pub bucket: String,
-    /// AWS access key ID (optional if using IAM role).
-    pub access_key_id: Option<String>,
-    /// AWS secret access key (optional if using IAM role).
-    pub secret_access_key: Option<String>,
-    /// Use IAM role-based authentication instead of static keys.
-    pub use_iam_role: bool,
-    /// Custom S3-compatible endpoint URL (e.g., MinIO).
-    pub endpoint: Option<String>,
-}
-
-/// Azure Blob Storage configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AzureConfig {
-    /// Azure Storage account name.
-    pub account_name: String,
-    /// Blob container name.
-    pub container: String,
-    /// Storage account access key (optional if using managed identity).
-    pub access_key: Option<String>,
-    /// Shared Access Signature token (optional).
-    pub sas_token: Option<String>,
-    /// Use Azure Managed Identity for authentication.
-    pub use_managed_identity: bool,
-}
-
-/// Google Cloud Storage configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GcsConfig {
-    /// Google Cloud project ID.
-    pub project_id: String,
-    /// GCS bucket name.
-    pub bucket: String,
-    /// Path to the service account JSON key file.
-    pub service_account_path: Option<String>,
-    /// Use GKE Workload Identity for authentication.
-    pub use_workload_identity: bool,
-}
-
 /// Filesystem configuration for performance optimization.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FilesystemOptimizationConfig {
@@ -1167,17 +1078,6 @@ mod tests {
         assert!(config.enable_gpu_similarity);
         assert_eq!(config.gpu_min_vector_size, 64);
         assert_eq!(config.gpu_min_batch_size, 100);
-    }
-
-    #[test]
-    fn metadata_backend_defaults_match_root_runtime_expectations() {
-        let config = MetadataBackendConfig::default();
-
-        assert_eq!(config.backend_type, "filestore");
-        assert_eq!(config.storage_url, "file://./metadata");
-        assert!(config.cloud_config.is_none());
-        assert_eq!(config.cache_size_mb, Some(256));
-        assert_eq!(config.flush_interval_secs, Some(60));
     }
 
     #[test]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -874,10 +874,9 @@ pub struct CoreStorageConfig {
 }
 
 pub use proximadb_config::{
-    AdvancedPruneConfig, AssignmentConfig, AzureConfig, CloudStorageConfig, CompactionConfig,
-    ConsensusConfig, FilesystemOptimizationConfig, GcsConfig, MetadataBackendConfig,
-    MonitoringConfig, OptimizationConfig, PruneModeConfig, S3Config, StorageLocation, TempStrategy,
-    TransactionalOperationsConfig,
+    AdvancedPruneConfig, AssignmentConfig, CompactionConfig, ConsensusConfig,
+    FilesystemOptimizationConfig, MonitoringConfig, OptimizationConfig, PruneModeConfig,
+    StorageLocation, TempStrategy, TransactionalOperationsConfig,
 };
 
 impl StorageConfig {

--- a/tests/integration/storage/metadata_backend_test.rs
+++ b/tests/integration/storage/metadata_backend_test.rs
@@ -16,7 +16,7 @@
 
 //! Unit tests for filestore metadata backend and dependency injection
 
-use proximadb::core::config::{MetadataBackendConfig, StorageConfig};
+use proximadb::core::config::StorageConfig;
 use proximadb::network::multi_server::{ServiceProfile, SharedServices};
 use proximadb::proto::proximadb_v1::{
     Collection as ProtoCollection, CollectionConfig as ProtoCollectionConfig, CollectionStats,
@@ -42,15 +42,6 @@ async fn test_single_metadata_backend_instance() {
     let metadata_path = temp_dir.path().join("metadata");
     let storage_path = temp_dir.path().join("storage");
 
-    // Create metadata backend config
-    let metadata_config = MetadataBackendConfig {
-        backend_type: "filestore".to_string(),
-        storage_url: format!("file://{}", metadata_path.to_string_lossy()),
-        cache_size_mb: Some(64),
-        cloud_config: None,
-        flush_interval_secs: Some(60),
-    };
-
     // Create storage config with temp directory
     let mut storage_config = StorageConfig::default();
     storage_config.storage_locations = vec![proximadb::core::config::StorageLocation {
@@ -68,7 +59,7 @@ async fn test_single_metadata_backend_instance() {
 
     // Create a minimal StorageConfig with our metadata configuration
     let storage_config = proximadb::core::config::StorageConfig {
-        metadata_url: metadata_config.storage_url.clone(),
+        metadata_url: format!("file://{}", metadata_path.to_string_lossy()),
         ..Default::default()
     };
 


### PR DESCRIPTION
TD-CONFIG-CONSOLIDATE-1 step 3 incremental retirement. Retires the dead MetadataBackendConfig cluster from the foundation config crate.

## Dead cluster (the WalStorageConfig pattern)
MetadataBackendConfig + its transitive sub-types (CloudStorageConfig, S3Config, AzureConfig, GcsConfig) — not a field of any live struct, zero serving consumers. The live GcsConfig twin lives in gcs_store.rs (separate type; verified no serving code imports the foundation one). Only the re-export + one integration test (incidental use) + the foundation's own defaults test reached them.

## Removed
- The 5 structs + MetadataBackendConfig's Default (foundation/proximadb-config).
- The re-export in src/core/config.rs.
- The foundation metadata_backend_defaults test.
- Updated the integration test (metadata_backend_test.rs) to supply metadata_url directly — it only read .storage_url from the type.

## Verified
44/44 foundation tests, all test targets compile (cargo check --tests), fmt, clippy (-D warnings), work-commit-check (env-gates 225).
