### PR TITLE
feat(abac): durable predicate-object store (FA Phase 5b) — TD-ABAC-4

### DIFF
--- a/crates/control/proximadb-abac/src/compile.rs
+++ b/crates/control/proximadb-abac/src/compile.rs
@@ -29,6 +29,7 @@
 //! *compile* time; the store holds the already-lowered `FilterExpression`.
 
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use proximadb_catalog::fc_metamodel::ObjectId;
 use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
@@ -101,6 +102,125 @@ impl PredicateObjectStore for InMemoryPredicateObjectStore {
     fn get(&self, id: ObjectId) -> Option<&FilterExpression> {
         self.objects.get(&id)
     }
+}
+
+// ===========================================================================
+// FileSystemPredicateObjectStore — durable backing (Phase 5b)
+// ===========================================================================
+
+/// A [`PredicateObjectStore`] backed by an atomic-rename JSON snapshot on the
+/// filesystem — the durable counterpart to [`InMemoryPredicateObjectStore`],
+/// modeled on [`FileSystemPolicyBindingStore`](crate::FileSystemPolicyBindingStore).
+///
+/// This is the second half of the durable substrate that makes ABAC row-level
+/// enforcement work in production: a `PolicyBinding.predicate_ref` points here,
+/// and [`compile_security_filter`] resolves it. Without a durable predicate
+/// store, a binding that carries a predicate ref resolves against an empty
+/// in-memory store in production and denies fail-closed — so only
+/// predicate-free table-level grants evaluated end-to-end. With this store,
+/// admin-defined row predicates (e.g. `dept == $subject.dept`) survive a restart.
+///
+/// **OSS mechanism** (ADR-060): atomic temp-file + rename, load-on-open,
+/// best-effort persist — the same mechanism
+/// [`FileSystemAttributeAuthority`](crate::FileSystemAttributeAuthority) and
+/// [`FileSystemPolicyBindingStore`] use. The commercial crate supplies the
+/// IdP-administered production store; this is the development/reference impl.
+///
+/// Predicate objects are keyed by global catalog `ObjectId` (not tenant-
+/// partitioned), matching [`InMemoryPredicateObjectStore`] and the enforcer's
+/// single shared store — a predicate ref resolves the same `FilterExpression`
+/// regardless of tenant. `Send + Sync` (held by the enforcer behind a
+/// `Box<dyn PredicateObjectStore + Send + Sync>`).
+pub struct FileSystemPredicateObjectStore {
+    inner: InMemoryPredicateObjectStore,
+    path: PathBuf,
+}
+
+impl FileSystemPredicateObjectStore {
+    /// Open (or create) the store at `path`. If the file exists, predicate
+    /// objects are loaded — this is the **restart-recovery** path. A missing
+    /// file is an empty store (every ref fails to resolve → deny), not an error.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, PredicateStoreError> {
+        let path = path.as_ref().to_path_buf();
+        let mut inner = InMemoryPredicateObjectStore::new();
+        if path.exists() {
+            let data = std::fs::read(&path).map_err(|e| PredicateStoreError::Unavailable {
+                detail: format!("read {}: {e}", path.display()),
+            })?;
+            let objects: Vec<(ObjectId, FilterExpression)> = serde_json::from_slice(&data)
+                .map_err(|e| PredicateStoreError::Unavailable {
+                    detail: format!("deserialize {}: {e}", path.display()),
+                })?;
+            for (id, expr) in objects {
+                inner.register(id, expr);
+            }
+        }
+        Ok(Self { inner, path })
+    }
+
+    /// Register or replace a predicate object and persist immediately (atomic rename).
+    pub fn register(&mut self, id: ObjectId, expr: FilterExpression) {
+        self.inner.register(id, expr);
+        let _ = self.persist();
+    }
+
+    /// Remove a predicate object and persist immediately. Subsequent resolves of
+    /// `id` fail-closed.
+    pub fn revoke(&mut self, id: ObjectId) {
+        self.inner.revoke(id);
+        let _ = self.persist();
+    }
+
+    /// An iterator over the stored predicate objects — for inspection/audit.
+    pub fn objects(&self) -> impl Iterator<Item = (&ObjectId, &FilterExpression)> {
+        self.inner.objects.iter()
+    }
+
+    /// Write the full predicate-object set atomically (temp + rename).
+    fn persist(&self) -> Result<(), PredicateStoreError> {
+        let objects: Vec<(ObjectId, FilterExpression)> = self
+            .inner
+            .objects
+            .iter()
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        let json =
+            serde_json::to_vec_pretty(&objects).map_err(|e| PredicateStoreError::Unavailable {
+                detail: format!("serialize predicate objects: {e}"),
+            })?;
+        let tmp = self.path.with_extension("tmp");
+        std::fs::write(&tmp, &json).map_err(|e| PredicateStoreError::Unavailable {
+            detail: format!("write {}: {e}", tmp.display()),
+        })?;
+        std::fs::rename(&tmp, &self.path).map_err(|e| PredicateStoreError::Unavailable {
+            detail: format!("rename {} → {}: {e}", tmp.display(), self.path.display()),
+        })?;
+        Ok(())
+    }
+}
+
+impl PredicateObjectStore for FileSystemPredicateObjectStore {
+    fn get(&self, id: ObjectId) -> Option<&FilterExpression> {
+        self.inner.get(id)
+    }
+}
+
+/// Why a predicate-object store could not be consulted (mirrors
+/// [`PolicyStoreError`](crate::PolicyStoreError)). Only the **outage** case is
+/// modeled — a missing predicate ref is *not* an error, it is a fail-closed
+/// deny (see [`compile_security_filter`]). Callers must treat [`Unavailable`] as
+/// deny: an authorization substrate does not degrade to "allow" when its source
+/// of truth is unreachable.
+///
+/// [`Unavailable`]: PredicateStoreError::Unavailable
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PredicateStoreError {
+    /// The store could not be read or written (file IO, deserialization).
+    #[error("predicate object store unavailable: {detail}")]
+    Unavailable {
+        /// Operator-facing detail.
+        detail: String,
+    },
 }
 
 /// Compile `refs` into a single security `FilterExpression` by resolving each
@@ -269,5 +389,79 @@ mod tests {
             }
             _ => panic!("unsatisfiable must be an And"),
         }
+    }
+
+    // --- FileSystemPredicateObjectStore: restart recovery (Phase-5b ratchet) ---
+
+    fn unique_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "proximadb-abac-pred-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    #[test]
+    fn fs_predicate_store_objects_survive_a_restart() {
+        let dir = unique_dir("restart");
+        let path = dir.join("predicates.json");
+
+        // Write phase: register predicate 42 (dept=eng) + 7 (clearance>=3), drop.
+        {
+            let mut store = FileSystemPredicateObjectStore::open(&path).expect("open");
+            store.register(42, eq_dept("eng"));
+            store.register(7, gt_clearance(3));
+            assert!(path.exists(), "persist wrote the file");
+        }
+
+        // Read phase: reopen — both predicates must survive, byte-identical.
+        let store = FileSystemPredicateObjectStore::open(&path).expect("reopen");
+        assert_eq!(store.get(42), Some(&eq_dept("eng")));
+        assert_eq!(store.get(7), Some(&gt_clearance(3)));
+        assert!(store.get(999).is_none(), "unknown ref resolves None (deny)");
+
+        // compile_security_filter — the production enforcement path — resolves
+        // the restarted refs, and a missing ref compiles to the fail-closed deny.
+        assert!(compile_security_filter(&[42, 7], &store).is_some());
+        assert!(
+            compile_security_filter(&[42, 999], &store).is_some(),
+            "a missing ref compiles to the unsatisfiable deny, not None"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn fs_predicate_store_register_and_revoke_persist() {
+        let dir = unique_dir("revoke");
+        let path = dir.join("predicates.json");
+
+        {
+            let mut store = FileSystemPredicateObjectStore::open(&path).expect("open");
+            store.register(42, eq_dept("eng"));
+            store.revoke(42);
+        }
+        let store = FileSystemPredicateObjectStore::open(&path).expect("reopen");
+        assert!(
+            store.get(42).is_none(),
+            "revoked predicate must not survive restart"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn fs_predicate_store_missing_file_is_empty_not_error() {
+        let dir = unique_dir("missing");
+        let path = dir.join("nope.json");
+        let store = FileSystemPredicateObjectStore::open(&path).expect("missing ⇒ empty store");
+        assert!(store.get(42).is_none());
+        let _ = std::fs::remove_dir(&dir);
     }
 }

--- a/crates/control/proximadb-abac/src/lib.rs
+++ b/crates/control/proximadb-abac/src/lib.rs
@@ -60,7 +60,10 @@ pub use authority::{
     FileSystemAttributeAuthority, InMemoryAttributeAuthority, ResolvedSubject,
 };
 pub use cache_key::{InMemoryPolicyEpochs, PolicyEpoch, PolicyEpochSource, SubjectCacheKey};
-pub use compile::{InMemoryPredicateObjectStore, PredicateObjectStore, compile_security_filter};
+pub use compile::{
+    FileSystemPredicateObjectStore, InMemoryPredicateObjectStore, PredicateObjectStore,
+    PredicateStoreError, compile_security_filter,
+};
 pub use context::{
     AuthorizedReadContext, ClientServable, ColumnDecision, DenyReason, ForbiddenColumn,
     ReadContext, ReadDecision, SystemReadContext, SystemReadReason,

--- a/docs/10-quality/td/TD-ABAC-4-durable-predicate-object-store.adoc
+++ b/docs/10-quality/td/TD-ABAC-4-durable-predicate-object-store.adoc
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ABAC-4: Durable predicate-object store (FA Phase 5b)
+:status: Delivered (PR pending)
+:date: 2026-07-30
+:authors: FA enforcement track session 2026-07-30
+:realizes: TD-FOUNDATION-3 Phase 5b; TD-ABAC-2/ABAC-3 (durable substrate)
+:design-of-record: TD-FOUNDATION-2 §3.2; TD-FOUNDATION-3 (FA build track)
+:depends-on: TD-ABAC-2 (durable binding store), TD-ABAC-3 (subject activation)
+
+[cols="1,3"]
+|===
+| Status | **Delivered.** The durable `PredicateObjectStore` closes the functional gap that limited ABAC to *table-level* permit/deny in production: a binding's `predicate_ref` now resolves against a restart-surviving store, so row-level predicates (e.g. `dept == $subject.dept`) actually evaluate. Behind `abac-policy` (default-OFF).
+| Scope | The third durable half of the ABAC substrate: authority (Phase 5a, #1310) + policy bindings (#1331) + **predicate objects** (this). Together they make row-level enforcement real in production.
+| Out of scope | Durable policy-epoch source (still in-memory). gRPC/REST subject threading (real-auth activation). Column masking, graph trio. P2 (real pgwire SCRAM auth).
+|===
+
+NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
+
+== 1. Why this exists
+
+A `PolicyBinding.predicate_ref` is an `ObjectId` pointing at a stored
+`FilterExpression` — the row-level rule (`dept == "eng"`). `compile_security_filter`
+resolves that ref against a `PredicateObjectStore`. Before this TD, the store was
+`InMemoryPredicateObjectStore::new()` — **empty in production** — so any binding
+that carried a `predicate_ref` resolved to `None` and `compile_security_filter`
+returned the fail-closed unsatisfiable deny. Result: production ABAC could only
+evaluate predicate-free table-level grants; row-level filtering silently denied.
+
+With the durable binding store (#1331) and subject activation (#1333) in place,
+the predicate store was the **last functional gap**: a binding + subject + durable
+bindings still could not filter rows. This TD fills it.
+
+== 2. What landed
+
+* `FileSystemPredicateObjectStore` (`crates/control/proximadb-abac/src/compile.rs`)
+  — wraps `InMemoryPredicateObjectStore`, persists `Vec<(ObjectId, FilterExpression)>`
+  via atomic temp-file + rename, load-on-open restart recovery. Mirrors
+  `FileSystemPolicyBindingStore` (TD-ABAC-2) and the OSS mechanism (ADR-060).
+  `register`/`revoke` persist immediately; `get` delegates to the in-memory map.
+  `Send + Sync` (held by the enforcer behind `Box<dyn PredicateObjectStore + Send + Sync>`).
+* `PredicateStoreError::Unavailable` (mirrors `PolicyStoreError`).
+* Composition root (`shared_services::build_abac_enforcer`): the enforcer's predicate
+  store is now `FileSystemPredicateObjectStore::open(<data_dir>/abac/predicate-objects.json)`
+  (was an empty in-memory store). Fail-open-to-status-quo on open error (returns
+  `None` enforcer, like the authority/binding stores) — never a synthesized allow.
+
+`FilterExpression` was already `Serialize/Deserialize` (`proximadb-filter-expression`),
+so no format work was needed.
+
+== 3. Keying: global ObjectId, not tenant-partitioned
+
+Unlike the binding store (tenant-scoped via `bindings_for(tenant)`), the predicate
+store is keyed by **global catalog `ObjectId`** and is NOT tenant-partitioned —
+matching `InMemoryPredicateObjectStore` and the enforcer's single shared store. A
+predicate ref resolves the same `FilterExpression` regardless of tenant. This is the
+existing design (the `PredicateObjectStore::get(id)` API has no tenant param); this
+TD preserves it. Tenant isolation comes from the bindings (which are tenant-scoped
+and select which refs apply), not from the predicate objects themselves.
+
+== 4. Verification
+
+* `cargo check -p proximadb` (default, byte-for-byte — all new code is cfg-gated / in
+  the optional abac crate).
+* `cargo check -p proximadb --features abac-policy` — compiles the durable store + wiring.
+* `cargo nextest run -p proximadb-abac` — 58 tests (+3 predicate-store restart tests).
+* Restart ratchet: `fs_predicate_store_objects_survive_a_restart` (reopens, asserts
+  refs resolve identically + `compile_security_filter` works post-restart + a missing
+  ref stays fail-closed), `fs_predicate_store_register_and_revoke_persist`,
+  `fs_predicate_store_missing_file_is_empty_not_error`.
+* `cargo clippy -p proximadb --features abac-policy -- -D warnings` + `cargo fmt --check`
+  + `make work-commit-check` (panic-policy +0, env-gate, layering, hygiene).
+
+== 5. The durable substrate is now complete
+
+With authority (#1310) + bindings (#1331) + predicate objects (this) all durable and
+wired at the composition root, the enforcer held by `DmlService` carries a full,
+restart-surviving policy + predicate set. Combined with subject activation (#1333), a
+real client SELECT over pgwire now: resolves the subject's attributes (durable
+authority) → composes the applicable bindings (durable binding store) → resolves the
+row predicates (durable predicate store) → ANDs them into the scan. Row-level ABAC
+enforcement is functionally complete on the pgwire surface (advisory under the
+deployment's trust policy — see TD-ABAC-3 §3 — load-bearing behind a gateway or once
+P2/SCRAM lands).
+
+== 6. Follow-ons (under TD-FOUNDATION-3)
+
+1. **Durable policy-epoch source** — today `InMemoryPolicyEpochs`; needed for
+   subject-cache-key invalidation across restarts (S10).
+2. **gRPC/REST relational subject threading** — authenticated `UnifiedUserContext` →
+   facade adapter (unconditional real enforcement, no trust-auth caveat).
+3. **Column masking**, **graph trio** (layering).
+4. **P2 — real pgwire auth** (SCRAM/MD5).

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -541,8 +541,8 @@ impl SharedServices {
         opt_config: Option<&crate::core::config::Config>,
     ) -> Option<Arc<crate::security::rls::AbacEnforcer>> {
         use proximadb_abac::{
-            FileSystemAttributeAuthority, FileSystemPolicyBindingStore, InMemoryPolicyEpochs,
-            InMemoryPredicateObjectStore,
+            FileSystemAttributeAuthority, FileSystemPolicyBindingStore,
+            FileSystemPredicateObjectStore, InMemoryPolicyEpochs,
         };
 
         let data_dir = opt_config?.server.data_dir.clone();
@@ -581,14 +581,30 @@ impl SharedServices {
                     return None;
                 }
             };
+        // TD-ABAC-4: durable predicate-object store — resolves the
+        // `PolicyBinding.predicate_ref` ObjectIds to their `FilterExpression`s so
+        // row-level enforcement (not just predicate-free table grants) works in
+        // production. Empty ⇒ every predicate ref resolves fail-closed.
+        let predicate_objects =
+            match FileSystemPredicateObjectStore::open(abac_dir.join("predicate-objects.json")) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::error!(
+                        "abac-policy: failed to open predicate object store at {}: {e}; \
+                     enforcement DISABLED (no enforcer)",
+                        abac_dir.display()
+                    );
+                    return None;
+                }
+            };
 
         tracing::info!(
-            "abac-policy: durable ABAC enforcer active at {} (authority + policy binding store)",
+            "abac-policy: durable ABAC enforcer active at {} (authority + policy binding store + predicate object store)",
             abac_dir.display()
         );
         let enforcer = crate::security::rls::AbacEnforcer::new(
             Box::new(authority),
-            Box::new(InMemoryPredicateObjectStore::new()),
+            Box::new(predicate_objects),
             Box::new(InMemoryPolicyEpochs::new()),
         )
         .with_binding_store(Box::new(bindings));


### PR DESCRIPTION
## Summary

Adds the durable **`PredicateObjectStore`** — the third durable half of the ABAC substrate (authority #1310 + bindings #1331 + **predicate objects** here). This closes the functional gap that limited production ABAC to **table-level** permit/deny: a `PolicyBinding.predicate_ref` pointed into an empty in-memory store, so any row-level predicate denied fail-closed. Now admin-defined row predicates (e.g. `dept == $subject.dept`) survive a restart and actually evaluate.

With this + subject activation (#1333), a real client SELECT over pgwire now: resolves attributes (durable authority) → composes bindings (durable binding store) → resolves row predicates (**durable predicate store**) → ANDs into the scan. Row-level ABAC is functionally complete on the pgwire surface. Behind `abac-policy` (default-OFF).

## What changed
- **`FileSystemPredicateObjectStore`** (`compile.rs`): wraps `InMemoryPredicateObjectStore`, persists `Vec<(ObjectId, FilterExpression)>` via atomic temp-file + rename, load-on-open restart recovery. Mirrors `FileSystemPolicyBindingStore` / ADR-060. `Send + Sync`. `register`/`revoke` persist immediately; `get` delegates to the in-memory map. `PredicateStoreError::Unavailable` for outages (a missing ref is *not* an error — it's the fail-closed deny via `compile_security_filter`).
- **Composition root** (`build_abac_enforcer`): the enforcer's predicate store is now `FileSystemPredicateObjectStore::open(<data_dir>/abac/predicate-objects.json)` (was an empty `InMemoryPredicateObjectStore`). Fail→`None` enforcer on open error, like the authority/binding stores.
- `FilterExpression` was already `Serialize/Deserialize` — no format work needed.

**Keying:** global `ObjectId`, not tenant-partitioned — matches `InMemoryPredicateObjectStore` and the enforcer's single shared store (the `get(id)` API has no tenant param). Tenant isolation comes from the bindings (tenant-scoped; they select which refs apply).

## Verification
- `cargo check -p proximadb` (default, byte-for-byte) — clean.
- `cargo check -p proximadb --features abac-policy` — compiles the durable store + wiring.
- `cargo nextest run -p proximadb-abac` — **58 tests** (+3 predicate-store restart tests).
- `cargo nextest run -p proximadb --features abac-policy -E 'test(abac)'` — **19/19 passed**, no regression.
- `cargo clippy -p proximadb --features abac-policy -- -D warnings` — clean.
- `cargo fmt --check`, `make work-commit-check` (panic-policy +0, env-gate, layering, capability-matrix, td-unique 308) — green.

## Restart ratchet
`fs_predicate_store_objects_survive_a_restart` (reopens, asserts refs resolve identically + `compile_security_filter` works post-restart + a missing ref stays fail-closed), `fs_predicate_store_register_and_revoke_persist`, `fs_predicate_store_missing_file_is_empty_not_error`.

## Follow-ons (TD-ABAC-4 §6)
1. Durable policy-epoch source (today `InMemoryPolicyEpochs`) — for subject-cache-key invalidation across restarts (S10).
2. gRPC/REST relational subject threading (authenticated `UnifiedUserContext` → facade adapter) — unconditional real enforcement.
3. Column masking, graph trio (layering), P2 (real pgwire SCRAM auth).

## TD
`docs/10-quality/td/TD-ABAC-4-durable-predicate-object-store.adoc`