### PR TITLE
fix(worktree): make `clean` defensive — never delete a fresh/active worktree

### DIFF
--- a/docs/10-quality/WORKSPACE_ISOLATION.md
+++ b/docs/10-quality/WORKSPACE_ISOLATION.md
@@ -50,12 +50,19 @@ scripts/worktree.sh guard                # exits non-zero if run in the main che
 scripts/worktree.sh check                # cargo check ONLY the crates changed vs develop
 scripts/worktree.sh test                 # cargo nextest ONLY the crates changed vs develop
 scripts/worktree.sh rm feat/my-thing     # remove after the PR merges (guards dirty)
-scripts/worktree.sh clean                # drop every worktree already merged to develop
+scripts/worktree.sh clean                # reclaim worktrees merged to develop (defensive: protects active worktrees)
 ```
 
 `new` refuses to clobber an existing branch/path; `rm` refuses to delete a
 dirty worktree (pass `--force` to discard) and only deletes the branch if it's
-merged; `clean` is the periodic housekeeping pass.
+merged; `clean` is the periodic housekeeping pass. `clean` is **defensive**: it
+reclaims only worktrees whose branch has genuinely landed in develop (squash- or
+merge-commit) and has a clean tree — it never deletes a *fresh/active* worktree
+whose branch tip still equals develop (no commits of its own; possibly mid-build
+with gitignored `target/` WIP invisible to `status --porcelain`), nor a dirty
+one. A branch later fast-forwarded so develop == its tip is indistinguishable
+from a fresh one and is likewise protected — remove such a worktree explicitly
+with `rm`.
 
 **Affected-only feedback.** `check`/`test` map your diff vs `develop` to the
 owning crates (via `scripts/affected_crates.py` + `cargo metadata`) and build/
@@ -95,12 +102,14 @@ new feat/x  ──▶  edit · commit · push · open PR  ──▶  PR merges  
    ever in a shared tree, fall back to `git commit -o <file>`).
 4. Clean up (`rm`) once your PR merges.
 5. **Commit WIP to your branch early and often — never carry valuable
-   uncommitted work in a worktree.** A worktree is disposable: `clean`,
-   `rm --force`, a concurrent session, or a merge/cleanup pass can remove or
-   reset it at any time, and **uncommitted edits are lost with the directory**.
-   Committed work survives in the branch ref (recoverable even if the worktree
-   is deleted). Commit each coherent increment (it's fine to amend/rebase
-   later); treat "still in the editor, not yet committed" as fragile.
+   uncommitted work in a worktree.** A worktree is disposable: `rm --force`, a
+   concurrent session, or a merge/cleanup pass can remove or reset it at any
+   time, and **uncommitted edits are lost with the directory**. Committed work
+   survives in the branch ref (recoverable even if the worktree is deleted).
+   Commit each coherent increment (it's fine to amend/rebase later); treat
+   "still in the editor, not yet committed" as fragile. (`clean` is defensive —
+   it protects a no-commit worktree whose tip == develop — but `rm --force` and
+   the OS can still drop a worktree, so committing remains the durable guard.)
 6. **Re-verify state before resuming or acting.** After any gap — and before
    any destructive or push step — confirm the worktree still exists
    (`scripts/worktree.sh list`) and the branch hasn't advanced under you

--- a/scripts/test_worktree_clean.sh
+++ b/scripts/test_worktree_clean.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regression test for `scripts/worktree.sh clean` — the defensive (no-deletion-of-
+# active-worktree) behavior. Runs entirely in a throwaway sandbox (a local
+# file-path "origin" + cloned main repo under mktemp), so it touches nothing real.
+#
+# Reproduces incident 2026-07-30: `clean` deleted a freshly-created worktree
+# mid-build because its branch tip == develop's tip (no commits yet), which
+# `merge-base --is-ancestor` treats as "merged", and `target/` WIP is gitignored
+# (invisible to `status --porcelain`).
+#
+#   bash scripts/test_worktree_clean.sh
+# Exit 0 = all scenarios pass; 1 = at least one failed.
+set -uo pipefail   # NOT -e: we assert explicitly and report every scenario.
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$REPO" ] || { echo "FAIL: run from within the repo"; exit 1; }
+WT="$REPO/scripts/worktree.sh"
+
+PASS=0; FAIL=0
+ok()   { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+BARE="$SANDBOX/origin.git"
+MAIN="$SANDBOX/main"
+WTS="$SANDBOX/wts"
+export PROXIMADB_WORKTREE_ROOT="$WTS"
+mkdir -p "$WTS"
+
+# --- sandbox: bare origin + main repo on `develop` with target/ gitignored ---
+git init --bare -q "$BARE"
+git init -q "$MAIN"
+git -C "$MAIN" checkout -q -b develop
+git -C "$MAIN" config user.email test@test
+git -C "$MAIN" config user.name test
+# Isolate from the host's GLOBAL core.excludesFile (some machines ignore *.txt
+# etc.), so only this repo's .gitignore (target/) applies in the sandbox.
+git -C "$MAIN" config core.excludesFile /dev/null
+printf 'target/\n' > "$MAIN/.gitignore"
+git -C "$MAIN" add .gitignore
+git -C "$MAIN" commit -q -m init
+git -C "$MAIN" remote add origin "$BARE"
+git -C "$MAIN" push -q -u origin develop
+echo "sandbox: $MAIN (develop -> $BARE)"
+
+new_wt() { ( cd "$MAIN" && bash "$WT" new "$1" >/dev/null 2>&1 ); }    # create a worktree (must run from sandbox repo so repo_main() resolves to it)
+clean()  { ( cd "$MAIN" && bash "$WT" clean 2>&1 ); }
+
+echo "== scenario 1: fresh, no-commit worktree with gitignored target/ is PROTECTED =="
+new_wt chore/fresh
+mkdir -p "$WTS/chore-fresh/target"; echo artifact > "$WTS/chore-fresh/target/foo"   # invisible to porcelain
+out="$(clean)"
+if [ -d "$WTS/chore-fresh" ]; then ok "fresh worktree survived clean"; else bad "fresh worktree was DELETED by clean"; fi
+echo "$out" | grep -q 'protect (fresh/active' && ok "protect message emitted" || { bad "no protect message"; printf '    clean output: %s\n' "$out"; }
+
+echo "== scenario 2: squash-merged worktree (distinct tip) IS reclaimed =="
+new_wt feat/squashed
+( cd "$WTS/feat-squashed" && printf 'content\n' > newfile.txt && git add newfile.txt && git commit -q -m "feat: add newfile" )
+# GitHub-style squash: same change lands on develop as a NEW commit (new SHA)
+( cd "$MAIN" && printf 'content\n' > newfile.txt && git add newfile.txt && git commit -q -m "feat: add newfile (#1)" && git push -q origin develop )
+out="$(clean)"
+[ -d "$WTS/feat-squashed" ] && bad "squash-merged worktree NOT reclaimed" || ok "squash-merged worktree reclaimed"
+echo "$out" | grep -q 'feat-squashed' && ok "squash-merged reported in clean output" || true
+
+echo "== scenario 3: merge-commit-merged worktree (proper ancestor) IS reclaimed =="
+new_wt feat/mergecommit
+( cd "$WTS/feat-mergecommit" && printf 'mc\n' > mcfile.txt && git add mcfile.txt && git commit -q -m "feat: mc" )
+( cd "$MAIN" && git merge -q --no-ff feat/mergecommit -m "merge feat/mergecommit" && git push -q origin develop )
+out="$(clean)"
+[ -d "$WTS/feat-mergecommit" ] && bad "merge-commit worktree NOT reclaimed" || ok "merge-commit worktree reclaimed"
+
+echo "== scenario 4: unmerged-ahead worktree (own commit, not landed) is PROTECTED =="
+new_wt feat/wip
+( cd "$WTS/feat-wip" && git commit -q --allow-empty -m "wip" )
+out="$(clean)"
+[ -d "$WTS/feat-wip" ] && ok "unmerged WIP worktree survived clean" || bad "unmerged WIP worktree was DELETED"
+
+echo
+echo "results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -128,12 +128,24 @@ wt_for_branch() {
 #      remote branch required, only the local develop ref.
 branch_in_develop() {
   local main br; main="$(repo_main)"; br="$1"
-  git -C "$main" merge-base --is-ancestor "$br" "$REMOTE/$BASE_DEFAULT" 2>/dev/null && return 0
-  local mb tree synth; mb="$(git -C "$main" merge-base "$REMOTE/$BASE_DEFAULT" "$br" 2>/dev/null)" || return 1
+  local dev; dev="$(git -C "$main" rev-parse --verify -q "$REMOTE/$BASE_DEFAULT" 2>/dev/null)" || return 1
+  # A branch whose tip is IDENTICAL to develop's tip has done no work of its own:
+  # it is a freshly-created worktree — possibly mid-build, holding uncommitted or
+  # gitignored WIP (e.g. target/) that `git status --porcelain` cannot see.
+  # `merge-base --is-ancestor` treats a commit as an ancestor of ITSELF, so
+  # tip-equality would falsely read as "merged" and target an ACTIVE worktree for
+  # deletion (incident 2026-07-30: a `clean` run deleted a worktree mid-build).
+  # Treat tip-equality as explicitly NOT landed. (A branch later fast-forwarded
+  # so develop == its tip is also protected — remove it with `worktree.sh rm`.
+  # Squash- and merge-commit-merged branches have a distinct tip and are still
+  # detected below, so automatic reclamation of those is unchanged.)
+  [ "$(git -C "$main" rev-parse --verify -q "$br" 2>/dev/null)" != "$dev" ] || return 1
+  git -C "$main" merge-base --is-ancestor "$br" "$dev" 2>/dev/null && return 0
+  local mb tree synth; mb="$(git -C "$main" merge-base "$dev" "$br" 2>/dev/null)" || return 1
   [ -n "$mb" ] || return 1
   tree="$(git -C "$main" rev-parse "$br^{tree}" 2>/dev/null)" || return 1
   synth="$(git -C "$main" commit-tree "$tree" -p "$mb" -m _ 2>/dev/null)" || return 1
-  [ "$(git -C "$main" cherry "$REMOTE/$BASE_DEFAULT" "$synth" 2>/dev/null | head -1 | cut -c1)" = "-" ]
+  [ "$(git -C "$main" cherry "$dev" "$synth" 2>/dev/null | head -1 | cut -c1)" = "-" ]
 }
 
 cmd_rm() {
@@ -171,6 +183,16 @@ cmd_clean() {
     # cmd_doctor); reattach to a branch or remove explicitly via `worktree.sh rm`.
     if [ -z "$br" ] || [ "$br" = "HEAD" ]; then
       [ "$br" = "HEAD" ] && printf 'skip (detached HEAD — reattach or `worktree.sh rm`): %s\n' "$dir" >&2
+      continue
+    fi
+    # DEFENSE (incident 2026-07-30): never reclaim a worktree whose branch has
+    # not diverged from develop (tip == develop). It is fresh/active — possibly
+    # mid-build with gitignored target/ WIP that is invisible to status
+    # --porcelain. branch_in_develop() also rejects tip-equality, but we print an
+    # explicit "protect" line here so `clean` is transparent about what it skips.
+    local _dev; _dev="$(git -C "$(repo_main)" rev-parse --verify -q "$REMOTE/$BASE_DEFAULT" 2>/dev/null)" || _dev=""
+    if [ -n "$_dev" ] && [ "$(git -C "$dir" rev-parse --verify -q HEAD 2>/dev/null)" = "$_dev" ]; then
+      printf 'protect (fresh/active - branch tip == develop, no own commits): %s (%s)\n' "$dir" "$br" >&2
       continue
     fi
     branch_in_develop "$br" || continue


### PR DESCRIPTION
## What

`scripts/worktree.sh clean` could delete a freshly-created (active) worktree mid-session — including one with an in-flight build — because it misclassified it as "merged."

## Root cause

`branch_in_develop()` tested landing via `git merge-base --is-ancestor <branch> origin/develop`. Git treats a commit as an ancestor of **itself**, so a worktree whose branch tip still equals `origin/develop`'s tip (no commits of its own yet) read as "merged." Because `target/` is gitignored, any in-progress build WIP was invisible to `git status --porcelain`, so the dirty-guard didn't save it — `clean` removed the worktree (and its build cache) outright.

This bit a session on 2026-07-30: a long compile was killed when its worktree directory vanished beneath it.

## Fix

- `branch_in_develop()`: treat **tip-equality** (branch tip == develop tip) as explicitly NOT landed. Require a distinct tip for the fast-forward / merge-commit ancestry path; the squash-merge detection (`git cherry`) is unchanged.
- `cmd_clean()`: explicit `protect (fresh/active …)` guard with a visible skip message (defense-in-depth + transparency). `cmd_doctor()` benefits too — it no longer falsely reports such worktrees as `MERGED`.

## Behavior preserved

Genuinely-landed branches are still auto-reclaimed — verified by the regression test for **both** integration styles this repo uses:
- **squash-merged** (distinct tip; detected via `git cherry`) → reclaimed ✅
- **merge-commit-merged** (proper ancestor; distinct tip) → reclaimed ✅

Only **fast-forward-merged** branches — where `develop` advanced to exactly the branch tip, making it byte-identical to a fresh worktree — are now also protected. Remove those explicitly with `worktree.sh rm`. (This repo squash-merges PRs by default, so FF-only merges are rare.)

## Test

New `scripts/test_worktree_clean.sh` — self-contained sandbox (local file-path "origin"; `PROXIMADB_WORKTREE_ROOT` override; isolated from the host's global gitignore). Four scenarios, six assertions, all green:
1. fresh/no-commit worktree with gitignored `target/` → **protected** (+ protect message)
2. squash-merged worktree → **reclaimed**
3. merge-commit-merged worktree → **reclaimed**
4. unmerged-ahead worktree → **protected**

Run: `bash scripts/test_worktree_clean.sh`

## Docs

`docs/10-quality/WORKSPACE_ISOLATION.md` updated to describe the defensive `clean` and refine the "commit early" guidance.

## Workaround for old checkouts (pre-merge)

`git commit --allow-empty -m seed` immediately after `worktree.sh new` diverges the branch tip so it isn't tip-equal to develop — a manual defense until this lands.

## Checklist
- [x] No `.unwrap()`/`.expect()`/`panic!()` (no Rust changed)
- [x] No AI attribution in commit/PR
- [x] `make work-commit-check` green
- [x] Regression test added + passing
- [x] Behavior-neutral for legitimate reclamation (squash + merge-commit)
