### PR TITLE
feat(abac): durable policy-binding store (FA Phase 5b) — TD-ABAC-2

### DIFF
--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -53,14 +53,18 @@ pub mod authority;
 pub mod cache_key;
 pub mod compile;
 pub mod context;
+pub mod policy_binding_store;
 
 pub use authority::{
     AttributeAuthority, AttributeBinding, AttributeDigest, AuthorityError,
-    InMemoryAttributeAuthority, ResolvedSubject,
+    FileSystemAttributeAuthority, InMemoryAttributeAuthority, ResolvedSubject,
 };
 pub use cache_key::{InMemoryPolicyEpochs, PolicyEpoch, PolicyEpochSource, SubjectCacheKey};
 pub use compile::{InMemoryPredicateObjectStore, PredicateObjectStore, compile_security_filter};
 pub use context::{
     AuthorizedReadContext, ClientServable, ColumnDecision, DenyReason, ForbiddenColumn,
     ReadContext, ReadDecision, SystemReadContext, SystemReadReason,
+};
+pub use policy_binding_store::{
+    FileSystemPolicyBindingStore, InMemoryPolicyBindingStore, PolicyBindingStore, PolicyStoreError,
 };

--- a/crates/control/proximadb-abac/src/policy_binding_store.rs
+++ b/crates/control/proximadb-abac/src/policy_binding_store.rs
@@ -1,0 +1,440 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Phase 5b — the durable policy-binding store.
+//!
+//! ABAC's enforcement needs two server-side sources of truth: the **authority**
+//! (a subject's attributes — [`AttributeAuthority`](crate::authority::AttributeAuthority),
+//! Phase 5a) and the **policy** (the `PolicyBinding`s that govern a target — this
+//! module). FA-c Phase 2 / #1324 wired the `AbacEnforcer` into the relational read
+//! path, but every test supplies the bindings in-memory: there was no durable
+//! source, so `abac-policy`-on in production denied every read fail-closed
+//! (`DenyReason::NoApplicablePolicy`). This module is that missing half.
+//!
+//! ## Why an empty binding set is *correct* here (unlike the authority)
+//!
+//! A subtlety that distinguishes this store from [`AttributeAuthority`]:
+//! [`resolve_effective_policy`](proximadb_catalog::fc_metamodel::resolve_effective_policy)
+//! is **deny-biased** — a tenant with *no* bindings composes to a fail-closed
+//! `Deny` (`applicable == 0`). So returning an empty `Vec` for an unknown tenant
+//! is a *well-defined* "deny everything" policy, not an error. Contrast the
+//! authority, where an empty attribute bag would sail through a Permit-with-no-
+//! predicate policy and admit everything (fail-*open*), which is why the authority
+//! treats a missing binding as [`AuthorityError`](crate::AuthorityError) instead.
+//! A *store outage* (unreachable/corrupt file) is still an error
+//! ([`PolicyStoreError::Unavailable`]) — an outage is not a policy.
+//!
+//! ## OSS mechanism (ADR-060)
+//!
+//! The durable impl ([`FileSystemPolicyBindingStore`]) uses the same persistence
+//! *mechanism* as [`FileSystemAttributeAuthority`](crate::FileSystemAttributeAuthority):
+//! atomic temp-file + rename, load-on-open, best-effort persist. The commercial
+//! crate supplies the IdP-administered production store; this is the
+//! development/reference impl that survives a process restart.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use proximadb_catalog::fc_metamodel::{PolicyBinding, TenantStableId};
+
+/// A durable source of a tenant's [`PolicyBinding`]s — the "policy" half of the
+/// ABAC durable substrate (the "authority" half is
+/// [`AttributeAuthority`](crate::authority::AttributeAuthority)).
+///
+/// Tenant-scoped by argument: a read for tenant T must consult only T's
+/// bindings, even when the same target id exists in another tenant (the
+/// `tenant_stable_id` field on every [`PolicyBinding`] is what keeps policy from
+/// crossing the tenant boundary). Implementations are `Send + Sync`: the
+/// [`AbacEnforcer`](crate::AbacEnforcer) (well, the adapter in the root crate)
+/// holds the store behind a `Box<dyn PolicyBindingStore + Send + Sync>` so it can
+/// be shared across the read-serving services.
+pub trait PolicyBindingStore: Send + Sync {
+    /// All policy bindings the store holds for `tenant_stable_id`. An empty
+    /// `Vec` is the well-defined "deny everything" policy (deny-biased
+    /// resolution), **not** an error — see the module docs.
+    fn bindings_for(&self, tenant_stable_id: TenantStableId) -> Vec<PolicyBinding>;
+}
+
+/// Why a policy-binding store could not be consulted.
+///
+/// Only the **outage** case is modeled: a missing/corrupt/on-disk-unreachable
+/// store. "No bindings for this tenant" is *not* an error — it is a well-defined
+/// deny-everything policy (see module docs). Callers must treat [`Unavailable`]
+/// as deny: an authorization substrate does not degrade to "allow" when its
+/// source of truth is unreachable.
+///
+/// [`Unavailable`]: PolicyStoreError::Unavailable
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PolicyStoreError {
+    /// The store could not be read or written (file IO, deserialization). The
+    /// caller must deny on this — never return an empty `Vec`, which would be a
+    /// *policy decision* (deny-everything) rather than the outage it is.
+    #[error("policy binding store unavailable: {detail}")]
+    Unavailable {
+        /// Operator-facing detail.
+        detail: String,
+    },
+}
+
+/// An in-memory [`PolicyBindingStore`] — the reference implementation, and the
+/// one tests use.
+///
+/// Mirrors [`InMemoryAttributeAuthority`](crate::authority::InMemoryAttributeAuthority):
+/// a `tenant → Vec<binding>` map. The durable implementation stores bindings as
+/// catalog objects in the reserved system namespace; this type deliberately keeps
+/// the same `(tenant, object_id)`-keyed shape so the durable impl can wrap it.
+#[derive(Debug, Default)]
+pub struct InMemoryPolicyBindingStore {
+    bindings: BTreeMap<TenantStableId, Vec<PolicyBinding>>,
+}
+
+impl InMemoryPolicyBindingStore {
+    /// A store holding no bindings (so every resolution denies).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace one binding, keyed by `(tenant_stable_id, object_id)`.
+    /// A binding with an `object_id` already present in its tenant replaces the
+    /// old one (idempotent re-PUT); otherwise it is appended.
+    pub fn upsert(&mut self, binding: PolicyBinding) {
+        let tenant = binding.tenant_stable_id;
+        let vec = self.bindings.entry(tenant).or_default();
+        if let Some(slot) = vec.iter_mut().find(|b| b.object_id == binding.object_id) {
+            *slot = binding;
+        } else {
+            vec.push(binding);
+        }
+    }
+
+    /// Replace a tenant's entire binding set atomically. This is the natural
+    /// admin operation ("publish tenant T's policy"); it drops every existing
+    /// binding for `tenant_stable_id` and installs `bindings`.
+    pub fn replace_tenant(
+        &mut self,
+        tenant_stable_id: TenantStableId,
+        bindings: Vec<PolicyBinding>,
+    ) {
+        self.bindings.insert(tenant_stable_id, bindings);
+    }
+
+    /// Remove a single binding by `(tenant, object_id)`. Returns whether a
+    /// binding was present.
+    pub fn remove(&mut self, tenant_stable_id: TenantStableId, object_id: u64) -> bool {
+        if let Some(vec) = self.bindings.get_mut(&tenant_stable_id) {
+            let before = vec.len();
+            vec.retain(|b| b.object_id != object_id);
+            vec.len() != before
+        } else {
+            false
+        }
+    }
+
+    /// An iterator over all bindings — for serialization/durability.
+    pub fn bindings(&self) -> impl Iterator<Item = &PolicyBinding> {
+        self.bindings.values().flatten()
+    }
+}
+
+impl PolicyBindingStore for InMemoryPolicyBindingStore {
+    fn bindings_for(&self, tenant_stable_id: TenantStableId) -> Vec<PolicyBinding> {
+        self.bindings
+            .get(&tenant_stable_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+// ===========================================================================
+// FileSystemPolicyBindingStore — durable backing (Phase 5b)
+// ===========================================================================
+
+/// A [`PolicyBindingStore`] backed by an atomic-rename JSON snapshot on the
+/// filesystem — modeled on
+/// [`FileSystemAttributeAuthority`](crate::FileSystemAttributeAuthority).
+///
+/// **OSS mechanism** (ADR-060): this is the persistence *mechanism* — atomic
+/// rename, load-on-open, best-effort persist. The commercial crate supplies the
+/// IdP-administered production store; this is the development/reference impl
+/// that survives a process restart.
+///
+/// Writes are **synchronous and atomic**: `upsert`/`replace_tenant`/`remove`
+/// immediately persist the full binding set via a temp-file + rename — the same
+/// trade-off [`FileSystemAttributeAuthority`] makes (simple, correct, adequate
+/// for development; a production impl might use per-binding rows).
+pub struct FileSystemPolicyBindingStore {
+    inner: InMemoryPolicyBindingStore,
+    path: PathBuf,
+}
+
+impl FileSystemPolicyBindingStore {
+    /// Open (or create) the store at `path`. If the file exists, bindings are
+    /// loaded — this is the **restart-recovery** path. A missing file is an empty
+    /// store (deny-everything), not an error.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, PolicyStoreError> {
+        let path = path.as_ref().to_path_buf();
+        let mut inner = InMemoryPolicyBindingStore::new();
+        if path.exists() {
+            let data = std::fs::read(&path).map_err(|e| PolicyStoreError::Unavailable {
+                detail: format!("read {}: {e}", path.display()),
+            })?;
+            let bindings: Vec<PolicyBinding> =
+                serde_json::from_slice(&data).map_err(|e| PolicyStoreError::Unavailable {
+                    detail: format!("deserialize {}: {e}", path.display()),
+                })?;
+            for b in bindings {
+                inner.upsert(b);
+            }
+        }
+        Ok(Self { inner, path })
+    }
+
+    /// Insert or replace a binding and persist immediately (atomic rename).
+    pub fn upsert(&mut self, binding: PolicyBinding) {
+        self.inner.upsert(binding);
+        let _ = self.persist();
+    }
+
+    /// Replace a tenant's binding set and persist immediately.
+    pub fn replace_tenant(
+        &mut self,
+        tenant_stable_id: TenantStableId,
+        bindings: Vec<PolicyBinding>,
+    ) {
+        self.inner.replace_tenant(tenant_stable_id, bindings);
+        let _ = self.persist();
+    }
+
+    /// Remove a binding and persist immediately.
+    pub fn remove(&mut self, tenant_stable_id: TenantStableId, object_id: u64) -> bool {
+        let removed = self.inner.remove(tenant_stable_id, object_id);
+        if removed {
+            let _ = self.persist();
+        }
+        removed
+    }
+
+    /// Write the full binding set atomically (temp + rename).
+    fn persist(&self) -> Result<(), PolicyStoreError> {
+        let bindings: Vec<PolicyBinding> = self.inner.bindings().cloned().collect();
+        let json =
+            serde_json::to_vec_pretty(&bindings).map_err(|e| PolicyStoreError::Unavailable {
+                detail: format!("serialize bindings: {e}"),
+            })?;
+        let tmp = self.path.with_extension("tmp");
+        std::fs::write(&tmp, &json).map_err(|e| PolicyStoreError::Unavailable {
+            detail: format!("write {}: {e}", tmp.display()),
+        })?;
+        std::fs::rename(&tmp, &self.path).map_err(|e| PolicyStoreError::Unavailable {
+            detail: format!("rename {} → {}: {e}", tmp.display(), self.path.display()),
+        })?;
+        Ok(())
+    }
+}
+
+impl PolicyBindingStore for FileSystemPolicyBindingStore {
+    fn bindings_for(&self, tenant_stable_id: TenantStableId) -> Vec<PolicyBinding> {
+        self.inner.bindings_for(tenant_stable_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proximadb_catalog::fc_metamodel::{
+        Effect, FieldMask, Scope, Target, resolve_effective_policy,
+    };
+
+    /// One permit-with-predicate binding governing table 200 in tenant 7.
+    fn permit_binding(object_id: u64, tenant: u64, table: u32, pred: Option<u64>) -> PolicyBinding {
+        PolicyBinding {
+            object_id,
+            tenant_stable_id: tenant,
+            scope: Scope::Table(table),
+            effect: Effect::Permit,
+            predicate_ref: pred,
+            field_mask: None,
+        }
+    }
+
+    #[test]
+    fn in_memory_returns_only_the_tenants_bindings() {
+        let mut store = InMemoryPolicyBindingStore::new();
+        store.upsert(permit_binding(1, 7, 200, Some(42)));
+        store.upsert(permit_binding(2, 8, 200, Some(43)));
+
+        assert_eq!(store.bindings_for(7).len(), 1);
+        assert_eq!(store.bindings_for(8).len(), 1);
+        assert!(
+            store.bindings_for(9).is_empty(),
+            "an unknown tenant has no bindings (deny-everything), not an error"
+        );
+    }
+
+    #[test]
+    fn upsert_replaces_by_object_id() {
+        let mut store = InMemoryPolicyBindingStore::new();
+        store.upsert(permit_binding(1, 7, 200, Some(42)));
+        // Same (tenant, object_id) with a different predicate → replace, not append.
+        store.upsert(permit_binding(1, 7, 200, Some(99)));
+        let bindings = store.bindings_for(7);
+        assert_eq!(bindings.len(), 1, "re-PUT replaces, it does not duplicate");
+        assert_eq!(bindings[0].predicate_ref, Some(99));
+    }
+
+    #[test]
+    fn replace_tenant_drops_the_old_set() {
+        let mut store = InMemoryPolicyBindingStore::new();
+        store.upsert(permit_binding(1, 7, 200, Some(42)));
+        store.replace_tenant(7, vec![permit_binding(2, 7, 201, Some(43))]);
+
+        let bindings = store.bindings_for(7);
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].object_id, 2, "the old binding 1 is gone");
+    }
+
+    #[test]
+    fn empty_binding_set_resolves_to_fail_closed_deny() {
+        // The whole point: an empty store is a well-defined "deny everything"
+        // policy, NOT an error. resolve_effective_policy must deny.
+        let store = InMemoryPolicyBindingStore::new();
+        let bindings = store.bindings_for(7);
+        let eff = resolve_effective_policy(
+            &bindings,
+            &Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+        );
+        assert_eq!(eff.decision, Effect::Deny);
+        assert_eq!(eff.applicable, 0);
+    }
+
+    #[test]
+    fn a_permit_binding_resolves_to_permit() {
+        let mut store = InMemoryPolicyBindingStore::new();
+        store.upsert(permit_binding(1, 7, 200, None));
+        let eff = resolve_effective_policy(
+            &store.bindings_for(7),
+            &Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+        );
+        assert_eq!(eff.decision, Effect::Permit);
+        assert_eq!(eff.applicable, 1);
+    }
+
+    #[test]
+    fn bindings_round_trip_through_serde_json() {
+        // FileSystemPolicyBindingStore serializes Vec<PolicyBinding>; confirm the
+        // whole struct (scope/effect/field_mask/optionals) survives.
+        let bindings = vec![
+            permit_binding(1, 7, 200, Some(42)),
+            PolicyBinding {
+                object_id: 2,
+                tenant_stable_id: 7,
+                scope: Scope::Column {
+                    table: 200,
+                    column: 3,
+                },
+                effect: Effect::Deny,
+                predicate_ref: None,
+                field_mask: Some(FieldMask::Redact),
+            },
+        ];
+        let json = serde_json::to_vec(&bindings).expect("serialize");
+        let back: Vec<PolicyBinding> = serde_json::from_slice(&json).expect("deserialize");
+        assert_eq!(bindings, back);
+    }
+
+    // --- FileSystemPolicyBindingStore: restart recovery (the Phase-5b ratchet) ---
+
+    fn unique_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "proximadb-abac-policy-store-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn fs_store_bindings_survive_a_restart() {
+        let dir = unique_dir("restart");
+        let path = dir.join("policy.json");
+
+        // Write phase: create the store, publish tenant 7's policy, drop it.
+        {
+            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            store.replace_tenant(
+                7,
+                vec![
+                    permit_binding(1, 7, 200, Some(42)),
+                    permit_binding(2, 7, 201, None),
+                ],
+            );
+            assert!(path.exists(), "persist wrote the file");
+        }
+        // `store` is dropped — in-memory state is gone.
+
+        // Read phase: reopen from the same path — both bindings must survive.
+        let store = FileSystemPolicyBindingStore::open(&path).expect("reopen");
+        let bindings = store.bindings_for(7);
+        assert_eq!(bindings.len(), 2, "tenant 7's policy survived the restart");
+
+        let eff = resolve_effective_policy(
+            &bindings,
+            &Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+        );
+        assert_eq!(eff.decision, Effect::Permit);
+        assert_eq!(eff.applicable, 1, "only the table-200 binding applies");
+
+        // A different tenant still has no bindings (no cross-tenant leak).
+        assert!(store.bindings_for(8).is_empty());
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn fs_store_upsert_and_remove_persist_individually() {
+        let dir = unique_dir("upsert-remove");
+        let path = dir.join("policy.json");
+
+        {
+            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            store.upsert(permit_binding(1, 7, 200, Some(42)));
+            assert!(store.remove(7, 1), "binding 1 was present");
+            assert!(!store.remove(7, 1), "binding 1 is now gone");
+        }
+
+        let store = FileSystemPolicyBindingStore::open(&path).expect("reopen");
+        assert!(
+            store.bindings_for(7).is_empty(),
+            "the removed binding must not survive restart"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn fs_store_opening_a_missing_file_is_an_empty_store_not_an_error() {
+        let dir = unique_dir("missing");
+        let path = dir.join("does-not-exist.json");
+
+        let store = FileSystemPolicyBindingStore::open(&path).expect("missing file ⇒ empty store");
+        assert!(store.bindings_for(7).is_empty());
+
+        let _ = std::fs::remove_dir(&dir);
+    }
+}

--- a/docs/10-quality/td/TD-ABAC-2-durable-policy-binding-store.adoc
+++ b/docs/10-quality/td/TD-ABAC-2-durable-policy-binding-store.adoc
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ABAC-2: Durable policy-binding store (FA Phase 5b)
+:status: Delivered (PR pending)
+:date: 2026-07-30
+:authors: FA enforcement track session 2026-07-30
+:realizes: TD-FOUNDATION-3 Phase 5b; ADR-060 (OSS persistence mechanism)
+:design-of-record: TD-FOUNDATION-2 §3.1/§3.2 (attribute-trust boundary, policy model); TD-FOUNDATION-3 (FA build track)
+:depends-on: TD-FOUNDATION-3 (P1 attribute authority — Phase 5a, #1310)
+
+[cols="1,3"]
+|===
+| Status | **Delivered.** The durable `PolicyBindingStore` closes the "no policy source" gap that made `abac-policy`-on deny every read fail-closed in production. Wired at the composition root behind `abac-policy` (default-OFF).
+| Scope | The "policy" half of the ABAC durable substrate — the restart-surviving source of a tenant's `PolicyBinding`s. (The "authority" half — a subject's attributes — landed in Phase 5a, `FileSystemAttributeAuthority`.)
+| Out of scope | Row-predicate durability (the predicate-object store is still in-memory), policy-epoch durability, subject-id plumbing into handlers, column masking. These are follow-on slices under TD-FOUNDATION-3; see §4.
+|===
+
+NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
+
+== 1. Why this exists
+
+FA-c Phase 2 (#1324) wired the `AbacEnforcer` into the relational read funnel and
+proved a SELECT filters rows by the subject's policy — but every test supplied
+the `PolicyBinding`s in-memory (`AbacEnforcer::with_bindings`). In production
+there was **no durable policy source**: turning `abac-policy` on made
+`AuthorizedReadContext::resolve` find zero applicable bindings for every target,
+so every read denied fail-closed (`DenyReason::NoApplicablePolicy`). The
+enforcement was correct but **inert** — exercised only in tests.
+
+Phase 5a (#1310) shipped the durable *authority* (`FileSystemAttributeAuthority`
+— a subject's attributes). This TD ships the durable *policy* (`PolicyBinding`s)
+and wires both into the composition root, so the enforcer the read-serving
+services hold carries a real, restart-surviving policy.
+
+== 2. What landed
+
+* `PolicyBindingStore` trait (`crates/control/proximadb-abac/src/policy_binding_store.rs`)
+  — tenant-scoped source of `Vec<PolicyBinding>`; `Send + Sync` (held by the
+  enforcer behind a `Box<dyn … + Send + Sync>`).
+* `InMemoryPolicyBindingStore` — reference impl + tests.
+* `FileSystemPolicyBindingStore` — atomic temp-file + rename JSON snapshot,
+  load-on-open restart recovery; mirrors `FileSystemAttributeAuthority` and the
+  `FileSystemCorpusVersionStore` OSS mechanism (ADR-060).
+* `AbacEnforcer::with_binding_store` + `predicate_for` loads the tenant's bindings
+  from the store per read (`src/security/rls/abac_adapter.rs`). `with_bindings`
+  is retained for substrate unit tests.
+* Composition root (`src/network/shared_services.rs::build_abac_enforcer`):
+  constructs the enforcer from the authority + policy store at `<data_dir>/abac/`
+  and `.with_abac_enforcer(...)` into `DmlService`. Behind `abac-policy`
+  (default-OFF) ⇒ default builds byte-for-byte unchanged.
+
+== 3. The empty-vs-unavailable distinction (the design crux)
+
+A tenant with **no bindings** returns an empty `Vec` — that is a *well-defined*
+"deny everything" policy, because `resolve_effective_policy` is deny-biased
+(`applicable == 0` ⇒ `Deny`). It is **not** an error. Contrast the *authority*,
+where an empty attribute bag would be fail-*open* (sail through a
+Permit-with-no-predicate) and so must be `AuthorityError`.
+
+A store **outage** (unreachable/corrupt file) *is* `PolicyStoreError::Unavailable`
+— an outage is not a policy. The composition root logs and falls back to
+"no enforcer" (status quo) rather than synthesizing an allow; this only matters
+on opt-in `abac-policy` builds.
+
+== 4. Verification
+
+* `cargo check -p proximadb-abac` and `--features abac-policy` both clean.
+* `cargo nextest run -p proximadb-abac` — 55 tests (+9 store tests: tenant
+  isolation, upsert/replace/remove, serde round-trip, deny-everything semantics).
+* **Restart ratchet** (store level): `fs_store_bindings_survive_a_restart`.
+* **Restart ratchet** (enforcer level): `enforcer_reconstitutes_the_same_result_after_a_restart`
+  and `enforcer_loads_bindings_from_the_store_not_the_held_set` — prove the
+  enforcer consults the durable store, not the (empty) held set, and that the
+  compiled `AbacScanResult` survives a drop + reopen.
+* `cargo clippy --features abac-policy -- -D warnings`, `cargo fmt --check`,
+  `make work-commit-check` (panic-policy +0). The pre-existing delvec
+  `PROXIMADB_OID_RESOLVER_CACHE_MB` env-gate red is out of scope (not in CI).
+
+== 5. Follow-ons (still under TD-FOUNDATION-3)
+
+1. **Durable predicate-object store** — today in-memory (`InMemoryPredicateObjectStore`),
+   so a durable policy whose `predicate_ref` points at an unregistered predicate
+   denies fail-closed; only predicate-free table-level grants evaluate end-to-end.
+2. **Durable policy-epoch source** — today `InMemoryPolicyEpochs`.
+3. **Subject-id plumbing** — thread `UnifiedUserContext.user_id` → `SubjectId`
+   through pgwire/REST handlers into `scan_table_relational` (today `None`), which
+   activates #1324 on real client SELECTs. This is the "activation" slice; this TD
+   is the "substrate" slice.
+4. **Column masking** — no seam; wire `AuthorizedReadContext::project`/`column_decision`.
+5. **Graph trio** — layering (foundation cannot depend on control); needs an ADR.
+
+== 6. Open question: fail-open on store outage at the composition root
+
+`build_abac_enforcer` returns `None` (no enforcer ⇒ no filtering) when a durable
+store cannot be opened, rather than denying all reads. This matches the
+`conditional_key_store` precedent and is acceptable *because* `abac-policy` is
+opt-in and default-OFF — but a production `abac-policy`-ON deployment may want
+fail-closed-everything on store corruption instead. Deferred: revisit at the
+GA-readiness review of the feature gate.

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -523,6 +523,78 @@ impl SharedServices {
         }
     }
 
+    /// Build the process-shared ABAC [`AbacEnforcer`](crate::security::rls::AbacEnforcer)
+    /// from the **durable** substrate (TD-ABAC-2, Phase 5b): the
+    /// `FileSystemAttributeAuthority` (#1310) + the `FileSystemPolicyBindingStore`
+    /// (this change), both restart-recovered from `<data_dir>/abac/`. The
+    /// predicate-object store and the policy-epoch source are **in-memory** today
+    /// (follow-ons: durable predicates, durable epochs) — so an opt-in
+    /// `abac-policy` build can evaluate table-level permit/deny (predicate-free
+    /// bindings) but not yet row-predicates until the predicate store is durable.
+    ///
+    /// Returns `None` on default builds (the feature is OFF) and when there is no
+    /// `data_dir` or a durable store cannot be opened — i.e. the status quo (no
+    /// enforcement). It never synthesizes an allow: absent ⇒ no enforcer ⇒ no
+    /// filtering, the same state as today.
+    #[cfg(feature = "abac-policy")]
+    fn build_abac_enforcer(
+        opt_config: Option<&crate::core::config::Config>,
+    ) -> Option<Arc<crate::security::rls::AbacEnforcer>> {
+        use proximadb_abac::{
+            FileSystemAttributeAuthority, FileSystemPolicyBindingStore, InMemoryPolicyEpochs,
+            InMemoryPredicateObjectStore,
+        };
+
+        let data_dir = opt_config?.server.data_dir.clone();
+        let abac_dir = std::path::Path::new(&data_dir).join("abac");
+        // A missing `data_dir` (embedded/ephemeral paths) ⇒ no durable substrate ⇒
+        // no enforcer. Best-effort dir creation; a create failure ⇒ None too.
+        if std::fs::create_dir_all(&abac_dir).is_err() {
+            tracing::warn!(
+                "abac-policy: could not create abac dir at {}",
+                abac_dir.display()
+            );
+            return None;
+        }
+
+        let authority =
+            match FileSystemAttributeAuthority::open(abac_dir.join("attribute-bindings.json")) {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::error!(
+                        "abac-policy: failed to open attribute authority at {}: {e}; \
+                         enforcement DISABLED (no enforcer)",
+                        abac_dir.display()
+                    );
+                    return None;
+                }
+            };
+        let bindings =
+            match FileSystemPolicyBindingStore::open(abac_dir.join("policy-bindings.json")) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(
+                        "abac-policy: failed to open policy binding store at {}: {e}; \
+                     enforcement DISABLED (no enforcer)",
+                        abac_dir.display()
+                    );
+                    return None;
+                }
+            };
+
+        tracing::info!(
+            "abac-policy: durable ABAC enforcer active at {} (authority + policy binding store)",
+            abac_dir.display()
+        );
+        let enforcer = crate::security::rls::AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(InMemoryPredicateObjectStore::new()),
+            Box::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_binding_store(Box::new(bindings));
+        Some(Arc::new(enforcer))
+    }
+
     /// Create shared services with full business logic configuration
     /// SharedServices owns all business logic and configuration decisions
     /// Returns (SharedServices, CollectionService) - the collection service is needed by StorageEngine
@@ -2319,6 +2391,18 @@ impl SharedServices {
         };
         let base_dml = match &conditional_key_store {
             Some(cks) => base_dml.with_conditional_key_store(cks.clone()),
+            None => base_dml,
+        };
+        // TD-ABAC-2 (Phase 5b): construct the durable ABAC enforcer (authority +
+        // policy binding store, both at <data_dir>/abac/) and DI it into the
+        // DML read funnel. Fully behind `abac-policy` (default-OFF) ⇒ default
+        // builds are byte-for-byte unchanged; `None` ⇒ no enforcement (status quo).
+        #[cfg(feature = "abac-policy")]
+        let base_dml = match Self::build_abac_enforcer(opt_config) {
+            Some(enforcer) => {
+                debug!("✅ SharedServices::new - durable ABAC enforcer wired into DmlService");
+                base_dml.with_abac_enforcer(enforcer)
+            }
             None => base_dml,
         };
         let dml_service_for_grpc = Arc::new(match dml_lock_service {

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -17,8 +17,8 @@ use crate::core::search::{
 use crate::security::rls::filter_lattice::admits_with_security;
 #[cfg(feature = "abac-policy")]
 use proximadb_abac::{
-    AttributeAuthority, AuthorizedReadContext, DenyReason, PolicyEpochSource, PredicateObjectStore,
-    compile_security_filter,
+    AttributeAuthority, AuthorizedReadContext, DenyReason, PolicyBindingStore, PolicyEpochSource,
+    PredicateObjectStore, compile_security_filter,
 };
 #[cfg(feature = "abac-policy")]
 use proximadb_catalog::fc_metamodel::{ObjectId, PolicyBinding, SubjectId, Target};
@@ -90,6 +90,10 @@ pub struct AbacEnforcer {
     /// (`predicate_for`); the per-call `scan_predicate_for(.., bindings)` variant
     /// remains for substrate unit tests.
     bindings: Vec<PolicyBinding>,
+    /// The durable policy source (Phase 5b). When set, `predicate_for` loads the
+    /// tenant's bindings from here per read — restart-surviving policy. When
+    /// unset, it falls back to the held `bindings` (the in-memory/test path).
+    binding_store: Option<Box<dyn PolicyBindingStore + Send + Sync>>,
 }
 
 #[cfg(feature = "abac-policy")]
@@ -107,6 +111,7 @@ impl AbacEnforcer {
             store,
             epochs,
             bindings: Vec::new(),
+            binding_store: None,
         }
     }
 
@@ -118,17 +123,35 @@ impl AbacEnforcer {
         self
     }
 
+    /// Install the durable policy source (builder, Phase 5b). When set,
+    /// [`predicate_for`](Self::predicate_for) loads the tenant's bindings from the
+    /// store on every read — a restart-surviving policy. This is the production
+    /// path; [`with_bindings`](Self::with_bindings) remains for tests.
+    pub fn with_binding_store(mut self, store: Box<dyn PolicyBindingStore + Send + Sync>) -> Self {
+        self.binding_store = Some(store);
+        self
+    }
+
     /// Resolve `subject`'s authorization for `target` and compile to a scan
-    /// predicate, using the enforcer's **held** bindings (self-contained policy).
-    /// This is the production call site: a service holds the enforcer and invokes
-    /// this per read.
+    /// predicate. When a durable [`PolicyBindingStore`] is installed, the
+    /// tenant's bindings are loaded from it per read (the production path);
+    /// otherwise the enforcer's held `bindings` are used (the in-memory/test
+    /// path). This is the one call a read-serving service makes per scan.
     pub fn predicate_for(
         &self,
         subject: &SubjectId,
         tenant: u64,
         target: Target,
     ) -> AbacScanResult {
-        self.scan_predicate_for(subject, tenant, target, &self.bindings)
+        let owned;
+        let bindings: &[PolicyBinding] = match &self.binding_store {
+            Some(store) => {
+                owned = store.bindings_for(tenant);
+                &owned
+            }
+            None => &self.bindings,
+        };
+        self.scan_predicate_for(subject, tenant, target, bindings)
     }
 
     /// Resolve `subject`'s authorization for `target` and compile to a scan
@@ -252,7 +275,8 @@ mod tests {
     use super::*;
     use crate::core::search::{ComparisonOperator, FilterExpression};
     use proximadb_abac::{
-        InMemoryAttributeAuthority, InMemoryPolicyEpochs, InMemoryPredicateObjectStore,
+        FileSystemPolicyBindingStore, InMemoryAttributeAuthority, InMemoryPolicyEpochs,
+        InMemoryPredicateObjectStore,
     };
     use proximadb_catalog::fc_metamodel::{AttrValue, Effect, Scope};
     use proximadb_data_model::ProximaValue;
@@ -418,6 +442,158 @@ mod tests {
             &bindings,
         );
         assert!(result.is_err(), "unbound subject must be denied");
+    }
+
+    // --- Phase 5b: durable policy-binding store (the enforcer loads from it) ---
+
+    /// Shared store/authority/predicate-store config for the durable-policy tests.
+    /// `dept=eng` is the only admitted dept; tenant 7's policy permits table 200
+    /// under predicate ref 42.
+    fn predicate_store_for_dept() -> InMemoryPredicateObjectStore {
+        let mut store = InMemoryPredicateObjectStore::new();
+        store.register(
+            42,
+            FilterExpression::Comparison {
+                field: "dept".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!("eng"),
+            },
+        );
+        store
+    }
+
+    #[test]
+    fn enforcer_loads_bindings_from_the_store_not_the_held_set() {
+        // The enforcer is built with EMPTY held bindings + a durable store holding
+        // tenant 7's permit. predicate_for must still resolve — proof it consulted
+        // the store, not the (empty) held set.
+        let dir = std::env::temp_dir().join(format!(
+            "proximadb-abac-enforcer-store-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("policy.json");
+
+        let mut authority = InMemoryAttributeAuthority::new();
+        authority.upsert(
+            proximadb_abac::AttributeBinding::new("alice", 7)
+                .with_attr("dept", AttrValue::Str("eng".into())),
+        );
+        let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+        store.replace_tenant(
+            7,
+            vec![PolicyBinding {
+                object_id: 1,
+                tenant_stable_id: 7,
+                scope: Scope::Table(200),
+                effect: Effect::Permit,
+                predicate_ref: Some(42),
+                field_mask: None,
+            }],
+        );
+
+        let enforcer = AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(predicate_store_for_dept()),
+            Box::new(InMemoryPolicyEpochs::new()),
+        )
+        // NOTE: no with_bindings — held bindings are empty by design.
+        .with_binding_store(Box::new(store));
+
+        match enforcer.predicate_for(
+            &SubjectId("alice".into()),
+            7,
+            Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+        ) {
+            AbacScanResult::Restricted(pred) => {
+                assert!(
+                    pred(&record_with("eng")),
+                    "alice (dept=eng) admits eng rows"
+                );
+                assert!(!pred(&record_with("hr")), "dept=hr is denied");
+            }
+            _ => panic!("alice must be Restricted via the store, not Denied/Unrestricted"),
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn enforcer_reconstitutes_the_same_result_after_a_restart() {
+        // The Phase-5b ratchet at the enforcer level: write tenant 7's policy via
+        // the durable store, drop it, reopen it, rebuild the enforcer — and the
+        // compiled AbacScanResult for alice is byte-identical. The policy survived
+        // the restart; the enforcement outcome did too.
+        let dir = std::env::temp_dir().join(format!(
+            "proximadb-abac-enforcer-restart-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("policy.json");
+        let target = Target {
+            namespace: 3,
+            table: 200,
+            column: None,
+        };
+
+        // Write phase: persist tenant 7's permit, then drop everything.
+        {
+            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            store.replace_tenant(
+                7,
+                vec![PolicyBinding {
+                    object_id: 1,
+                    tenant_stable_id: 7,
+                    scope: Scope::Table(200),
+                    effect: Effect::Permit,
+                    predicate_ref: Some(42),
+                    field_mask: None,
+                }],
+            );
+        }
+
+        // Read phase: reopen the durable store and build a fresh enforcer over it
+        // (authority/predicate-store/epochs are reconstructed identically — only
+        // the policy source is what persisted).
+        fn fresh_enforcer(store: FileSystemPolicyBindingStore) -> AbacEnforcer {
+            let mut authority = InMemoryAttributeAuthority::new();
+            authority.upsert(
+                proximadb_abac::AttributeBinding::new("alice", 7)
+                    .with_attr("dept", AttrValue::Str("eng".into())),
+            );
+            AbacEnforcer::new(
+                Box::new(authority),
+                Box::new(predicate_store_for_dept()),
+                Box::new(InMemoryPolicyEpochs::new()),
+            )
+            .with_binding_store(Box::new(store))
+        }
+
+        let store = FileSystemPolicyBindingStore::open(&path).expect("reopen");
+        let enforcer = fresh_enforcer(store);
+        let result = enforcer.predicate_for(&SubjectId("alice".into()), 7, target);
+
+        match result {
+            AbacScanResult::Restricted(pred) => {
+                assert!(pred(&record_with("eng")));
+                assert!(!pred(&record_with("hr")));
+            }
+            _ => panic!("alice must be Restricted after restart"),
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
     }
 
     // --- Phase 3: vector-path post-filter ---


### PR DESCRIPTION
## Summary

Adds the durable **`PolicyBindingStore`** substrate — the "policy" half of the ABAC durable substrate (the "authority" half, `FileSystemAttributeAuthority`, landed in #1310). This closes the gap that made `abac-policy`-on deny every read fail-closed in production: there was no durable source of a tenant's `PolicyBinding`s, so every test supplied them in-memory (#1324).

The durable enforcer is now constructed at the composition root from the authority + policy store and DI'd into `DmlService`. Fully behind `abac-policy` (**default-OFF**) → default builds are byte-for-byte unchanged.

## What changed

- **`PolicyBindingStore` trait** + `InMemoryPolicyBindingStore` (ref) + `FileSystemPolicyBindingStore` (atomic-rename JSON snapshot, load-on-open restart recovery), mirroring `FileSystemAttributeAuthority` / ADR-060. `crates/control/proximadb-abac/src/policy_binding_store.rs`.
- **`AbacEnforcer::with_binding_store`** + `predicate_for` loads the tenant's bindings from the store per read (`src/security/rls/abac_adapter.rs`). `with_bindings` retained for substrate unit tests — backward-compatible with #1324's path.
- **Composition root** (`shared_services::build_abac_enforcer`): constructs the enforcer from the authority + policy store at `<data_dir>/abac/` and `.with_abac_enforcer(...)` into `DmlService`, behind `abac-policy`.

### Empty-vs-unavailable distinction (the design crux)
A tenant with **no bindings** is a well-defined "deny everything" (deny-biased `resolve_effective_policy` ⇒ empty `Vec`, **not** an error). A store **outage** is `PolicyStoreError::Unavailable` (deny); the composition root logs and falls back to no-enforcer (status quo) — never a synthesized allow.

## Verification
- `cargo check -p proximadb` (default, byte-for-byte) — clean.
- `cargo check -p proximadb --features abac-policy` — clean.
- `cargo nextest run -p proximadb-abac` — **55 passed** (+9 store tests incl. `fs_store_bindings_survive_a_restart`).
- `cargo nextest run -p proximadb --features abac-policy -E 'test(abac)'` — **19 passed**, incl. 2 new enforcer restart tests, **no regressions** (substrate + #1324 relational enforcement + vector post-filter).
- `cargo clippy -p proximadb --features abac-policy -- -D warnings` + `cargo clippy -p proximadb-abac --all-targets -- -D warnings` — clean.
- `cargo fmt --check`, `make work-commit-check` (panic-policy +0, env-gate, layering, tenant-path, hygiene, td-adr-unique, attribution) — green.

## Restart ratchet (the Phase-5b deliverable)
- Store level: `fs_store_bindings_survive_a_restart`.
- Enforcer level: `enforcer_reconstitutes_the_same_result_after_a_restart` + `enforcer_loads_bindings_from_the_store_not_the_held_set` (proves the enforcer consults the durable store, not the held set).

## Follow-ons (under TD-FOUNDATION-3, documented in TD-ABAC-2 §5)
- Durable predicate-object store + policy-epoch source (today in-memory → only predicate-free table-level grants evaluate end-to-end).
- SubjectId plumbing into pgwire/REST handlers — the **activation** slice that makes real client SELECTs enforce (handlers still pass `None`).
- Column masking.

## TD
`docs/10-quality/td/TD-ABAC-2-durable-policy-binding-store.adoc`