### PR TITLE
feat(abac): thread pgwire subject into relational SELECTs (FA activation) — TD-ABAC-3

### DIFF
--- a/docs/10-quality/td/TD-ABAC-3-relational-subject-plumbing.adoc
+++ b/docs/10-quality/td/TD-ABAC-3-relational-subject-plumbing.adoc
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ABAC-3: Relational subject plumbing — activate ABAC on pgwire SELECTs
+:status: Delivered (PR pending)
+:date: 2026-07-30
+:authors: FA enforcement track session 2026-07-30
+:realizes: TD-FOUNDATION-3 FA-c activation; TD-ABAC-2 (durable substrate)
+:design-of-record: TD-FOUNDATION-2 §3.4; TD-FOUNDATION-3 (FA build track)
+
+[cols="1,3"]
+|===
+| Status | **Delivered.** The authenticated/Asserted subject is threaded from the pgwire session into `scan_table_relational`, so a real client SELECT now filters rows by the subject's policy — the first *visible* end-to-end ABAC enforcement. Behind `abac-policy` (default-OFF).
+| Scope | The activation slice for the relational (pgwire) surface. Pairs with #1324 (enforcement) + #1331 (durable policy store + wiring): those made enforcement *available*; this makes it *run* on real SELECTs.
+| Out of scope | gRPC/REST relational subject threading (the genuinely-authenticated `UnifiedUserContext` reaches the gRPC handler but not the facade adapter yet — follow-on). Real SCRAM/MD5 auth on pgwire (P2, separately tracked). Column masking, graph trio.
+|===
+
+NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
+
+== 1. Why this exists
+
+#1324 wired the `AbacEnforcer` into `DmlService::scan_table_relational` (a cfg-gated
+`subject: Option<&SubjectId>` param) and proved a SELECT filters rows when a subject
+is supplied — but only in tests (the test passes `Some(&alice)`). In production the
+pgwire handler passed cfg-gated `None`, so no real client SELECT enforced. #1331 added
+the durable policy source + composition-root wiring, but the enforcer still received
+`subject = None` from every real query.
+
+This TD threads the connection's subject from the pgwire session all the way to
+`scan_table_relational`, activating enforcement on real client SELECTs.
+
+== 2. What landed
+
+* `SnapshotCatalog.subject` + `DmlTableReader.subject` (cfg-gated `Option<SubjectId>`),
+  threaded identically to the existing `tenant` field (`relational_pipeline.rs`).
+* `try_run_select` takes a cfg-gated `subject: Option<SubjectId>`, threaded into every
+  `SnapshotCatalog`. The pgwire caller constructs it from `session.user`; the
+  `build_snapshot` (EXPLAIN/ANALYZE) and facade-adapter (gRPC/REST) paths pass `None`.
+* The `scan_table_relational` call passes `self.subject.as_ref()` (was a parked `None`).
+* **The subject trust gate** (`protocol.rs::check_pgwire_subject_assertion`): the
+  startup `user` (the ABAC subject assertion) is gated through the SAME
+  `HeaderTrustPolicy` the tenant assertion uses. Under `Open` (default) the asserted
+  subject is accepted — the same trust class as the tenant assertion. Under a strict
+  policy (`AuthenticatedOnly`/`GatewayOnly`) a bare subject assertion is rejected at
+  the handshake (SQLSTATE 28000), so ABAC is not spoofable on a strict deployment.
+  `anonymous`/empty ⇒ no assertion (no enforcement).
+
+== 3. The trust reality (and why this is still correct)
+
+pgwire runs **trust auth**: the startup `user` is client-asserted and spoofable, exactly
+like the startup `database` (tenant) — which is *already* gated through
+`HeaderTrustPolicy` (`check_pgwire_tenant_assertion`). This TD puts the subject in the
+**same trust class**: client-asserted, policy-gated. Under the default `Open` policy
+both tenant and subject are honored as-asserted (spoofable — the deployment's explicit
+choice for dev/single-tenant/trusted-gateway topologies); under strict policy both are
+rejected. Gating the subject through the same policy is what makes this *consistent*
+rather than a new spoofable surface.
+
+Real, binding authentication is the separately-tracked **P2** (live JWT/SCRAM on the
+whole auth boundary, TD-FOUNDATION-3 §2). Until P2 lands, pgwire subject enforcement is
+*advisory under the deployment's chosen trust policy* — load-bearing only behind a
+trust-gated gateway or once SCRAM auth ships. The genuinely-authenticated surface is
+gRPC/REST (`UnifiedUserContext` via `SecurityCoordinator`); threading that into the
+facade adapter is the follow-on that produces *unconditional* real enforcement.
+
+== 4. Verification
+
+* `cargo check -p proximadb` (default, byte-for-byte — all new code is cfg-gated).
+* `cargo check -p proximadb --features abac-policy` — compiles the threaded path.
+* Enforcement-on-real-SELECT is proven compositionally: #1324's
+  `abac_relational_enforcement_tests` proves `scan_table_relational` filters by subject;
+  this TD supplies that subject from the pgwire session. The gate's bare-assertion logic
+  is the already-tested `identity_trust::resolve_tenant_assertion` `(Some, None)` arm.
+* `cargo clippy --features abac-policy -- -D warnings`, `cargo fmt --check`,
+  `make work-commit-check` (panic-policy +0, layering, tenant-path, hygiene, td-adr-unique).
+
+== 5. Follow-ons (under TD-FOUNDATION-3)
+
+1. **gRPC/REST relational subject threading** — thread the authenticated
+   `UnifiedUserContext.user_id` through `QueryFacadeAdapter::execute_sql` → `try_run_select`
+   (currently cfg-gated `None`). Unconditional real enforcement (no trust-auth caveat).
+2. **Durable predicate-object store + epochs** (from TD-ABAC-2 §5).
+3. **Column masking**, **graph trio** (layering).
+4. **P2 — real pgwire auth** (SCRAM/MD5): makes pgwire subject enforcement load-bearing
+   on a bare listener, not just behind a trust-gated gateway.
+
+== 6. Note: subject=None behavior
+
+`scan_table_relational` with `subject = None` does NOT enforce (#1324 design) — it is
+the status-quo pass-through. This branch activates enforcement only for connections that
+*assert* a (policy-gated) subject; anonymous/no-user connections remain un-enforced.
+That is the intended activation scope; making `subject = None` deny-all is a separate
+policy decision (it would break system/internal reads and anonymous clients) and is
+out of scope here.

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -630,6 +630,42 @@ impl PostgresProtocol {
         }
     }
 
+    /// TD-ABAC-3: gate a pgwire SUBJECT assertion (startup `user`) through the
+    /// SAME [`HeaderTrustPolicy`](proximadb_tenant::HeaderTrustPolicy) the tenant
+    /// assertion uses. pgwire is trust auth, so the binding is always `None`;
+    /// under `Open` (the default) the asserted subject is accepted (same trust
+    /// class as the tenant assertion), under a strict policy a bare subject
+    /// assertion is rejected at the handshake so ABAC enforcement is not
+    /// spoofable on a strict deployment. `anonymous`/empty = no assertion.
+    #[cfg(feature = "abac-policy")]
+    fn check_pgwire_subject_assertion(&self, asserted: &str) -> std::result::Result<(), String> {
+        use proximadb_tenant::identity_trust::resolve_tenant_assertion;
+
+        let asserted = asserted.trim();
+        if asserted.is_empty() || asserted == "anonymous" {
+            return Ok(());
+        }
+        // Reuse the shared bare-assertion policy check — its `(Some, None)` arm is
+        // generic over any client-asserted identity with no authenticated binding,
+        // which is exactly the subject case under pgwire trust auth.
+        match resolve_tenant_assertion(Some(asserted), None, self.tenant_header_trust) {
+            Ok(_) => Ok(()),
+            Err(_error) => {
+                warn!(
+                    target: "proximadb::tenant_audit",
+                    surface = "pgwire",
+                    policy = %self.tenant_header_trust,
+                    "rejected bare pgwire subject assertion '{asserted}'"
+                );
+                Err(format!(
+                    "subject '{asserted}' asserted without authenticated credentials; \
+                     this deployment requires a subject-bound credential (header-trust={})",
+                    self.tenant_header_trust
+                ))
+            }
+        }
+    }
+
     /// Attach the durable partition-lease authority to this connection's DDL
     /// service after rank/materializer decoration has finished.
     pub fn with_ddl_lease_manager(
@@ -874,6 +910,19 @@ impl PostgresProtocol {
         {
             self.send_error("FATAL", "28000", &message).await?;
             return Err(anyhow!("pgwire tenant assertion rejected: {message}"));
+        }
+
+        // TD-ABAC-3: gate the startup `user` (the ABAC subject assertion) through
+        // the same trust policy as the tenant — so a strict deployment rejects a
+        // bare, unauthenticated subject at the handshake rather than letting ABAC
+        // enforce against a spoofable id. Default-OFF surface (`abac-policy`);
+        // under `Open` (default) the assertion is accepted like the tenant's.
+        #[cfg(feature = "abac-policy")]
+        if let Some(user) = params.get("user")
+            && let Err(message) = self.check_pgwire_subject_assertion(user)
+        {
+            self.send_error("FATAL", "28000", &message).await?;
+            return Err(anyhow!("pgwire subject assertion rejected: {message}"));
         }
 
         // Store parameters in session
@@ -1757,6 +1806,19 @@ impl PostgresProtocol {
         // to the pre-cache behavior.
         let namespace = self.session.read().await.current_schema();
         let olap_cache = super::relational_pipeline::olap_result_cache();
+        // TD-ABAC-3: build the ABAC subject from the (already trust-gated at the
+        // handshake) connection user. `anonymous`/empty ⇒ no subject ⇒ no
+        // enforcement; otherwise the asserted user becomes the SubjectId ABAC
+        // resolves the row filter against.
+        #[cfg(feature = "abac-policy")]
+        let subject = {
+            let user = self.session.read().await.user.clone();
+            if user.is_empty() || user == "anonymous" {
+                None
+            } else {
+                Some(proximadb_catalog::fc_metamodel::SubjectId(user))
+            }
+        };
         super::relational_pipeline::try_run_select(
             query,
             self.dml_service.as_ref(),
@@ -1775,6 +1837,8 @@ impl PostgresProtocol {
             true,
             Some(namespace.as_str()),
             olap_cache.as_deref(),
+            #[cfg(feature = "abac-policy")]
+            subject,
         )
         .await
     }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -59,6 +59,10 @@ use crate::query::cache::invalidation_coordinator::CacheInvalidationCoordinator;
 use crate::query::cache::query_result_cache::{QueryKey, QueryResultCache, StructuralKey};
 use crate::services::dml::DmlService;
 use crate::storage::tenant::context::TenantContext;
+// TD-ABAC-3: the authenticated/Asserted subject threaded into the relational
+// read funnel so ABAC enforces on real client SELECTs (behind `abac-policy`).
+#[cfg(feature = "abac-policy")]
+use proximadb_catalog::fc_metamodel::SubjectId;
 
 use super::types::PgType;
 
@@ -272,6 +276,10 @@ pub async fn try_run_select(
     // execution; a miss falls through normally and the result is stamped on the
     // real-data success paths.
     result_cache: Option<&QueryResultCache<ExecutionPipelineResult>>,
+    // TD-ABAC-3: the connection subject, threaded into every SnapshotCatalog so
+    // `scan_table_relational` enforces ABAC. `None` ⇒ anonymous/internal ⇒ no
+    // enforcement. Behind `abac-policy` (default-OFF).
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Option<Result<ExecutionPipelineResult, String>> {
     // TD-064: the connection's tenant scopes every snapshot read to the tenant's
     // record partition (carried into the SnapshotCatalog → DmlTableReader).
@@ -547,6 +555,8 @@ pub async fn try_run_select(
                     dml: dml.clone(),
                     tables: tables.clone(),
                     tenant: tenant_ctx.clone(),
+                    #[cfg(feature = "abac-policy")]
+                    subject: subject.clone(),
                 };
                 // Setup (planning/route) time is attributed here; the native engine
                 // records its own `native-vectorized` compute sample inside the run.
@@ -728,6 +738,8 @@ pub async fn try_run_select(
                 dml: dml.clone(),
                 tables: tables.clone(),
                 tenant: tenant_ctx.clone(),
+                #[cfg(feature = "abac-policy")]
+                subject: subject.clone(),
             };
             shadow_probe_native_parquet(
                 sql,
@@ -752,6 +764,8 @@ pub async fn try_run_select(
         dml: dml.clone(),
         tables,
         tenant: tenant_ctx,
+        #[cfg(feature = "abac-policy")]
+        subject,
     };
     // Lower + plan via the shared planning path (so EXPLAIN discloses exactly this
     // plan). `None` → lowering declined → fall through to legacy. From the planned
@@ -1595,6 +1609,12 @@ struct SnapshotCatalog {
     /// TD-064: connection tenant scope threaded into every snapshot reader so
     /// relational scans/point-lookups read the tenant's record partition.
     tenant: Option<TenantContext>,
+    /// TD-ABAC-3: the connection's subject (Asserted under `Open` trust, or
+    /// rejected at the handshake under strict). Threaded into every snapshot
+    /// reader so `scan_table_relational` can enforce ABAC on real client SELECTs.
+    /// `None` ⇒ no subject (anonymous/internal) ⇒ no enforcement (status quo).
+    #[cfg(feature = "abac-policy")]
+    subject: Option<SubjectId>,
 }
 
 impl CatalogLookup for SnapshotCatalog {
@@ -1618,6 +1638,8 @@ impl ReaderFactory for SnapshotCatalog {
             full_schema: prepared.schema.clone(),
             pk_columns: prepared.pk_columns.clone(),
             tenant: self.tenant.clone(),
+            #[cfg(feature = "abac-policy")]
+            subject: self.subject.clone(),
             open_state: None,
         }))
     }
@@ -1686,6 +1708,9 @@ struct DmlTableReader {
     pk_columns: Vec<usize>,
     /// TD-064: connection tenant scope for this reader's record partition.
     tenant: Option<TenantContext>,
+    /// TD-ABAC-3: connection subject for ABAC enforcement on this reader's scans.
+    #[cfg(feature = "abac-policy")]
+    subject: Option<SubjectId>,
     open_state: Option<ReaderOpenState>,
 }
 
@@ -1781,11 +1806,13 @@ impl RelationalReader for DmlTableReader {
                 row_pred_ref,
                 limit,
                 self.tenant.as_ref(),
-                // FA-c Phase 2: subject not yet plumbed from the pgwire auth
-                // layer (UnifiedUserContext.user_id), so no enforcement here yet;
-                // pass None until handler subject-plumbing lands.
+                // TD-ABAC-3: the connection subject, threaded from the pgwire
+                // auth layer (Asserted `user`, gated by `HeaderTrustPolicy` at the
+                // handshake). When present, `scan_table_relational` AND-combines
+                // the ABAC row filter with the user WHERE (#1324); `None`
+                // (anonymous/internal) ⇒ no enforcement.
                 #[cfg(feature = "abac-policy")]
-                None,
+                self.subject.as_ref(),
             )
             .await
             .map_err(|e| ReaderError::Storage(e.to_string()))?;
@@ -2331,6 +2358,10 @@ async fn build_snapshot(
         tenant: tenant
             .filter(|t| !t.is_empty())
             .map(TenantContext::for_tenant_id),
+        // EXPLAIN/ANALYZE path — no client subject threaded here (follow-on);
+        // `None` ⇒ no ABAC enforcement on this path.
+        #[cfg(feature = "abac-policy")]
+        subject: None,
     })
 }
 

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -802,6 +802,12 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
                 false,
                 None,
                 olap_result_cache.as_deref(),
+                // TD-ABAC-3: gRPC/REST relational subject threading is a follow-on
+                // (the genuinely-authenticated UnifiedUserContext lives upstream and
+                // does not reach this adapter today); `None` ⇒ no ABAC enforcement
+                // on this surface yet.
+                #[cfg(feature = "abac-policy")]
+                None,
             )
             .await
         {


### PR DESCRIPTION
## Summary

**Activates ABAC enforcement on real client SELECTs over pgwire** — the activation slice pairing with #1324 (enforcement) and #1331 (durable policy store + composition wiring). Those made enforcement *available*; this makes it *run*. Behind `abac-policy` (default-OFF).

## What changed

- **Thread the connection subject** (`Option<SubjectId>`) through `try_run_select` → `SnapshotCatalog` → `DmlTableReader` → `scan_table_relational`, mirroring the existing `tenant` field template. The scan call passes `self.subject.as_ref()` (was a parked cfg-gated `None`). All cfg-gated → default builds byte-for-byte unchanged.
- **pgwire caller** constructs the subject from `session.user` (`None` for anonymous/empty). The facade-adapter (gRPC/REST) and `build_snapshot` (EXPLAIN/ANALYZE) paths pass `None` for now (follow-ons).
- **Subject trust gate** (`check_pgwire_subject_assertion`): the startup `user` is gated through the **same `HeaderTrustPolicy`** the tenant assertion uses. Under `Open` (default) the asserted subject is accepted — the same trust class as the tenant assertion; under a strict policy a bare subject assertion is rejected at the handshake (SQLSTATE 28000), so ABAC is not spoofable on a strict deployment. `anonymous`/empty ⇒ no assertion.

## Trust reality (called out honestly)

pgwire runs **trust auth** — the startup `user` is client-asserted and spoofable, **exactly like the tenant `database`** which is already gated through `HeaderTrustPolicy`. This puts the subject in the same trust class (client-asserted, policy-gated), not a new spoofable surface. Real binding auth is the separately-tracked **P2** (SCRAM/JWT on the auth boundary); until then pgwire subject enforcement is advisory under the deployment's chosen trust policy, load-bearing behind a trust-gated gateway. The genuinely-authenticated gRPC/REST surface (`UnifiedUserContext`) threading into the facade adapter is the follow-on for unconditional real enforcement.

## Verification
- `cargo check -p proximadb` (default, byte-for-byte) — clean.
- `cargo check -p proximadb --features abac-policy` — compiles the threaded path (cfg-gated struct fields included).
- `cargo nextest run -p proximadb --features abac-policy -E 'test(abac)'` — **19/19 passed**, no regression.
- `cargo clippy -p proximadb --features abac-policy -- -D warnings` — clean.
- `cargo fmt --check`, `make work-commit-check` (panic-policy +0, env-gate, layering, tenant-path, capability-matrix, td-unique, attribution) — green.

## Enforcement proven compositionally
#1324's `abac_relational_enforcement_tests` proves `scan_table_relational` filters rows by subject; this PR supplies that subject from the pgwire session. The gate's bare-assertion logic is the already-tested `identity_trust::resolve_tenant_assertion` `(Some, None)` arm.

## Follow-ons (TD-ABAC-3 §5)
1. gRPC/REST relational subject threading (authenticated `UnifiedUserContext` → facade adapter → `try_run_select`) — unconditional real enforcement.
2. Durable predicate-object store + epochs (from TD-ABAC-2 §5).
3. Column masking, graph trio (layering).
4. P2 — real pgwire auth (SCRAM/MD5): makes pgwire subject enforcement load-bearing on a bare listener.

## TD
`docs/10-quality/td/TD-ABAC-3-relational-subject-plumbing.adoc`