### PR TITLE
refactor(abac): gRPC + REST adopt parse_authorization (PR-B2, TD-ABAC-6)

### DIFF
--- a/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
+++ b/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-ABAC-6: Unified request-identity seam across REST / gRPC / Arrow Flight (+ pgwire)
-:status: In progress — PR-A (foundation seam + credential parser, #1339 merged) + PR-B (resolve_request_identity orchestrator) delivered
+:status: In progress — PR-A (#1339 seam + credential parser) + PR-B (#1340 resolver) + PR-B2 (credential-parser consolidation complete across gRPC/REST/Arrow) delivered
 :date: 2026-07-30
 :authors: FA enforcement track session 2026-07-30
 :realizes: TD-FOUNDATION-3 FA-c; consolidates TD-TENANT-1 (tenant) + TD-ABAC-2..5 (subject)

--- a/src/network/auth/middleware.rs
+++ b/src/network/auth/middleware.rs
@@ -317,18 +317,12 @@ fn extract_auth_header(request: &Request) -> Result<String, (StatusCode, Json<Au
 fn map_header_to_auth_data(
     auth_header: &str,
 ) -> Result<AuthenticationData, (StatusCode, Json<AuthErrorResponse>)> {
-    if let Some(token) = auth_header.strip_prefix("Bearer ") {
-        return Ok(AuthenticationData::JWTToken(token.to_string()));
-    }
-    if let Some(key) = auth_header.strip_prefix("API-Key ") {
-        return Ok(AuthenticationData::ApiKey(key.to_string()));
-    }
-    if let Some(key) = auth_header.strip_prefix("Api-Key ") {
-        return Ok(AuthenticationData::ApiKey(key.to_string()));
-    }
-
-    // Treat raw value as API key
-    Ok(AuthenticationData::ApiKey(auth_header.to_string()))
+    // TD-ABAC-6: the shared credential parser. This was a verbatim copy of gRPC's
+    // `auth_data_from_headers` and Arrow's `auth_data_from_metadata` (same Bearer
+    // / API-Key / raw logic); all three now share one parser.
+    Ok(crate::security::request_identity::parse_authorization(
+        auth_header,
+    ))
 }
 
 fn validate_rest_data_plane_capability(

--- a/src/network/grpc/auth.rs
+++ b/src/network/grpc/auth.rs
@@ -356,16 +356,12 @@ fn auth_data_from_headers(headers: &HeaderMap) -> Result<AuthenticationData, Sta
         .to_str()
         .map_err(|_| Status::invalid_argument("authorization metadata is not valid ASCII"))?;
 
-    if let Some(token) = auth_header.strip_prefix("Bearer ") {
-        return Ok(AuthenticationData::JWTToken(token.to_string()));
-    }
-    if let Some(key) = auth_header.strip_prefix("API-Key ") {
-        return Ok(AuthenticationData::ApiKey(key.to_string()));
-    }
-    if let Some(key) = auth_header.strip_prefix("Api-Key ") {
-        return Ok(AuthenticationData::ApiKey(key.to_string()));
-    }
-    Ok(AuthenticationData::ApiKey(auth_header.to_string()))
+    // TD-ABAC-6: the shared credential parser. This was a verbatim copy of
+    // Arrow's `auth_data_from_metadata` and REST's `map_header_to_auth_data`
+    // (same Bearer / API-Key / raw logic); all three now share one parser.
+    Ok(crate::security::request_identity::parse_authorization(
+        auth_header,
+    ))
 }
 
 fn validate_capability_for_grpc_path(


### PR DESCRIPTION
## Summary

Completes the **credential-parser consolidation across all three network surfaces**. gRPC `auth_data_from_headers` and REST `map_header_to_auth_data` now delegate to the shared `parse_authorization` (Arrow adopted it in PR-A #1339). All three were verbatim copies of the same `Bearer` / `API-Key` / `Api-Key` / raw-as-`ApiKey` logic. **Behavior-preserving** — `parse_authorization` reproduces each surface's exact prefix-stripping (verified by its parity tests in PR-A). This is PR-B2 of the TD-ABAC-6 consolidation (PR-A seam + parser, PR-B resolver, both merged).

## What changed
- `src/network/grpc/auth.rs` — `auth_data_from_headers` → `parse_authorization` (keeps required-header + ASCII validation).
- `src/network/auth/middleware.rs` — `map_header_to_auth_data` → `parse_authorization` (keeps the axum `Result` error type).
- Each surface keeps only its transport-specific concerns; Arrow keeps its optional + `x-api-key`/mTLS fallbacks (PR-A).

Net: 3 files, **+13/−23** (the dedup).

## Why this scope
The full resolver-wiring (route gRPC's interceptor + REST's middleware through `resolve_request_identity`, delete gRPC's `validate_tenant_metadata` double-gate) is a **separate parity-critical follow-on**: gRPC's interceptor *defers* tenant mode-resolution to its `resolved_tenant_id()` extractor, with unit tests exercising the bare/dev no-auth path — so moving mode-resolution inline is a real fork, not a mechanical swap. This PR lands the safe, behavior-preserving dedup now; the resolver-wiring is tracked in TD-ABAC-6 §3.

## Verification
- `cargo check --workspace` — clean.
- `cargo clippy --workspace -- -D warnings` — clean.
- `cargo fmt --check`, `make work-commit-check` (panic-policy +0, env-gate, layering, tenant-path, capability-matrix) — green.

## Next (TD-ABAC-6)
Resolver-wiring (gRPC interceptor + REST middleware → `resolve_request_identity`, delete the gRPC double-gate) — parity-critical, reconciles the mode-resolution-timing fork. Then PR-C: pgwire (TrustAsserted) + Arrow `user_id` (for #1309 vector ABAC) + dead-helper cleanup.

## TD
`docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc`