### PR TITLE
refactor(abac): resolve_request_identity orchestrator (PR-B, TD-ABAC-6)

### DIFF
--- a/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
+++ b/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-ABAC-6: Unified request-identity seam across REST / gRPC / Arrow Flight (+ pgwire)
-:status: In progress — PR-A (foundation seam + shared credential parser) delivered
+:status: In progress — PR-A (foundation seam + credential parser, #1339 merged) + PR-B (resolve_request_identity orchestrator) delivered
 :date: 2026-07-30
 :authors: FA enforcement track session 2026-07-30
 :realizes: TD-FOUNDATION-3 FA-c; consolidates TD-TENANT-1 (tenant) + TD-ABAC-2..5 (subject)

--- a/src/security/request_identity.rs
+++ b/src/security/request_identity.rs
@@ -7,13 +7,22 @@
 //! `resolve_subject_assertion`) lives in `proximadb_tenant::identity_trust`
 //! (tenant/subject ids are bare strings there — no catalog dep). This module
 //! holds the pieces that MUST live in the root crate because they name
-//! `SecurityCoordinator` / `AuthenticationData` (security) or `SubjectId`
-//! (catalog): the credential parser and the `SubjectId` lift. The full
-//! `resolve_request_identity` orchestrator lands with the gRPC/REST wiring
-//! (PR-B); this PR-A seeds the module with the credential parser every surface
-//! reuses.
+//! `SecurityCoordinator` / `AuthenticationData` (security): the credential parser
+//! (`parse_authorization`, PR-A) and the identity orchestrator
+//! (`resolve_request_identity`, PR-B). The `&str → SubjectId` lift for the ABAC
+//! boundary lands with the read-path wiring.
 
 use crate::security::AuthenticationData;
+use crate::security::SecurityCoordinator;
+use crate::security::UnifiedUserContext;
+use proximadb_tenant::identity_trust::{
+    AuthenticatedTenantBinding, ResolvedTenantAssertion, resolve_subject_assertion,
+    resolve_tenant_assertion,
+};
+use proximadb_tenant::{
+    AuthClass, HeaderTrustPolicy, ResolveRequestTenantError, ResolvedRequestIdentity,
+    TenantDeploymentMode, resolve_request_tenant_for_mode,
+};
 
 /// Parse an `authorization` header/metadata **value** into
 /// [`AuthenticationData`] — the ONE credential parser every network surface
@@ -46,8 +55,133 @@ pub fn parse_authorization(value: &str) -> AuthenticationData {
     }
 }
 
