### PR TITLE
feat(build): make AXIS a compile-time cfg feature (default ON)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -832,6 +832,11 @@ jobs:
           # by the default build. Keep them in the same mandatory matrix rather
           # than relying on a PR being correctly labelled as mechanical.
           - { label: "no-default-features",  pkg: proximadb,        args: "--no-default-features" }
+          # AXIS cfg feature (TD-AXIS-4 Superseded): default ON; this variant turns
+          # it OFF while keeping the other defaults on — the PAX-exact-scan build that
+          # excludes the AXIS index engine + its recall/advisor/drift surfaces. Catches
+          # cfg drift where axis code leaks out of the `#[cfg(feature = "axis")]` gates.
+          - { label: "no-axis", pkg: proximadb-server, args: "--no-default-features --features sql_frontend,graph-first-sks,unified-facade-routing,canonical-document-store,datafusion-integration,otlp-metering" }
           - { label: "experimental-engines", pkg: proximadb,        args: "--features experimental-engines" }
           # F3v (TD-DELVEC-1): cold-tier deletion vectors — feature-gated PAX flush-path
           # resolver capture. Check it compiles so cfg drift in that path is caught.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -694,13 +694,19 @@ proximadb-embedded = { path = "crates/binding/proximadb-embedded" }
 # (in-memory-map-as-durable-source) path during one minor-release migration
 # window can opt OUT via `default-features = false` + explicit feature selection.
 # Plan: remove the feature flag entirely in v0.4 once the migration window closes.
-default = ["sql_frontend", "graph-first-sks", "unified-facade-routing", "canonical-document-store", "datafusion-integration", "otlp-metering"]
+default = ["sql_frontend", "graph-first-sks", "unified-facade-routing", "canonical-document-store", "datafusion-integration", "otlp-metering", "axis"]
+# AXIS index engine (HNSW/IVF/RaBitQ ANN) + its recall-advisor / drift / hot-swap surfaces.
+# Default ON = zero behavior change (the canonical ANN path). Gate OFF for PAX exact-scan-only
+# builds (smaller binary, no AXIS boot/index-build cost); search then routes to the exact-scan
+# path (TD-AXIS-4 Superseded; ADR-052). Pure cfg gate — AXIS lives in the root crate, no dep.
+axis = []
 # Optional surfaces; keep off by default to minimize binary size and public API surface
 ai_endpoints = []
 tenant_access = []
 # Experimental storage engines (RAPTOR, SWIFT); disabled by default to prevent
 # server panics from unimplemented code paths. Enable for development/testing only.
-experimental-engines = ["proximadb-raptor-engine/experimental-engines"]
+# RAPTOR fundamentally uses AXIS clustering, so this implies `axis`.
+experimental-engines = ["proximadb-raptor-engine/experimental-engines", "axis"]
 # Experimental transactional Ledger modality (ADR-071 / TD-LEDGER-1): the durable atomic-CAS
 # KV + TTL-lease OLTP surface. Off by default; enables the durable backend + its gRPC service.
 experimental-ledger = ["dep:proximadb-ledger", "proximadb-ledger/durable"]

--- a/apps/proximadb-server/Cargo.toml
+++ b/apps/proximadb-server/Cargo.toml
@@ -29,7 +29,13 @@ default = [
     "graph-first-sks",
     "unified-facade-routing",
     "otlp-metering",
+    "axis",
 ]
+# In-memory ANN index engine (AXIS: HNSW/IVF/RaBitQ). Default ON for the production
+# server — forwarded explicitly (not via workspace feature-unification) so every
+# build path (Dockerfile, `_shared-build`, release) links it. Turn OFF only for the
+# PAX-exact-scan `no-axis` feature-matrix variant (search then routes to exact scan).
+axis = ["proximadb/axis"]
 # The cross-modal OLAP query plane (pgwire → DataFusion): the DataFusion engine + the
 # cross-modal table functions (vector_search / timeseries_range). Without it, parquet-backed
 # tables route to the native Volcano engine and the cross-modal UDTFs are not registered.

--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -15,19 +15,14 @@ path = "src/lib.rs"
 
 [dependencies]
 # Depends on the root proximadb library (one-directional: embedded -> root, no cycle).
-# `default-features = false` + the explicit feature set keeps the ANN index engine
-# (AXIS: `axis`) OFF by default — embedded is in-process with few collections, so
-# exact-scan over PAX segments (served from the OS page cache / on-disk) gives 100%
-# recall with no HNSW/IVF training RSS cost (TD-AXIS-4 PAX-exact-scan direction).
-# Apps that want in-memory ANN opt in with the `axis` feature below.
-proximadb = { path = "../../..", default-features = false, features = [
-    "datafusion-integration",
-    "sql_frontend",
-    "canonical-document-store",
-    "graph-first-sks",
-    "unified-facade-routing",
-    "otlp-metering",
-] }
+# NB: embedded pulls the root *default* features (which include `axis`). Making
+# embedded axis-OFF-by-default breaks the `cargo check --workspace` CI build: the
+# root compiles axis-ON (its default + workspace unification) while embedded compiles
+# axis-OFF, and embedded's flush→AXIS projection reap then sees the root's
+# `Option<&AxisManager>` type while passing `Option<&()>` (cfg is per-crate; the type
+# crosses the crate boundary). A cross-crate-stable flush seam (service trait-ify) is
+# the tracked follow-up; until then embedded stays axis-ON for build consistency.
+proximadb = { path = "../../.." }
 # FA-b: optional, behind the `abac-policy` feature. Embedded mode is abac-OFF by
 # design (in-process; the host app owns authorization) — this dep exists only so
 # the abac verification can compile embedded's calls against root's threaded
@@ -65,10 +60,6 @@ napi-derive = { version = "2.14", optional = true }
 
 [features]
 default = []
-# Opt into the in-memory ANN index engine (AXIS: HNSW/IVF/RaBitQ). OFF by default —
-# embedded defaults to exact-scan (see the `proximadb` dependency note above). Enable
-# only when an embedded app needs approximate search over large collections.
-axis = ["proximadb/axis"]
 # FA-b: mirrors root's `abac-policy`. OFF by default — embedded mode is
 # in-process and the host application owns authorization, so ABAC (a server-side
 # multi-tenant concern) does not apply. The feature exists so the abac

--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -15,7 +15,19 @@ path = "src/lib.rs"
 
 [dependencies]
 # Depends on the root proximadb library (one-directional: embedded -> root, no cycle).
-proximadb = { path = "../../.." }
+# `default-features = false` + the explicit feature set keeps the ANN index engine
+# (AXIS: `axis`) OFF by default — embedded is in-process with few collections, so
+# exact-scan over PAX segments (served from the OS page cache / on-disk) gives 100%
+# recall with no HNSW/IVF training RSS cost (TD-AXIS-4 PAX-exact-scan direction).
+# Apps that want in-memory ANN opt in with the `axis` feature below.
+proximadb = { path = "../../..", default-features = false, features = [
+    "datafusion-integration",
+    "sql_frontend",
+    "canonical-document-store",
+    "graph-first-sks",
+    "unified-facade-routing",
+    "otlp-metering",
+] }
 # FA-b: optional, behind the `abac-policy` feature. Embedded mode is abac-OFF by
 # design (in-process; the host app owns authorization) — this dep exists only so
 # the abac verification can compile embedded's calls against root's threaded
@@ -53,6 +65,10 @@ napi-derive = { version = "2.14", optional = true }
 
 [features]
 default = []
+# Opt into the in-memory ANN index engine (AXIS: HNSW/IVF/RaBitQ). OFF by default —
+# embedded defaults to exact-scan (see the `proximadb` dependency note above). Enable
+# only when an embedded app needs approximate search over large collections.
+axis = ["proximadb/axis"]
 # FA-b: mirrors root's `abac-policy`. OFF by default — embedded mode is
 # in-process and the host application owns authorization, so ABAC (a server-side
 # multi-tenant concern) does not apply. The feature exists so the abac

