### PR TITLE
refactor(storage-common): move segment-format detection + PAX read down from root (TD-DECOMP-1)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -1919,6 +1919,53 @@ impl PaxSegmentScanner {
     }
 }
 
+// ── Mixed-format PAX read (the Pax branch of the segment read router) ──────────
+
+/// Decode a PAX vector segment (the columnar format) back to records — the Pax
+/// arm of the root-level mixed-format read router (`read_segment_records`).
+///
+/// Pure PAX: no format detection and no legacy path (the router has already
+/// dispatched here via
+/// [`crate::segment_layout::SegmentFormat::detect`]). Records are reconstructed
+/// via the canonical inverse ([`PaxSegmentScanner::read_records`]); for a
+/// coalesced segment with an SQ8 Region B (ADR-065), the SQ8 rerank vectors are
+/// overlaid by row index (block row order == Region B cluster order) so
+/// compaction / recovery / full-read see the vectors rather than silently
+/// dropping them. Factored out of the root crate so it is unit-testable without
+/// linking the root; byte-for-byte identical to the former in-root path.
+pub fn read_pax_segment_records(
+    bytes: &[u8],
+    embedding_model_ids: &[String],
+    user_column_keys: &[String],
+    tenant_ctx: Option<&str>,
+) -> Result<Vec<ProximaRecord>> {
+    let mut scanner = PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())?;
+    let mut recs = scanner.read_records(embedding_model_ids, user_column_keys, tenant_ctx)?;
+    // ADR-065 Region B: a coalesced segment with an SQ8 region stores its vectors
+    // in Region B (blocks are pure row data). Overlay the SQ8 vectors by row index
+    // — block row order == Region B cluster order, so recs[i] <-> Region B row i.
+    if is_coalesced_segment(bytes)
+        && let Ok(h) = SegmentHeaderPrefix::parse(bytes)
+        && h.sq8_len > 0
+    {
+        let region = &bytes[h.sq8_off as usize..(h.sq8_off + h.sq8_len) as usize];
+        if let Ok(sq8) = proximadb_block_format::coalesced_sq8::Sq8Region::from_bytes(region) {
+            let dim = sq8.header.dim;
+            for (i, rec) in recs.iter_mut().enumerate() {
+                if let Some(v) = sq8.decode_row(i) {
+                    rec.embeddings.push(proximadb_records::EmbeddingCell {
+                        modality: "dense".into(),
+                        dim,
+                        values: proximadb_records::EmbeddingValues::Fp32(v),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+    }
+    Ok(recs)
+}
+
 // ── Compaction (TD-114) ─────────────────────────────────────────────────────────
 
 /// Statistics from a PAX segment compaction.

--- a/crates/storage/proximadb-storage-common/src/segment_layout.rs
+++ b/crates/storage/proximadb-storage-common/src/segment_layout.rs
@@ -29,6 +29,7 @@ use anyhow::{Result, bail};
 use std::collections::HashMap;
 
 use crate::pax_block::SEGMENT_MAGIC;
+use proximadb_block_format::BLOCK_MAGIC;
 
 /// Segment-header magic — the presence-field for the coalesced-RaBitQ layout.
 /// Chosen disjoint from the block magic `PBLK` (`0x50…`) so detection is
@@ -65,6 +66,52 @@ pub const SEG_HEADER_PREFIX_V3_LEN: usize = 72;
 /// presence-field that selects the scan-then-rerank read path (mixed-read).
 pub fn is_coalesced_segment(bytes: &[u8]) -> bool {
     bytes.len() >= SEG_HEADER_MAGIC.len() && &bytes[..SEG_HEADER_MAGIC.len()] == SEG_HEADER_MAGIC
+}
+
+/// On-disk format of a persisted vector segment.
+///
+/// PAX segments (columnar; carry SQ8 / RaBitQ codes for quantized ANN) are
+/// recognised by magic; anything else is the legacy row-based `ProximaDataBlock`
+/// (raw f32). Detection is unambiguous — the PAX head (`PBLK` or the coalesced
+/// header `PXH1`) is disjoint from the legacy version/compression byte — so the
+/// legacy path is never mis-routed.
+///
+/// This is the format-layer detection primitive, factored out of the root
+/// `segment_format` module so it is unit-testable without linking the root crate;
+/// the root re-exports it and its mixed-format read router builds on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum SegmentFormat {
+    /// Legacy row-based block (raw f32). The default for segments written before P3
+    /// and for any manifest entry that predates the format field.
+    #[default]
+    ProximaBlocks,
+    /// Columnar PAX segment (carries SQ8 / RaBitQ codes; enables quantized ANN).
+    Pax,
+}
+
+impl SegmentFormat {
+    /// Detect a persisted segment's format from its raw bytes, mixed-read-safe.
+    ///
+    /// Returns [`SegmentFormat::ProximaBlocks`] for anything not recognisably a PAX
+    /// segment, so the legacy path is never mis-routed on truncated or unknown input.
+    pub fn detect(bytes: &[u8]) -> Self {
+        if is_pax_segment(bytes) {
+            SegmentFormat::Pax
+        } else {
+            SegmentFormat::ProximaBlocks
+        }
+    }
+}
+
+/// True iff `bytes` is a PAX segment: a recognised PAX head AND the trailing
+/// segment magic. Both ends are checked so a stray prefix or suffix alone can't
+/// false-positive. The head is EITHER the legacy block magic `PBLK` (block 0 at
+/// offset 0) OR the coalesced-RaBitQ header magic (ADR-062) — both tail with
+/// [`SEGMENT_MAGIC`], so the trailing check is the common anchor.
+fn is_pax_segment(bytes: &[u8]) -> bool {
+    bytes.len() >= BLOCK_MAGIC.len() + SEGMENT_MAGIC.len()
+        && (bytes.starts_with(&BLOCK_MAGIC) || is_coalesced_segment(bytes))
+        && bytes.ends_with(SEGMENT_MAGIC)
 }
 
 /// The fixed header-prefix at offset 0 (56 B for v1, 72 B for v3). The RaBitQ
@@ -992,6 +1039,49 @@ pub fn segment_tail(footer_body: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mixed-format segment detection must be unambiguous by magic and never
+    /// mis-route the legacy path. Golden table ported from the former root
+    /// `segment_format` tests — locks the disjointness of BLOCK_MAGIC /
+    /// SEG_HEADER_MAGIC / SEGMENT_MAGIC now that detection lives in this crate
+    /// (and proves the moved logic is unit-testable WITHOUT linking the root).
+    #[test]
+    fn segment_format_detect_golden_table() {
+        // Empty / short / unknown bytes -> legacy (never mis-route).
+        assert_eq!(SegmentFormat::detect(&[]), SegmentFormat::ProximaBlocks);
+        assert_eq!(
+            SegmentFormat::detect(&[0x01, 0, 0]),
+            SegmentFormat::ProximaBlocks
+        );
+        assert_eq!(
+            SegmentFormat::detect(&[0x05, 0, 0]),
+            SegmentFormat::ProximaBlocks
+        );
+
+        // PAX head (BLOCK_MAGIC) + trailing SEGMENT_MAGIC -> Pax.
+        let mut pax = BLOCK_MAGIC.to_vec();
+        pax.extend_from_slice(SEGMENT_MAGIC);
+        assert_eq!(SegmentFormat::detect(&pax), SegmentFormat::Pax);
+
+        // Coalesced head (SEG_HEADER_MAGIC) + trailing SEGMENT_MAGIC -> Pax.
+        let mut coalesced = SEG_HEADER_MAGIC.to_vec();
+        coalesced.extend_from_slice(SEGMENT_MAGIC);
+        assert_eq!(SegmentFormat::detect(&coalesced), SegmentFormat::Pax);
+
+        // Head magic alone (no trailing SEGMENT_MAGIC) -> NOT Pax: a stray prefix
+        // alone must never false-positive.
+        assert_eq!(
+            SegmentFormat::detect(&BLOCK_MAGIC[..]),
+            SegmentFormat::ProximaBlocks
+        );
+        assert_eq!(
+            SegmentFormat::detect(&SEG_HEADER_MAGIC[..]),
+            SegmentFormat::ProximaBlocks
+        );
+
+        // Default (e.g. a manifest entry predating the format field) is legacy.
+        assert_eq!(SegmentFormat::default(), SegmentFormat::ProximaBlocks);
+    }
 
     fn sample_footer() -> SegmentFooterIndex {
         SegmentFooterIndex {

--- a/docs/10-quality/td/TD-DECOMP-1-segment-format-to-storage-common.adoc
+++ b/docs/10-quality/td/TD-DECOMP-1-segment-format-to-storage-common.adoc
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-1: Move segment-format detection + PAX read down to proximadb-storage-common (god-crate decomposition step 1)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing (delivered by this slice)
+| Severity | Low — build/dev-loop only; zero runtime, API, or on-disk-format impact
+| Component | `crates/storage/proximadb-storage-common` (`segment_layout`, `pax_block`); root `src/storage/engines/sst/segment_format.rs`
+| Relates to | `roadmap/techdebt/P2_GOD_CRATE_TEST_DECOMPOSITION.md` (god-crate decomposition); the build/CI-shape effort (D1 evidence: root monolith = 850K LOC, filtered root-lib test = 13.45 min / 26.68 GB peak)
+|===
+
+== Why
+
+The root `proximadb` crate is an 850K-LOC monolith (`src/storage` alone is 325K
+LOC, 38%). A single filtered `cargo test --lib <x> --no-run` recompiles + links the
+entire root in one rustc process — measured baseline 13.45 min wall / 26.68 GB peak
+RSS at `jobs=3` (sccache-warm; the root crate is the uncached bottleneck). Any
+self-contained *format-layer* logic that lives in the root cannot be unit-tested
+without linking the monolith, so edits to it pay the full 13-minute tax for a
+check that belongs in a leaf crate.
+
+The mixed-format segment **detection** (`SegmentFormat` / `is_pax_segment`) and the
+**PAX-decode** body of the read router are pure format-layer concerns (byte/magic
+detection + the canonical `PaxSegmentScanner` inverse + SQ8 Region-B overlay) with
+exactly one root dependency — the legacy `ProximaDataBlock::deserialize`. Their
+ownership belongs in `proximadb-storage-common`, next to the already-co-located
+`is_coalesced_segment`, `SegmentHeaderPrefix`, and `PaxSegmentScanner::read_records`.
+
+== What moved (behavior-neutral)
+
+* `SegmentFormat` + `SegmentFormat::detect` + `is_pax_segment` →
+  `proximadb-storage-common::segment_layout` (alongside `is_coalesced_segment`).
+* The Pax-branch body of `read_segment_records` → a new pure
+  `pax_block::read_pax_segment_records` (alongside `PaxSegmentScanner::read_records`).
+* The root keeps a `pub use` re-export of `SegmentFormat` and a *thin*
+  `read_segment_records` router that delegates PAX to the new leaf function and the
+  legacy branch to `ProximaDataBlock::deserialize`.
+
+Behavior-neutrality is structural: `read_segment_records`'s public signature is
+**unchanged** (all four production call sites — `trait_impl.rs`, `compaction.rs`,
+`search/mod.rs` ×2 — and the root's own test suite are untouched), the moved logic
+is verbatim, and the legacy root dependency stays in the root (no injected trait, no
+new public API, no wire/on-disk format change). `proximadb-storage-common` has no
+dependency on the root crate (verified) — so no cycle is possible.
+
+== Verification
+
+* New `segment_format_detect_golden_table` test in `segment_layout` (ported from the
+  former root tests) passes in the leaf crate; storage-common's full suite (465
+  tests) runs without linking the root.
+* `cargo clippy -p proximadb --lib -- -D warnings` clean (the CI clippy gate); the
+  three imports the move made test-only are `#[cfg(test)]`-gated.
+* Root `segment_format` test module green through the delegating router.
+
+== Follow-ups (out of scope here)
+
+* Move the heavier write / search / probe half of `segment_format` (it reaches eight
+  distinct root service surfaces — `FileSystem`, `crate::core::config`,
+  observability, metrics, `block_cluster`, `survivor_range_cache`,
+  `sst_query_engine`, `search`); needs several injected traits, so it is a later
+  slice once this read/detection seam is established.
+* The complementary compile-time levers (dev/test dep `opt-level` tax, RAM-derived
+  CI job parallelism, touched-crate fast lane) and the embedded/on-prem/cloud
+  deployment-shape documentation are tracked separately under the build/CI-shape effort.

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -22,61 +22,39 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
-use proximadb_block_format::{
-    BLOCK_MAGIC, BlockCompression, BlockMode, RankMetric, VectorQuant, col_id,
-};
+use proximadb_block_format::{BlockCompression, BlockMode, RankMetric, VectorQuant, col_id};
 use proximadb_cache::{CacheKind, L2CacheStats, L2Class, PersistentByteStore};
 use proximadb_records::ProximaRecord;
 use proximadb_storage_common::pax_block::{
     PaxSegmentScanner, PaxSegmentWriter, SEGMENT_MAGIC, ScanPredicate, SegmentMeta,
 };
+// These three are now used only by this module's `#[cfg(test)]` suite — the
+// detection (`SegmentFormat` / `is_pax_segment`) and the PAX-decode body they
+// served moved down to `proximadb-storage-common`. Gated to test so the non-test
+// lib build stays warning-clean under clippy `-D warnings` (the CI gate).
+#[cfg(test)]
+use proximadb_block_format::BLOCK_MAGIC;
+#[cfg(test)]
 use proximadb_storage_common::segment_layout::{SegmentHeaderPrefix, is_coalesced_segment};
 
 use crate::storage::engines::core::formats::proximablocks::ProximaDataBlock;
 use crate::storage::engines::sst::survivor_range_cache::SurvivorRangeCache;
 
-/// On-disk format of a persisted vector segment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
-pub enum SegmentFormat {
-    /// Legacy row-based block (raw f32). The default for segments written before P3
-    /// and for any manifest entry that predates the format field.
-    #[default]
-    ProximaBlocks,
-    /// Columnar PAX segment (carries SQ8 / RaBitQ codes; enables quantized ANN).
-    Pax,
-}
-
-impl SegmentFormat {
-    /// Detect a persisted segment's format from its raw bytes, mixed-read-safe.
-    ///
-    /// Returns [`SegmentFormat::ProximaBlocks`] for anything not recognisably a PAX
-    /// segment, so the legacy path is never mis-routed on truncated or unknown input.
-    pub fn detect(bytes: &[u8]) -> Self {
-        if is_pax_segment(bytes) {
-            SegmentFormat::Pax
-        } else {
-            SegmentFormat::ProximaBlocks
-        }
-    }
-}
-
-/// True iff `bytes` is a PAX segment: a recognised PAX head AND the trailing
-/// segment magic. Both ends are checked so a stray prefix or suffix alone can't
-/// false-positive. The head is EITHER the legacy block magic `PBLK` (block 0 at
-/// offset 0) OR the coalesced-RaBitQ header magic (ADR-062) — both tail with
-/// `SEGMENT_MAGIC`, so the trailing check is the common anchor.
-fn is_pax_segment(bytes: &[u8]) -> bool {
-    bytes.len() >= BLOCK_MAGIC.len() + SEGMENT_MAGIC.len()
-        && (bytes.starts_with(&BLOCK_MAGIC) || is_coalesced_segment(bytes))
-        && bytes.ends_with(SEGMENT_MAGIC)
-}
+// `SegmentFormat` (detection + `is_pax_segment`) now lives in the format layer —
+// `proximadb_storage_common::segment_layout` — so the mixed-format detection
+// primitive is unit-testable without linking the root crate. Re-exported here so
+// every existing `crate::storage::engines::sst::segment_format::SegmentFormat`
+// reference (and the router below) resolves unchanged (behavior-neutral move).
+pub use proximadb_storage_common::segment_layout::SegmentFormat;
 
 /// Decode a persisted vector segment back to records, routing on the detected format.
 ///
-/// PAX segments are decoded via the canonical inverse
-/// ([`PaxSegmentScanner::read_records`]); legacy segments via
-/// [`ProximaDataBlock::deserialize`]. This is the single mixed-read entry the
-/// Phase A.2 wiring will call from the cold-search, compaction, and recovery paths.
+/// PAX segments are decoded via the format-layer inverse
+/// ([`proximadb_storage_common::pax_block::read_pax_segment_records`]); legacy
+/// segments via [`ProximaDataBlock::deserialize`]. This root-level router is the
+/// single mixed-read entry called from the cold-search, compaction, and recovery
+/// paths. Its signature is unchanged from before the detection + PAX-decode logic
+/// moved down to `proximadb-storage-common` — the move is behavior-neutral.
 ///
 /// `embedding_model_ids` / `user_column_keys` are the collection's schema keys used
 /// to reconstruct PAX records positionally (empty slices = best-effort defaults);
@@ -92,46 +70,14 @@ pub fn read_segment_records(
     tenant_ctx: Option<&str>,
 ) -> Result<Vec<ProximaRecord>> {
     match SegmentFormat::detect(bytes) {
-        SegmentFormat::Pax => {
-            // ADR-065 Region B: a coalesced segment with an SQ8 region stores its
-            // vectors in Region B, NOT in the blocks (blocks are pure row data).
-            // read_records reconstructs from blocks alone, so it would silently drop
-            // the vectors — fail closed instead. The coalesced SEARCH path
-            // (rabitq_search_segment_coalesced) reads Region B directly; full
-            // Region-B read_records/compaction/recovery is a follow-up.
-            let mut scanner =
-                PaxSegmentScanner::from_bytes(bytes.to_vec(), ScanPredicate::default())?;
-            let mut recs =
-                scanner.read_records(embedding_model_ids, user_column_keys, tenant_ctx)?;
-            // ADR-065 Region B: a coalesced segment with an SQ8 region stores its
-            // vectors in Region B (blocks are pure row data). Overlay the SQ8
-            // vectors by row index — block row order == Region B cluster order, so
-            // recs[i] <-> Region B row i. (Exact-f32 preference via F32_TIER is a
-            // follow-up; this returns the SQ8 rerank vectors so compaction / recovery
-            // / full-read see the vectors rather than silently dropping them.)
-            if is_coalesced_segment(bytes)
-                && let Ok(h) = SegmentHeaderPrefix::parse(bytes)
-                && h.sq8_len > 0
-            {
-                let region = &bytes[h.sq8_off as usize..(h.sq8_off + h.sq8_len) as usize];
-                if let Ok(sq8) =
-                    proximadb_block_format::coalesced_sq8::Sq8Region::from_bytes(region)
-                {
-                    let dim = sq8.header.dim;
-                    for (i, rec) in recs.iter_mut().enumerate() {
-                        if let Some(v) = sq8.decode_row(i) {
-                            rec.embeddings.push(proximadb_records::EmbeddingCell {
-                                modality: "dense".into(),
-                                dim,
-                                values: proximadb_records::EmbeddingValues::Fp32(v),
-                                ..Default::default()
-                            });
-                        }
-                    }
-                }
-            }
-            Ok(recs)
-        }
+        SegmentFormat::Pax => Ok(
+            proximadb_storage_common::pax_block::read_pax_segment_records(
+                bytes,
+                embedding_model_ids,
+                user_column_keys,
+                tenant_ctx,
+            )?,
+        ),
         SegmentFormat::ProximaBlocks => Ok(ProximaDataBlock::deserialize(bytes, None)?.records),
     }
 }


### PR DESCRIPTION
## What

Move the mixed-format segment **detection** (`SegmentFormat` / `detect` / `is_pax_segment`) and the **PAX-decode** body of the read router out of the root `proximadb` crate down into `proximadb-storage-common`, so this format-layer logic is unit-testable without linking the 850K-LOC root monolith.

Part of the build/CI-shape effort; recorded as **TD-DECOMP-1** (god-crate decomposition step 1).

## Why

Measured baseline (this branch, default features, sccache-warm): a single filtered `cargo test --lib <x> --no-run` recompiles + links the entire root in one rustc — **13.45 min wall / 26.68 GB peak RSS @ `jobs=3`**. The root crate is the uncached bottleneck (sccache can't help it). Any self-contained format-layer logic that lives in the root pays the full 13-minute tax for a unit check that belongs in a leaf crate.

The detection + PAX-decode are pure format-layer concerns (byte/magic detection + the canonical `PaxSegmentScanner` inverse + SQ8 Region-B overlay) with exactly one root dependency — the legacy `ProximaDataBlock::deserialize`. Their ownership is in `proximadb-storage-common`, next to the already-co-located `is_coalesced_segment`, `SegmentHeaderPrefix`, and `PaxSegmentScanner::read_records`.

## Change

- `SegmentFormat` + `detect` + `is_pax_segment` → `proximadb-storage-common::segment_layout` (alongside `is_coalesced_segment`).
- Pax-branch body of `read_segment_records` → new pure `pax_block::read_pax_segment_records` (alongside `PaxSegmentScanner::read_records`).
- Root keeps a `pub use` re-export of `SegmentFormat` and a thin `read_segment_records` router that delegates PAX to the new leaf function and the legacy branch to `ProximaDataBlock::deserialize`.

## Behavior-neutrality (by construction)

- `read_segment_records`'s **public signature is unchanged** → all 4 production call sites (`trait_impl.rs`, `compaction.rs`, `search/mod.rs` ×2) and the root's own test suite are untouched.
- Moved logic is **verbatim**; the legacy `ProximaDataBlock` dependency stays in the root (no injected trait, no new public API, no wire/on-disk format change).
- **Cycle-free**: `proximadb-storage-common` has no dependency on the root crate (verified).

## Verification

| Check | Result |
|---|---|
| new `segment_format_detect_golden_table` test (leaf crate) | ✅ pass |
| `cargo check -p proximadb-storage-common --tests` | ✅ exit 0 |
| `cargo check -p proximadb --lib` (re-export + router + 4 call sites) | ✅ exit 0 |
| `cargo clippy -p proximadb --lib -- -D warnings` (CI gate) | ✅ 0 warnings |
| root `segment_format` test module via the delegating router | ✅ **29 passed, 0 failed** |
| `make work-commit-check` | ✅ exit 0 |
| `check_td_adr_unique.py` | ✅ TD-DECOMP-1 unique |

Payoff: detection + PAX-decode are now unit-testable in the leaf crate in seconds; storage-common's full **465-test** suite runs without linking the root.

## Out of scope (follow-ups noted in TD-DECOMP-1)

- Moving the heavier write/search/probe half of `segment_format` (reaches 8 root service surfaces — needs several injected traits).
- The complementary compile-time levers (dev/test dep `opt-level` tax, RAM-derived CI job parallelism, touched-crate fast lane) and embedded/on-prem/cloud deployment-shape docs — separate slices under the same effort.