+/// The full result of [`resolve_request_identity`]: the uniform identity plus the
+/// underlying `UnifiedUserContext` (when authenticated), so each surface can still
+/// extract its surface-specific concerns (e.g. `DataPlaneCapability`, roles) that
+/// are genuinely per-surface and not part of the shared identity contract.
+pub struct ResolvedIdentity {
+    /// The uniform tenant + subject + auth-class identity.
+    pub identity: ResolvedRequestIdentity,
+    /// The credential-resolved user context (None on the trust-asserted path).
+    pub user_context: Option<UnifiedUserContext>,
+}
+
+/// Why request-identity resolution failed. Surfaces map this onto their own
+/// protocol error vocabulary (HTTP 401/403, gRPC `UNAUTHENTICATED`/`PERMISSION_DENIED`,
+/// SQLSTATE 28000).
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    /// The credential was rejected by the `SecurityCoordinator`.
+    #[error("authentication failed: {0}")]
+    Authentication(String),
+    /// A tenant or subject assertion was rejected by the deployment trust policy.
+    #[error("identity assertion rejected: {0}")]
+    Assertion(String),
+    /// The resolved tenant is invalid for the deployment mode (e.g. missing under
+    /// `MultiTenant`, or an unsafe id).
+    #[error(transparent)]
+    TenantResolution(#[from] ResolveRequestTenantError),
+}
+
+/// The ONE identity resolver every network surface calls (TD-ABAC-6). Orchestrates
+/// the credential → `authenticate_request` → tenant/subject trust-gate sequence that
+/// gRPC, Arrow, REST, and pgwire each re-implemented. Each surface supplies only a
+/// thin transport adapter (extract the credential + the asserted tenant/subject from
+/// its transport) and maps [`IdentityError`] onto its protocol's error vocabulary.
+///
+/// Two paths, distinguished by whether a credential was verified:
+/// * **Authenticated** (`coordinator` + `credential`): the credential is the proof.
+///   Tenant is reconciled against the credential binding; subject = `user_id` (no
+///   assertion gate — the credential IS the proof); `AuthClass::Authenticated`.
+/// * **Trust-asserted** (no credential, e.g. pgwire trust auth or a no-coordinator
+///   dev/embedded path): tenant and subject are client-asserted, both gated through
+///   [`HeaderTrustPolicy`] (the same gate TD-TENANT-1 uses for tenant); `AuthClass::TrustAsserted`,
+///   or `Anonymous` when nothing was asserted.
+pub async fn resolve_request_identity(
+    coordinator: Option<&SecurityCoordinator>,
+    credential: Option<AuthenticationData>,
+    asserted_tenant: Option<&str>,
+    asserted_subject: Option<&str>,
+    trust: HeaderTrustPolicy,
+    mode: &TenantDeploymentMode,
+) -> Result<ResolvedIdentity, IdentityError> {
+    let user_context: Option<UnifiedUserContext> = match (coordinator, credential) {
+        (Some(coordinator), Some(credential)) => Some(
+            coordinator
+                .authenticate_request(credential)
+                .await
+                .map_err(|e| IdentityError::Authentication(e.to_string()))?,
+        ),
+        _ => None,
+    };
+
+    match user_context {
+        // Authenticated: tenant reconciled against the credential binding; subject
+        // is credential-derived (no assertion gate).
+        Some(user_context) => {
+            let binding =
+                user_context
+                    .tenant_id
+                    .as_ref()
+                    .map(|tenant_id| AuthenticatedTenantBinding {
+                        tenant_id: tenant_id.clone(),
+                        is_gateway_principal: user_context.is_gateway_principal(),
+                    });
+            let resolved = resolve_tenant_assertion(asserted_tenant, binding.as_ref(), trust)
+                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+            let tenant = resolve_tenant_for_mode(&resolved, mode)?;
+            Ok(ResolvedIdentity {
+                identity: ResolvedRequestIdentity {
+                    tenant,
+                    subject: Some(user_context.user_id.clone()),
+                    auth_class: AuthClass::Authenticated,
+                },
+                user_context: Some(user_context),
+            })
+        }
+        // Trust-asserted (or anonymous): both tenant and subject are client-asserted
+        // and gated through the deployment trust policy.
+        None => {
+            let resolved = resolve_tenant_assertion(asserted_tenant, None, trust)
+                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+            let tenant = resolve_tenant_for_mode(&resolved, mode)?;
+            let subject = resolve_subject_assertion(asserted_subject, trust)
+                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+            let auth_class = match (&resolved, &subject) {
+                (ResolvedTenantAssertion::NoTenant, None) => AuthClass::Anonymous,
+                _ => AuthClass::TrustAsserted,
+            };
+            Ok(ResolvedIdentity {
+                identity: ResolvedRequestIdentity {
+                    tenant,
+                    subject,
+                    auth_class,
+                },
+                user_context: None,
+            })
+        }
+    }
+}
+
+/// Map a resolved tenant assertion to its effective string and apply the deployment
+/// mode (single-tenant default / multi-tenant-required). Mirrors the sequence gRPC
+/// and Arrow run inline today.
+fn resolve_tenant_for_mode(
+    resolved: &ResolvedTenantAssertion,
+    mode: &TenantDeploymentMode,
+) -> Result<String, IdentityError> {
+    let tenant_str = match resolved {
+        ResolvedTenantAssertion::Asserted(t) | ResolvedTenantAssertion::Credential(t) => {
+            Some(t.as_str())
+        }
+        ResolvedTenantAssertion::NoTenant => None,
+    };
+    Ok(resolve_request_tenant_for_mode(tenant_str, mode)?)
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use super::*;
 
     #[test]
@@ -77,5 +211,90 @@ mod tests {
             parse_authorization("bare-key-no-scheme"),
             AuthenticationData::ApiKey(k) if k == "bare-key-no-scheme"
         ));
