### PR TITLE
refactor(abac): Arrow adopts resolve_request_identity + REST subject surfacing (PR-C, TD-ABAC-6)

### DIFF
--- a/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
+++ b/docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-ABAC-6: Unified request-identity seam across REST / gRPC / Arrow Flight (+ pgwire)
-:status: In progress — PR-A (#1339 seam + credential parser) + PR-B (#1340 resolver) + PR-B2 (credential-parser consolidation complete across gRPC/REST/Arrow) delivered
+:status: Substantially complete — PR-A (#1339 seam + parser) + PR-B (#1340 resolver) + PR-B2 (#1341 parser adopted by gRPC/REST/Arrow) merged. PR-C: Arrow adopts `resolve_request_identity` + surfaces `user_id` (#1309 enabler); REST surfaces the subject on `MiddlewareTenantContext` (#1338); `IdentityError::Assertion` carries the structured `TenantAssertionError`. gRPC/pgwire/REST *full* orchestrator adoption DEFERRED — they are already primitive-consolidated and the bundled orchestrator doesn't fit their shapes (§6).
 :date: 2026-07-30
 :authors: FA enforcement track session 2026-07-30
 :realizes: TD-FOUNDATION-3 FA-c; consolidates TD-TENANT-1 (tenant) + TD-ABAC-2..5 (subject)
@@ -10,7 +10,7 @@
 
 [cols="1,3"]
 |===
-| Status | **PR-A delivered (pending):** the unified identity *model* (`AuthClass` + `ResolvedRequestIdentity` + `resolve_subject_assertion`) in the foundation seam, the shared `parse_authorization` credential parser, and Arrow's adoption of it. PR-B (gRPC+REST resolver) + PR-C (pgwire + cleanup) remain.
+| Status | **Credential-parser consolidation DONE** (PR-A/B/B2): the unified identity *model* (`AuthClass` + `ResolvedRequestIdentity` + `resolve_subject_assertion`), the shared `parse_authorization` (now called by all three authenticated surfaces), and the `resolve_request_identity` orchestrator. **PR-C (this):** Arrow adopts the orchestrator end-to-end and surfaces `user_id` (the #1309 enabler); REST surfaces the subject on `MiddlewareTenantContext`; `IdentityError::Assertion` carries the structured error. **DEFERRED to a follow-up slice:** routing gRPC/pgwire/REST *through* `resolve_request_identity` — see §6.
 | Problem | ABAC threading (TD-ABAC-3/5) surfaced that each network surface re-implements the same identity pipeline in parallel: 3 near-identical credential parsers, duplicated resolution pipelines, and a trust-vs-auth distinction buried in comments. Arrow even *drops* `user_id`. This TD consolidates it into one seam.
 | Principle | Co-design (mandate #1): the contract is the identity, not the transport. Each surface keeps only a thin transport adapter; the resolution is shared. Behavior-preserving.
 |===
@@ -55,31 +55,47 @@ TD-TENANT-1 tenant gate every surface calls). Added (PR-A):
   (collapses the three copies); each surface extracts the raw value from its transport
   + keeps surface-specific fallbacks (Arrow's mTLS / `x-api-key`).
 
-**Still to land (PR-B/C):**
+**Landed (PR-B/C):**
 * `resolve_request_identity(coordinator, credential, asserted_tenant,
   asserted_subject, trust, mode) -> ResolvedIdentity { identity, user_context }` —
   the ONE orchestrator (authenticate → tenant/subject gates → `ResolvedRequestIdentity`).
-* `subject_id_of` / `subject_str_of` lifts (→ `SubjectId` for ABAC, → `&str` for the
-  runtime port).
+  Adopted by Arrow (PR-C); gRPC/pgwire/REST adoption deferred (§6).
+* `IdentityError::Assertion(TenantAssertionError)` — structured (PR-C) so each surface
+  keeps full `tenant_audit` fidelity (Mismatch vs UnauthenticatedAssertionRejected).
+
+NOTE: the `subject_id_of` / `subject_str_of` `&str → SubjectId` lift (→ `SubjectId` for
+ABAC, → `&str` for the runtime port) lands with the read-path consumers (#1309), not the
+identity seam.
 
 `AuthClass` is **informational** in this refactor — it does NOT change enforcement
 (pgwire stays advisory, gRPC load-bearing). A future hardening slice may refuse
 `TrustAsserted` as load-bearing; that is a separate policy decision.
 
-== 3. Phased delivery
+== 3. Phased delivery (as landed)
 
-* **PR-A (this PR):** foundation seam + `parse_authorization` + Arrow adopts
-  `parse_authorization` (first concrete dedup). Pure additive library — no behavior
-  change, no dead code (the per-surface context-field wiring lands with consumers).
-* **PR-B:** the `resolve_request_identity` orchestrator; wire **gRPC** (delete
-  `auth_data_from_headers` + the redundant `validate_tenant_metadata` double-gate;
-  `GrpcAuthContext` carries `ResolvedRequestIdentity`) + **REST** (collapse the two
-  middleware layers; thread the subject — fixes the #1338 REST follow-on). gRPC/REST
-  adopt `parse_authorization`.
-* **PR-C:** wire **pgwire** (`resolve_request_identity(coordinator=None)` →
-  `TrustAsserted`; the SELECT-path subject from the resolved identity); **Arrow**
-  `AuthenticatedFlightContext` gains `user_id` (consumed by #1309 vector ABAC);
-  delete remaining dead helpers; final dedup audit.
+* **PR-A (#1339):** foundation seam + `parse_authorization` + Arrow adopts
+  `parse_authorization`. Pure additive library — no behavior change.
+* **PR-B (#1340):** the `resolve_request_identity` orchestrator + `ResolvedIdentity` /
+  `IdentityError`. Pure additive — no consumer yet.
+* **PR-B2 (#1341):** gRPC + REST adopt `parse_authorization` (Arrow did in PR-A) — the
+  credential-parser consolidation is COMPLETE across all three authenticated surfaces.
+* **PR-C (this PR):**
+  ** Arrow adopts `resolve_request_identity` end-to-end — the ONE surface whose
+     monolithic `authenticated_flight_context` (authenticate → tenant-gate → mode-gate
+     in a single function, no intervening steps) is the orchestrator's clean fit.
+  ** `AuthenticatedFlightContext` gains `user_id` (surfaced from the resolved identity)
+     — the #1309 vector-ABAC enabler (previously dropped at `service.rs`).
+  ** `IdentityError::Assertion` now carries the structured `TenantAssertionError`
+     (was `String`) so each surface keeps full `tenant_audit` fidelity.
+  ** REST surfaces the authenticated subject on `MiddlewareTenantContext.subject`
+     (from `UnifiedUserContext.user_id`) — the #1338 follow-on; the REST analog of
+     gRPC's `user_id` accessor and Arrow's new `user_id`. Per-handler *consumption* is
+     #1309 (separate).
+* **DEFERRED (follow-up slice):** routing gRPC / pgwire / REST *through*
+  `resolve_request_identity`. They are already primitive-consolidated (they call
+  `resolve_tenant_assertion` / `resolve_request_tenant_for_mode` directly); forcing the
+  bundled orchestrator onto them is either a behavior change or needs an orchestrator
+  variant that accepts a pre-authenticated context. See §6.
 
 == 4. Verification (PR-A)
 
@@ -100,3 +116,42 @@ TD-TENANT-1 tenant gate every surface calls). Added (PR-A):
 * Arrow vector-path ABAC threading (#1309) — *enabled* by PR-C (user_id surfaced) but
   wired separately.
 * Column masking, graph trio, P2 (real pgwire SCRAM).
+
+== 6. Why gRPC / pgwire / REST don't (yet) call resolve_request_identity
+
+`resolve_request_identity` *bundles* `authenticate_request → resolve_tenant_assertion
+→ resolve_request_tenant_for_mode → resolve_subject_assertion` into one call. That
+bundle fits a surface whose identity path is one monolithic function with no intervening
+steps — which is exactly Arrow's `authenticated_flight_context`. The other three
+surfaces have shapes the bundle does not fit, and each is **already consolidated at the
+primitive level** (TD-TENANT-1: they call `resolve_tenant_assertion` /
+`resolve_request_tenant_for_mode` directly). Forcing the orchestrator onto them is
+either a behavior change or needs an orchestrator variant. The PR-C decision
+(behavior-preserving) was to defer rather than change behavior:
+
+* **gRPC** authenticates *first* (to run the data-plane capability pre-checks
+  `validate_capability_for_grpc_path` + `validate_tenant_metadata`), so the orchestrator
+  would re-authenticate. Its mode-gate is also deferred to a per-handler extractor
+  (`resolved_tenant_id`), and `validate_tenant_metadata` enforces a capability-specific
+  invariant ("capability tokens must carry a tenant_id" + no gateway delegation for
+  capabilities) that the general tenant gate does not — removing it (the original PR-B
+  plan) is a behavior change, not pure dedup.
+* **pgwire** is trust-auth (`coordinator=None`) and separates tenant *resolution*
+  (`resolve_startup_tenant`) from tenant *gating* (`check_pgwire_tenant_assertion`),
+  which short-circuits the canonical `DEFAULT_TENANT` (accepted even under a strict
+  policy). The orchestrator bundles resolution+gate, so it cannot reproduce that quirk;
+  adopting it would reject `database=default` under strict (a behavior change). Its
+  subject gate is also `abac-policy`-gated and emits a subject-specific message the
+  shared `TenantAssertionError` ("tenant '…'") would mangle.
+* **REST** splits auth (auth layer authenticates + injects `UnifiedUserContext`) from
+  tenant resolution (tenant layer). The tenant layer has no coordinator and derives
+  `TenantIdSource` from the `ResolvedTenantAssertion` *variant* — which the orchestrator
+  collapses to a bare tenant string.
+
+**Path to full adoption (follow-up slice):** add a `resolve_request_identity_from_context(
+user_context, asserted_tenant, asserted_subject, trust, mode)` entry point that resolves
+identity from a *pre-authenticated* `UnifiedUserContext` (no re-authenticate). That fits
+gRPC (post-capability-check) and REST's auth layer, and would let all four surfaces share
+the ONE resolver without behavior change. Filed as the natural continuation of this TD,
+not blocking it: the credential-parser dedup (the bulk of the duplication) is already
+complete, and Arrow's adoption proves the orchestrator's shape end-to-end.

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -69,6 +69,15 @@ fn flight_data_wire_bytes(flight_data: &[FlightData]) -> u64 {
 #[derive(Debug, Clone)]
 struct AuthenticatedFlightContext {
     tenant_id: String,
+    /// The authenticated principal's user id (TD-ABAC-6). Surfaced from the
+    /// resolved identity so the vector/ANN read path can thread it as the ABAC
+    /// subject (#1309) — previously dropped here. `None` on the trust-asserted
+    /// path (no credential) or when no subject was resolved.
+    ///
+    /// Unconsumed until #1309 wires the vector-path ABAC subject; allowed dead
+    /// here deliberately (the surfacing IS this PR's deliverable).
+    #[allow(dead_code)]
+    user_id: Option<String>,
     capability: Option<DataPlaneCapability>,
 }
 
@@ -571,87 +580,79 @@ impl ProximaFlightService {
         metadata: &tonic::metadata::MetadataMap,
         peer_certs: Option<Arc<Vec<tonic::transport::CertificateDer<'static>>>>,
     ) -> std::result::Result<AuthenticatedFlightContext, TonicStatus> {
-        use proximadb_tenant::identity_trust::{
-            AuthenticatedTenantBinding, ResolvedTenantAssertion, resolve_tenant_assertion,
-        };
-
         let requested_tenant_id = Self::tenant_id_from_metadata(metadata);
-        let Some(security_coordinator) = &self.security_coordinator else {
-            // No auth wired: the assertion is bare by definition — the
-            // deployment policy decides (TD-TENANT-1). `Open` preserves the
-            // legacy behavior; strict policies reject the assertion.
-            let tenant_id = match resolve_tenant_assertion(
-                requested_tenant_id.as_deref(),
-                None,
-                self.tenant_header_trust,
-            ) {
-                Ok(ResolvedTenantAssertion::Asserted(tenant)) => Some(tenant),
-                Ok(ResolvedTenantAssertion::Credential(_)) => unreachable!("no binding provided"),
-                Ok(ResolvedTenantAssertion::NoTenant) => None,
-                Err(error) => {
-                    tracing::warn!(
-                        target: "proximadb::tenant_audit",
-                        surface = "arrow_flight",
-                        policy = %self.tenant_header_trust,
-                        %error,
-                        "rejected bare x-tenant-id without authenticated tenant binding"
-                    );
-                    return Err(TonicStatus::permission_denied(error.to_string()));
-                }
-            };
-            let tenant_id =
-                Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
-            return Ok(AuthenticatedFlightContext {
-                tenant_id,
-                capability: None,
-            });
-        };
+        let credential = Self::auth_data_from_metadata(metadata)?
+            .or_else(|| Self::auth_data_from_peer_certs(peer_certs));
+        let coordinator = self.security_coordinator.as_deref();
 
-        let auth_data = Self::auth_data_from_metadata(metadata)?
-            .or_else(|| Self::auth_data_from_peer_certs(peer_certs))
-            .ok_or_else(|| TonicStatus::unauthenticated("Arrow Flight authentication required"))?;
-        let user_context = security_coordinator
-            .authenticate_request(auth_data)
-            .await
-            .map_err(|e| TonicStatus::unauthenticated(format!("Authentication failed: {}", e)))?;
+        // An auth-wired deployment (coordinator present) requires a credential —
+        // token or mTLS peer cert. No credential ⇒ unauthenticated.
+        if coordinator.is_some() && credential.is_none() {
+            return Err(TonicStatus::unauthenticated(
+                "Arrow Flight authentication required",
+            ));
+        }
 
-        let capability = DataPlaneCapability::from_user_context(&user_context);
-        // TD-TENANT-1: the ONE shared reconciliation primitive (same call
-        // REST / gRPC / pgwire make) replaces the hand-rolled mismatch match.
-        let binding = user_context
-            .tenant_id
-            .as_ref()
-            .map(|tenant_id| AuthenticatedTenantBinding {
-                tenant_id: tenant_id.clone(),
-                is_gateway_principal: user_context.is_gateway_principal(),
-            });
-        let tenant_id = match resolve_tenant_assertion(
+        // TD-ABAC-6: the ONE identity resolver (authenticate → tenant/subject
+        // trust-gate → mode gate). Arrow has no subject-assertion surface, so
+        // the subject comes from the credential (authenticated) or is absent
+        // (trust-asserted). The two former branches — no-coordinator (bare
+        // assertion) and coordinator (authenticated binding) — are exactly the
+        // orchestrator's trust-asserted vs authenticated paths.
+        let resolved = crate::security::request_identity::resolve_request_identity(
+            coordinator,
+            credential,
             requested_tenant_id.as_deref(),
-            binding.as_ref(),
+            None,
             self.tenant_header_trust,
-        ) {
-            Ok(
-                ResolvedTenantAssertion::Asserted(tenant)
-                | ResolvedTenantAssertion::Credential(tenant),
-            ) => Some(tenant),
-            Ok(ResolvedTenantAssertion::NoTenant) => None,
-            Err(error) => {
+            &self.tenant_deployment_mode,
+        )
+        .await
+        .map_err(|err| Self::identity_error_to_flight_status(err, self.tenant_header_trust))?;
+
+        Ok(AuthenticatedFlightContext {
+            tenant_id: resolved.identity.tenant,
+            // #1309: surface the authenticated principal so the vector/ANN read
+            // path can thread it as the ABAC subject (previously dropped here).
+            user_id: resolved.identity.subject,
+            capability: resolved
+                .user_context
+                .as_ref()
+                .and_then(DataPlaneCapability::from_user_context),
+        })
+    }
+
+    /// Map the unified [`IdentityError`] onto a Flight gRPC status, preserving
+    /// the per-surface `tenant_audit` trail for assertion rejections
+    /// (TD-TENANT-1). The orchestrator never logs; each surface owns its audit.
+    fn identity_error_to_flight_status(
+        error: crate::security::request_identity::IdentityError,
+        trust: proximadb_tenant::HeaderTrustPolicy,
+    ) -> TonicStatus {
+        use crate::security::request_identity::IdentityError;
+        match error {
+            IdentityError::Authentication(message) => {
+                TonicStatus::unauthenticated(format!("Authentication failed: {message}"))
+            }
+            IdentityError::Assertion(error) => {
                 tracing::warn!(
                     target: "proximadb::tenant_audit",
                     surface = "arrow_flight",
-                    policy = %self.tenant_header_trust,
+                    policy = %trust,
                     %error,
                     "rejected x-tenant-id under tenant trust policy"
                 );
-                return Err(TonicStatus::permission_denied(error.to_string()));
+                TonicStatus::permission_denied(error.to_string())
             }
-        };
-        let tenant_id =
-            Self::resolve_tenant_for_mode(tenant_id.as_deref(), &self.tenant_deployment_mode)?;
-        Ok(AuthenticatedFlightContext {
-            tenant_id,
-            capability,
-        })
+            IdentityError::TenantResolution(error) => match error {
+                proximadb_tenant::ResolveRequestTenantError::MissingTenant => {
+                    TonicStatus::unauthenticated(error.to_string())
+                }
+                proximadb_tenant::ResolveRequestTenantError::InvalidTenant(_) => {
+                    TonicStatus::invalid_argument(error.to_string())
+                }
+            },
+        }
     }
 
     fn validate_flight_write_capability(

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -95,6 +95,13 @@ pub struct MiddlewareTenantContext {
     /// ADR-031 stable numeric namespace id (`NamespaceId = u16`). Threaded but
     /// unused until `PROXIMADB_TYPED_PATHS`; `None` = legacy string-resolved path.
     pub namespace_stable_id: Option<u16>,
+    /// The authenticated principal's subject id (#1338 / TD-ABAC-6). Surfaced
+    /// from `UnifiedUserContext.user_id` so REST read paths can thread it as
+    /// the ABAC principal — the direct analog of gRPC's `user_id` accessor and
+    /// Arrow's `AuthenticatedFlightContext.user_id`. `None` on the
+    /// trust-asserted / unauthenticated path. Per-handler consumption (#1309)
+    /// is wired separately; this field is the surfacing.
+    pub subject: Option<String>,
 }
 
 impl MiddlewareTenantContext {
@@ -110,6 +117,7 @@ impl MiddlewareTenantContext {
             tenant_stable_id: None,
             namespace_id: None,
             namespace_stable_id: None,
+            subject: None,
         }
     }
 
@@ -557,6 +565,18 @@ impl Default for TenantExtractor {
 ///
 /// This middleware extracts tenant_id from the request and injects
 /// MiddlewareTenantContext into request extensions.
+/// #1338 (TD-ABAC-6): the authenticated principal's user id, read from the auth
+/// layer's `UnifiedUserContext` extension. Surfaced onto
+/// [`MiddlewareTenantContext::subject`] so REST read paths can thread it as the
+/// ABAC principal — the analog of gRPC's `user_id` accessor / Arrow's `user_id`
+/// field. `None` on the trust-asserted / unauthenticated path (no auth layer, or
+/// auth disabled).
+fn authenticated_subject(req: &Request) -> Option<String> {
+    req.extensions()
+        .get::<crate::security::UnifiedUserContext>()
+        .map(|user| user.user_id.clone())
+}
+
 pub async fn tenant_middleware(
     axum::extract::State(extractor): axum::extract::State<TenantExtractor>,
     mut req: Request,
@@ -604,6 +624,10 @@ pub async fn tenant_middleware(
             if let Some(tier) = tier_claim {
                 crate::services::record_store::set_tenant_tier(&context.tenant_id, tier);
             }
+            // #1338 (TD-ABAC-6): surface the authenticated subject so REST read
+            // paths can thread it as the ABAC principal (mirrors gRPC's
+            // `user_id` accessor / Arrow's `user_id` field).
+            context.subject = authenticated_subject(&req);
             // Also inject api-crate MiddlewareTenantContext for port-backed handlers in proximadb-api
             req.extensions_mut()
                 .insert(proximadb_api::rest::TenantContext {
@@ -622,7 +646,8 @@ pub async fn tenant_middleware(
                 ).into_response()
             } else {
                 // No tenant required, use anonymous context
-                let default_ctx = MiddlewareTenantContext::default_tenant();
+                let mut default_ctx = MiddlewareTenantContext::default_tenant();
+                default_ctx.subject = authenticated_subject(&req);
                 req.extensions_mut()
                     .insert(proximadb_api::rest::TenantContext {
                         tenant_id: default_ctx.tenant_id.clone(),
@@ -1101,6 +1126,56 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(open.status(), StatusCode::OK);
+    }
+
+    /// #1338 (TD-ABAC-6): the authenticated principal's user_id is surfaced on
+    /// `MiddlewareTenantContext.subject` — the REST analog of gRPC's `user_id`
+    /// accessor and Arrow's `user_id` field — so read paths can thread it as the
+    /// ABAC principal. Proves the surfacing (per-handler consumption is #1309).
+    #[tokio::test]
+    async fn tenant_context_surfaces_the_authenticated_subject() {
+        use axum::{Extension, Router, routing::get};
+        use tower::ServiceExt;
+
+        // Simulate the auth layer injecting an authenticated UnifiedUserContext.
+        let inject_user = axum::middleware::from_fn(|mut req: Request, next: Next| async move {
+            let mut user = crate::security::UnifiedUserContext::anonymous();
+            user.user_id = "alice".to_string();
+            user.tenant_id = Some("acme".to_string());
+            user.auth_method = crate::security::UnifiedAuthMethod::JWT;
+            req.extensions_mut().insert(user);
+            next.run(req).await
+        });
+
+        let app = Router::new()
+            .route(
+                "/probe",
+                get(
+                    |Extension(ctx): Extension<MiddlewareTenantContext>| async move {
+                        ctx.subject.unwrap_or_else(|| "none".to_string())
+                    },
+                ),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                extractor(HeaderTrustPolicy::Open),
+                tenant_middleware,
+            ))
+            .layer(inject_user);
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/probe")
+                    .body(axum::body::Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        assert_eq!(&body[..], b"alice");
     }
 
     #[test]

--- a/src/security/request_identity.rs
+++ b/src/security/request_identity.rs
@@ -16,8 +16,8 @@ use crate::security::AuthenticationData;
 use crate::security::SecurityCoordinator;
 use crate::security::UnifiedUserContext;
 use proximadb_tenant::identity_trust::{
-    AuthenticatedTenantBinding, ResolvedTenantAssertion, resolve_subject_assertion,
-    resolve_tenant_assertion,
+    AuthenticatedTenantBinding, ResolvedTenantAssertion, TenantAssertionError,
+    resolve_subject_assertion, resolve_tenant_assertion,
 };
 use proximadb_tenant::{
     AuthClass, HeaderTrustPolicy, ResolveRequestTenantError, ResolvedRequestIdentity,
@@ -75,8 +75,12 @@ pub enum IdentityError {
     #[error("authentication failed: {0}")]
     Authentication(String),
     /// A tenant or subject assertion was rejected by the deployment trust policy.
+    /// Carries the structured [`TenantAssertionError`] so each surface can emit
+    /// its own `tenant_audit` trail with full fidelity (Mismatch vs
+    /// UnauthenticatedAssertionRejected) and map it onto its protocol's error
+    /// vocabulary — the orchestrator itself never logs.
     #[error("identity assertion rejected: {0}")]
-    Assertion(String),
+    Assertion(TenantAssertionError),
     /// The resolved tenant is invalid for the deployment mode (e.g. missing under
     /// `MultiTenant`, or an unsafe id).
     #[error(transparent)]
@@ -128,7 +132,7 @@ pub async fn resolve_request_identity(
                         is_gateway_principal: user_context.is_gateway_principal(),
                     });
             let resolved = resolve_tenant_assertion(asserted_tenant, binding.as_ref(), trust)
-                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+                .map_err(IdentityError::Assertion)?;
             let tenant = resolve_tenant_for_mode(&resolved, mode)?;
             Ok(ResolvedIdentity {
                 identity: ResolvedRequestIdentity {
@@ -143,10 +147,10 @@ pub async fn resolve_request_identity(
         // and gated through the deployment trust policy.
         None => {
             let resolved = resolve_tenant_assertion(asserted_tenant, None, trust)
-                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+                .map_err(IdentityError::Assertion)?;
             let tenant = resolve_tenant_for_mode(&resolved, mode)?;
             let subject = resolve_subject_assertion(asserted_subject, trust)
-                .map_err(|e| IdentityError::Assertion(e.to_string()))?;
+                .map_err(IdentityError::Assertion)?;
             let auth_class = match (&resolved, &subject) {
                 (ResolvedTenantAssertion::NoTenant, None) => AuthClass::Anonymous,
                 _ => AuthClass::TrustAsserted,


### PR DESCRIPTION
## Summary

TD-ABAC-6 PR-C — the resolver-wiring. Arrow Flight's monolithic `authenticated_flight_context` (authenticate → tenant-gate → mode-gate in one function, no intervening steps) is the one surface that is the clean fit for the `resolve_request_identity` orchestrator landed in PR-B (#1340). It now routes through the ONE resolver end-to-end.

- **Arrow → orchestrator:** `authenticated_flight_context` calls `resolve_request_identity`; the two former branches (no-coordinator bare-assertion, coordinator authenticated-binding) map onto the orchestrator's trust-asserted vs authenticated paths. `AuthenticatedFlightContext` gains `user_id` (surfaced from the resolved identity) — the **#1309 vector-ABAC enabler** (previously dropped at context construction). `identity_error_to_flight_status` maps `IdentityError → tonic::Status` while keeping the `tenant_audit` trail.
- **`IdentityError::Assertion` structured:** now carries the `TenantAssertionError` (was `String`) so every surface keeps full audit fidelity (Mismatch vs UnauthenticatedAssertionRejected).
- **REST subject surfacing (#1338):** `MiddlewareTenantContext.subject` surfaces `UnifiedUserContext.user_id` — the REST analog of gRPC's `user_id` accessor and Arrow's new `user_id`. Per-handler *consumption* is #1309 (separate).
- **gRPC/pgwire/REST full orchestrator adoption DEFERRED** (behavior-preserving): they authenticate-separately (gRPC capability pre-checks) / carry surface quirks (pgwire `DEFAULT_TENANT` accepted-under-strict) / split layers (REST), and are already primitive-consolidated (they call `resolve_tenant_assertion` / `resolve_request_tenant_for_mode` directly). Full fit needs a `resolve_request_identity_from_context` variant (a follow-up slice), not a behavior change. Documented in new TD-ABAC-6 §6.

Behavior-preserving. gRPC/pgwire/REST remain primitive-consolidated. The credential-parser consolidation (#1341) is already complete; this PR adds the orchestrator's first concrete consumer (Arrow).

## Verification
- `cargo nextest -p proximadb --lib` — 22 passed (Arrow identity 9, REST tenant incl. new `tenant_context_surfaces_the_authenticated_subject`, orchestrator 7, `parse_authorization` parity).
- `cargo clippy -p proximadb` (lib+tests clean; only a pre-existing example lint remains, untouched).
- `cargo fmt --check`; `cargo check -p proximadb-server` (mandate #11); `make work-commit-check` (panic-policy +0, layering, tenant-path, env-gate registry, hygiene).

TD: `docs/10-quality/td/TD-ABAC-6-unified-identity-seam.adoc`
