### PR TITLE
docs(td): TD-IOTRACE-4 — plumb persistent-L2 cache counters (#1325) into the io-trace envelope and warehouse

### DIFF
--- a/docs/10-quality/td/TD-IOTRACE-4-persistent-l2-cache-counters-not-in-trace.adoc
+++ b/docs/10-quality/td/TD-IOTRACE-4-persistent-l2-cache-counters-not-in-trace.adoc
@@ -1,0 +1,83 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IOTRACE-4: Persistent-L2 cache counters not plumbed into the io-trace envelope/warehouse
+:toc: macro
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open** (filed 2026-07-31)
+| Severity | Medium — cache-dimension observability/fidelity gap, not revenue-blocking (the KRU physical counters are TD-IOTRACE-2, Resolved #1091). Becomes higher-stakes as the persistent L2 tier (#1325) changes what "warm" means for real workloads.
+| Component | Observability — `crates/modalities/proximadb-observability-engine/src/{io_trace.rs,trace_envelope.rs}`, `src/observability/io_trace_warehouse.rs`
+| Introduced-by | PR #1325 (persistent L2 PAX warm tier, ADR-085) — the counters exist but stop at process-local stats
+| Pillar | COST, OBS
+|===
+
+toc::[]
+
+== Symptom
+
+PR #1325 introduced a persistent local-disk L2 cache tier (ADR-085) with hit/miss
+counters at two sites:
+
+* `PersistentArcBytesL2` — `l2_hits`/`l2_misses`
+  (`crates/foundation/proximadb-cache/src/lib.rs:608`), exposed via the per-tenant
+  stats snapshot (`lib.rs:1009`);
+* `SurvivorRangeCache` — `parent_l2_hits`/`parent_l2_misses`
+  (`src/storage/engines/sst/survivor_range_cache.rs:79`), exposed via
+  `l2_stats() -> L2CacheStats`.
+
+Neither flows into the **query-scoped io-trace chain**. The chain today carries
+only the footer-cache counters:
+
+* `IoTrace` accumulates `footer_hits`/`footer_misses` (`io_trace.rs:182`) →
+* `IoTraceSnapshot.footer_hits/footer_misses` (`io_trace.rs:780`) →
+* `TraceHeader.footer_hits/footer_misses` (`trace_envelope.rs:92`, mapped at
+  `trace_envelope.rs:249`) →
+* the durable `trace_header` warehouse parquet
+  (`src/observability/io_trace_warehouse.rs:530`).
+
+So per-query L2 cache state is invisible to every downstream consumer of the
+warehouse: dashboards, the route-cost calibration loop, and the AnvaiOps
+fleet-priors aggregation (TD-M1), whose cold/warm cell classification keys on
+`footer_hits/(footer_hits+footer_misses) < 0.5 ⇒ cold`.
+
+== Why it matters (co-design)
+
+The co-design mandate requires each dimension's cost term to be *observable
+per-query* — the cache dimension is metered and the `ComputeScheduler`/priors
+cost cells key on cache state. With #1325 live, the footer ratio becomes a less
+faithful proxy: a segment can be footer-cold (fresh process, empty in-memory
+footer cache) yet **L2-warm** (persistent tier survives restart), so its queries
+pay near-warm physical GETs while the trace classifies them cold. Downstream
+that skews cold-cell priors toward warm numbers — the exact artifact the k-floor
+aggregation is supposed to keep honest.
+
+== Proposed fix (small, additive, mixed-read-safe)
+
+1. **Accumulate**: add `l2_hits`/`l2_misses` to `IoTrace` and record them on the
+   L2 lookup paths (the `SurvivorRangeCache` and `PersistentArcBytesL2` hit/miss
+   sites already count — wire the same increments into the ambient query
+   `IoTrace`, as the footer cache does).
+2. **Snapshot**: add the two fields to `IoTraceSnapshot` (and its
+   `is_empty`/summary formatting).
+3. **Envelope**: add them to `TraceHeader` with `#[serde(default)]` so old
+   envelopes deserialize (mixed-read-safe; billing untouched — the envelope is a
+   serialization view, per TD-TRACE-2 S3).
+4. **Warehouse**: add two `Int64` columns to the `trace_header` schema. Additive
+   column at the end; readers of existing per-segment parquet files must treat
+   the columns as optional/0-default (same posture as any warehouse schema
+   evolution — never a flag-day rewrite).
+5. **Downstream (separate repo, after this lands)**: AnvaiOps
+   `fleet-priors/aggregate.py` can then switch (or add) the cache-state signal
+   from footer ratio to L2 ratio; noted in TD-M1's Progress section.
+
+Acceptance: an e2e that runs a query served from the persistent L2 tier and
+asserts nonzero `l2_hits` in the emitted warehouse row (and zero with the tier
+disabled).
+
+== Non-goals
+
+* No change to KRU/metering events (TD-IOTRACE-2 owns those; already Resolved).
+* No change to the footer counters or their consumers — the L2 counters are
+  additive alongside them.


### PR DESCRIPTION
## Summary
Files **TD-IOTRACE-4**: PR #1325's persistent L2 warm tier (ADR-085) counts hits/misses (`PersistentArcBytesL2.l2_hits/l2_misses`, `SurvivorRangeCache.parent_l2_hits/parent_l2_misses`) but the counters stop at process-local stats — they never enter the query-scoped io-trace chain (`IoTrace` → `IoTraceSnapshot` → `TraceEnvelope`/`TraceHeader` → `trace_header` warehouse parquet), which still carries only `footer_hits`/`footer_misses`.

Consequence: per-query L2 cache state is invisible to every warehouse consumer. In particular, the fleet-priors cold/warm cell classification (AnvaiOps TD-M1) keys on the footer-hit ratio, and #1325 makes that proxy less faithful — a footer-cold but L2-warm segment gets classified cold while paying near-warm physical GETs, skewing cold-cell priors.

The TD proposes the small additive plumbing (trace accumulation → snapshot → serde-default envelope fields → two Int64 warehouse columns, mixed-read-safe throughout) plus an e2e acceptance gate (nonzero `l2_hits` in the emitted warehouse row when serving from the L2 tier).

Docs-only; `check_td_adr_unique.py` clean (TD-IOTRACE-4 unclaimed on develop).

## Test plan
- [x] `scripts/check_td_adr_unique.py` — 0 errors
- [x] `scripts/check_no_agent_attribution.py --range origin/develop..HEAD` — clean