### PR TITLE
refactor(abac): unified identity seam — AuthClass + shared credential parser (PR-A, TD-ABAC-6)

### DIFF
--- a/crates/foundation/proximadb-tenant/src/identity_trust.rs
+++ b/crates/foundation/proximadb-tenant/src/identity_trust.rs
@@ -210,6 +210,94 @@ pub fn resolve_tenant_assertion(
     }
 }
 
+// ===========================================================================
+// Request identity — the unified tenant+subject+auth-class seam (TD-ABAC-6)
+// ===========================================================================
+//
+// `resolve_tenant_assertion` (above) is already the ONE tenant gate every
+// network surface calls (TD-TENANT-1). ABAC enforcement (TD-ABAC-2..5) added a
+// parallel *subject* concern and surfaced that each surface re-implements the
+// same identity pipeline. This section is the tenant+subject+auth-class
+// analogue: a single `ResolvedRequestIdentity` every surface produces, with the
+// trust-vs-auth distinction made explicit and auditable. Foundation hosts it
+// because tenant/subject ids are plain strings here (no catalog dep); the
+// `&str → SubjectId` lift stays at the root ABAC boundary.
+
+/// How a request's identity was established (TD-ABAC-6). Makes the
+/// trust-auth-vs-real-auth distinction — previously buried in comments (pgwire is
+/// advisory/spoofable; gRPC/REST/Arrow are load-bearing) — auditable in the type
+/// system. Informational in the consolidation refactor: it does NOT change
+/// enforcement (a future hardening slice may refuse `TrustAsserted` as
+/// load-bearing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthClass {
+    /// A verified credential (API key / JWT / mTLS cert) was resolved by the
+    /// `SecurityCoordinator`. Enforcement against this identity is load-bearing.
+    Authenticated,
+    /// Client-asserted with NO credential (pgwire trust auth, or a dev/embedded
+    /// path with no coordinator). Enforcement is advisory — spoofable unless the
+    /// deployment's [`HeaderTrustPolicy`] gates the assertion.
+    TrustAsserted,
+    /// Nothing resolved (no credential, no assertion, anonymous/dev). No subject;
+    /// enforcement does not apply.
+    Anonymous,
+}
+
+impl std::fmt::Display for AuthClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Authenticated => write!(f, "authenticated"),
+            Self::TrustAsserted => write!(f, "trust-asserted"),
+            Self::Anonymous => write!(f, "anonymous"),
+        }
+    }
+}
+
+/// The resolved identity every network surface produces uniformly (TD-ABAC-6):
+/// the effective tenant, the principal (when one was resolved or policy-accepted),
+/// and how it was established. Bare strings (foundation can't name the catalog's
+/// `SubjectId`); the root `src/security/request_identity` lifts `subject` to
+/// `SubjectId` at the ABAC boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRequestIdentity {
+    /// The effective tenant after assertion-vs-binding reconciliation.
+    pub tenant: String,
+    /// The principal id, when one was resolved (credential) or policy-accepted
+    /// (bare assertion). `None` ⇒ anonymous ⇒ no subject ⇒ no ABAC enforcement.
+    pub subject: Option<String>,
+    /// How the identity was established — the auditable trust/auth distinction.
+    pub auth_class: AuthClass,
+}
+
+/// Reconcile a client-asserted **subject** (no authenticated binding) under the
+/// deployment policy — the subject analogue of [`resolve_tenant_assertion`]'s
+/// `(Some, None)` bare-assertion arm, factored out so the subject gate is not
+/// pgwire-only. `Open` (default) accepts the assertion; `AuthenticatedOnly` /
+/// `GatewayOnly` reject it. `None`/empty/`"anonymous"` ⇒ no assertion ⇒ `Ok(None)`.
+///
+/// On authenticated surfaces the subject comes from the verified credential (no
+/// assertion, no gate) — this function is only for the trust-asserted path.
+pub fn resolve_subject_assertion(
+    asserted: Option<&str>,
+    policy: HeaderTrustPolicy,
+) -> Result<Option<String>, TenantAssertionError> {
+    let asserted = asserted
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && *s != "anonymous");
+    match asserted {
+        None => Ok(None),
+        Some(subject) => match policy {
+            HeaderTrustPolicy::Open => Ok(Some(subject.to_string())),
+            HeaderTrustPolicy::AuthenticatedOnly | HeaderTrustPolicy::GatewayOnly => {
+                Err(TenantAssertionError::UnauthenticatedAssertionRejected {
+                    asserted: subject.to_string(),
+                })
+            }
+        },
+    }
+}
+
 /// Role marking a gateway/service principal permitted to delegate tenants
 /// under [`HeaderTrustPolicy::GatewayOnly`]. Stamped from credential data
 /// (e.g. a `gateway: true` JWT claim) at `UnifiedUserContext` construction.