+    }
+
+    // --- resolve_request_identity (TD-ABAC-6) ---
+    //
+    // The Authenticated path needs a real SecurityCoordinator (covered by the
+    // surface integration tests when wired); these unit tests cover the
+    // trust-asserted path (coordinator=None), which is the pgwire/dev parity case.
+
+    fn single_tenant_mode() -> TenantDeploymentMode {
+        TenantDeploymentMode::SingleTenant {
+            default_tenant: "default-tenant".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn trust_asserted_open_accepts_tenant_and_subject() {
+        let resolved = resolve_request_identity(
+            None,
+            None,
+            Some("acme"),
+            Some("alice"),
+            HeaderTrustPolicy::Open,
+            &single_tenant_mode(),
+        )
+        .await
+        .expect("Open accepts bare assertions");
+
+        assert_eq!(resolved.identity.tenant, "acme");
+        assert_eq!(resolved.identity.subject.as_deref(), Some("alice"));
+        assert_eq!(resolved.identity.auth_class, AuthClass::TrustAsserted);
+        assert!(resolved.user_context.is_none());
+    }
+
+    #[tokio::test]
+    async fn trust_asserted_strict_rejects_a_subject_assertion() {
+        let result = resolve_request_identity(
+            None,
+            None,
+            Some("acme"),
+            Some("alice"),
+            HeaderTrustPolicy::AuthenticatedOnly,
+            &single_tenant_mode(),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("strict policy must reject a bare subject assertion");
+        };
+        assert!(matches!(err, IdentityError::Assertion(_)));
+    }
+
+    #[tokio::test]
+    async fn nothing_asserted_is_anonymous_with_default_tenant() {
+        // No coordinator, no assertions ⇒ Anonymous; SingleTenant supplies its
+        // default tenant.
+        let resolved = resolve_request_identity(
+            None,
+            None,
+            None,
+            None,
+            HeaderTrustPolicy::Open,
+            &single_tenant_mode(),
+        )
+        .await
+        .expect("anonymous resolves");
+
+        assert_eq!(resolved.identity.tenant, "default-tenant");
+        assert!(resolved.identity.subject.is_none());
+        assert_eq!(resolved.identity.auth_class, AuthClass::Anonymous);
+    }
+
+    #[tokio::test]
+    async fn multitenant_without_a_tenant_is_rejected() {
+        let result = resolve_request_identity(
+            None,
+            None,
+            None,
+            None,
+            HeaderTrustPolicy::Open,
+            &TenantDeploymentMode::MultiTenant,
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("MultiTenant must reject a request with no tenant");
+        };
+        assert!(matches!(err, IdentityError::TenantResolution(_)));
     }
 }


### PR DESCRIPTION
## Summary

The **ONE identity resolver** every network surface will call — the orchestration core of the unified identity seam (TD-ABAC-6). Collapses the duplicated `authenticate → resolve_tenant_assertion → resolve_request_tenant_for_mode` pipeline that gRPC, Arrow, REST, and pgwire each re-implemented. **Pure additive — no consumer yet (no behavior change).** This is PR-B; PR-A (#1339, the foundation seam + `parse_authorization`) is merged.

## What changed (`src/security/request_identity.rs`)
- `resolve_request_identity(coordinator, credential, asserted_tenant, asserted_subject, trust, mode) -> ResolvedIdentity { identity, user_context }`. Two paths:
  - **Authenticated** (credential verified): tenant reconciled against the credential binding; subject = `user_id` (no assertion gate — the credential is the proof); `AuthClass::Authenticated`.
  - **TrustAsserted** (no credential, e.g. pgwire/dev): tenant + subject client-asserted, both gated through `HeaderTrustPolicy`; `AuthClass::TrustAsserted` (or `Anonymous`).
  - Returns the `user_context` so each surface keeps its per-surface concerns (capability, roles).
- `ResolvedIdentity` + `IdentityError` (`Authentication`/`Assertion`/`TenantResolution`), which each surface maps onto its protocol error vocabulary.

## Verification
- `cargo check -p proximadb` — clean.
- `cargo nextest run -p proximadb request_identity` — **7 passed** (3 `parse_authorization` parity + 4 resolver: TrustAsserted accept / strict-reject, Anonymous+default-tenant, MultiTenant-missing-reject).
- `cargo nextest run -p proximadb-tenant` — 30 passed (seam, from PR-A).
- `cargo clippy -p proximadb -- -D warnings`, `cargo fmt --check`, `make work-commit-check` — green.

## Why a resolver-only PR
The gRPC/REST/pgwire **wiring** (PR-B2/B3) is not a clean mechanical swap — gRPC's interceptor *defers* mode resolution to its extractor and keeps a tier hook + the `validate_tenant_metadata` double-gate. So each surface is wired + parity-verified against its own tests one at a time. Shipping the proven resolver first (then wiring surfaces incrementally) is the safe progression for a security-critical refactor. The Authenticated path needs a real `SecurityCoordinator` (covered by surface integration tests when wired).

## Next (TD-ABAC-6)
PR-B2: wire gRPC (reconcile the resolver's inline mode-resolution with gRPC's deferred extractor; keep capability/RPC-allowlist). PR-B3: REST (collapse the two middleware layers, thread the subject). PR-C: pgwire (TrustAsserted) + Arrow `user_id` (for #1309 vector ABAC) + dead-helper cleanup.

## TD
`docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc`