### PR TITLE
feat(abac): thread authenticated subject through SQL ports + gRPC activation — TD-ABAC-5

### DIFF
--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -4412,6 +4412,7 @@ impl EmbeddedProximaDB {
                     }),
                     collection.map(str::to_string),
                     None, // embedded single-process: no per-request tenant
+                    None, // TD-ABAC-5: embedded single-process: no per-request subject
                 )
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -268,6 +268,7 @@ pub(crate) mod test_support {
             parameters: Option<Vec<ProximaValue>>,
             collection: Option<String>,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
         ) -> Result<ExecuteQueryResponse> {
             self.calls.lock().unwrap().push(ApiCall::Sql {
                 query,
@@ -391,6 +392,7 @@ pub(crate) mod test_support {
             _query: String,
             _collection: Option<String>,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
         ) -> Result<JsonValue> {
             Ok(JsonValue::Array(Vec::new()))
         }
@@ -473,6 +475,7 @@ mod tests {
             "select * from docs".to_string(),
             None,
             Some("docs".to_string()),
+            None,
             None,
         )
         .await
@@ -631,7 +634,7 @@ mod tests {
             .unwrap();
         assert!(
             query
-                .execute_sql("select 1".to_string(), Some("docs".to_string()), None)
+                .execute_sql("select 1".to_string(), Some("docs".to_string()), None, None)
                 .await
                 .unwrap()
                 .is_array()

--- a/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
+++ b/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
@@ -410,7 +410,7 @@ pub async fn execute_sql(
 
     match state
         .handlers
-        .execute_sql_v1(query, parameters, request.collection, None)
+        .execute_sql_v1(query, parameters, request.collection, None, None)
         .await
     {
         Ok(v1_resp) => {

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -625,6 +625,7 @@ impl ApiHandlersPort for UnifiedHandlers {
         _parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
     ) -> Result<ExecuteQueryResponse> {
         let adapter = self
             .query_adapter
@@ -632,7 +633,9 @@ impl ApiHandlersPort for UnifiedHandlers {
             .ok_or_else(|| anyhow!("SQL execution requires QueryAdapterPort (not wired)"))?;
 
         let start = Instant::now();
-        let json_result = adapter.execute_sql(query, collection, tenant_id).await?;
+        let json_result = adapter
+            .execute_sql(query, collection, tenant_id, subject)
+            .await?;
 
         let records = json_result
             .get("records")
@@ -893,6 +896,7 @@ mod tests {
             _query: String,
             _collection: Option<String>,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
         ) -> Result<serde_json::Value> {
             Ok(json!({
                 "columns": ["id", "score", "flag", "none", "obj"],
@@ -1076,6 +1080,7 @@ mod tests {
                 None,
                 Some("docs".to_string()),
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1130,7 +1135,7 @@ mod tests {
         );
         assert!(
             handlers
-                .execute_sql_v1("select 1".to_string(), None, None, None)
+                .execute_sql_v1("select 1".to_string(), None, None, None, None)
                 .await
                 .unwrap_err()
                 .to_string()
@@ -1160,6 +1165,7 @@ mod tests {
                 _query: String,
                 _collection: Option<String>,
                 _tenant_id: Option<&str>,
+                _subject: Option<&str>,
             ) -> Result<serde_json::Value> {
                 Ok(json!(["text", 7, false, null, {"shape": "object"}]))
             }
@@ -1171,7 +1177,7 @@ mod tests {
             Some(Arc::new(ArrayQueryAdapter)),
         );
         let sql = handlers
-            .execute_sql_v1("select values".to_string(), None, None, None)
+            .execute_sql_v1("select values".to_string(), None, None, None, None)
             .await
             .unwrap();
         assert_eq!(sql.rows_returned, 5);

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -153,5 +153,11 @@ pub trait ApiHandlersPort: Send + Sync {
         // haven't been wired pass `None`); production gRPC/REST threads the real
         // tenant from the request.
         tenant_id: Option<&str>,
+        // TD-ABAC-5: the authenticated subject (principal id), threaded to ABAC
+        // enforcement at the relational read boundary. Opaque `&str` here because
+        // this port (runtime layer) cannot name `SubjectId` (catalog/control); the
+        // root-crate adapter converts it. `None` ⇒ anonymous/unwired ⇒ no
+        // enforcement (status quo). Enforcement is behind `abac-policy`.
+        subject: Option<&str>,
     ) -> Result<ExecuteQueryResponse>;
 }

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -191,10 +191,15 @@ pub trait QueryAdapterPort: Send + Sync {
     /// `tenant_id` scopes relational SQL to the tenant's partition (TD-064); the
     /// adapter routes relational SELECT through the tenant-scoped relational
     /// pipeline (`try_run_select`, TD-121) before falling back to the facade.
+    ///
+    /// `subject` (TD-ABAC-5) is the authenticated principal id, threaded to ABAC
+    /// enforcement. Opaque `&str` here (runtime layer can't name `SubjectId`);
+    /// the root-crate adapter converts it. `None` ⇒ no enforcement.
     async fn execute_sql(
         &self,
         query: String,
         collection: Option<String>,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
     ) -> Result<JsonValue>;
 }

--- a/docs/10-quality/td/TD-ABAC-5-sql-port-subject-threading.adoc
+++ b/docs/10-quality/td/TD-ABAC-5-sql-port-subject-threading.adoc
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ABAC-5: SQL port-trait subject threading + gRPC activation
+:status: Delivered (PR pending)
+:date: 2026-07-30
+:authors: FA enforcement track session 2026-07-30
+:realizes: TD-FOUNDATION-3 FA-c activation; TD-ABAC-3 (pgwire activation)
+:design-of-record: TD-FOUNDATION-3 (FA build track); ADR-060
+
+[cols="1,3"]
+|===
+| Status | **Delivered.** The authenticated subject is threaded through the SQL port traits (`execute_sql_v1` / `execute_sql`) and activated on the gRPC surface — the first *unconditional, real-auth* ABAC enforcement (no trust-auth caveat). REST extractor wiring + the `execute_unified_query`/`federated_query` path are follow-ons.
+| Scope | Activation-completion across network surfaces. pgwire was activated in TD-ABAC-3 (advisory under trust auth); this activates gRPC with a genuinely-authenticated subject.
+| Out of scope | REST `Extension<UnifiedUserContext>` extractor wiring on the `execute_sql_v1` route; the REST prod `execute_unified_query`→`federated_query` path (separate surface that doesn't reach `try_run_select`). Durable policy-epoch source, column masking, graph trio, P2.
+|===
+
+NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
+
+== 1. Why this exists
+
+TD-ABAC-3 activated enforcement on pgwire, but pgwire runs **trust auth** — the
+subject is client-asserted and spoofable (advisory under the deployment's trust
+policy). The genuinely-authenticated surface is gRPC/REST (`UnifiedUserContext`
+resolved via `SecurityCoordinator` from API key/JWT/cert). To get *unconditional*
+real enforcement, the authenticated subject must reach the relational read path
+on those surfaces.
+
+The gRPC `ExecuteQuery` path resolves the user but did not thread it into the SQL
+execution chain: `record_service.rs::execute_query` → `ApiHandlersPort::execute_sql_v1`
+→ `QueryAdapterPort::execute_sql` → `try_run_select`. `try_run_select` already took a
+cfg-gated `subject` param (TD-ABAC-3) but the adapter passed `None`. This TD threads
+the subject through both port traits and supplies the real gRPC subject.
+
+== 2. What landed
+
+* An **opaque `subject: Option<&str>`** trailing param on both port traits —
+  `ApiHandlersPort::execute_sql_v1` (`proximadb-runtime/src/port.rs`) and
+  `QueryAdapterPort::execute_sql` (`proximadb-runtime/src/service_ports.rs`) —
+  forwarded through `UnifiedHandlers::execute_sql_v1` (`handlers.rs`).
+  +
+  **Why opaque `&str`, not `SubjectId`:** the port traits live in `proximadb-runtime`,
+  which has no `proximadb-catalog` dependency and cannot name `SubjectId`. The
+  `String → SubjectId` conversion happens at the **root-crate boundary**
+  (`QueryFacadeAdapter::execute_sql`), keeping `SubjectId` and the feature gate
+  entirely inside the root crate (no new runtime-crate dependency, no cfg-on-
+  `async_trait`-method risk, no cross-crate cfg-coherence hazard on the `dyn` trait).
+* **gRPC activation:** `record_service.rs::execute_query` captures
+  `grpc_auth::user_id(&request)` (before the request is moved) and passes it through
+  `execute_sql_v1` → `try_run_select`. This is the headline — real authenticated
+  enforcement on gRPC SQL SELECTs.
+* **Root-crate conversion:** `QueryFacadeAdapter::execute_sql` converts
+  `Option<&str> → Option<SubjectId>` (behind `abac-policy`) and passes it to
+  `try_run_select` (was a parked `None`).
+* All impls (`UnifiedHandlers`, `QueryFacadeAdapter`, `NoopQueryAdapterPort`,
+  `RecordingApiPort`, `MockQueryAdapterPort`, `ArrayQueryAdapter`) + callers (gRPC,
+  REST, embedded, tests) updated. The param is **unconditional** (always present);
+  enforcement is behind `abac-policy` (default-OFF) — default builds byte-for-byte.
+
+== 3. Trust class
+
+gRPC resolves the subject from a verified credential (`grpc_auth::user_id`), so gRPC
+subject enforcement is **unconditional real enforcement** (not spoofable) — unlike
+pgwire's trust-auth advisory (TD-ABAC-3 §3). This is the path to load-bearing ABAC
+without waiting for P2 (SCRAM auth on pgwire).
+
+== 4. Verification
+
+* `cargo check --workspace` (default, byte-for-byte — the trait param is unconditional
+  but ignored when the feature is off).
+* `cargo check --workspace --all-targets --features abac-policy` — compiles the
+  threaded path + all test impls/callers.
+* `cargo nextest run --features abac-policy -E 'test(abac)'` — no regression (21/21).
+* `cargo clippy --features abac-policy -- -D warnings`, `cargo fmt --check`,
+  `make work-commit-check` (panic-policy +0, env-gate, layering, capability-matrix).
+
+== 5. Follow-ons (under TD-FOUNDATION-3)
+
+1. **REST `execute_sql_v1` extractor** — add `Option<Extension<UnifiedUserContext>>`
+   to the REST SQL handler and pass `user_id` (currently `None`). The trait param is
+   already in place.
+2. **REST prod `execute_unified_query`→`federated_query` path** — a separate surface
+   that does not reach `try_run_select`; needs its own subject wiring.
+3. **Durable policy-epoch source** (S10 cache-key invalidation).
+4. **Column masking**, **graph trio** (layering), **P2** (real pgwire SCRAM auth).

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -2281,6 +2281,9 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         request: Request<V2QueryRequest>,
     ) -> Result<Response<V2QueryResponse>, Status> {
         let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
+        // TD-ABAC-5: capture the authenticated subject before the request is moved;
+        // threaded to ABAC enforcement at the relational read boundary.
+        let user_id = grpc_auth::user_id(&request);
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -2289,7 +2292,13 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .execute_sql_v1(q.query, None, collection, Some(tenant_id.as_str()))
+            .execute_sql_v1(
+                q.query,
+                None,
+                collection,
+                Some(tenant_id.as_str()),
+                user_id.as_deref(),
+            )
             .await
             .map_err(|e| {
                 // A DML lock conflict → ABORTED (retryable); other errors → INTERNAL.

--- a/src/network/rest/canonical/handlers.rs
+++ b/src/network/rest/canonical/handlers.rs
@@ -878,6 +878,9 @@ pub async fn execute_sql(
             sql_params_to_proxima_values(request.parameters.clone()),
             request.collection,
             None,
+            // TD-ABAC-5: REST UnifiedUserContext extractor wiring is a follow-on;
+            // None ⇒ no ABAC enforcement on this surface yet.
+            None,
         )
         .await
     {

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -721,6 +721,7 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         query: String,
         _collection: Option<String>,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
     ) -> anyhow::Result<serde_json::Value> {
         use crate::query::QueryResultData;
 
@@ -791,6 +792,13 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         // so this is a no-op unless the flag is set.
         // namespace=None: SQL port path has no pgwire search_path.
         let olap_result_cache = crate::network::postgres::relational_pipeline::olap_result_cache();
+        // TD-ABAC-5: convert the opaque runtime-trait subject string → SubjectId at
+        // this root-crate boundary (the runtime port can't name SubjectId). Behind
+        // `abac-policy`; when off the string is unused (no enforcement).
+        #[cfg(feature = "abac-policy")]
+        let subject_id = subject.map(|s| proximadb_catalog::fc_metamodel::SubjectId(s.to_string()));
+        #[cfg(not(feature = "abac-policy"))]
+        let _ = subject;
         if let Some(dml) = self.dml_service.as_ref()
             && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
                 &query,
@@ -802,12 +810,9 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
                 false,
                 None,
                 olap_result_cache.as_deref(),
-                // TD-ABAC-3: gRPC/REST relational subject threading is a follow-on
-                // (the genuinely-authenticated UnifiedUserContext lives upstream and
-                // does not reach this adapter today); `None` ⇒ no ABAC enforcement
-                // on this surface yet.
+                // TD-ABAC-5: the authenticated subject (gRPC/REST) → ABAC enforcement.
                 #[cfg(feature = "abac-policy")]
-                None,
+                subject_id,
             )
             .await
         {


### PR DESCRIPTION
## Summary

Activates **unconditional, real-auth ABAC enforcement on the gRPC SQL surface** — the first surface without pgwire's trust-auth spoofability caveat. gRPC resolves the subject from a verified credential (`grpc_auth::user_id`), so this is *load-bearing* enforcement (vs pgwire's advisory-under-trust-auth from TD-ABAC-3). Behind `abac-policy` (default-OFF).

## What changed
- **Opaque `subject: Option<&str>`** threaded through both SQL port traits — `ApiHandlersPort::execute_sql_v1` (`port.rs`) and `QueryAdapterPort::execute_sql` (`service_ports.rs`) — forwarded via `UnifiedHandlers::execute_sql_v1`.
  - **Why opaque `&str`, not `SubjectId`:** the port traits live in `proximadb-runtime`, which has no `proximadb-catalog` dependency and cannot name `SubjectId`. The `String → SubjectId` conversion is at the **root-crate boundary** (`QueryFacadeAdapter::execute_sql`), keeping `SubjectId` + the feature gate entirely inside the root crate — no new runtime-crate dependency, no cfg-on-`async_trait`-method risk, no cross-crate cfg-coherence hazard on the `dyn` trait.
- **gRPC activation:** `record_service.rs::execute_query` captures `grpc_auth::user_id(&request)` (before the move) and passes it through `execute_sql_v1` → `try_run_select`.
- **Root-crate conversion:** `QueryFacadeAdapter` converts `Option<&str> → Option<SubjectId>` (behind `abac-policy`) for `try_run_select` (was a parked `None`).
- The trait param is **unconditional** (always present); enforcement is behind `abac-policy` (default-OFF) → default builds byte-for-byte. All 6 impls + 8 entry callers (gRPC/REST/embedded/tests) updated.

## Scope note (follow-ons, documented in TD-ABAC-5 §5)
- **REST `execute_sql_v1`** passes `None` here — adding the `Option<Extension<UnifiedUserContext>>` extractor is a tight follow-on (the trait param is already in place).
- The REST prod `execute_unified_query`→`federated_query` path is a separate surface that doesn't reach `try_run_select` — its own follow-on.

## Verification
- `cargo check --workspace` (default, byte-for-byte) — clean.
- `cargo check --workspace --all-targets --features abac-policy` — clean (all test impls/callers).
- `cargo clippy --workspace --features abac-policy -- -D warnings` — clean.
- `cargo nextest run -p proximadb --features abac-policy -E 'test(abac)'` — **21/21 passed**, no regression.
- `cargo fmt --check`, `make work-commit-check` (panic-policy +0, env-gate, layering, capability-matrix, td-unique 310) — green.

## TD
`docs/10-quality/td/TD-ABAC-5-sql-port-subject-threading.adoc`