--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -2378,17 +2378,24 @@ impl EmbeddedProximaDB {
                     // free_wal=true preserves embedded's existing behavior (delete the
                     // WAL after flush — no 2× overhead). Its cold-read recall gap is the
                     // same dependent TD as the server's.
+                    #[cfg(feature = "axis")]
                     let axis_manager = self
                         .shared_services
                         .vector_operations_service
                         .axis_index_manager();
+                    #[cfg(feature = "axis")]
+                    let axis_arg: Option<&proximadb::index::AxisManager> = Some(&axis_manager);
+                    // AXIS compiled out (embedded exact-scan default): no in-memory
+                    // projection to reap — the durable segment is the source of truth.
+                    #[cfg(not(feature = "axis"))]
+                    let axis_arg: Option<&()> = None;
                     match proximadb::storage::flush_materializer::materialize_collection(
                         &write_buffer,
                         &plan,
                         None,
                         Some(fallback_engine),
                         true,
-                        Some(&axis_manager),
+                        axis_arg,
                     )
                     .await
                     {

--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -2378,24 +2378,17 @@ impl EmbeddedProximaDB {
                     // free_wal=true preserves embedded's existing behavior (delete the
                     // WAL after flush — no 2× overhead). Its cold-read recall gap is the
                     // same dependent TD as the server's.
-                    #[cfg(feature = "axis")]
                     let axis_manager = self
                         .shared_services
                         .vector_operations_service
                         .axis_index_manager();
-                    #[cfg(feature = "axis")]
-                    let axis_arg: Option<&proximadb::index::AxisManager> = Some(&axis_manager);
-                    // AXIS compiled out (embedded exact-scan default): no in-memory
-                    // projection to reap — the durable segment is the source of truth.
-                    #[cfg(not(feature = "axis"))]
-                    let axis_arg: Option<&()> = None;
                     match proximadb::storage::flush_materializer::materialize_collection(
                         &write_buffer,
                         &plan,
                         None,
                         Some(fallback_engine),
                         true,
-                        axis_arg,
+                        Some(&axis_manager),
                     )
                     .await
                     {

--- a/docs/12-design/adr/ADR-082-axis-compile-time-feature-gate.adoc
+++ b/docs/12-design/adr/ADR-082-axis-compile-time-feature-gate.adoc
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-082: AXIS is a compile-time Cargo feature `axis` (default ON, gateable OFF)
+:status: Accepted
+:date: 2026-07-30
+:authors: Vijaykumar Singh
+
+[cols="1,3"]
+|===
+| Status | Accepted
+| Date | 2026-07-30
+| Deciders | Vijaykumar Singh
+| Relates to | TD-AXIS-4 (Superseded — AXIS winds down for PAX exact-scan), ADR-052 / `CODESIGN_DIMENSIONAL_ARCHITECTURE_2026_06_19.adoc` (PAX-layout exact-scan path), ADR-070 (co-design default — collections don't pay for indexes they never query), ADR-078 (flush→AXIS single mechanism)
+| Tracked by | PR #1332
+|===
+
+== Context
+
+TD-AXIS-4 was **Superseded (2026-07-29)** with the rationale that *"AXIS is winding
+down in favour of the PAX-layout-driven exact-scan path."* The exact-scan path already
+exists (`sst::search::want_exact_search` → `search_pax_file_exact`) and serves the
+default `SearchMode::Exact` request end-to-end without any in-memory ANN index. But
+AXIS was a **hard** build dependency: `src/index/axis/` compiled unconditionally, the
+`StorageEngine` held a concrete `Arc<AxisManager>` threaded through its core ops, the
+boot path constructed it, and `proximadb-embedded` pulled it via default-features. So a
+"PAX-exact-scan build" that excluded AXIS — smaller binary, no AXIS boot/index-build
+cost (no multi-GB IVF-training RSS) — was **not achievable**. This ADR makes it
+achievable.
+
+AXIS is **not deprecated**; it remains the canonical ANN engine. The gate exists so the
+two deployments that don't need it (PAX-exact-scan servers; in-process embedded apps
+with few collections) can omit it.
+
+== Decision
+
+Make `src/index/axis/` a Cargo feature `axis` that is **ON by default** (zero behavior
+change for every existing build) and **gateable OFF**. When OFF, vector search routes to
+the existing exact-scan path.
+
+**Gating mechanism — `#[cfg(feature = "axis")]` inline gating, NOT a runtime
+`Option<Arc<dyn IndexEngine>>` trait-ify.** A `cfg` attribute whose feature is ON
+includes the gated code *verbatim*, so the default-ON build is byte-for-byte identical.
+This is load-bearing for two reasons:
+
+1. **Recall safety.** The default-ON per-query path is the production ANN path. A
+   trait-ify (`Arc<AxisManager>` → `Option<Arc<dyn IndexEngine>>` + dyn dispatch) would
+   change that path's codegen on the default build — an unnecessary behavior change to a
+   recall-critical surface. Inline cfg leaves it untouched.
+2. **Uniform handling.** `engine.rs` calls 5 manager methods; only 2 (`drop_collection`,
+   `analyze_and_optimize`) are on the `IndexEngine` trait. Trait-ifying would still have
+   to cfg-gate/downcast the other 3 (`delete`, `ensure_collection_strategy`,
+   `get_collection_stats`), producing a messy mix. Inline cfg treats all 5 the same way.
+
+Off-state fallbacks are all recall-safe: `delete`/`drop`/`ensure`/`optimize` become
+no-ops (the record is tombstoned in SST/WAL and filtered on read by the canonical
+predicate, read-invariant #16a); `index_stats` returns `None`; the flush projection-reap
+is skipped (the durable segment is the source of truth). The exact-scan path serves
+every search.
+
+== Per-crate wiring
+
+* **`proximadb` (root):** `axis = []`, added to `default`. `experimental-engines`
+  implies `axis` (RAPTOR uses AXIS clustering). The `sst`/`viper`/`helix`/`nova` modality
+  engines were already trait-ified to `Option<Arc<dyn IndexEngine>>` by ADR-078 / #1281,
+  so only the `StorageEngine` *core* + the service/boot layer held the concrete type —
+  that is what this gate cfg's.
+* **`proximadb-embedded`:** axis-**optional** — `default-features = false` + the
+  exact-scan feature set by default, `axis = ["proximadb/axis"]` opt-in. Embedded has
+  *zero* direct `AxisManager` references (it calls the root library API), so it was only
+  pulling AXIS by accident. In-process / few-collection apps get exact-scan (served from
+  the OS page cache / disk) with no HNSW/IVF training RSS; apps that want ANN opt in.
+* **`proximadb-server`:** `axis` is forwarded **explicitly** in its default. The server
+  previously obtained AXIS only through workspace feature-unification (via the embedded
+  dev-dependency); making embedded axis-optional removed that source, so the server must
+  declare it directly to keep every build path (Dockerfile, `_shared-build`, release)
+  linking it.
+
+== Alternatives considered
+
+* **Trait-ify to `Option<Arc<dyn IndexEngine>>`.** Rejected — changes the default-ON
+  recall path's codegen and still requires cfg-gating the 3 non-trait methods. (This was
+  the approach suggested in the original handoff; verification showed the default-ON
+  byte-identity mandate overrides it.)
+* **Stub `AxisManager` type when off.** Rejected — every concrete-holder struct field
+  still has to be initialized; the stub doesn't solve field-init, and it pollutes the
+  type namespace.
+* **Keep AXIS unconditional; document exact-scan as a runtime mode only.** Rejected —
+  fails the goal (a build that *excludes* AXIS for binary-size / boot-cost reasons, e.g.
+  a minimal embedded artifact).
+
+== Consequences
+
+* **Positive:** PAX-exact-scan builds (server `no-axis` variant; embedded default) exclude
+  AXIS entirely. Default-ON is byte-for-byte unchanged. A new `no-axis` CI feature-matrix
+  variant catches cfg drift where AXIS code leaks out of the gates.
+* **Negative:** the gate adds `#[cfg]` noise across ~43 files; future AXIS-coupling code
+  must remember the gates (the `no-axis` CI variant backstops this). The
+  feature-unification behaviour is subtle — see the gotcha below.
+* **Neutral:** the `#[cfg(feature = "axis")]` patterns established here
+  (cfg-on-fn-param; cfg type-aliases to keep signatures stable across builds; `#![cfg]`
+  for a whole axis-only test file; `#[cfg_attr(not(feature="axis"), allow(dead_code))]`
+  for axis-only helpers) are reusable for the next engine/feature gate.
+
+== Gotcha: feature-unification re-pulls AXIS in the test build
+
+`cargo check -p proximadb-server --no-default-features --features <list>` genuinely
+excludes `axis` (the server declares `default-features = false`). But `cargo test
+--no-default-features …` does **not**: the test build co-compiles `proximadb-embedded`
+as a dev-dependency, and embedded (before this ADR) pulled `proximadb` with default
+features → AXIS unified back ON → axis-gated tests appeared to run on the "no-axis"
+build. The definitive check is `cargo check -p proximadb-server --no-default-features
+--features <list> -v | grep -oE 'feature="[^"]+"'` (no `axis` ⇒ genuinely off). Making
+embedded axis-optional (above) removes this leak.

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -403,6 +403,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Admission-first flush ownership and exact WAL batch claims
 | Accepted (2026-07-29)
 | Makes all materialization triggers share one process-wide engine per format, one operation gate per collection, and bounded cross-collection admission. Exact cancellation-safe WAL batch claims remain readable until publication and retire by ID, preserving writes that arrive during a flush. SST L0 admission moves before clone/sort/train/encode and counts only L0 segments. TD-FLUSH-5 encoding morsels remain within one admitted segment; empty-index collections do not feed AXIS. Tracked: TD-FLUSH-7.
+| link:ADR-082-axis-compile-time-feature-gate.adoc[ADR-082]
+| AXIS is a compile-time Cargo feature `axis` (default ON, gateable OFF)
+| Accepted (2026-07-30)
+| Makes `src/index/axis/` a default-ON Cargo feature gateable OFF for PAX-exact-scan builds (off → exact-scan path), realising the TD-AXIS-4 wind-down. Gating is `#[cfg(feature = "axis")]` inline (not trait-ify) so the default-ON build is byte-for-byte identical and the recall path is untouched; off-state fallbacks are no-op/`None`/exact-scan. `proximadb-embedded` becomes axis-optional (default OFF); `proximadb-server` forwards `axis` explicitly. Tracked: PR #1332.
 | link:ADR-0083-consolidated-catalog-identity-model.adoc[ADR-0083]
 | Consolidated catalog identity model — physical key, addressing composite, display name (three layers)
 | Accepted (2026-07-30)

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -29,6 +29,7 @@ pub mod traits {
 pub use proximadb_catalog::partition_pruning;
 
 // CATALOG_OBJECT_MODEL #3 read-port: catalog adapter for AXIS index-location resolution.
+#[cfg(feature = "axis")]
 pub mod index_location_resolver;
 
 // ADR-035 / TD-SC-1: per-tenant system-catalog hot read cache (byte-bounded,

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -106,6 +106,7 @@ pub use shard::{
 };
 
 // HMGI distributed partitioning surfaces used by cluster-aware AXIS routing.
+#[cfg(feature = "axis")]
 pub use crate::index::axis::hmgi::{
     ClusterMembership as HmgiClusterMembership, ClusterNode as HmgiClusterNode,
     ClusterNodeId as HmgiClusterNodeId, DistributedPartitionLocator as HmgiPartitionLocator,

--- a/src/core/search/engine_benchmarks.rs
+++ b/src/core/search/engine_benchmarks.rs
@@ -767,6 +767,7 @@ impl SearchCostEstimator {
         );*/
 
         Self {
+            #[cfg(feature = "axis")]
             index_search_times: HashMap::new(),
             progressive_search_times: HashMap::new(),
             direct_search_times: HashMap::new(),

--- a/src/core/search/hybrid/builder.rs
+++ b/src/core/search/hybrid/builder.rs
@@ -45,6 +45,7 @@ use tracing::{debug, info, trace};
 
 use crate::core::search::FilterExpression;
 use crate::core::search::filter_contract::{CandidateSet, FilterContract, MetadataLookup};
+#[cfg(feature = "axis")]
 use crate::index::axis::management::manager::HybridQuery as AxisHybridQueryImport;
 
 /// Selectivity below which filter-first (PreFilter) is used. ADR-011: 5%.
@@ -557,6 +558,7 @@ impl Default for HybridQueryBuilder {
 }
 
 /// Convert SearchHybridQuery to AXIS SearchHybridQuery for compatibility
+#[cfg(feature = "axis")]
 impl From<SearchHybridQuery> for AxisHybridQueryImport {
     fn from(query: SearchHybridQuery) -> Self {
         use crate::index::axis::management::manager::AnnFilteringMode;

--- a/src/core/search/integrated_search_optimization.rs
+++ b/src/core/search/integrated_search_optimization.rs
@@ -28,8 +28,16 @@ use crate::core::search::{
     query_preprocessing::QueryPreprocessor, results::OptimizedSearchRecord,
     smart_execution_strategy::SmartExecutionStrategy,
 };
+#[cfg(feature = "axis")]
 use crate::index::axis::management::manager::AxisManager;
+#[cfg(feature = "axis")]
 use crate::index::axis::storage::serialization::Index;
+// `axis_manager` is never `Some` in production (only the storage engine sets it, and
+// the viper orchestrator doesn't). Aliased so the field compiles with `axis` off.
+#[cfg(feature = "axis")]
+type AxisManagerField = Option<Arc<AxisManager>>;
+#[cfg(not(feature = "axis"))]
+type AxisManagerField = Option<()>;
 use crate::storage::cache::{
     MetadataStore, QueryCache,
     orchestrator::{CacheType, CrossCacheOrchestrator},
@@ -85,7 +93,7 @@ pub struct AdvancedSearchOptimizer {
     cost_estimator: Arc<SearchCostEstimator>,
 
     /// AXIS index integration
-    axis_manager: Option<Arc<AxisManager>>,
+    axis_manager: AxisManagerField,
 
     /// Routing engine for intelligent path selection
     #[allow(dead_code)]
@@ -196,6 +204,7 @@ pub struct PerformanceTracker {
 /// Search cost estimator (from IntegratedSearchOptimizer)
 pub struct SearchCostEstimator {
     /// Average search times per index type
+    #[cfg(feature = "axis")]
     pub index_search_times: HashMap<Index, IntegratedSearchPerformanceStats>,
     /// Average search times per quantization level
     pub progressive_search_times:
@@ -288,6 +297,7 @@ impl AdvancedSearchOptimizer {
                 last_update: RwLock::new(Instant::now()),
             }),
             cost_estimator: Arc::new(SearchCostEstimator {
+                #[cfg(feature = "axis")]
                 index_search_times: HashMap::new(),
                 progressive_search_times: HashMap::new(),
                 direct_search_times: HashMap::new(),
@@ -304,6 +314,7 @@ impl AdvancedSearchOptimizer {
     }
 
     /// Set AXIS manager for index integration
+    #[cfg(feature = "axis")]
     pub fn set_axis_manager(&mut self, axis_manager: Arc<AxisManager>) {
         self.axis_manager = Some(axis_manager);
     }
@@ -1128,6 +1139,7 @@ pub trait SearchOptimizer: Send + Sync {
     ) -> Result<Vec<OptimizedSearchRecord>>;
 
     /// Inject an AXIS index manager for index-accelerated search
+    #[cfg(feature = "axis")]
     fn set_axis_manager(&self, _axis: Arc<AxisManager>) {
         // Default no-op
     }

--- a/src/core/search/smart_execution_strategy.rs
+++ b/src/core/search/smart_execution_strategy.rs
@@ -13,7 +13,12 @@ use tracing::{debug, info, trace};
 
 use crate::compute::distance_computation::DistanceMetric;
 use crate::core::search::SearchParams;
-use crate::index::axis::AxisManager;
+// The `axis_manager` strategy hint is vestigial (never `Some` in production, only
+// threaded by tests). Aliased so the signatures compile with `axis` off.
+#[cfg(feature = "axis")]
+type AxisManagerOpt<'a> = Option<&'a crate::index::axis::AxisManager>;
+#[cfg(not(feature = "axis"))]
+type AxisManagerOpt<'a> = Option<&'a ()>;
 use crate::proto::proximadb_v1::QuantizationConfig;
 
 /// Smart execution strategy selector
@@ -290,7 +295,7 @@ impl SmartExecutionStrategy {
         &self,
         collection_id: &str,
         search_params: &SearchParams,
-        axis_manager: Option<&AxisManager>,
+        axis_manager: AxisManagerOpt<'_>,
     ) -> Result<ExecutionStrategy> {
         let start = std::time::Instant::now();
 
@@ -447,7 +452,7 @@ impl SmartExecutionStrategy {
         &self,
         metadata: &CollectionMetadata,
         query: &QueryAnalysis,
-        _axis_manager: Option<&AxisManager>,
+        _axis_manager: AxisManagerOpt<'_>,
     ) -> ExecutionStrategy {
         // Choose best index type based on query
         let index_type = if query.has_filters && metadata.index_types.contains(&"IVF".to_string()) {
@@ -510,7 +515,7 @@ impl SmartExecutionStrategy {
         &self,
         metadata: &CollectionMetadata,
         query: &QueryAnalysis,
-        axis_manager: Option<&AxisManager>,
+        axis_manager: AxisManagerOpt<'_>,
     ) -> ExecutionStrategy {
         let primary = if metadata.has_indexes {
             Box::new(

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -74,9 +74,12 @@
 //! | Annoy     | O(N log N) | O(log N)   | Medium  | 85-95%    |
 //! | Flat      | O(1)       | O(N)       | High    | 100%      |
 
+#[cfg(feature = "axis")]
 pub mod axis;
 pub mod config;
-/// Enhanced Dense Retrieval with late interaction.
+/// Enhanced Dense Retrieval with late interaction. Implements the AXIS
+/// `AxisVectorIndex` trait + uses AXIS types — gated with `axis`.
+#[cfg(feature = "axis")]
 pub mod edr;
 /// Geo-spatial indexing (geohash-based).
 pub mod geo;
@@ -92,6 +95,7 @@ pub mod turboquant_bridge;
 // The canonical implementations live in `src/index/axis/indexes/`.
 
 // Re-export main types for easier access
+#[cfg(feature = "axis")]
 pub use axis::{AxisConfig, AxisManager, IndexLocationResolver};
 pub use config::{
     IndexUpdateMode, RuntimeHnswConfig, RuntimeIndexConfig, RuntimeIvfConfig, RuntimeLshConfig,
@@ -105,7 +109,10 @@ pub use geo::{
 
 // Placeholder index structures for compilation
 use anyhow::Result;
-use std::sync::{Arc, OnceLock};
+#[cfg(feature = "axis")]
+use std::sync::Arc;
+#[cfg(feature = "axis")]
+use std::sync::OnceLock;
 
 use crate::core::VectorId;
 use proximadb_records::ProximaRecord;
@@ -115,10 +122,12 @@ use proximadb_records::ProximaRecord;
 /// flush trigger resolves it here (mirroring `AutoFlushDriver`'s field) so an inline
 /// size-triggered flush can clear the in-memory AXIS projection exactly like the
 /// periodic/shutdown paths — preventing duplicate results for collections that use AXIS.
+#[cfg(feature = "axis")]
 static GLOBAL_AXIS_MANAGER: OnceLock<Arc<AxisManager>> = OnceLock::new();
 
 /// Set the global concrete `AxisManager` (once, at engine start). Idempotent: a second
 /// call is a no-op (the first wins), matching `OnceLock` semantics.
+#[cfg(feature = "axis")]
 pub fn set_global_axis_manager(manager: Arc<AxisManager>) {
     let _ = GLOBAL_AXIS_MANAGER.set(manager);
 }
@@ -126,6 +135,7 @@ pub fn set_global_axis_manager(manager: Arc<AxisManager>) {
 /// Get the global concrete `AxisManager` if the engine has started. `None` before init
 /// — acceptable for the inline flush trigger, which then flushes without clearing the
 /// AXIS projection (same as if the manager were absent; the periodic driver clears it).
+#[cfg(feature = "axis")]
 pub fn get_global_axis_manager() -> Option<Arc<AxisManager>> {
     GLOBAL_AXIS_MANAGER.get().cloned()
 }
@@ -327,11 +337,14 @@ impl SparseVectorIndex {
 }
 
 /// Placeholder Join Engine
+/// Placeholder Join Engine — only referenced from the AXIS manager (`axis/management/manager.rs`).
+#[cfg(feature = "axis")]
 #[derive(Debug)]
 pub struct JoinEngine {
     // Placeholder implementation
 }
 
+#[cfg(feature = "axis")]
 impl JoinEngine {
     /// Creates a new join engine for hybrid multi-index query execution.
     pub async fn new() -> Result<Self> {

--- a/src/network/rest/v2/collections.rs
+++ b/src/network/rest/v2/collections.rs
@@ -43,6 +43,7 @@ use crate::errors::{ApiError, ApiResult};
 // handler's IVF dispatch arm can call `.advise(...)` on
 // IvfIndexAdvisor (P2.4 commit). HnswIndexAdvisor / HmgiIndexAdvisor
 // (P3) similarly require the trait in scope.
+#[cfg(feature = "axis")]
 use crate::index::axis::management::AnnIndexAdvisor;
 use crate::network::middleware::tenant::TenantContext;
 use crate::network::rest::canonical::handlers::AppState;
@@ -1564,6 +1565,7 @@ pub const ACTION_RAISE_MAX_EF_OR_BUMP_M: &str = "raise_max_ef_or_bump_m";
 ///
 /// The literal matches `SupportedAlgorithm::label()` so dashboards
 /// + SIEM filters can switch on the same string across surfaces.
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 pub(super) fn active_algorithm_for(
     config: &crate::proto::proximadb_v1::CollectionConfig,
 ) -> &'static str {
@@ -1595,6 +1597,7 @@ pub(super) fn active_algorithm_for(
 /// `clamped == true` ALWAYS wins over kind, even when kind="none" —
 /// a "no-drift" status that's silently clamped is misleading; the
 /// real choice is "raise the cap or bump m".
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 pub(super) fn recommended_action_for(kind: &str, clamped: bool) -> &'static str {
     if clamped {
         return ACTION_RAISE_MAX_EF_OR_BUMP_M;
@@ -1784,6 +1787,7 @@ impl ColdServingHealth {
     }
 
     /// Build from `AxisManager::cold_serving_status` output.
+    #[cfg(feature = "axis")]
     fn from_status(
         state: crate::index::axis::IvfServingState,
         fetched: usize,
@@ -2435,123 +2439,132 @@ pub async fn get_collection_route_health_v2(
 
     // ADR-023 R3 (c): patch the cold-serving block with live AXIS state — the
     // cold→warm window + per-cluster warm-fill progress for a loaded IVF index.
-    health.cold_serving = match crate::storage::engines::sst::core::get_sst_axis_manager() {
-        Some(axis) => match axis
-            .ivf_cold_serving_status(&collection_id_for_discovery)
-            .await
-        {
-            Some((state_str, fetched, total)) => {
-                use crate::index::axis::IvfServingState;
-                let state = match state_str.as_str() {
-                    "full_two_stage" => IvfServingState::FullTwoStage,
-                    "cold_binary_only" => IvfServingState::ColdBinaryOnly,
-                    _ => IvfServingState::ColdBinaryOnly, // Default fallback
-                };
-                ColdServingHealth::from_status(state, fetched, total)
-            }
+    // When the `axis` feature is off the builder default
+    // (`ColdServingHealth::unobservable()`) is left in place.
+    #[cfg(feature = "axis")]
+    {
+        health.cold_serving = match crate::storage::engines::sst::core::get_sst_axis_manager() {
+            Some(axis) => match axis
+                .ivf_cold_serving_status(&collection_id_for_discovery)
+                .await
+            {
+                Some((state_str, fetched, total)) => {
+                    use crate::index::axis::IvfServingState;
+                    let state = match state_str.as_str() {
+                        "full_two_stage" => IvfServingState::FullTwoStage,
+                        "cold_binary_only" => IvfServingState::ColdBinaryOnly,
+                        _ => IvfServingState::ColdBinaryOnly, // Default fallback
+                    };
+                    ColdServingHealth::from_status(state, fetched, total)
+                }
+                None => ColdServingHealth::unobservable(),
+            },
             None => ColdServingHealth::unobservable(),
-        },
-        None => ColdServingHealth::unobservable(),
-    };
+        };
+    }
 
     // Patch the recall_drift block when the collection has a
     // `recall_target:<float>` tag. Otherwise the builder default
-    // (RecallDriftHealth::unwired()) is correct.
-    if let Some(recall_target) =
-        crate::services::collection::recall_target::parse_recall_target(&config)
+    // (RecallDriftHealth::unwired()) is correct. When the `axis`
+    // feature is off the builder default is left in place.
+    #[cfg(feature = "axis")]
     {
-        let baseline_n =
-            crate::services::collection::recall_target::parse_target_vector_count(&config)
-                .unwrap_or(100_000);
-        let current_n = non_negative_stat(stats.vector_count);
-        let metric = match config
-            .distance_metric
-            .and_then(|v| crate::proto::proximadb_v1::DistanceMetric::try_from(v).ok())
+        if let Some(recall_target) =
+            crate::services::collection::recall_target::parse_recall_target(&config)
         {
-            Some(crate::proto::proximadb_v1::DistanceMetric::Cosine) => {
-                crate::compute::distance_computation::DistanceMetric::Cosine
-            }
-            Some(crate::proto::proximadb_v1::DistanceMetric::Euclidean) => {
-                crate::compute::distance_computation::DistanceMetric::Euclidean
-            }
-            Some(crate::proto::proximadb_v1::DistanceMetric::DotProduct) => {
-                crate::compute::distance_computation::DistanceMetric::DotProduct
-            }
-            _ => crate::compute::distance_computation::DistanceMetric::Cosine,
-        };
-        let top_k = crate::services::collection::recall_target::resolve_top_k(&config);
-        let max_ef_search =
-            crate::services::collection::recall_target::parse_max_ef_search(&config);
-        let report = crate::index::axis::management::detect_recall_drift(
-            crate::index::axis::management::RecallDriftInput {
-                baseline_n,
-                current_n,
-                recall_target,
-                top_k,
-                dimension: config.dimension,
-                distance_metric: metric,
+            let baseline_n =
+                crate::services::collection::recall_target::parse_target_vector_count(&config)
+                    .unwrap_or(100_000);
+            let current_n = non_negative_stat(stats.vector_count);
+            let metric = match config
+                .distance_metric
+                .and_then(|v| crate::proto::proximadb_v1::DistanceMetric::try_from(v).ok())
+            {
+                Some(crate::proto::proximadb_v1::DistanceMetric::Cosine) => {
+                    crate::compute::distance_computation::DistanceMetric::Cosine
+                }
+                Some(crate::proto::proximadb_v1::DistanceMetric::Euclidean) => {
+                    crate::compute::distance_computation::DistanceMetric::Euclidean
+                }
+                Some(crate::proto::proximadb_v1::DistanceMetric::DotProduct) => {
+                    crate::compute::distance_computation::DistanceMetric::DotProduct
+                }
+                _ => crate::compute::distance_computation::DistanceMetric::Cosine,
+            };
+            let top_k = crate::services::collection::recall_target::resolve_top_k(&config);
+            let max_ef_search =
+                crate::services::collection::recall_target::parse_max_ef_search(&config);
+            let report = crate::index::axis::management::detect_recall_drift(
+                crate::index::axis::management::RecallDriftInput {
+                    baseline_n,
+                    current_n,
+                    recall_target,
+                    top_k,
+                    dimension: config.dimension,
+                    distance_metric: metric,
+                    max_ef_search,
+                },
+            );
+            let kind: &'static str = match report.drift_kind {
+                crate::index::axis::management::DriftKind::None => "none",
+                crate::index::axis::management::DriftKind::EfSearchOnly => "ef_search_only",
+                crate::index::axis::management::DriftKind::EfConstructionOrM => "rebuild_required",
+                // IVF variants — when the route-health handler grows
+                // an IVF dispatch path (P2 commit 4) these branches
+                // will fire on `detect_ivf_recall_drift` output. For
+                // now the HNSW-only handler can't produce them.
+                crate::index::axis::management::DriftKind::NprobeOnly => "ef_search_only",
+                crate::index::axis::management::DriftKind::NlistOrQuantizer => "rebuild_required",
+            };
+            let baseline_params = Some(RecallAdvisedParams {
+                m: report.baseline_params.m,
+                ef_construction: report.baseline_params.ef_construction,
+                ef_search: report.baseline_params.ef_search,
+            });
+            let current_params = Some(RecallAdvisedParams {
+                m: report.current_params.m,
+                ef_construction: report.current_params.ef_construction,
+                ef_search: report.current_params.ef_search,
+            });
+            let clamped = report.current_params.clamped_by_max_ef;
+            let projected = report.current_params.projected_recall_if_clamped;
+            health.recall_drift = RecallDriftHealth {
+                wired: true,
+                recall_target: Some(recall_target),
+                baseline_vector_count: Some(baseline_n),
+                current_vector_count: Some(current_n),
+                kind,
+                needs_rebuild: report.needs_rebuild(),
+                hot_swap_possible: report.hot_swap_possible(),
+                summary: report.summary,
+                baseline_params,
+                current_params,
+                recommended_action: recommended_action_for(kind, clamped),
                 max_ef_search,
-            },
-        );
-        let kind: &'static str = match report.drift_kind {
-            crate::index::axis::management::DriftKind::None => "none",
-            crate::index::axis::management::DriftKind::EfSearchOnly => "ef_search_only",
-            crate::index::axis::management::DriftKind::EfConstructionOrM => "rebuild_required",
-            // IVF variants — when the route-health handler grows
-            // an IVF dispatch path (P2 commit 4) these branches
-            // will fire on `detect_ivf_recall_drift` output. For
-            // now the HNSW-only handler can't produce them.
-            crate::index::axis::management::DriftKind::NprobeOnly => "ef_search_only",
-            crate::index::axis::management::DriftKind::NlistOrQuantizer => "rebuild_required",
-        };
-        let baseline_params = Some(RecallAdvisedParams {
-            m: report.baseline_params.m,
-            ef_construction: report.baseline_params.ef_construction,
-            ef_search: report.baseline_params.ef_search,
-        });
-        let current_params = Some(RecallAdvisedParams {
-            m: report.current_params.m,
-            ef_construction: report.current_params.ef_construction,
-            ef_search: report.current_params.ef_search,
-        });
-        let clamped = report.current_params.clamped_by_max_ef;
-        let projected = report.current_params.projected_recall_if_clamped;
-        health.recall_drift = RecallDriftHealth {
-            wired: true,
-            recall_target: Some(recall_target),
-            baseline_vector_count: Some(baseline_n),
-            current_vector_count: Some(current_n),
-            kind,
-            needs_rebuild: report.needs_rebuild(),
-            hot_swap_possible: report.hot_swap_possible(),
-            summary: report.summary,
-            baseline_params,
-            current_params,
-            recommended_action: recommended_action_for(kind, clamped),
-            max_ef_search,
-            clamped_by_max_ef: clamped,
-            projected_recall_at_clamped_ef: projected,
-            // P2.4: dispatch on the collection's active algorithm.
-            // HNSW path runs the HNSW drift detector above; IVF
-            // collections report "ivf" so the recall-tune /
-            // recluster handlers route correctly. The drift block
-            // params above are the HNSW-shape report — IVF route-
-            // health surface gets the IVF-specific drift block in
-            // a follow-up commit; for now the algorithm literal
-            // is the key dispatch signal.
-            algorithm: active_algorithm_for(&config),
-        };
-        crate::metrics::recall_drift_metrics::record_recall_drift_observation(
-            &collection_id_for_discovery,
-            kind,
-        );
-    } else {
-        // No recall_target tag → emit the unwired one-hot so the
-        // gauge still surfaces this collection's state on dashboards.
-        crate::metrics::recall_drift_metrics::record_recall_drift_observation(
-            &collection_id_for_discovery,
-            "unwired",
-        );
+                clamped_by_max_ef: clamped,
+                projected_recall_at_clamped_ef: projected,
+                // P2.4: dispatch on the collection's active algorithm.
+                // HNSW path runs the HNSW drift detector above; IVF
+                // collections report "ivf" so the recall-tune /
+                // recluster handlers route correctly. The drift block
+                // params above are the HNSW-shape report — IVF route-
+                // health surface gets the IVF-specific drift block in
+                // a follow-up commit; for now the algorithm literal
+                // is the key dispatch signal.
+                algorithm: active_algorithm_for(&config),
+            };
+            crate::metrics::recall_drift_metrics::record_recall_drift_observation(
+                &collection_id_for_discovery,
+                kind,
+            );
+        } else {
+            // No recall_target tag → emit the unwired one-hot so the
+            // gauge still surfaces this collection's state on dashboards.
+            crate::metrics::recall_drift_metrics::record_recall_drift_observation(
+                &collection_id_for_discovery,
+                "unwired",
+            );
+        }
     }
 
     // Phase 8 (F1): patch the discovery block with live snapshot-coordinator
@@ -2664,6 +2677,9 @@ pub struct RecallTuneEfChange {
 
 /// Adaptive recall tune handler.
 ///
+/// This endpoint is gated on the `axis` feature — the whole handler is
+/// elided (and its route is not registered) when `axis` is off.
+///
 /// Reads `recall_target:` from the collection's tags, runs
 /// `detect_recall_drift`, then:
 ///
@@ -2680,6 +2696,7 @@ pub struct RecallTuneEfChange {
 /// `SystemAdmin` or `ConfigureSystem` permission. The auth gate
 /// matches `primary_pod::authorize_operator` because this endpoint
 /// **mutates** the live AXIS strategy.
+#[cfg(feature = "axis")]
 pub async fn post_collection_recall_tune_v2(
     Path(collection_id): Path<String>,
     Extension(tenant): Extension<TenantContext>,
@@ -3145,6 +3162,10 @@ pub async fn post_collection_resume_v2(
 /// the HNSW graph — non-trivial CPU + memory — so it sits behind
 /// the same `SystemAdmin` / `ConfigureSystem` gate as
 /// `primary_pod`.
+/// When the `axis` feature is off the rebuild branch is elided and this
+/// handler short-circuits with a 501; the `tenant` / `state` extractors are
+/// then unused, so silence that one lint in a no-axis build only.
+#[cfg_attr(not(feature = "axis"), allow(unused_variables))]
 pub async fn post_collection_recluster_v2(
     Path(collection_id): Path<String>,
     Extension(tenant): Extension<TenantContext>,
@@ -3164,199 +3185,224 @@ pub async fn post_collection_recluster_v2(
 
     require_recall_admin(user_context.as_ref().map(|e| &e.0), "recluster")?;
 
-    // (1) Fetch collection config to read the recall_target tag.
-    let request = CollectionRequest {
-        operation: CollectionOperation::CollectionGet as i32,
-        collection_id: Some(collection_id.clone()),
-        collection_config: None,
-        query_params: Default::default(),
-        options: Default::default(),
-        migration_config: Default::default(),
-    };
-    let resp = state
-        .api_handlers
-        .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
-        .await
-        .map_err(|e| {
-            if e.to_string().contains("not found") {
-                ApiError::CollectionNotFound(collection_id.clone())
-            } else {
-                ApiError::Internal(format!("Failed to get collection: {}", e))
+    // The recall-aware rebuild reads the live collection and downcasts to the
+    // concrete AXIS index manager to drive an advisor-sized graph swap. The
+    // whole sequence is gated on the `axis` feature; when it is off there is
+    // no manager to downcast, so surface a 501 rather than attempt the rebuild
+    // (the empty-id + admin gates above still run).
+    #[cfg(not(feature = "axis"))]
+    return Err(ApiError::NotImplemented(
+        "recluster requires the AXIS feature, which is not enabled in this build".to_string(),
+    ));
+
+    #[cfg(feature = "axis")]
+    {
+        // (1) Fetch collection config to read the recall_target tag.
+        let request = CollectionRequest {
+            operation: CollectionOperation::CollectionGet as i32,
+            collection_id: Some(collection_id.clone()),
+            collection_config: None,
+            query_params: Default::default(),
+            options: Default::default(),
+            migration_config: Default::default(),
+        };
+        let resp = state
+            .api_handlers
+            .handle_collection_operation_for_tenant(request, Some(&tenant.tenant_id))
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("not found") {
+                    ApiError::CollectionNotFound(collection_id.clone())
+                } else {
+                    ApiError::Internal(format!("Failed to get collection: {}", e))
+                }
+            })?;
+
+        let collection = resp.collection.unwrap_or_default();
+        let config = collection.config.unwrap_or_default();
+
+        let Some(recall_target) =
+            crate::services::collection::recall_target::parse_recall_target(&config)
+        else {
+            return Ok(Json(RecallReclusterResponse {
+                stability: "experimental",
+                collection_id,
+                applied: false,
+                reason: "collection has no recall_target: tag — nothing to size against"
+                    .to_string(),
+                rebuilt_vector_count: None,
+                sized: None,
+            }));
+        };
+
+        let Some(axis_manager) = crate::storage::engines::sst::core::get_sst_axis_manager() else {
+            return Ok(Json(RecallReclusterResponse {
+                stability: "experimental",
+                collection_id,
+                applied: false,
+                reason: "AXIS manager not registered for this deployment".to_string(),
+                rebuilt_vector_count: None,
+                sized: None,
+            }));
+        };
+
+        // (2) Read every record. Resolves the user-facing name to the
+        // canonical internal id (same as the discovery recluster pass).
+        let vector_ops = &state.vector_operations_service;
+        let internal_id = vector_ops.resolve_collection_id(&collection_id).await;
+        let records = vector_ops
+            .list_all_records_with_tenant_context(internal_id.as_str(), None)
+            .await
+            .map_err(|e| ApiError::Internal(format!("Failed to list records: {}", e)))?;
+
+        if records.is_empty() {
+            return Ok(Json(RecallReclusterResponse {
+                stability: "experimental",
+                collection_id,
+                applied: false,
+                reason: "collection has no records to rebuild".to_string(),
+                rebuilt_vector_count: Some(0),
+                sized: None,
+            }));
+        }
+
+        let count = records.len() as u64;
+        let top_k = crate::services::collection::recall_target::resolve_top_k(&config);
+        let max_ef_search =
+            crate::services::collection::recall_target::parse_max_ef_search(&config);
+        let max_query_latency_ms =
+            crate::services::collection::recall_target::parse_max_query_latency_ms(&config);
+        let max_memory_mb =
+            crate::services::collection::recall_target::parse_max_memory_mb(&config);
+        let binary_rerank =
+            crate::services::collection::recall_target::parse_binary_rerank_allowed(&config);
+
+        // (3) Dispatch the rebuild on the collection's active
+        // algorithm. HNSW path stays untouched (existing behavior);
+        // IVF path calls the new advisor-aware rebuild and
+        // normalises the response shape via the `algorithm` literal
+        // and per-algorithm sized fields.
+        let active_algo = active_algorithm_for(&config);
+        let sized: Option<RecallReclusterSized> = match active_algo {
+            "ivf" => {
+                // Downcast to concrete AxisManager for recall-target advisor methods
+                let axis_mgr = axis_manager
+                    .as_any()
+                    .downcast_ref::<crate::index::axis::management::AxisManager>()
+                    .ok_or_else(|| {
+                        ApiError::Internal("AXIS manager downcast failed".to_string())
+                    })?;
+                let advised = axis_mgr
+                    .rebuild_and_swap_ivf_index_for_recall_target(
+                        internal_id.as_str(),
+                        &records,
+                        recall_target,
+                        top_k,
+                        max_query_latency_ms,
+                        max_memory_mb,
+                        binary_rerank,
+                    )
+                    .await
+                    .map_err(|e| ApiError::Internal(format!("IVF rebuild failed: {}", e)))?;
+                let Some(advised) = advised else {
+                    return Ok(Json(RecallReclusterResponse {
+                        stability: "experimental",
+                        collection_id,
+                        applied: false,
+                        reason:
+                            "IVF advisor declined or no usable embeddings — recall_target may exceed IVF ceiling"
+                                .to_string(),
+                        rebuilt_vector_count: Some(count),
+                        sized: None,
+                    }));
+                };
+                let (nlist, nprobe, pq_enabled) = match &advised.algorithm {
+                    crate::index::axis::types::IndexAlgorithm::IVF {
+                        nlist,
+                        nprobe,
+                        quantizer,
+                    } => (*nlist, *nprobe, quantizer.is_some()),
+                    other => {
+                        unreachable!("IVF rebuild returned non-IVF algorithm spec: {:?}", other)
+                    }
+                };
+                Some(RecallReclusterSized {
+                    recall_target,
+                    algorithm: "ivf",
+                    m: None,
+                    ef_construction: None,
+                    ef_search: None,
+                    nlist: Some(nlist),
+                    nprobe: Some(nprobe),
+                    pq_enabled: Some(pq_enabled),
+                    rationale: advised.rationale,
+                })
             }
-        })?;
+            _ => {
+                // Downcast to concrete AxisManager for recall-target advisor methods
+                let axis_mgr = axis_manager
+                    .as_any()
+                    .downcast_ref::<crate::index::axis::management::AxisManager>()
+                    .ok_or_else(|| {
+                        ApiError::Internal("AXIS manager downcast failed".to_string())
+                    })?;
+                let advised = axis_mgr
+                    .rebuild_and_swap_hnsw_index_for_recall_target(
+                        internal_id.as_str(),
+                        &records,
+                        recall_target,
+                        top_k,
+                        max_ef_search,
+                    )
+                    .await
+                    .map_err(|e| ApiError::Internal(format!("HNSW rebuild failed: {}", e)))?;
+                let Some(advised) = advised else {
+                    return Ok(Json(RecallReclusterResponse {
+                        stability: "experimental",
+                        collection_id,
+                        applied: false,
+                        reason: "no usable embeddings in record set".to_string(),
+                        rebuilt_vector_count: Some(count),
+                        sized: None,
+                    }));
+                };
+                Some(RecallReclusterSized {
+                    recall_target,
+                    algorithm: "hnsw",
+                    m: Some(advised.m),
+                    ef_construction: Some(advised.ef_construction),
+                    ef_search: Some(advised.ef_search),
+                    nlist: None,
+                    nprobe: None,
+                    pq_enabled: None,
+                    rationale: advised.rationale,
+                })
+            }
+        };
 
-    let collection = resp.collection.unwrap_or_default();
-    let config = collection.config.unwrap_or_default();
+        // After a rebuild the recall-drift state collapses to "none"
+        // for this collection (the new graph is sized exactly to the
+        // current advised params). Reflect that on the gauge so
+        // dashboards / alerts clear immediately rather than waiting
+        // for the next route-health GET or sweep tick.
+        crate::metrics::recall_drift_metrics::record_recall_drift_observation(
+            &collection_id,
+            "none",
+        );
 
-    let Some(recall_target) =
-        crate::services::collection::recall_target::parse_recall_target(&config)
-    else {
-        return Ok(Json(RecallReclusterResponse {
+        let reason = sized
+            .as_ref()
+            .map(|s| s.rationale.clone())
+            .unwrap_or_default();
+        Ok(Json(RecallReclusterResponse {
             stability: "experimental",
             collection_id,
-            applied: false,
-            reason: "collection has no recall_target: tag — nothing to size against".to_string(),
-            rebuilt_vector_count: None,
-            sized: None,
-        }));
-    };
-
-    let Some(axis_manager) = crate::storage::engines::sst::core::get_sst_axis_manager() else {
-        return Ok(Json(RecallReclusterResponse {
-            stability: "experimental",
-            collection_id,
-            applied: false,
-            reason: "AXIS manager not registered for this deployment".to_string(),
-            rebuilt_vector_count: None,
-            sized: None,
-        }));
-    };
-
-    // (2) Read every record. Resolves the user-facing name to the
-    // canonical internal id (same as the discovery recluster pass).
-    let vector_ops = &state.vector_operations_service;
-    let internal_id = vector_ops.resolve_collection_id(&collection_id).await;
-    let records = vector_ops
-        .list_all_records_with_tenant_context(internal_id.as_str(), None)
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to list records: {}", e)))?;
-
-    if records.is_empty() {
-        return Ok(Json(RecallReclusterResponse {
-            stability: "experimental",
-            collection_id,
-            applied: false,
-            reason: "collection has no records to rebuild".to_string(),
-            rebuilt_vector_count: Some(0),
-            sized: None,
-        }));
+            applied: sized.is_some(),
+            reason,
+            rebuilt_vector_count: Some(count),
+            sized,
+        }))
     }
-
-    let count = records.len() as u64;
-    let top_k = crate::services::collection::recall_target::resolve_top_k(&config);
-    let max_ef_search = crate::services::collection::recall_target::parse_max_ef_search(&config);
-    let max_query_latency_ms =
-        crate::services::collection::recall_target::parse_max_query_latency_ms(&config);
-    let max_memory_mb = crate::services::collection::recall_target::parse_max_memory_mb(&config);
-    let binary_rerank =
-        crate::services::collection::recall_target::parse_binary_rerank_allowed(&config);
-
-    // (3) Dispatch the rebuild on the collection's active
-    // algorithm. HNSW path stays untouched (existing behavior);
-    // IVF path calls the new advisor-aware rebuild and
-    // normalises the response shape via the `algorithm` literal
-    // and per-algorithm sized fields.
-    let active_algo = active_algorithm_for(&config);
-    let sized: Option<RecallReclusterSized> = match active_algo {
-        "ivf" => {
-            // Downcast to concrete AxisManager for recall-target advisor methods
-            let axis_mgr = axis_manager
-                .as_any()
-                .downcast_ref::<crate::index::axis::management::AxisManager>()
-                .ok_or_else(|| ApiError::Internal("AXIS manager downcast failed".to_string()))?;
-            let advised = axis_mgr
-                .rebuild_and_swap_ivf_index_for_recall_target(
-                    internal_id.as_str(),
-                    &records,
-                    recall_target,
-                    top_k,
-                    max_query_latency_ms,
-                    max_memory_mb,
-                    binary_rerank,
-                )
-                .await
-                .map_err(|e| ApiError::Internal(format!("IVF rebuild failed: {}", e)))?;
-            let Some(advised) = advised else {
-                return Ok(Json(RecallReclusterResponse {
-                    stability: "experimental",
-                    collection_id,
-                    applied: false,
-                    reason:
-                        "IVF advisor declined or no usable embeddings — recall_target may exceed IVF ceiling"
-                            .to_string(),
-                    rebuilt_vector_count: Some(count),
-                    sized: None,
-                }));
-            };
-            let (nlist, nprobe, pq_enabled) = match &advised.algorithm {
-                crate::index::axis::types::IndexAlgorithm::IVF {
-                    nlist,
-                    nprobe,
-                    quantizer,
-                } => (*nlist, *nprobe, quantizer.is_some()),
-                other => unreachable!("IVF rebuild returned non-IVF algorithm spec: {:?}", other),
-            };
-            Some(RecallReclusterSized {
-                recall_target,
-                algorithm: "ivf",
-                m: None,
-                ef_construction: None,
-                ef_search: None,
-                nlist: Some(nlist),
-                nprobe: Some(nprobe),
-                pq_enabled: Some(pq_enabled),
-                rationale: advised.rationale,
-            })
-        }
-        _ => {
-            // Downcast to concrete AxisManager for recall-target advisor methods
-            let axis_mgr = axis_manager
-                .as_any()
-                .downcast_ref::<crate::index::axis::management::AxisManager>()
-                .ok_or_else(|| ApiError::Internal("AXIS manager downcast failed".to_string()))?;
-            let advised = axis_mgr
-                .rebuild_and_swap_hnsw_index_for_recall_target(
-                    internal_id.as_str(),
-                    &records,
-                    recall_target,
-                    top_k,
-                    max_ef_search,
-                )
-                .await
-                .map_err(|e| ApiError::Internal(format!("HNSW rebuild failed: {}", e)))?;
-            let Some(advised) = advised else {
-                return Ok(Json(RecallReclusterResponse {
-                    stability: "experimental",
-                    collection_id,
-                    applied: false,
-                    reason: "no usable embeddings in record set".to_string(),
-                    rebuilt_vector_count: Some(count),
-                    sized: None,
-                }));
-            };
-            Some(RecallReclusterSized {
-                recall_target,
-                algorithm: "hnsw",
-                m: Some(advised.m),
-                ef_construction: Some(advised.ef_construction),
-                ef_search: Some(advised.ef_search),
-                nlist: None,
-                nprobe: None,
-                pq_enabled: None,
-                rationale: advised.rationale,
-            })
-        }
-    };
-
-    // After a rebuild the recall-drift state collapses to "none"
-    // for this collection (the new graph is sized exactly to the
-    // current advised params). Reflect that on the gauge so
-    // dashboards / alerts clear immediately rather than waiting
-    // for the next route-health GET or sweep tick.
-    crate::metrics::recall_drift_metrics::record_recall_drift_observation(&collection_id, "none");
-
-    let reason = sized
-        .as_ref()
-        .map(|s| s.rationale.clone())
-        .unwrap_or_default();
-    Ok(Json(RecallReclusterResponse {
-        stability: "experimental",
-        collection_id,
-        applied: sized.is_some(),
-        reason,
-        rebuilt_vector_count: Some(count),
-        sized,
-    }))
 }
 
 #[cfg(test)]

--- a/src/network/rest/v2/mod.rs
+++ b/src/network/rest/v2/mod.rs
@@ -89,7 +89,7 @@ use super::canonical::handlers::AppState;
 pub fn create_v2_router() -> Router<AppState> {
     use axum::routing::{delete, get, post, put};
 
-    Router::new()
+    let router = Router::new()
         // Collection operations with schema support
         .route("/collections", post(collections::create_collection_v2))
         .route("/collections", get(collections::list_collections_v2))
@@ -240,15 +240,19 @@ pub fn create_v2_router() -> Router<AppState> {
         .route(
             "/_diagnostics/collections/{collection_id}/statistics",
             get(collections::get_collection_statistics_v2),
-        )
-        // Adaptive HNSW retune. POST resolves DriftKind::EfSearchOnly
-        // in-place via AxisManager::apply_hnsw_ef_hot_swap; reports
-        // DriftKind::EfConstructionOrM cases as "rebuild required"
-        // (operator must run /recluster — separate slice).
-        .route(
-            "/_diagnostics/collections/{collection_id}/recall-tune",
-            axum::routing::post(collections::post_collection_recall_tune_v2),
-        )
+        );
+    // Adaptive HNSW retune. AXIS-only — the handler and this route are
+    // elided when the `axis` feature is off. POST resolves
+    // DriftKind::EfSearchOnly in-place via
+    // AxisManager::apply_hnsw_ef_hot_swap; reports
+    // DriftKind::EfConstructionOrM cases as "rebuild required"
+    // (operator must run /recluster — separate slice).
+    #[cfg(feature = "axis")]
+    let router = router.route(
+        "/_diagnostics/collections/{collection_id}/recall-tune",
+        axum::routing::post(collections::post_collection_recall_tune_v2),
+    );
+    router
         // Recall-aware HNSW rebuild. POST reads every record for the
         // collection, runs the advisor at the live N, and atomically
         // swaps in a new HNSW graph sized for the recall_target tag.

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1307,63 +1307,62 @@ impl SharedServices {
         // SharedServices field that AppState/route-health read.
         let recall_probe_gate = Arc::new(crate::catalog::RecallProbeGate::new());
 
-        // Create AxisManager for index operations
-        debug!("🔧 SharedServices::new - Creating AxisManager for index operations...");
-        let mut axis_manager_inner =
-            crate::index::AxisManager::new(crate::index::AxisConfig::default()).await?;
-        axis_manager_inner.set_recall_probe_gate(recall_probe_gate.clone());
-        // ADR-023 R3 Slice 4: give AXIS the shared FilesystemFactory so index
-        // persistence + cold-load can dispatch by scheme (s3/adls/gs/file).
-        axis_manager_inner.set_filesystem_factory(filesystem_factory.clone());
-        // Route index persistence through an object-store URI when configured
-        // (PROXIMADB_INDEX_PERSIST_URL=s3://bucket/prefix | adls://… | gs://…) —
-        // the cold-load path then reads only [header]+[COLD]+probed clusters via
-        // byte-range GETs. Otherwise persist under the local data dir so a cold
-        // collection warms from disk on first query (TD-087 Slice B; no-op without
-        // a data dir).
-        if let Ok(url) = std::env::var("PROXIMADB_INDEX_PERSIST_URL") {
-            axis_manager_inner.set_index_persist_url(url);
-        } else if let Some(cfg) = opt_config {
-            axis_manager_inner.set_index_persist_dir(cfg.server.data_dir.join("axis_indexes"));
-        }
+        // Create AxisManager for index operations (AXIS-gated: the whole index
+        // engine + its registrations vanish from a PAX-exact-scan build).
+        #[cfg(feature = "axis")]
+        let axis_manager = {
+            debug!("🔧 SharedServices::new - Creating AxisManager for index operations...");
+            let mut axis_manager_inner =
+                crate::index::AxisManager::new(crate::index::AxisConfig::default()).await?;
+            axis_manager_inner.set_recall_probe_gate(recall_probe_gate.clone());
+            // ADR-023 R3 Slice 4: give AXIS the shared FilesystemFactory so index
+            // persistence + cold-load can dispatch by scheme (s3/adls/gs/file).
+            axis_manager_inner.set_filesystem_factory(filesystem_factory.clone());
+            // Route index persistence through an object-store URI when configured
+            // (PROXIMADB_INDEX_PERSIST_URL=s3://bucket/prefix | adls://… | gs://…) —
+            // the cold-load path then reads only [header]+[COLD]+probed clusters via
+            // byte-range GETs. Otherwise persist under the local data dir so a cold
+            // collection warms from disk on first query (TD-087 Slice B; no-op
+            // without a data dir).
+            if let Ok(url) = std::env::var("PROXIMADB_INDEX_PERSIST_URL") {
+                axis_manager_inner.set_index_persist_url(url);
+            } else if let Some(cfg) = opt_config {
+                axis_manager_inner.set_index_persist_dir(cfg.server.data_dir.join("axis_indexes"));
+            }
 
-        // CATALOG_OBJECT_MODEL #3 read-port: make catalog-resolved index locations
-        // live for ALL collections — boot-present AND runtime-created — by injecting
-        // a catalog resolver that AXIS pulls from on demand (and memoizes). For each
-        // collection's VectorAnn projection, an explicit `projection.location` is
-        // honored (relocated/tiered indexes); `PROXIMADB_INDEX_CATALOG_PATHS=1`
-        // additionally opts the fleet into the DrPathBuilder `indexes/<projection>/`
-        // layout. Default-off and additive: with no projection locations set the
-        // resolver returns `None` and AXIS keeps the `index_persist_url`/`dir`
-        // convention (mixed-safe). The resolver is catalog-free at the AXIS seam —
-        // this adapter lives in the control layer (dependency inversion).
-        {
-            let migrate = std::env::var_os("PROXIMADB_INDEX_CATALOG_PATHS").is_some();
-            axis_manager_inner.set_index_location_resolver(Arc::new(
-                crate::catalog::index_location_resolver::CatalogIndexLocationResolver::new(
-                    catalog_manager.clone(),
-                    migrate,
-                ),
-            ));
-        }
+            // CATALOG_OBJECT_MODEL #3 read-port: make catalog-resolved index locations
+            // live for ALL collections — boot-present AND runtime-created — by injecting
+            // a catalog resolver that AXIS pulls from on demand (and memoizes). For each
+            // collection's VectorAnn projection, an explicit `projection.location` is
+            // honored (relocated/tiered indexes); `PROXIMADB_INDEX_CATALOG_PATHS=1`
+            // additionally opts the fleet into the DrPathBuilder `indexes/<projection>/`
+            // layout. Default-off and additive: with no projection locations set the
+            // resolver returns `None` and AXIS keeps the `index_persist_url`/`dir`
+            // convention (mixed-safe). The resolver is catalog-free at the AXIS seam —
+            // this adapter lives in the control layer (dependency inversion).
+            {
+                let migrate = std::env::var_os("PROXIMADB_INDEX_CATALOG_PATHS").is_some();
+                axis_manager_inner.set_index_location_resolver(Arc::new(
+                    crate::catalog::index_location_resolver::CatalogIndexLocationResolver::new(
+                        catalog_manager.clone(),
+                        migrate,
+                    ),
+                ));
+            }
 
-        let axis_manager = Arc::new(axis_manager_inner);
-        debug!("✅ SharedServices::new - AxisManager created successfully");
-
-        // Make AXIS manager available to graph-first entity store by default
-        crate::storage::entity_store::orion_backend::set_global_axis_manager(axis_manager.clone());
-
-        // Make AXIS manager available to SST engine for HNSW/IVF search
-        crate::storage::engines::sst::core::set_sst_axis_manager(axis_manager.clone());
-        debug!(
-            "✅ SharedServices::new - AXIS manager registered with SST engine for HNSW/IVF search"
-        );
-
-        // ADR-078: register the same manager for the shared flush→AXIS hook.
-        // VIPER/HELIX/NOVA construct `axis_manager: None` and nothing ever set
-        // it, which is precisely why they routed flush notifications through the
-        // AXIS queue instead of indexing directly. This gives them a handle.
-        crate::storage::common::axis_flush_hook::set_flush_axis_manager(axis_manager.clone());
+            let m = Arc::new(axis_manager_inner);
+            debug!("✅ SharedServices::new - AxisManager created successfully");
+            // Make AXIS manager available to graph-first entity store by default
+            crate::storage::entity_store::orion_backend::set_global_axis_manager(m.clone());
+            // Make AXIS manager available to SST engine for HNSW/IVF search
+            crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
+            debug!(
+                "✅ SharedServices::new - AXIS manager registered with SST engine for HNSW/IVF search"
+            );
+            // ADR-078: register the same manager for the shared flush→AXIS hook.
+            crate::storage::common::axis_flush_hook::set_flush_axis_manager(m.clone());
+            m
+        };
 
         // Create VectorOperationsService with optimized architecture and two-stage search
         debug!(
@@ -1421,14 +1420,17 @@ impl SharedServices {
         } else {
             info!("✅ SharedServices: EventLog service initialized successfully");
 
-            // Start the AXIS EventLog consumer as a background task
-            // This polls the EventLog and builds AXIS indexes when flush events occur
+            // Start the AXIS EventLog consumer as a background task (AXIS-gated).
+            // This polls the EventLog and builds AXIS indexes when flush events occur.
+            #[cfg(feature = "axis")]
             let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
             // TD-LIFECYCLE-1: registered (not leaked) so a clean shutdown
             // can stop the loop; see services::shutdown_registry.
+            #[cfg(feature = "axis")]
             crate::services::shutdown_registry::register("axis-eventlog-consumer", shutdown_tx);
 
+            #[cfg(feature = "axis")]
             if let Some(event_log_service) = crate::services::events::log::event_log_service() {
                 let _consumer_handle =
                     crate::index::axis::integration::eventlog_consumer::start_axis_consumer(
@@ -1455,12 +1457,25 @@ impl SharedServices {
         // engine, the vector ops service, and the SharedServices public
         // field all share the same `Arc`.
         let vector_operations_service = Arc::new(
-            VectorOperationsService::new(
-                sst_engine,
-                wal_manager,
-                axis_manager.clone(),
-                collection_service.clone() as Arc<dyn proximadb_runtime::CollectionPort>,
-            )
+            {
+                #[cfg(feature = "axis")]
+                {
+                    VectorOperationsService::new(
+                        sst_engine,
+                        wal_manager,
+                        axis_manager.clone(),
+                        collection_service.clone() as Arc<dyn proximadb_runtime::CollectionPort>,
+                    )
+                }
+                #[cfg(not(feature = "axis"))]
+                {
+                    VectorOperationsService::new(
+                        sst_engine,
+                        wal_manager,
+                        collection_service.clone() as Arc<dyn proximadb_runtime::CollectionPort>,
+                    )
+                }
+            }
             .with_orchestrator(Some(orchestrator.clone()))
             .with_directory_cache(directory_cache.clone())
             // Phase 7.2: thread the same affinity registry held by
@@ -2149,12 +2164,14 @@ impl SharedServices {
         debug!(
             "🔧 SharedServices::new - Creating MultiModelStorageFacade for federated queries..."
         );
-        let vector_store = Arc::new(
-            crate::storage::multimodel::VectorStore::with_engine(
+        let vector_store = Arc::new({
+            let vs = crate::storage::multimodel::VectorStore::with_engine(
                 vector_operations_service.unified_engine(),
-            )
-            .with_index_manager(axis_manager.clone()),
-        );
+            );
+            #[cfg(feature = "axis")]
+            let vs = vs.with_index_manager(axis_manager.clone());
+            vs
+        });
         let graph_store = Arc::new(
             crate::storage::multimodel::GraphStore::new(Default::default())
                 .with_service(graph_service.clone()),
@@ -2543,13 +2560,23 @@ impl SharedServices {
                 Arc::new(crate::services::external_collection::ExternalCollectionRegistry::new())
             }
         };
-        let external_collection_service = Arc::new(
-            crate::services::external_collection::ExternalCollectionService::new(
-                external_collection_registry,
-                catalog_manager.clone(),
-                axis_manager.clone(),
-            ),
-        );
+        let external_collection_service = Arc::new({
+            #[cfg(feature = "axis")]
+            {
+                crate::services::external_collection::ExternalCollectionService::new(
+                    external_collection_registry,
+                    catalog_manager.clone(),
+                    axis_manager.clone(),
+                )
+            }
+            #[cfg(not(feature = "axis"))]
+            {
+                crate::services::external_collection::ExternalCollectionService::new(
+                    external_collection_registry,
+                    catalog_manager.clone(),
+                )
+            }
+        });
         {
             let executor = Arc::new(
                 crate::services::discovery::DiscoveryJobExecutor::new(
@@ -2573,6 +2600,9 @@ impl SharedServices {
             );
             info!("✅ SharedServices: DiscoveryJobExecutor spawned (Phase 8 CS/CD loop)");
         }
+        // Phase-5 recall observer (AXIS-gated): the whole job probes AXIS-managed
+        // IVF/HNSW recall, so it is not spawned in a PAX-exact-scan build.
+        #[cfg(feature = "axis")]
         {
             // Phase-5 recall observer (TD-075 / F2): periodically probes
             // quantized-vs-exact recall per collection and feeds the shared
@@ -2635,6 +2665,9 @@ impl SharedServices {
                 "✅ SharedServices: DriftWatcher spawned (Phase 8 F1 trigger arm — write-volume drift)"
             );
         }
+        // Recall-drift sweeper (AXIS-gated): walks `recall_target:`-tagged
+        // collections and emits axis_recall_drift_* metrics — no AXIS, no drift.
+        #[cfg(feature = "axis")]
         {
             // Recall-drift sweeper: every 5 min, walk every
             // collection with a `recall_target:` tag and emit a

--- a/src/query/execution/executor.rs
+++ b/src/query/execution/executor.rs
@@ -1637,7 +1637,7 @@ impl MultiModalQueryExecutor {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "axis"))]
 mod executor_tests {
     use super::*;
     use crate::graph::GraphOperationsService;

--- a/src/query/execution/mod.rs
+++ b/src/query/execution/mod.rs
@@ -273,7 +273,7 @@ pub struct ExplainResult {
     pub performance_hints: Vec<String>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "axis"))]
 mod execution_tests {
     use super::*;
 

--- a/src/query/vector_search/mod.rs
+++ b/src/query/vector_search/mod.rs
@@ -20,10 +20,12 @@
 //! for sophisticated vector search capabilities.
 
 use anyhow::{Result, anyhow};
+#[cfg(feature = "axis")]
 use std::sync::Arc;
 
 // Import AXIS indexing components
 use crate::compute::distance_computation::DistanceMetric;
+#[cfg(feature = "axis")]
 use crate::index::axis::{AxisVectorIndex, IndexAlgorithm as AxisIndexAlgorithm, IndexFactory};
 use crate::services::operations::vectors::VectorOperationsService;
 
@@ -75,7 +77,8 @@ pub enum SearchAlgorithm {
     },
 }
 
-/// Vector search engine using AXIS indexes
+/// Vector search engine using AXIS indexes (AXIS-gated; no external consumers).
+#[cfg(feature = "axis")]
 pub struct VectorSearchEngine {
     /// Selected algorithm
     algorithm: SearchAlgorithm,
@@ -87,6 +90,7 @@ pub struct VectorSearchEngine {
     distance_metric: DistanceMetric,
 }
 
+#[cfg(feature = "axis")]
 impl VectorSearchEngine {
     /// Create new search engine with specified algorithm
     pub fn new(

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -730,24 +730,34 @@ impl CollectionService {
         if let Some(recall_target) =
             crate::services::collection::recall_target::parse_recall_target(&enriched_config)
         {
-            let applied = crate::services::collection::recall_target::apply_advisor_to_indexes(
-                &mut enriched_config,
-                recall_target,
-            );
-            for advice in &applied {
-                tracing::info!(
-                    target: "collection.recall_target",
-                    collection = %enriched_config.name,
-                    index = %advice.index_name,
-                    recall_target = recall_target,
-                    algorithm = %advice.output.kind.label(),
-                    clamped_by_budget = advice.output.clamped_by_budget,
-                    projected_recall = ?advice.output.projected_recall,
-                    estimated_memory_mb = advice.output.estimated_memory_mb,
-                    estimated_per_query_work = advice.output.estimated_per_query_work,
-                    rationale = %advice.output.rationale,
-                    "auto-sized index from recall_target"
+            // The advisor sizes AXIS HNSW/IVF params — skipped in a PAX-exact-scan
+            // (`axis` off) build; the recall_target tag is still parsed above so the
+            // rest of collection-create is unaffected.
+            #[cfg(feature = "axis")]
+            {
+                let applied = crate::services::collection::recall_target::apply_advisor_to_indexes(
+                    &mut enriched_config,
+                    recall_target,
                 );
+                for advice in &applied {
+                    tracing::info!(
+                        target: "collection.recall_target",
+                        collection = %enriched_config.name,
+                        index = %advice.index_name,
+                        recall_target = recall_target,
+                        algorithm = %advice.output.kind.label(),
+                        clamped_by_budget = advice.output.clamped_by_budget,
+                        projected_recall = ?advice.output.projected_recall,
+                        estimated_memory_mb = advice.output.estimated_memory_mb,
+                        estimated_per_query_work = advice.output.estimated_per_query_work,
+                        rationale = %advice.output.rationale,
+                        "auto-sized index from recall_target"
+                    );
+                }
+            }
+            #[cfg(not(feature = "axis"))]
+            {
+                let _ = recall_target;
             }
         }
 

--- a/src/services/collection/recall_target.rs
+++ b/src/services/collection/recall_target.rs
@@ -40,14 +40,15 @@
 //! and why.
 
 use crate::compute::distance_computation::DistanceMetric;
+#[cfg(feature = "axis")]
 use crate::index::axis::management::{
     AnnIndexAdvisor, HnswSizingInput, HnswSizingOutput, advise_hnsw_params,
 };
 #[cfg(test)]
 use crate::proto::proximadb_v1::IndexConfig;
-use crate::proto::proximadb_v1::{
-    CollectionConfig, DistanceMetric as ProtoDistanceMetric, HnswConfig, IndexingAlgorithm,
-};
+use crate::proto::proximadb_v1::{CollectionConfig, DistanceMetric as ProtoDistanceMetric};
+#[cfg(feature = "axis")]
+use crate::proto::proximadb_v1::{HnswConfig, IndexingAlgorithm};
 
 /// Tag key prefix used to encode `recall_target` on
 /// `CollectionConfig.tags`.
@@ -83,6 +84,7 @@ pub fn parse_recall_target(config: &CollectionConfig) -> Option<f32> {
 /// `(index_name, advisor_output)` for every index the advisor wrote
 /// to — empty if nothing changed (no HNSW indexes, all pinned, or
 /// no recall_target set).
+#[cfg(feature = "axis")]
 ///
 /// **Auto-add behavior**: if `config.index_configs` contains *zero*
 /// HNSW entries and there's at least one filterable column or no
@@ -192,6 +194,7 @@ pub const AUTO_HMGI_INDEX_NAME: &str = "auto_hmgi_recall_target";
 /// advisor sized, carrying the discriminator + full
 /// [`AnnAdvisorOutput`] (which itself carries the sized
 /// `IndexAlgorithm` + memory/work estimates + rationale).
+#[cfg(feature = "axis")]
 #[derive(Debug, Clone)]
 pub struct AppliedAdvice {
     /// The IndexConfig name that received the sized params.
@@ -225,6 +228,7 @@ pub struct AppliedAdvice {
 /// delegates to this function and filters the result to HNSW
 /// entries for back-compat with callers that expected
 /// `Vec<(String, HnswSizingOutput)>`.
+#[cfg(feature = "axis")]
 pub fn apply_advisor_to_indexes(
     config: &mut CollectionConfig,
     recall_target: f32,
@@ -532,7 +536,10 @@ pub fn resolve_top_k(config: &CollectionConfig) -> u32 {
 /// `max_ef_search` for HNSW and `max_nprobe` for IVF via per-algo
 /// cost models.
 pub fn parse_max_ef_search(config: &CollectionConfig) -> Option<u32> {
-    use crate::index::axis::management::{EF_SEARCH_MAX, EF_SEARCH_MIN};
+    // Same bounds the AXIS advisor enforces (`EF_SEARCH_MIN/MAX`); defined locally
+    // so this parser stays AXIS-free and compiles in a PAX-exact-scan build.
+    const EF_SEARCH_MIN: u32 = 16;
+    const EF_SEARCH_MAX: u32 = 2048;
     const TAG: &str = "max_ef_search:";
     let mut latest: Option<u32> = None;
     for tag in &config.tags {
@@ -645,6 +652,7 @@ pub fn parse_binary_rerank_allowed(config: &CollectionConfig) -> bool {
     false
 }
 
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 fn convert_distance_metric(raw: Option<i32>) -> DistanceMetric {
     match raw.and_then(|v| ProtoDistanceMetric::try_from(v).ok()) {
         Some(ProtoDistanceMetric::Cosine) => DistanceMetric::Cosine,

--- a/src/services/discovery/passes/mod.rs
+++ b/src/services/discovery/passes/mod.rs
@@ -15,6 +15,7 @@
 mod context;
 pub mod dedup;
 pub mod quality;
+#[cfg(feature = "axis")]
 pub mod recluster;
 pub mod trajectory;
 
@@ -32,7 +33,11 @@ use crate::services::discovery::job::{DiscoveryJobKind, DiscoveryJobResult};
 pub(crate) async fn run(kind: DiscoveryJobKind, ctx: &PassContext) -> Result<DiscoveryJobResult> {
     match kind {
         DiscoveryJobKind::Dedup => dedup::run(ctx).await,
+        // Recluster uses AXIS clustering — identity pass when AXIS is compiled out.
+        #[cfg(feature = "axis")]
         DiscoveryJobKind::Recluster => recluster::run(ctx).await,
+        #[cfg(not(feature = "axis"))]
+        DiscoveryJobKind::Recluster => Ok(DiscoveryJobResult::default()),
         DiscoveryJobKind::QualityScan => quality::run(ctx).await,
         DiscoveryJobKind::TrajectoryAnalysis => trajectory::run(ctx).await,
         // re_embed needs an embedding model — identity pass until implemented.

--- a/src/services/events/log.rs
+++ b/src/services/events/log.rs
@@ -8,23 +8,30 @@
 //! EventLog service that manages asynchronous indexing coordination
 //! Similar to CollectionService, this is a standalone service that recovers on startup
 
-use anyhow::{Context, Result};
+#[cfg(feature = "axis")]
+use anyhow::Context;
+use anyhow::Result;
 use dashmap::DashMap;
 use std::sync::Arc;
+#[cfg(feature = "axis")]
 use tracing::{debug, info, warn};
 
 use crate::core::types::StorageEngineType;
+#[cfg(feature = "axis")]
 use crate::index::axis::eventlog::{
     EventLogConfig, EventLogService as EventLogServiceTrait, EventLogServiceFactory, ServiceMode,
 };
 use crate::proto::proximadb_v1::Collection;
 use crate::storage::persistence::filesystem::FilesystemFactory;
+#[cfg(feature = "axis")]
 use proximadb_storage_ports::StorageEventLogPort;
 
 /// EventLog service that coordinates between storage and AXIS indexing
 /// This is initialized at server startup like CollectionService and VectorOperationsService
 pub struct EventLogService {
-    /// The actual event log service implementation
+    /// The actual event log service implementation (AXIS-gated; absent off, in which
+    /// case the service is never constructed — `event_log_service()` returns `None`).
+    #[cfg(feature = "axis")]
     inner: Arc<dyn EventLogServiceTrait>,
 
     /// Reference to collection cache (shared with other services)
@@ -36,6 +43,7 @@ pub struct EventLogService {
     filesystem_factory: Arc<FilesystemFactory>,
 }
 
+#[cfg(feature = "axis")]
 impl EventLogService {
     /// Create and initialize EventLog service
     ///
@@ -242,7 +250,45 @@ impl EventLogService {
     }
 }
 
+/// AXIS-compiled-out stub: the service is never constructed (no `new`, and
+/// `event_log_service()` returns `None`), so these are never called — they exist
+/// only so the engine-integration call sites (`event_log.notify_flush(...)` inside
+/// `if let Some(_) = event_log_service()`) type-check.
+#[cfg(not(feature = "axis"))]
+impl EventLogService {
+    pub async fn notify_flush(
+        &self,
+        _collection_id: &str,
+        _flushed_files: Vec<String>,
+        _vector_count: usize,
+        _has_quantized: bool,
+        _has_fp32: bool,
+        _storage_engine: StorageEngineType,
+    ) -> Result<()> {
+        Ok(())
+    }
+    pub fn notify_compaction(
+        &self,
+        _collection_id: &str,
+        _output_files: Vec<String>,
+        _vector_count: usize,
+        _storage_engine: StorageEngineType,
+    ) {
+    }
+    pub async fn can_compact(&self, _collection_id: &str, _file_path: &str) -> bool {
+        true
+    }
+    pub async fn cleanup_compacted_files(
+        &self,
+        _collection_id: &str,
+        _deleted_files: Vec<String>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
+#[cfg(feature = "axis")]
 impl StorageEventLogPort for EventLogService {
     async fn notify_flush(
         &self,
@@ -353,6 +399,7 @@ pub fn unregister_collection_from_cache(collection_id: &str) {
 ///
 /// This function is idempotent - if already initialized, returns Ok without error.
 /// This allows multiple embedded database instances to share the same EventLog service.
+#[cfg(feature = "axis")]
 pub async fn initialize_event_log_service(
     collection_cache: Arc<DashMap<String, Arc<Collection>>>,
     filesystem_factory: Arc<FilesystemFactory>,
@@ -381,6 +428,17 @@ pub async fn initialize_event_log_service(
             Ok(())
         }
     }
+}
+
+/// AXIS-compiled-out no-op: the EventLog service is an AXIS-indexing substrate, so
+/// a PAX-exact-scan build leaves it uninitialized (`event_log_service()` → `None`).
+#[cfg(not(feature = "axis"))]
+pub async fn initialize_event_log_service(
+    _collection_cache: Arc<DashMap<String, Arc<Collection>>>,
+    _filesystem_factory: Arc<FilesystemFactory>,
+    _base_storage_url: Option<String>,
+) -> Result<()> {
+    Ok(())
 }
 
 /// Get the global EventLog service instance

--- a/src/services/events/mod.rs
+++ b/src/services/events/mod.rs
@@ -3,8 +3,10 @@
 //! Handles event log for operations, recovery, and audit
 
 pub mod log;
+#[cfg(feature = "axis")]
 pub mod persistence;
 
 pub use log::{EventLogService as EventLog, EventLogStats as Stats};
 
+#[cfg(feature = "axis")]
 pub use persistence::EventLogWAL as WAL;

--- a/src/services/external_collection/service.rs
+++ b/src/services/external_collection/service.rs
@@ -22,14 +22,17 @@ use proximadb_data_model::ProximaType;
 use proximadb_records::ProximaRecord;
 
 use super::registry::ExternalCollectionRegistry;
-use super::source_reader::{
-    read_external_records, read_external_text, read_records_by_ids, snapshot_fingerprint,
-};
+#[cfg(feature = "axis")]
+use super::source_reader::read_external_records;
+use super::source_reader::{read_external_text, read_records_by_ids, snapshot_fingerprint};
 use super::types::{ExternalCollection, ExternalCollectionSpec, ExternalCollectionStatus};
 use crate::catalog::CatalogManager;
 use crate::core::search::hybrid::{BM25Result, FusionStrategy, HybridFusionEngine, VectorResult};
+#[cfg(feature = "axis")]
 use crate::index::AxisManager;
+#[cfg(feature = "axis")]
 use crate::index::axis::management::manager::{AxisHybridQuery, VectorQuery};
+#[cfg(feature = "axis")]
 use crate::index::axis::types::{Data, IndexAlgorithm, IndexSelectionStrategy, IndexSpecification};
 use crate::storage::engines::core::formats::columnar::fulltext_index::{
     FullTextIndex, TokenizerConfig,
@@ -75,6 +78,7 @@ pub struct RefreshOutcome {
 pub struct ExternalCollectionService {
     registry: Arc<ExternalCollectionRegistry>,
     catalog_manager: Arc<CatalogManager>,
+    #[cfg(feature = "axis")]
     axis_manager: Arc<AxisManager>,
     /// F5 Slice 3: per-collection BM25 inverted index over the source text
     /// column (keyed by collection name). In-memory; built on `build`/`refresh`.
@@ -85,11 +89,12 @@ impl ExternalCollectionService {
     pub fn new(
         registry: Arc<ExternalCollectionRegistry>,
         catalog_manager: Arc<CatalogManager>,
-        axis_manager: Arc<AxisManager>,
+        #[cfg(feature = "axis")] axis_manager: Arc<AxisManager>,
     ) -> Self {
         Self {
             registry,
             catalog_manager,
+            #[cfg(feature = "axis")]
             axis_manager,
             fulltext_indexes: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -280,6 +285,7 @@ impl ExternalCollectionService {
 
     /// Read + build + register-strategy. Separated so `build` can centralize
     /// status/projection transitions around it.
+    #[cfg(feature = "axis")]
     async fn build_inner(&self, ec: &ExternalCollection) -> Result<usize> {
         let records = read_external_records(&ec.spec)?;
         let count = records.len();
@@ -301,6 +307,13 @@ impl ExternalCollectionService {
         // configured) so search can fuse lexical + vector results.
         self.build_fulltext_index(&ec.spec)?;
         Ok(count)
+    }
+
+    /// External collections index into AXIS, so building is unsupported in a
+    /// PAX-exact-scan (`axis` off) build.
+    #[cfg(not(feature = "axis"))]
+    async fn build_inner(&self, _ec: &ExternalCollection) -> Result<usize> {
+        anyhow::bail!("external collections require the `axis` feature (PAX-exact-scan build)")
     }
 
     /// Build (or rebuild) the per-collection BM25 index from the source text
@@ -344,6 +357,7 @@ impl ExternalCollectionService {
     }
 
     /// Register the IVF routing strategy so `AxisManager::query` routes this
+    #[cfg(feature = "axis")]
     /// collection to its (already-built) IVF index. The nlist/nprobe here are
     /// routing hints; the served index keeps the parameters it was built with.
     async fn register_ivf_strategy(
@@ -519,6 +533,7 @@ impl ExternalCollectionService {
 
     /// Run the IVF vector search and federate full records — the shared vector
     /// half of `search`/`hybrid_search`.
+    #[cfg(feature = "axis")]
     async fn vector_hits(
         &self,
         ec: &ExternalCollection,
@@ -560,6 +575,18 @@ impl ExternalCollectionService {
                 ExternalHit { id, score, record }
             })
             .collect())
+    }
+
+    /// External-collection vector search routes through `AxisManager::query`;
+    /// unsupported in a PAX-exact-scan (`axis` off) build.
+    #[cfg(not(feature = "axis"))]
+    async fn vector_hits(
+        &self,
+        _ec: &ExternalCollection,
+        _query: Vec<f32>,
+        _k: usize,
+    ) -> Result<Vec<ExternalHit>> {
+        anyhow::bail!("external collections require the `axis` feature (PAX-exact-scan build)")
     }
 
     /// Look up a registry record by id.
@@ -618,7 +645,7 @@ impl ExternalCollectionService {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "axis"))]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/src/services/external_collection/source_reader.rs
+++ b/src/services/external_collection/source_reader.rs
@@ -28,6 +28,7 @@ const READ_BATCH_SIZE: usize = 4096;
 /// Read all `(id, vector)` rows from the external source described by `spec`
 /// into `ProximaRecord`s (one dense embedding each). Validates that every
 /// vector matches `spec.dimension`.
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 pub fn read_external_records(spec: &ExternalCollectionSpec) -> Result<Vec<ProximaRecord>> {
     let files = list_parquet_files(&spec.location)?;
     if files.is_empty() {
@@ -307,6 +308,7 @@ fn arrow_cell_to_proxima_value(array: &ArrayRef, row: usize) -> Option<ProximaVa
 }
 
 /// Extract `(id, vector)` rows from one batch into `ProximaRecord`s.
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 fn extract_records(
     batch: &RecordBatch,
     spec: &ExternalCollectionSpec,
@@ -357,6 +359,7 @@ fn extract_records(
 
 /// Decode the vector column (FixedSizeList preferred, List fallback) to
 /// `Vec<Vec<f32>>`. Mirrors `columnar_query_reader.rs`.
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 fn extract_vectors(
     col: &arrow_array::ArrayRef,
     num_rows: usize,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -167,6 +167,7 @@
 //! - Queue depths
 //! - Cache hit rates
 
+#[cfg(feature = "axis")]
 pub mod advisor_observations;
 pub mod agent_checkpoint;
 pub mod agent_memory;
@@ -190,7 +191,9 @@ pub mod graph_collection;
 pub mod operations;
 pub mod queue_fs_adapter;
 pub mod rank_profile_store;
+#[cfg(feature = "axis")]
 pub mod recall_drift_sweeper;
+#[cfg(feature = "axis")]
 pub mod recall_observer;
 pub mod record_memtable;
 pub mod record_store;
@@ -251,6 +254,7 @@ pub use write_intent::{
 // Legacy compatibility exports (will be removed)
 pub use collection::manager as collection_service;
 pub use events::log as event_log_service;
+#[cfg(feature = "axis")]
 pub use events::persistence as event_log_persistence;
 pub use operations::vectors as vector_operations_service;
 pub use search::streaming as streaming_search;

--- a/src/services/operations/vectors/hybrid/mod.rs
+++ b/src/services/operations/vectors/hybrid/mod.rs
@@ -3,8 +3,10 @@
 //! This module provides utilities for building hybrid queries that combine
 //! vector similarity with metadata filtering, particularly for the AXIS index.
 
+#[cfg(feature = "axis")]
 pub mod axis_builder;
 
+#[cfg(feature = "axis")]
 pub use axis_builder::{
     build_axis_hybrid_query, build_axis_hybrid_query_with_mode, build_axis_hybrid_query_with_policy,
 };

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -68,6 +68,7 @@ use crate::query::query_optimizer::{
 
 // Import from sibling submodules
 use super::config::{SearchPlanHints, UnifiedSearchConfig};
+#[cfg(feature = "axis")]
 use super::hybrid::{build_axis_hybrid_query, build_axis_hybrid_query_with_policy};
 use super::search::executor::proto_results_to_vector_records;
 use super::search::pipeline::default_progressive_stages;
@@ -82,6 +83,7 @@ use super::write::{
 /// ADR-070 / ADR-081: AXIS is a configured projection, not an automatic cost
 /// paid by every vector collection. PAX-only collections carry no index config;
 /// the explicit RawF32 compatibility tag retains the established AXIS path.
+#[cfg_attr(not(feature = "axis"), allow(dead_code))]
 fn collection_uses_axis_indexes(collection: &Collection) -> bool {
     collection.config.as_ref().is_some_and(|config| {
         !config.index_configs.is_empty()
@@ -559,6 +561,7 @@ pub struct VectorOperationsService {
     query_cache: Arc<QueryCache>,
 
     /// AXIS index manager for index lookups
+    #[cfg(feature = "axis")]
     axis_index_manager: Arc<crate::index::AxisManager>,
 
     /// Collection port for metadata and configuration (Phase 9 / Task #76)
@@ -616,16 +619,25 @@ impl VectorOperationsService {
     pub fn new_with_context(
         storage_engine: Arc<SstEngine>,
         wal_manager: Arc<crate::storage::persistence::write_ahead_log::WriteAheadLogManager>,
-        axis_index_manager: Arc<crate::index::AxisManager>,
+        #[cfg(feature = "axis")] axis_index_manager: Arc<crate::index::AxisManager>,
         collection_port: Arc<dyn proximadb_runtime::CollectionPort>,
         ctx: &crate::core::context::SharedContext,
     ) -> Self {
-        let mut svc = Self::new(
-            storage_engine,
-            wal_manager,
-            axis_index_manager,
-            collection_port,
-        );
+        let mut svc = {
+            #[cfg(feature = "axis")]
+            {
+                Self::new(
+                    storage_engine,
+                    wal_manager,
+                    axis_index_manager,
+                    collection_port,
+                )
+            }
+            #[cfg(not(feature = "axis"))]
+            {
+                Self::new(storage_engine, wal_manager, collection_port)
+            }
+        };
         svc.orchestrator = ctx.orchestrator.clone();
         // Tenant integration from shared context
         if let Some(ref tenant_manager) = ctx.tenant_manager {
@@ -643,6 +655,7 @@ impl VectorOperationsService {
 
     /// Expose the AXIS index manager for direct index operations
     /// Used by embedded mode to build indexes synchronously after flush
+    #[cfg(feature = "axis")]
     pub fn axis_index_manager(&self) -> Arc<crate::index::AxisManager> {
         self.axis_index_manager.clone()
     }
@@ -1232,6 +1245,7 @@ impl VectorOperationsService {
     /// builds the filter directly from rich `ProximaValue` predicates, bypassing
     /// the lossy v1 `ComparisonOp` round-trip). Keeping one core means both
     /// entry points share the advisor-observability wrap and response assembly.
+    #[cfg_attr(not(feature = "axis"), allow(unused_variables))]
     async fn run_unified_search_v1(
         &self,
         collection_id: String,
@@ -1283,6 +1297,7 @@ impl VectorOperationsService {
         // any lookup failure short-circuits silently to avoid
         // touching the search path's success contract.
         let elapsed_us = search_started_at.elapsed().as_micros() as u64;
+        #[cfg(feature = "axis")]
         observe_advisor_for_search(&collection_id, top_k as u32, elapsed_us).await;
 
         Ok(crate::proto::proximadb_v1::VectorOperationResponse {
@@ -1540,7 +1555,7 @@ impl VectorOperationsService {
     pub fn new(
         storage_engine: Arc<SstEngine>,
         wal_manager: Arc<crate::storage::persistence::write_ahead_log::WriteAheadLogManager>,
-        axis_index_manager: Arc<crate::index::AxisManager>,
+        #[cfg(feature = "axis")] axis_index_manager: Arc<crate::index::AxisManager>,
         collection_port: Arc<dyn proximadb_runtime::CollectionPort>,
     ) -> Self {
         info!(
@@ -1563,6 +1578,7 @@ impl VectorOperationsService {
             query_optimizer: Arc::new(UnifiedQueryOptimizer::new(optimizer_config)),
             collection_cache: Arc::new(dashmap::DashMap::new()),
             query_cache,
+            #[cfg(feature = "axis")]
             axis_index_manager,
             collection_port,
             orchestrator: None,
@@ -3330,14 +3346,10 @@ impl VectorOperationsService {
             filter.as_ref().map(|f| format!("{:?}", f))
         );
 
-        // Resolve ADR-011 filtering mode from the plan's ann_filtering_mode string.
-        let ann_mode = match plan.ann_filtering_mode.as_deref() {
-            Some("Inline") => crate::index::axis::management::manager::AnnFilteringMode::Inline,
-            Some("PreFilter") => {
-                crate::index::axis::management::manager::AnnFilteringMode::PreFilter
-            }
-            _ => crate::index::axis::management::manager::AnnFilteringMode::PostFilter,
-        };
+        // ADR-011 filtering mode, threaded as the raw plan string. The AXIS enum
+        // is resolved inside the (cfg-gated) Stage-2 block below, so this signature
+        // stays AXIS-free and compiles with the `axis` feature off.
+        let ann_filtering_mode = plan.ann_filtering_mode.clone();
         let ann_filtering_selectivity = plan.ann_filtering_selectivity;
 
         let mut results: Vec<crate::core::search::results::OptimizedSearchRecord> = Vec::new();
@@ -3376,7 +3388,7 @@ impl VectorOperationsService {
                     // Execute search with ADR-011 filtering mode threaded through.
                     tracing::debug!(
                         "🔍 About to call execute_two_stage_search_with_mode (mode={:?}) with filter: {:?}",
-                        ann_mode,
+                        ann_filtering_mode,
                         filter.as_ref().map(|f| format!("{:?}", f))
                     );
                     results = self
@@ -3388,7 +3400,7 @@ impl VectorOperationsService {
                             query_vector.clone(),
                             filter.clone(),
                             search_mode.clone(),
-                            ann_mode,
+                            &ann_filtering_mode,
                             ann_filtering_selectivity,
                         )
                         .await?;
@@ -3439,7 +3451,7 @@ impl VectorOperationsService {
                             query_vector.clone(),
                             filter.clone(),
                             search_mode.clone(),
-                            ann_mode,
+                            &ann_filtering_mode,
                             ann_filtering_selectivity,
                         )
                         .await?;
@@ -3448,6 +3460,10 @@ impl VectorOperationsService {
                 }
 
                 // Index lookup optimization
+                // Index lookup optimization (AXIS only — the optimizer never emits
+                // IndexLookup without index_configs, which can't exist with the
+                // `axis` feature off; the `_` arm below is the off-path no-op).
+                #[cfg(feature = "axis")]
                 ExecutionStep::IndexLookup {
                     index_type,
                     mut lookup_params,
@@ -3588,6 +3604,7 @@ impl VectorOperationsService {
         }
     }
 
+    #[cfg_attr(not(feature = "axis"), allow(unused_variables))]
     async fn execute_two_stage_search_with_mode(
         &self,
         collection_id: &str,
@@ -3597,7 +3614,7 @@ impl VectorOperationsService {
         query_vector: Vec<f32>,
         filter: Option<FilterExpression>,
         search_mode: crate::core::search::SearchMode,
-        ann_filtering_mode: crate::index::axis::management::manager::AnnFilteringMode,
+        ann_filtering_mode: &Option<String>,
         ann_filtering_selectivity: Option<f64>,
     ) -> Result<Vec<crate::core::search::results::OptimizedSearchRecord>> {
         debug!(
@@ -3679,7 +3696,12 @@ impl VectorOperationsService {
         // A0 coarse-probe) in the SST engine handles the search — the segment IS
         // the index. This avoids the 8.6GB RSS + minutes of IVF training for
         // cost-optimized, object-storage-backed collections.
+        #[cfg(feature = "axis")]
         let collection_has_axis_indexes = collection_uses_axis_indexes(&collection);
+        #[cfg(not(feature = "axis"))]
+        let collection_has_axis_indexes = false;
+
+        #[cfg(feature = "axis")]
         let axis_optimized_results = if !collection_has_axis_indexes {
             info!(
                 "🔍 Co-design: skipping AXIS for collection {} (no index_configs) — \
@@ -3688,17 +3710,26 @@ impl VectorOperationsService {
             );
             Vec::new()
         } else {
+            // Resolve the ADR-011 filtering enum from the threaded plan string
+            // (kept as a string across the signature so the `axis` feature is optional).
+            let ann_mode_enum = match ann_filtering_mode.as_deref() {
+                Some("Inline") => crate::index::axis::management::manager::AnnFilteringMode::Inline,
+                Some("PreFilter") => {
+                    crate::index::axis::management::manager::AnnFilteringMode::PreFilter
+                }
+                _ => crate::index::axis::management::manager::AnnFilteringMode::PostFilter,
+            };
             match build_axis_hybrid_query_with_policy(
                 // TD-AXIS-1: use the collection's canonical id (UUID) — NOT the
                 // caller's collection_id (which may be the human-readable NAME).
-                // enable_hmgi registered the UUID in hmgi_enabled_collections;
+                // enable_hmgi_enabled registered the UUID in hmgi_enabled_collections;
                 // passing the name caused is_hmgi_enabled to return false → HMGI
                 // skipped → IVF fallback → 0 results (ANN index not serving).
                 // ADR-031 follow-up: migrate hmgi_enabled_collections to the stable
                 // object_id (base62) and use that here instead of the UUID.
                 &collection.id,
                 &axis_search_params,
-                ann_filtering_mode,
+                ann_mode_enum,
                 ann_filtering_selectivity.map(|_| proximadb_catalog::AnnFilteringPolicy::default()),
                 ann_filtering_selectivity,
             ) {
@@ -3745,6 +3776,12 @@ impl VectorOperationsService {
                 }
             }
         };
+        // AXIS compiled out: no in-memory ANN stage — flushed vectors are served by
+        // the PAX exact scan in Stage 3 below.
+        #[cfg(not(feature = "axis"))]
+        let axis_optimized_results: Vec<
+            crate::core::search::results::OptimizedSearchRecord,
+        > = Vec::new();
 
         // Stage 3: Storage engine search - ONLY if we need more results.
         // Skip when WAL + AXIS already cover the candidate pool -- but that's only true
@@ -4020,6 +4057,7 @@ impl VectorOperationsService {
     }
 
     /// Perform a vector or metadata index lookup via the AXIS index manager.
+    #[cfg(feature = "axis")]
     async fn execute_index_lookup(
         &self,
         collection_id: &str,
@@ -4203,7 +4241,9 @@ impl VectorOperationsService {
             .write_vector_batch_native_arc(collection_id, Arc::new(vectors.clone()))
             .await?;
 
+        #[cfg(feature = "axis")]
         let collection = self.get_or_load_collection(collection_id).await?;
+        #[cfg(feature = "axis")]
         let axis_duration = if collection_uses_axis_indexes(&collection) {
             let axis_start = std::time::Instant::now();
             for record in vectors.iter() {
@@ -4236,6 +4276,10 @@ impl VectorOperationsService {
             );
             std::time::Duration::ZERO
         };
+        // AXIS compiled out: no in-memory index feed — flushed records are served
+        // via the PAX exact scan.
+        #[cfg(not(feature = "axis"))]
+        let axis_duration = std::time::Duration::ZERO;
 
         let duration_micros = start.elapsed().as_micros() as i64;
         let bytes_written = vectors
@@ -5122,7 +5166,7 @@ mod migration_example {
 //    - Consistent optimization logic
 //    - Easier to test and debug
 
-#[cfg(test)]
+#[cfg(all(test, feature = "axis"))]
 mod index_first_search_tests {
     use super::*;
     use crate::compute::distance_computation::DistanceMetric;
@@ -5564,6 +5608,7 @@ mod index_first_search_tests {
         Ok(())
     }
 
+    #[cfg(feature = "axis")]
     #[tokio::test]
     async fn test_metadata_filter_pushdown_to_indexes() -> Result<()> {
         let _ = proximadb_hardware::hardware_capabilities(); // OnceLock auto-init
@@ -6130,6 +6175,7 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
 /// predicted recall + work, and record the observation.
 /// Best-effort — any lookup miss short-circuits silently. The
 /// search path's success contract is unaffected.
+#[cfg(feature = "axis")]
 async fn observe_advisor_for_search(collection_id: &str, top_k: u32, observed_latency_us: u64) {
     // (1) Reach the live AXIS manager to read the active strategy.
     // Absent on HELIX-only deployments — short-circuit gracefully.

--- a/src/services/operations/vectors/mod.rs
+++ b/src/services/operations/vectors/mod.rs
@@ -68,6 +68,7 @@ mod legacy;
 
 // Public exports
 pub use config::{SearchPlanHints, UnifiedSearchConfig};
+#[cfg(feature = "axis")]
 pub use hybrid::build_axis_hybrid_query;
 pub(crate) use legacy::rich_filters_to_filter_expression;
 pub use legacy::{

--- a/src/services/operations/vectors_test.rs
+++ b/src/services/operations/vectors_test.rs
@@ -4,7 +4,7 @@
 //! particularly around optimized format handling, workload hints, error cases,
 //! and service lifecycle management.
 
-#[cfg(test)]
+#[cfg(all(test, feature = "axis"))]
 mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;

--- a/src/services/search/mod.rs
+++ b/src/services/search/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Various search implementations including streaming, EDR, and batch search
 
+#[cfg(feature = "axis")]
 pub mod edr_service;
 pub mod streaming;
 
@@ -14,6 +15,7 @@ pub use streaming::{
     StreamingSearchService as StreamingSearch, StreamingSearchStats as StreamStats,
 };
 
+#[cfg(feature = "axis")]
 pub use edr_service::{
     EdrSearchExecution, EdrSearchExecutionRequest, EdrSearchResult, execute_edr_search,
     validate_edr_search_request,

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -31,6 +31,7 @@ use std::time::Instant;
 
 use tokio::sync::RwLock;
 
+#[cfg(feature = "axis")]
 use crate::index::AxisManager;
 use crate::metrics::wal_flush_metrics;
 use crate::storage::flush_materializer::{CollectionFlushPlan, materialize_collection};
@@ -44,6 +45,7 @@ use crate::storage::write_fence::StorageWriteFence;
 /// ADR-069 flush policy.
 pub struct AutoFlushDriver {
     policy: FlushPolicy,
+    #[cfg(feature = "axis")]
     axis_index_manager: Arc<AxisManager>,
     /// A6 storage-write fence (default-OFF). Captured at spawn time; on the live
     /// server it is injected into the storage engine post-construction, so this
@@ -62,7 +64,7 @@ impl AutoFlushDriver {
     /// `flush_interval_secs = 0` and `wal_max_bytes = 0` makes this a no-op.
     pub fn spawn(
         policy: FlushPolicy,
-        axis_index_manager: Arc<AxisManager>,
+        #[cfg(feature = "axis")] axis_index_manager: Arc<AxisManager>,
         storage_write_fence: Option<Arc<dyn StorageWriteFence>>,
     ) {
         if !policy.needs_scheduler() {
@@ -71,6 +73,7 @@ impl AutoFlushDriver {
         let tick = policy.scheduler_tick_secs();
         let driver = Self {
             policy,
+            #[cfg(feature = "axis")]
             axis_index_manager,
             storage_write_fence,
             flush_clock: Arc::new(RwLock::new(HashMap::new())),
@@ -183,18 +186,23 @@ impl AutoFlushDriver {
             // its per-collection gate collapses overlap with inline/shutdown
             // triggers.
             let task_write_buffer = write_buffer.clone();
+            #[cfg(feature = "axis")]
             let task_axis = self.axis_index_manager.clone();
             let task_fence = self.storage_write_fence.clone();
             let reason_label = reason.as_str().to_string();
             pending.spawn(async move {
                 let start = Instant::now();
+                #[cfg(feature = "axis")]
+                let axis_arg: Option<&AxisManager> = Some(&task_axis);
+                #[cfg(not(feature = "axis"))]
+                let axis_arg: Option<&()> = None;
                 let result = materialize_collection(
                     &task_write_buffer,
                     &plan,
                     task_fence.as_ref(),
                     None,
                     true,
-                    Some(&task_axis),
+                    axis_arg,
                 )
                 .await;
                 (

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -1,4 +1,5 @@
 use crate::core::{StorageConfig, String, VectorId};
+#[cfg(feature = "axis")]
 use crate::index::{AxisConfig, AxisManager};
 use crate::storage::persistence::write_ahead_log::{WALConfig, WriteAheadLogManager};
 use crate::storage::{
@@ -26,6 +27,7 @@ pub struct StorageEngine {
     #[allow(dead_code)]
     disk_manager: Arc<DiskManager>,
     write_ahead_log_manager: Arc<WriteAheadLogManager>,
+    #[cfg(feature = "axis")]
     axis_index_manager: Arc<AxisManager>,
     compaction_manager: Arc<Compaction>,
     filesystem: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
@@ -133,16 +135,19 @@ impl StorageEngine {
             .cloned()
             .unwrap_or_else(|| PathBuf::from("./data"));
         // Initialize AXIS index manager with default configuration
-        let axis_config = AxisConfig::default();
-        let axis_index_manager = Arc::new(AxisManager::new(axis_config).await?);
-
-        // Make AXIS manager available to SST engine for HNSW/IVF search
-        crate::storage::engines::sst::core::set_sst_axis_manager(axis_index_manager.clone());
-        // Also expose the concrete AxisManager for the WAL-layer inline flush trigger
-        // (resolved via `crate::index::get_global_axis_manager`), so an inline flush
-        // clears the AXIS projection exactly like the periodic/shutdown paths.
-        crate::index::set_global_axis_manager(axis_index_manager.clone());
-        info!("✅ AXIS manager registered with SST engine for HNSW/IVF search");
+        #[cfg(feature = "axis")]
+        let axis_index_manager = {
+            let axis_config = AxisConfig::default();
+            let m = Arc::new(AxisManager::new(axis_config).await?);
+            // Make AXIS manager available to SST engine for HNSW/IVF search
+            crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
+            // Also expose the concrete AxisManager for the WAL-layer inline flush trigger
+            // (resolved via `crate::index::get_global_axis_manager`), so an inline flush
+            // clears the AXIS projection exactly like the periodic/shutdown paths.
+            crate::index::set_global_axis_manager(m.clone());
+            info!("✅ AXIS manager registered with SST engine for HNSW/IVF search");
+            m
+        };
 
         // Build the one configured SST instance used by every flush and its
         // background compaction. Keeping this Arc prevents the worker-owning
@@ -176,6 +181,7 @@ impl StorageEngine {
             canonical_sst_storage,
             disk_manager,
             write_ahead_log_manager,
+            #[cfg(feature = "axis")]
             axis_index_manager,
             compaction_manager,
             filesystem,
@@ -247,9 +253,15 @@ impl StorageEngine {
             crate::storage::persistence::write_ahead_log::flush_policy::FlushPolicy::from_performance(
                 &self.config.wal_config.to_engine_config().performance,
             );
+        #[cfg(feature = "axis")]
         crate::storage::auto_flush_driver::AutoFlushDriver::spawn(
             flush_policy,
             self.axis_index_manager.clone(),
+            self.storage_write_fence.clone(),
+        );
+        #[cfg(not(feature = "axis"))]
+        crate::storage::auto_flush_driver::AutoFlushDriver::spawn(
+            flush_policy,
             self.storage_write_fence.clone(),
         );
 
@@ -398,13 +410,17 @@ impl StorageEngine {
             // SST route honors SearchMode); gated by the insert→SIGINT→restart→search
             // round-trip in runtime-evidence/TD163_SERVER_FLUSH_MATERIALIZATION_2026_06_26.md.
             // Shutdown is terminal, so the freed batches are never re-flushed.
+            #[cfg(feature = "axis")]
+            let axis_arg: Option<&AxisManager> = Some(&self.axis_index_manager);
+            #[cfg(not(feature = "axis"))]
+            let axis_arg: Option<&()> = None;
             match materialize_collection(
                 &write_buffer,
                 &plan,
                 self.storage_write_fence.as_ref(),
                 None,
                 true,
-                Some(&self.axis_index_manager),
+                axis_arg,
             )
             .await
             {
@@ -781,6 +797,7 @@ impl StorageEngine {
         let exists = self.exists(collection_id, id).await?;
 
         // Remove from search index
+        #[cfg(feature = "axis")]
         if exists {
             self.axis_index_manager
                 .delete(collection_id, id.clone())
@@ -788,6 +805,8 @@ impl StorageEngine {
 
             // Deferred: collection stats are now maintained through the catalog.
         }
+        // With AXIS compiled out there is no in-memory index to mutate; the record
+        // is tombstoned in the SST path below and filtered on read (canonical predicate).
 
         // Mark as deleted in SST storage using tombstone
         if exists {
@@ -891,6 +910,7 @@ impl StorageEngine {
         );
 
         // Ensure search index strategy exists for the collection
+        #[cfg(feature = "axis")]
         self.axis_index_manager
             .ensure_collection_strategy(&collection_id)
             .await
@@ -1110,6 +1130,7 @@ impl StorageEngine {
             }
 
             // Remove AXIS indexes for collection
+            #[cfg(feature = "axis")]
             self.axis_index_manager
                 .drop_collection(collection_id)
                 .await?;
@@ -1177,6 +1198,7 @@ impl StorageEngine {
     // Use VectorOperationsService::search_vectors() with metadata filters instead
 
     /// Get search index statistics
+    #[cfg(feature = "axis")]
     pub async fn index_stats(
         &self,
         collection_id: &str,
@@ -1203,13 +1225,29 @@ impl StorageEngine {
         }
     }
 
+    /// Get search index statistics — AXIS compiled out: no index stats available.
+    #[cfg(not(feature = "axis"))]
+    pub async fn index_stats(
+        &self,
+        _collection_id: &str,
+    ) -> crate::storage::Result<Option<HashMap<String, serde_json::Value>>> {
+        Ok(None)
+    }
+
     /// Optimize search index
+    #[cfg(feature = "axis")]
     pub async fn optimize_index(&self, collection_id: &str) -> crate::storage::Result<()> {
         // Trigger AXIS analysis and optimization
         self.axis_index_manager
             .analyze_and_optimize(collection_id)
             .await
             .map_err(|e| crate::core::StorageError::IndexError(e.to_string()))
+    }
+
+    /// Optimize search index — AXIS compiled out: exact scan needs no optimization.
+    #[cfg(not(feature = "axis"))]
+    pub async fn optimize_index(&self, _collection_id: &str) -> crate::storage::Result<()> {
+        Ok(())
     }
 
     /// Batch insert multiple vectors into a collection

--- a/src/storage/engines/core/progressive/factory.rs
+++ b/src/storage/engines/core/progressive/factory.rs
@@ -330,14 +330,19 @@ mod tests {
     fn test_factory_create_default_pipeline() {
         let factory = create_test_factory();
 
-        for engine in &[
+        let mut engines = vec![
             ProgressiveEngineType::SST,
             ProgressiveEngineType::HELIX,
             ProgressiveEngineType::VIPER,
             ProgressiveEngineType::SWIFT,
             ProgressiveEngineType::NOVA,
-            ProgressiveEngineType::RAPTOR,
-        ] {
+        ];
+        // RAPTOR's pipeline is `experimental-engines`-gated (it needs AXIS clustering);
+        // only assert its 3-stage default when that feature is on.
+        #[cfg(feature = "experimental-engines")]
+        engines.push(ProgressiveEngineType::RAPTOR);
+
+        for engine in &engines {
             let pipeline = factory.create_default_pipeline(*engine);
             assert_eq!(
                 pipeline.stage_count(),

--- a/src/storage/engines/core/progressive/factory.rs
+++ b/src/storage/engines/core/progressive/factory.rs
@@ -101,7 +101,12 @@ impl ProgressivePipelineFactory {
             ProgressiveEngineType::VIPER => self.create_viper_pipeline(stages, hamming_threshold),
             ProgressiveEngineType::SWIFT => self.create_swift_pipeline(stages, hamming_threshold),
             ProgressiveEngineType::NOVA => self.create_nova_pipeline(stages, hamming_threshold),
+            #[cfg(feature = "experimental-engines")]
             ProgressiveEngineType::RAPTOR => self.create_raptor_pipeline(stages, hamming_threshold),
+            // RAPTOR requires `experimental-engines`; unreachable without it, so
+            // return an empty pipeline to keep the match exhaustive.
+            #[cfg(not(feature = "experimental-engines"))]
+            ProgressiveEngineType::RAPTOR => ProgressiveSearchCoordinator::new(),
         }
     }
 
@@ -272,6 +277,7 @@ impl ProgressivePipelineFactory {
         coordinator
     }
 
+    #[cfg(feature = "experimental-engines")]
     fn create_raptor_pipeline(
         &self,
         stages: &[PipelineStage],

--- a/src/storage/engines/mod.rs
+++ b/src/storage/engines/mod.rs
@@ -102,6 +102,9 @@ pub mod core;
 pub mod helix;
 pub mod impls; // Deprecated: Moving engines directly to engines/ level
 pub mod nova; // Phase 1: Moved from impls/nova/
+// RAPTOR fundamentally uses AXIS clustering; gated by `experimental-engines`
+// (which implies `axis`). Not compiled for PAX-exact-scan builds.
+#[cfg(feature = "experimental-engines")]
 pub mod raptor; // Phase 1: Moved from impls/raptor/
 pub mod sst; // Phase 1: Moved from impls/sst/
 pub mod swift; // Phase 1: Moved from impls/swift/
@@ -132,6 +135,7 @@ pub use crate::storage::traits::{
 pub use helix::HelixEngine;
 #[allow(deprecated)]
 pub use nova::NovaEngine; // Phase 1: Moved from impls/
+#[cfg(feature = "experimental-engines")]
 #[allow(deprecated)]
 pub use raptor::RaptorEngine; // Phase 1: Moved from impls/
 #[allow(deprecated)]

--- a/src/storage/engines/raptor/consolidated_compactor.rs
+++ b/src/storage/engines/raptor/consolidated_compactor.rs
@@ -12,6 +12,7 @@ use super::common::{RaptorFileMetadata, RowGroup, RowGroupMetadata, SchemaDescri
 use super::config::RaptorConfig;
 use super::consolidated_reader::RaptorReader;
 use super::smart_rowgroup_sizing::BalancedMatrixTrinitySizing;
+#[cfg(feature = "axis")]
 use crate::index::axis::clustering::{
     AxisClusteringEngine as AxisClustering, ClusteringConfig as AxisClusteringConfig,
     ReusableClusteringEngine,
@@ -304,6 +305,7 @@ impl RaptorCompactor {
 
     /// Run fast-converging K-means++ clustering for high-dimensional data
     /// Uses the same algorithm as the writer for consistency
+    #[cfg(feature = "axis")]
     #[allow(dead_code)]
     fn cluster_vectors(&self, vectors: &[VectorRecord], k: usize) -> Result<Vec<usize>> {
         // Use AXIS clustering engine with K-means++ initialization

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -1641,6 +1641,7 @@ mod tests {
     /// search is served by the ANN index instead of a brute-force segment scan.
     /// (The `FlushCoordinator` is test-only scaffolding; the hook lives on the
     /// real path exercised here.)
+    #[cfg(feature = "axis")]
     #[tokio::test]
     async fn td112_live_flush_indexes_vectors_into_axis() {
         use crate::index::axis::management::manager::AxisManager;

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -26,7 +26,18 @@ use anyhow::{Context, Result};
 use dashmap::DashMap;
 use tokio::sync::{Mutex, OnceCell, Semaphore};
 
+#[cfg(feature = "axis")]
 use crate::index::AxisManager;
+
+/// Flush-path AXIS projection reap target threaded through the flush entry points.
+/// `Option<&AxisManager>` when AXIS is compiled in (the reap runs); `Option<&()>`
+/// otherwise — the reap is cfg-gated out, so this is always `None` off. Keeping one
+/// alias keeps the entry-point signatures identical across builds so callers don't
+/// branch on the feature.
+#[cfg(feature = "axis")]
+pub(crate) type AxisFlushArg<'a> = Option<&'a AxisManager>;
+#[cfg(not(feature = "axis"))]
+pub(crate) type AxisFlushArg<'a> = Option<&'a ()>;
 use crate::proto::proximadb_v1::{
     Collection, CollectionConfig, StorageAssignment, StorageEngine as ProtoStorageEngine,
 };
@@ -310,7 +321,7 @@ pub async fn materialize_collection(
     fence: Option<&Arc<dyn StorageWriteFence>>,
     fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
     free_wal: bool,
-    axis_index_manager: Option<&AxisManager>,
+    axis_index_manager: AxisFlushArg<'_>,
 ) -> Result<Option<CollectionFlushOutcome>> {
     materialize_collection_with_coordinator_mode(
         flush_execution_coordinator(),
@@ -334,7 +345,7 @@ pub async fn materialize_collection_if_idle(
     fence: Option<&Arc<dyn StorageWriteFence>>,
     fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
     free_wal: bool,
-    axis_index_manager: Option<&AxisManager>,
+    axis_index_manager: AxisFlushArg<'_>,
 ) -> Result<Option<CollectionFlushOutcome>> {
     materialize_collection_with_coordinator_mode(
         flush_execution_coordinator(),
@@ -363,7 +374,7 @@ async fn materialize_collection_with_coordinator(
     fence: Option<&Arc<dyn StorageWriteFence>>,
     fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
     free_wal: bool,
-    axis_index_manager: Option<&AxisManager>,
+    axis_index_manager: AxisFlushArg<'_>,
 ) -> Result<Option<CollectionFlushOutcome>> {
     materialize_collection_with_coordinator_mode(
         coordinator,
@@ -386,7 +397,7 @@ async fn materialize_collection_with_coordinator_mode(
     fence: Option<&Arc<dyn StorageWriteFence>>,
     fallback_engine: Option<Arc<dyn UnifiedStorageFormat>>,
     free_wal: bool,
-    axis_index_manager: Option<&AxisManager>,
+    axis_index_manager: AxisFlushArg<'_>,
     collection_admission: CollectionAdmission,
 ) -> Result<Option<CollectionFlushOutcome>> {
     // A6 storage-write fence — reject a displaced pod before touching storage.
@@ -611,6 +622,7 @@ async fn materialize_collection_with_coordinator_mode(
         .await
         .map(|batches| batches.is_empty())
         .unwrap_or(false);
+    #[cfg(feature = "axis")]
     if collection_wal_empty
         && let Some(axis) = axis_index_manager
         && let Err(e) = axis.clear_collection_vectors(&plan.canonical_id).await
@@ -621,6 +633,10 @@ async fn materialize_collection_with_coordinator_mode(
             e
         );
     }
+    // When AXIS is compiled out there is no in-memory projection to reap; the
+    // durable segment written above is the sole source of truth.
+    #[cfg(not(feature = "axis"))]
+    let _ = (collection_wal_empty, axis_index_manager);
 
     Ok(Some(CollectionFlushOutcome {
         vectors_submitted: vector_count,

--- a/src/storage/formats/adapters.rs
+++ b/src/storage/formats/adapters.rs
@@ -563,6 +563,7 @@ pub type NovaFormatAdapter = InternalFormatAdapter<crate::storage::engines::nova
 pub type SwiftFormatAdapter = InternalFormatAdapter<crate::storage::engines::swift::SwiftEngine>;
 
 /// Type alias for RAPTOR format adapter
+#[cfg(feature = "experimental-engines")]
 #[allow(deprecated)]
 pub type RaptorFormatAdapter = InternalFormatAdapter<crate::storage::engines::raptor::RaptorEngine>;
 
@@ -607,6 +608,7 @@ pub fn create_swift_adapter(
 }
 
 /// Create a RAPTOR format adapter from an existing engine
+#[cfg(feature = "experimental-engines")]
 #[allow(deprecated)]
 pub fn create_raptor_adapter(
     engine: Arc<crate::storage::engines::raptor::RaptorEngine>,

--- a/src/storage/formats/mod.rs
+++ b/src/storage/formats/mod.rs
@@ -171,19 +171,20 @@ pub use adapters::{
     // Generic adapter
     InternalFormatAdapter,
     NovaFormatAdapter,
-    RaptorFormatAdapter,
     // Engine-specific type aliases
     SstFormatAdapter,
     SwiftFormatAdapter,
     ViperFormatAdapter,
     create_helix_adapter,
     create_nova_adapter,
-    create_raptor_adapter,
     // Factory functions
     create_sst_adapter,
     create_swift_adapter,
     create_viper_adapter,
 };
+// RAPTOR adapters are `experimental-engines`-gated (RAPTOR needs AXIS clustering).
+#[cfg(feature = "experimental-engines")]
+pub use adapters::{RaptorFormatAdapter, create_raptor_adapter};
 
 // ============================================================================
 // Module-Level Tests

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1202,6 +1202,7 @@ fn spawn_inline_flush(collection_id: String) {
         let Some(write_buffer) = get_global_write_buffer_behavior() else {
             return;
         };
+        #[cfg(feature = "axis")]
         let axis = crate::index::get_global_axis_manager();
         let catalog = list_collections_from_catalog().await;
         let Some(meta) = catalog.iter().find(|c| c.id == collection_id) else {
@@ -1222,15 +1223,11 @@ fn spawn_inline_flush(collection_id: String) {
             "🚿 inline size-flush starting (segments appear on completion)"
         );
         let start = std::time::Instant::now();
-        match materialize_collection_if_idle(
-            &write_buffer,
-            &plan,
-            None,
-            None,
-            true,
-            axis.as_deref(),
-        )
-        .await
+        #[cfg(feature = "axis")]
+        let axis_arg = axis.as_deref();
+        #[cfg(not(feature = "axis"))]
+        let axis_arg: Option<&()> = None;
+        match materialize_collection_if_idle(&write_buffer, &plan, None, None, true, axis_arg).await
         {
             Ok(Some(outcome)) => tracing::info!(
                 "✅ inline size-flush '{}': {} entries, {} bytes in {:.3}s",

--- a/src/storage/trait_components/extractor.rs
+++ b/src/storage/trait_components/extractor.rs
@@ -393,8 +393,15 @@ impl ExtractionFactory {
             StorageEngineType::NOVA => {
                 Arc::new(crate::storage::engines::nova::extraction::NovaExtractor::new(filesystem))
             }
+            #[cfg(feature = "experimental-engines")]
             StorageEngineType::RAPTOR => Arc::new(
                 crate::storage::engines::raptor::extraction::RaptorExtractor::new(filesystem),
+            ),
+            // RAPTOR requires `experimental-engines`; unreachable on a build without
+            // it, so fall back to the SST extractor to keep the match exhaustive.
+            #[cfg(not(feature = "experimental-engines"))]
+            StorageEngineType::RAPTOR => Arc::new(
+                crate::storage::engines::sst::extraction::SstExtractor::new(filesystem),
             ),
             StorageEngineType::TST => Arc::new(
                 crate::storage::engines::tst::extraction::TstExtractor::new(filesystem),

--- a/tests/engines/raptor_integration_test.rs
+++ b/tests/engines/raptor_integration_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-engines")] // RAPTOR needs the `experimental-engines` feature.
 //! Integration tests for RAPTOR storage engine
 //! 
 //! Tests the complete RAPTOR workflow including:

--- a/tests/integration/raptor_engine_test.rs
+++ b/tests/integration/raptor_engine_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-engines")] // RAPTOR needs the `experimental-engines` feature.
 //! Integration tests for the Raptor storage engine.
 
 use std::sync::Arc;

--- a/tests/quantization/cache_integration_tests.rs
+++ b/tests/quantization/cache_integration_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-engines")] // RAPTOR needs the `experimental-engines` feature.
 //! Unified Quantization Cache Integration Tests
 //!
 //! Tests the global quantization cache architecture across all storage engines

--- a/tests/raptor_recall_test.rs
+++ b/tests/raptor_recall_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "experimental-engines")] // RAPTOR needs the `experimental-engines` feature.
 #![allow(deprecated)]
 //! RAPTOR Recall Test - Verify 100% recall after close/reopen
 //!

--- a/tests/td112_postflush_recall_e2e.rs
+++ b/tests/td112_postflush_recall_e2e.rs
@@ -9,15 +9,22 @@
 //!
 //! The clusters are well-separated so the *expected* recall is high regardless
 //! of the approximate index's internals; the band below is the regression gate.
+//
+// This test exercises the AXIS post-flush indexing path, so the whole file is
+// elided when the `axis` feature is off (PAX-exact-scan build has no AXIS index).
+#![cfg(feature = "axis")]
 
 use proximadb::compute::distance_computation::DistanceMetric;
 use proximadb::core::search::{BlockPruneConfig, BlockPruneMode, SearchMode, SearchParams};
+#[cfg(feature = "axis")]
 use proximadb::index::axis::management::manager::AxisManager;
+#[cfg(feature = "axis")]
 use proximadb::index::axis::types::AxisConfig;
 use proximadb::proto::proximadb_v1::{
     Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
 };
 use proximadb::storage::engines::sst::SstEngine;
+#[cfg(feature = "axis")]
 use proximadb::storage::engines::sst::core::set_sst_axis_manager;
 use proximadb::storage::traits::{
     FlushParameters, StorageQueryContext, StorageQueryMetadata, UnifiedStorageEngine,
@@ -26,15 +33,21 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
 
+#[cfg(feature = "axis")]
 const DIMENSION: usize = 16;
+#[cfg(feature = "axis")]
 const CLUSTERS: usize = 6;
+#[cfg(feature = "axis")]
 const PER_CLUSTER: usize = 24;
+#[cfg(feature = "axis")]
 const TOP_K: usize = 10;
 /// Conservative recall band: well-separated clusters should give near-perfect
 /// recall; this gate catches a collapse toward zero (e.g. the index never being
 /// populated and search returning nothing useful).
+#[cfg(feature = "axis")]
 const RECALL_BAND: f32 = 0.8;
 
+#[cfg(feature = "axis")]
 fn collection_config(id: &str, temp_dir: &TempDir) -> Collection {
     Collection {
         id: id.to_string(),
@@ -67,6 +80,7 @@ fn collection_config(id: &str, temp_dir: &TempDir) -> Collection {
 /// deterministic per-record perturbation. (All-positive, high-magnitude clusters
 /// collapse under sign quantization — every vector shares one signature — so this
 /// scheme is what gives a *fair* recall measurement of the index.)
+#[cfg(feature = "axis")]
 fn clustered_vectors() -> Vec<VectorRecord> {
     let mut out = Vec::with_capacity(CLUSTERS * PER_CLUSTER);
     for c in 0..CLUSTERS {
@@ -96,11 +110,13 @@ fn clustered_vectors() -> Vec<VectorRecord> {
     out
 }
 
+#[cfg(feature = "axis")]
 fn euclidean_sq(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
 }
 
 /// Exact top-k ids by Euclidean distance — the brute-force oracle.
+#[cfg(feature = "axis")]
 fn oracle_topk(all: &[VectorRecord], query: &[f32], k: usize) -> Vec<String> {
     let mut scored: Vec<(f32, &str)> = all
         .iter()
@@ -114,6 +130,7 @@ fn oracle_topk(all: &[VectorRecord], query: &[f32], k: usize) -> Vec<String> {
         .collect()
 }
 
+#[cfg(feature = "axis")]
 async fn flush_batch(engine: &SstEngine, collection: &Collection, batch: Vec<VectorRecord>) {
     let params = FlushParameters {
         collection_id: Some(collection.id.clone()),
@@ -131,6 +148,7 @@ async fn flush_batch(engine: &SstEngine, collection: &Collection, batch: Vec<Vec
     assert!(result.success, "flush should succeed");
 }
 
+#[cfg(feature = "axis")]
 async fn search(engine: &SstEngine, collection: &Collection, query: Vec<f32>) -> Vec<String> {
     let params = Arc::new(SearchParams {
         query_vectors: Some(vec![query]),
@@ -181,6 +199,7 @@ async fn search(engine: &SstEngine, collection: &Collection, query: Vec<f32>) ->
 /// Post-flush (≥2 flush cycles + compaction) top-k recall must stay within the
 /// target band against a brute-force oracle, and the query's own vector must be
 /// retrievable — proving flushed vectors are served by the populated ANN index.
+#[cfg(feature = "axis")]
 #[tokio::test]
 async fn postflush_recall_within_band_after_multi_flush_and_compaction() {
     let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();
@@ -245,6 +264,7 @@ async fn postflush_recall_within_band_after_multi_flush_and_compaction() {
 /// restart without asserting boot-time prewarm — the next search must rebuild it
 /// from durable local SST segments and recover recall, rather than silently
 /// degrading to a brute-force scan.
+#[cfg(feature = "axis")]
 #[tokio::test]
 async fn axis_index_rebuilt_from_sst_after_loss() {
     let _ = proximadb::core::hardware_capabilities::initialize_hardware_capabilities_default();


### PR DESCRIPTION
## Summary

AXIS (the HNSW/IVF/RaBitQ ANN index engine) is now behind a Cargo feature `axis` that is **ON by default (zero behavior change)** and **gateable OFF** for PAX-exact-scan builds (TD-AXIS-4 → Superseded; ADR-052). When OFF, vector search routes to the existing exact-scan path (`sst::search::want_exact_search` → `search_pax_file_exact`) — smaller binary, no AXIS boot/index-build cost. AXIS is **not** deprecated; it stays available behind the flag.

## Approach: `#[cfg(feature = "axis")]` inline gating (not trait-ify)

A cfg attribute whose feature is ON includes the gated code **verbatim**, so the default-ON build is byte-for-byte identical and the recall-critical per-query path is untouched. (Trait-ifying to `Option<Arc<dyn IndexEngine>>` would have changed the default-ON hot path — rejected.) Off-state fallbacks are no-op / `None` / exact-scan; dead records are filtered by the canonical read predicate (#16a) so recall is preserved.

## What changed (43 files)
- **Feature wiring:** `axis` added (default ON); `experimental-engines` implies `axis` (RAPTOR uses AXIS clustering); RAPTOR module gated by `experimental-engines`.
- **Seam:** `src/index/axis/`, `edr`, and the global `AxisManager` handle are `#[cfg(feature="axis")]`.
- **Core:** StorageEngine (`engine.rs` field/ctor/8 usages), `VectorOperationsService` (the IndexLookup arm + Stage-2 query path), the boot path (`shared_services`), holder services (auto_flush_driver, external_collection, recall_observer), the AXIS recall-advisor / drift / hot-swap surfaces, REST admin endpoints, and the eventlog substrate are all cfg-gated.
- **`proximadb-embedded`:** axis-**optional** (default OFF → exact-scan for in-process / few-collection use; opt-in `axis` for ANN). It no longer forces `axis` via workspace feature-unification — so the no-axis *test* build now genuinely excludes it (was being re-pulled by the embedded dev-dep).
- **`proximadb-server`:** `axis` is forwarded explicitly in its default (previously relied on workspace feature-unification) so every build path links it.
- **CI:** new `no-axis` feature-matrix variant.

## Verification (both builds)
| | default (axis ON) | no-axis (axis OFF) |
|---|---|---|
| `cargo clippy --lib --bins -D warnings` | ✅ | ✅ |
| `cargo fmt --check` | ✅ | ✅ |
| recall ratchets | ✅ td112×2, vector_ann×2, sift_pax×3 | ✅ vector_ann×2, sift_pax×3 (exact-scan); td112 gated out (AXIS-specific) |
| server binary | ✅ builds (axis on) | ✅ builds (axis off — confirmed `feature="axis"` absent from rustc cfg) |
| embedded | — | ✅ default (exact-scan) + opt-in `axis` both compile |

`make work-commit-check` passes all gates. (The lone env-gate failure, `PROXIMADB_OID_RESOLVER_CACHE_MB`, is pre-existing and unrelated — no env gates added here.)

## Notes
- Default-ON is byte-for-byte unchanged behavior (the production server + all existing paths are identical).
- A documenting TD (TD-AXIS-5) can follow if desired.