@@ -377,5 +465,68 @@ mod tests {
             serde_json::from_str::<HeaderTrustPolicy>("\"gateway-only\"").unwrap(),
             HeaderTrustPolicy::GatewayOnly
         );
+    }
+
+    // --- TD-ABAC-6: resolve_subject_assertion + AuthClass ---
+
+    #[test]
+    fn subject_bare_assertion_accepted_only_under_open() {
+        assert_eq!(
+            resolve_subject_assertion(Some("alice"), HeaderTrustPolicy::Open),
+            Ok(Some("alice".to_string()))
+        );
+        for policy in [
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert!(matches!(
+                resolve_subject_assertion(Some("alice"), policy),
+                Err(TenantAssertionError::UnauthenticatedAssertionRejected { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn subject_none_empty_or_anonymous_is_no_assertion() {
+        for policy in [
+            HeaderTrustPolicy::Open,
+            HeaderTrustPolicy::AuthenticatedOnly,
+            HeaderTrustPolicy::GatewayOnly,
+        ] {
+            assert_eq!(resolve_subject_assertion(None, policy), Ok(None));
+            assert_eq!(resolve_subject_assertion(Some(""), policy), Ok(None));
+            assert_eq!(resolve_subject_assertion(Some("  "), policy), Ok(None));
+            assert_eq!(
+                resolve_subject_assertion(Some("anonymous"), policy),
+                Ok(None)
+            );
+        }
+    }
+
+    #[test]
+    fn auth_class_displays_and_serdes_kebab() {
+        assert_eq!(AuthClass::Authenticated.to_string(), "authenticated");
+        assert_eq!(AuthClass::TrustAsserted.to_string(), "trust-asserted");
+        assert_eq!(AuthClass::Anonymous.to_string(), "anonymous");
+        assert_eq!(
+            serde_json::to_string(&AuthClass::TrustAsserted).unwrap(),
+            "\"trust-asserted\""
+        );
+        assert_eq!(
+            serde_json::from_str::<AuthClass>("\"authenticated\"").unwrap(),
+            AuthClass::Authenticated
+        );
+    }
+
+    #[test]
+    fn resolved_identity_carries_the_three_facets() {
+        let id = ResolvedRequestIdentity {
+            tenant: "acme".to_string(),
+            subject: Some("alice".to_string()),
+            auth_class: AuthClass::Authenticated,
+        };
+        assert_eq!(id.tenant, "acme");
+        assert_eq!(id.subject.as_deref(), Some("alice"));
+        assert_eq!(id.auth_class, AuthClass::Authenticated);
     }
 }

--- a/crates/foundation/proximadb-tenant/src/lib.rs
+++ b/crates/foundation/proximadb-tenant/src/lib.rs
@@ -428,7 +428,7 @@ pub use rbac_context::{
 // ============================================================================
 pub mod identity_trust;
 pub use identity_trust::{
-    AuthenticatedTenantBinding, GATEWAY_ROLE, HeaderTrustPolicy, OPERATOR_ROLE,
-    ResolvedTenantAssertion, TenantAssertionError, TenantStableIdResolver,
-    resolve_tenant_assertion,
+    AuthClass, AuthenticatedTenantBinding, GATEWAY_ROLE, HeaderTrustPolicy, OPERATOR_ROLE,
+    ResolvedRequestIdentity, ResolvedTenantAssertion, TenantAssertionError, TenantStableIdResolver,
+    resolve_subject_assertion, resolve_tenant_assertion,
 };

--- a/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
+++ b/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-ABAC-6: Unified request-identity seam across REST / gRPC / Arrow Flight (+ pgwire)
+:status: In progress — PR-A (foundation seam + shared credential parser) delivered
+:date: 2026-07-30
+:authors: FA enforcement track session 2026-07-30
+:realizes: TD-FOUNDATION-3 FA-c; consolidates TD-TENANT-1 (tenant) + TD-ABAC-2..5 (subject)
+:design-of-record: TD-TENANT-1 (`identity_trust.rs`); plan `docs` consolidation review
+:depends-on: TD-ABAC-2/3/4/5 (#1331/#1333/#1335/#1338), #1336
+
+[cols="1,3"]
+|===
+| Status | **PR-A delivered (pending):** the unified identity *model* (`AuthClass` + `ResolvedRequestIdentity` + `resolve_subject_assertion`) in the foundation seam, the shared `parse_authorization` credential parser, and Arrow's adoption of it. PR-B (gRPC+REST resolver) + PR-C (pgwire + cleanup) remain.
+| Problem | ABAC threading (TD-ABAC-3/5) surfaced that each network surface re-implements the same identity pipeline in parallel: 3 near-identical credential parsers, duplicated resolution pipelines, and a trust-vs-auth distinction buried in comments. Arrow even *drops* `user_id`. This TD consolidates it into one seam.
+| Principle | Co-design (mandate #1): the contract is the identity, not the transport. Each surface keeps only a thin transport adapter; the resolution is shared. Behavior-preserving.
+|===
+
+NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
+
+== 1. The duplication (the problem)
+
+Three concerns were duplicated across REST / gRPC / Arrow Flight:
+
+* **Credential parsing** (`authorization` → `AuthenticationData`): gRPC
+  `auth_data_from_headers` (`grpc/auth.rs`), Arrow `auth_data_from_metadata`
+  (`arrow_ipc/service.rs`), REST `map_header_to_auth_data` (`auth/middleware.rs`) —
+  verbatim copies of the same `Bearer`/`API-Key`/raw logic.
+* **Resolution pipeline** (`authenticate_request → AuthenticatedTenantBinding →
+  resolve_tenant_assertion → resolve_request_tenant_for_mode`): duplicated in gRPC +
+  Arrow; REST splits it across two middleware layers.
+* **Audit/error mapping**: identical `warn!(tenant_audit)` + reject, differing only
+  in a `surface=` label.
+
+Plus two symptoms: **Arrow drops `user_id`** (`AuthenticatedFlightContext` keeps only
+`tenant_id`+`capability`), and the **trust-auth-vs-real-auth distinction is not in the
+type system** (pgwire enforcement is advisory/spoofable; gRPC/REST load-bearing — but
+only comments say so). gRPC also *double-gates* tenant (a legacy
+`validate_tenant_assertion` alongside the shared `resolve_tenant_assertion`).
+
+== 2. The seam (the design)
+
+Two-layer split forced by layering (mandate #17): foundation can't name `SubjectId`
+(control); the runtime port can't either (opaque `Option<&str>`).
+
+**Layer 1 — extend the existing foundation seam** (`identity_trust.rs`, already the
+TD-TENANT-1 tenant gate every surface calls). Added (PR-A):
+* `AuthClass { Authenticated, TrustAsserted, Anonymous }` — the auditable distinction.
+* `ResolvedRequestIdentity { tenant, subject, auth_class }` — bare-string identity.
+* `resolve_subject_assertion` — the subject analogue of `resolve_tenant_assertion`'s
+  bare-assertion arm (pgwire's `check_pgwire_subject_assertion` proved that arm
+  generic); the subject gate stops being pgwire-only.
+
+**Layer 2 — root helpers** (`src/security/request_identity.rs`). Added (PR-A):
+* `parse_authorization(value) -> AuthenticationData` — the ONE credential parser
+  (collapses the three copies); each surface extracts the raw value from its transport
+  + keeps surface-specific fallbacks (Arrow's mTLS / `x-api-key`).
+
+**Still to land (PR-B/C):**
+* `resolve_request_identity(coordinator, credential, asserted_tenant,
+  asserted_subject, trust, mode) -> ResolvedIdentity { identity, user_context }` —
+  the ONE orchestrator (authenticate → tenant/subject gates → `ResolvedRequestIdentity`).
+* `subject_id_of` / `subject_str_of` lifts (→ `SubjectId` for ABAC, → `&str` for the
+  runtime port).
+
+`AuthClass` is **informational** in this refactor — it does NOT change enforcement
+(pgwire stays advisory, gRPC load-bearing). A future hardening slice may refuse
+`TrustAsserted` as load-bearing; that is a separate policy decision.
+
+== 3. Phased delivery
+
+* **PR-A (this PR):** foundation seam + `parse_authorization` + Arrow adopts
+  `parse_authorization` (first concrete dedup). Pure additive library — no behavior
+  change, no dead code (the per-surface context-field wiring lands with consumers).
+* **PR-B:** the `resolve_request_identity` orchestrator; wire **gRPC** (delete
+  `auth_data_from_headers` + the redundant `validate_tenant_metadata` double-gate;
+  `GrpcAuthContext` carries `ResolvedRequestIdentity`) + **REST** (collapse the two
+  middleware layers; thread the subject — fixes the #1338 REST follow-on). gRPC/REST
+  adopt `parse_authorization`.
+* **PR-C:** wire **pgwire** (`resolve_request_identity(coordinator=None)` →
+  `TrustAsserted`; the SELECT-path subject from the resolved identity); **Arrow**
+  `AuthenticatedFlightContext` gains `user_id` (consumed by #1309 vector ABAC);
+  delete remaining dead helpers; final dedup audit.
+
+== 4. Verification (PR-A)
+
+* `cargo check --workspace` (the seam is foundation; `parse_authorization` is root lib
+  — both compile in the default build, not `abac-policy`-gated).
+* `cargo nextest run -p proximadb-tenant` — identity_trust unit tests
+  (`resolve_subject_assertion` Open/strict/anonymous, `AuthClass` serde/display,
+  `ResolvedRequestIdentity`).
+* `cargo nextest run -p proximadb request_identity` — `parse_authorization` parity
+  tests (Bearer→JWT, API-Key/Api-Key→ApiKey, raw→ApiKey).
+* Arrow `service_tests.rs` unchanged (parity — the parser swap is behavior-neutral).
+* `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`,
+  `make work-commit-check` (panic-policy +0, layering, tenant-path, capability-matrix).
+
+== 5. Out of scope
+
+* Changing enforcement behavior (`AuthClass` is auditable, not a gate).
+* Arrow vector-path ABAC threading (#1309) — *enabled* by PR-C (user_id surfaced) but
+  wired separately.
+* Column masking, graph trio, P2 (real pgwire SCRAM).

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -516,16 +516,12 @@ impl ProximaFlightService {
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            if let Some(token) = auth_header.strip_prefix("Bearer ") {
-                return Ok(Some(AuthenticationData::JWTToken(token.to_string())));
-            }
-            if let Some(key) = auth_header
-                .strip_prefix("API-Key ")
-                .or_else(|| auth_header.strip_prefix("Api-Key "))
-            {
-                return Ok(Some(AuthenticationData::ApiKey(key.to_string())));
-            }
-            return Ok(Some(AuthenticationData::ApiKey(auth_header.to_string())));
+            // TD-ABAC-6: the shared credential parser — this branch was a
+            // verbatim copy of gRPC's `auth_data_from_headers` and REST's
+            // `map_header_to_auth_data` (same Bearer/API-Key/raw logic).
+            return Ok(Some(
+                crate::security::request_identity::parse_authorization(auth_header),
+            ));
         }
 
         for key in ["x-api-key", "api-key"] {

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -9,6 +9,7 @@ pub mod auth_service;
 pub mod encryption;
 pub mod monitoring;
 pub mod rbac_service;
+pub mod request_identity;
 pub mod rls;
 pub mod security_coordinator;
 pub mod validation;

--- a/src/security/request_identity.rs
+++ b/src/security/request_identity.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Shared request-identity helpers (TD-ABAC-6) — the root-crate half of the
+//! unified identity seam.
+//!
+//! The foundation half (`AuthClass`, `ResolvedRequestIdentity`,
+//! `resolve_subject_assertion`) lives in `proximadb_tenant::identity_trust`
+//! (tenant/subject ids are bare strings there — no catalog dep). This module
+//! holds the pieces that MUST live in the root crate because they name
+//! `SecurityCoordinator` / `AuthenticationData` (security) or `SubjectId`
+//! (catalog): the credential parser and the `SubjectId` lift. The full
+//! `resolve_request_identity` orchestrator lands with the gRPC/REST wiring
+//! (PR-B); this PR-A seeds the module with the credential parser every surface
+//! reuses.
+
+use crate::security::AuthenticationData;
+
+/// Parse an `authorization` header/metadata **value** into
+/// [`AuthenticationData`] — the ONE credential parser every network surface
+/// reuses.
+///
+/// Collapses three near-identical copies: gRPC `auth_data_from_headers`
+/// (`src/network/grpc/auth.rs`), Arrow `auth_data_from_metadata`
+/// (`src/network/arrow_ipc/service.rs`), and REST `map_header_to_auth_data`
+/// (`src/network/auth/middleware.rs`) — all three implemented the same
+/// `Bearer` / `API-Key` / `Api-Key` / raw-as-ApiKey prefix logic.
+///
+/// Each surface's adapter extracts the raw value from its transport
+/// (`http::HeaderMap` / `tonic::MetadataMap` / pgwire startup params) and keeps
+/// only its surface-specific concerns: required-vs-optional semantics and any
+/// extra fallbacks (e.g. Arrow's mTLS peer-cert and `x-api-key`/`api-key`
+/// header fallbacks). The shared scheme-parsing lives here.
+pub fn parse_authorization(value: &str) -> AuthenticationData {
+    if let Some(token) = value.strip_prefix("Bearer ") {
+        AuthenticationData::JWTToken(token.to_string())
+    } else if let Some(key) = value
+        .strip_prefix("API-Key ")
+        .or_else(|| value.strip_prefix("Api-Key "))
+    {
+        AuthenticationData::ApiKey(key.to_string())
+    } else {
+        // No recognized scheme → treat the raw value as an API key. This is the
+        // legacy behavior all three surfaces had; preserving it keeps the
+        // consolidation behavior-neutral.
+        AuthenticationData::ApiKey(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bearer_prefix_is_jwt() {
+        assert!(matches!(
+            parse_authorization("Bearer eyJabc.def.ghi"),
+            AuthenticationData::JWTToken(t) if t == "eyJabc.def.ghi"
+        ));
+    }
+
+    #[test]
+    fn api_key_prefixes_are_api_key() {
+        assert!(matches!(
+            parse_authorization("API-Key secret_123"),
+            AuthenticationData::ApiKey(k) if k == "secret_123"
+        ));
+        assert!(matches!(
+            parse_authorization("Api-Key secret_456"),
+            AuthenticationData::ApiKey(k) if k == "secret_456"
+        ));
+    }
+
+    #[test]
+    fn raw_value_falls_back_to_api_key() {
+        // Legacy behavior: an unrecognized scheme is treated as a bare API key.
+        assert!(matches!(
+            parse_authorization("bare-key-no-scheme"),
+            AuthenticationData::ApiKey(k) if k == "bare-key-no-scheme"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

First slice of consolidating the per-surface identity pipeline — REST / gRPC / Arrow Flight each re-implement credential parsing + resolution in parallel (and Arrow even drops `user_id`). **Pure additive foundation, behavior-preserving, no dead code** (per-surface context-field wiring lands with consumers in PR-B/C). This is PR-A of the TD-ABAC-6 stack (plan: PR-B = resolver + gRPC/REST; PR-C = pgwire + Arrow user_id + cleanup).

## What changed

**Layer 1 — extend the existing foundation seam** (`identity_trust.rs`, already the TD-TENANT-1 tenant gate every surface calls):
- `AuthClass { Authenticated, TrustAsserted, Anonymous }` — makes the trust-vs-auth distinction (pgwire advisory/spoofable vs gRPC/REST load-bearing) **auditable in the type system** instead of buried in comments. Informational — does not change enforcement.
- `ResolvedRequestIdentity { tenant, subject, auth_class }` — the bare-string identity every surface will produce uniformly.
- `resolve_subject_assertion` — the subject analogue of `resolve_tenant_assertion`'s bare-assertion arm (pgwire's `check_pgwire_subject_assertion` proved it generic); the subject gate stops being pgwire-only.

**Layer 2 — root `src/security/request_identity.rs`:**
- `parse_authorization(value) -> AuthenticationData` — the ONE credential parser, collapsing gRPC `auth_data_from_headers` + Arrow `auth_data_from_metadata` + REST `map_header_to_auth_data` (three verbatim copies of the same `Bearer`/`API-Key`/raw logic). **Arrow adopts it** (first concrete dedup); gRPC/REST adopt in PR-B.

## Why
Co-designed (mandate #1): the contract is the identity, not the transport. Each surface keeps only a thin transport adapter; the resolution is shared. Dedup + auditability (`AuthClass`) + unblocks the Arrow `user_id` gap (PR-C, consumed by #1309 vector ABAC).

## Verification
- `cargo check --workspace` — clean (the seam is foundation, `parse_authorization` is root lib — not `abac-policy`-gated).
- `cargo nextest run -p proximadb-tenant` — **30 passed** (+4 seam tests: `resolve_subject_assertion` Open/strict/anonymous, `AuthClass` serde/display, `ResolvedRequestIdentity`).
- `cargo nextest run -p proximadb request_identity` — **3 passed** (`parse_authorization` parity).
- Arrow `service_tests.rs` unchanged (parser swap is behavior-neutral).
- `cargo clippy --workspace -- -D warnings`, `cargo fmt --check`, `make work-commit-check` (panic-policy +0, layering, tenant-path, capability-matrix) — green.

## What's next (PR-B/C, in TD-ABAC-6)
- **PR-B:** `resolve_request_identity` orchestrator + wire gRPC (delete the redundant `validate_tenant_metadata` double-gate; `GrpcAuthContext` carries `ResolvedRequestIdentity`) + REST (collapse the two middleware layers, thread the subject — fixes the #1338 REST follow-on); gRPC/REST adopt `parse_authorization`.
- **PR-C:** pgwire (`resolve_request_identity(coordinator=None)` → `TrustAsserted`) + Arrow `AuthenticatedFlightContext.user_id` (consumed by #1309) + dead-helper cleanup.

## TD
`docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc`