### PR TITLE
feat(embedded): make AXIS opt-out-able (exact-scan embedded via --no-default-features)

### DIFF
--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -15,14 +15,14 @@ path = "src/lib.rs"
 
 [dependencies]
 # Depends on the root proximadb library (one-directional: embedded -> root, no cycle).
-# NB: embedded pulls the root *default* features (which include `axis`). Making
-# embedded axis-OFF-by-default breaks the `cargo check --workspace` CI build: the
-# root compiles axis-ON (its default + workspace unification) while embedded compiles
-# axis-OFF, and embedded's flush→AXIS projection reap then sees the root's
-# `Option<&AxisManager>` type while passing `Option<&()>` (cfg is per-crate; the type
-# crosses the crate boundary). A cross-crate-stable flush seam (service trait-ify) is
-# the tracked follow-up; until then embedded stays axis-ON for build consistency.
-proximadb = { path = "../../.." }
+# `default-features = false` + the explicit `[features]` forwarding below makes AXIS
+# opt-OUT-able: the default mirrors the root's default (AXIS on), but
+# `--no-default-features` (or a feature set without `axis`) yields an exact-scan-only
+# embedded build (no in-memory HNSW/IVF, no training RSS) for in-process / few-collection
+# apps — the PAX-exact-scan direction (TD-AXIS-4, ADR-082). Because embedded's `axis`
+# feature forwards `proximadb/axis`, embedded's axis cfg is always in sync with the
+# root's, so the flush→AXIS reap's cross-crate type stays consistent in every build.
+proximadb = { path = "../../..", default-features = false }
 # FA-b: optional, behind the `abac-policy` feature. Embedded mode is abac-OFF by
 # design (in-process; the host app owns authorization) — this dep exists only so
 # the abac verification can compile embedded's calls against root's threaded
@@ -59,7 +59,29 @@ napi = { version = "2.14", features = ["napi9"], optional = true }
 napi-derive = { version = "2.14", optional = true }
 
 [features]
-default = []
+# Default mirrors the root crate's default (ADR-082): the production feature set
+# INCLUDING `axis` (in-memory ANN). Drop `axis` (via `--no-default-features` or a
+# curated feature set) for an exact-scan-only embedded build.
+default = [
+    "datafusion-integration",
+    "sql_frontend",
+    "canonical-document-store",
+    "graph-first-sks",
+    "unified-facade-routing",
+    "otlp-metering",
+    "axis",
+]
+# Forward each root feature (the dep is `default-features = false`, so every feature
+# the embedded default needs must be explicitly forwarded).
+datafusion-integration = ["proximadb/datafusion-integration"]
+sql_frontend = ["proximadb/sql_frontend"]
+canonical-document-store = ["proximadb/canonical-document-store"]
+graph-first-sks = ["proximadb/graph-first-sks"]
+unified-facade-routing = ["proximadb/unified-facade-routing"]
+otlp-metering = ["proximadb/otlp-metering"]
+# In-memory ANN index engine (AXIS: HNSW/IVF/RaBitQ). ON by default; OFF
+# (`--no-default-features`) yields the exact-scan embedded build.
+axis = ["proximadb/axis"]
 # FA-b: mirrors root's `abac-policy`. OFF by default — embedded mode is
 # in-process and the host application owns authorization, so ABAC (a server-side
 # multi-tenant concern) does not apply. The feature exists so the abac

--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -2353,17 +2353,24 @@ impl EmbeddedProximaDB {
                     // free_wal=true preserves embedded's existing behavior (delete the
                     // WAL after flush — no 2× overhead). Its cold-read recall gap is the
                     // same dependent TD as the server's.
+                    #[cfg(feature = "axis")]
                     let axis_manager = self
                         .shared_services
                         .vector_operations_service
                         .axis_index_manager();
+                    #[cfg(feature = "axis")]
+                    let axis_arg: Option<&proximadb::index::AxisManager> = Some(&axis_manager);
+                    // `axis` off (exact-scan embedded): no in-memory projection to reap
+                    // — the durable segment is the source of truth.
+                    #[cfg(not(feature = "axis"))]
+                    let axis_arg: Option<&()> = None;
                     match proximadb::storage::flush_materializer::materialize_collection(
                         &write_buffer,
                         &plan,
                         None,
                         Some(fallback_engine),
                         true,
-                        Some(&axis_manager),
+                        axis_arg,
                     )
                     .await
                     {

--- a/docs/12-design/adr/ADR-082-axis-compile-time-feature-gate.adoc
+++ b/docs/12-design/adr/ADR-082-axis-compile-time-feature-gate.adoc
@@ -64,16 +64,24 @@ every search.
   engines were already trait-ified to `Option<Arc<dyn IndexEngine>>` by ADR-078 / #1281,
   so only the `StorageEngine` *core* + the service/boot layer held the concrete type —
   that is what this gate cfg's.
-* **`proximadb-embedded`:** axis-**optional** — `default-features = false` + the
-  exact-scan feature set by default, `axis = ["proximadb/axis"]` opt-in. Embedded has
-  *zero* direct `AxisManager` references (it calls the root library API), so it was only
-  pulling AXIS by accident. In-process / few-collection apps get exact-scan (served from
-  the OS page cache / disk) with no HNSW/IVF training RSS; apps that want ANN opt in.
+* **`proximadb-embedded`:** axis-**optional** — `default-features = false` on the root
+  dep + explicit `[features]` forwarding, mirroring the server. The `default` includes
+  `axis` (so default embedded stays axis-ON, consistent with the workspace build where the
+  root is always axis-ON), but `--no-default-features` (or a curated feature set without
+  `axis`) yields an exact-scan-only build — no in-memory HNSW/IVF, no training RSS — for
+  in-process / few-collection apps. Embedded has *zero* direct `AxisManager` references
+  (it calls the root library API). Because embedded's `axis` feature forwards
+  `proximadb/axis`, embedded's axis cfg is always in sync with the root's, so the
+  flush→AXIS reap's cross-crate type stays consistent in every build. (An earlier cut made
+  embedded default axis-OFF; that broke `cargo check --workspace` — the root compiled
+  axis-ON while embedded compiled axis-OFF, and the cfg-dependent `AxisFlushArg` type
+  mismatched across the crate boundary. Default-OFF is structurally impossible while the
+  root's axis is default-ON; the opt-OUT path is the achievable goal.)
 * **`proximadb-server`:** `axis` is forwarded **explicitly** in its default. The server
   previously obtained AXIS only through workspace feature-unification (via the embedded
-  dev-dependency); making embedded axis-optional removed that source, so the server must
-  declare it directly to keep every build path (Dockerfile, `_shared-build`, release)
-  linking it.
+  dev-dependency); making embedded `default-features = false` removed that source, so the
+  server must declare it directly to keep every build path (Dockerfile, `_shared-build`,
+  release) linking it.
 
 == Alternatives considered
 


### PR DESCRIPTION
## Summary

Completes the **ADR-082 follow-up**: `proximadb-embedded` is now AXIS opt-out-able. It mirrors the server's feature-forwarding (`default-features = false` on the root dep + explicit `[features]` forwarding), with `default` **including** `axis`.

- **Default embedded = axis-ON** (consistent with `cargo check --workspace`, where the root is always axis-ON) — no behavior change for existing embedded apps.
- **`--no-default-features` (or a feature set without `axis`) = exact-scan-only embedded** — no in-memory HNSW/IVF, no IVF-training RSS — for in-process / few-collection apps. This is the PAX-exact-scan direction (TD-AXIS-4, ADR-082): the OS page cache / on-disk PAX segments give 100% recall with no index-build cost.

Embedded has **zero** direct `AxisManager` references (it calls the root library API). Because embedded's `axis` feature forwards `proximadb/axis`, embedded's axis cfg is always in sync with the root's — so the flush→AXIS reap's cross-crate `AxisFlushArg` type stays consistent in every build. (The earlier default-OFF cut broke this: the root compiled axis-ON while embedded compiled axis-OFF, mismatching the cfg-dependent type across the crate boundary. Default-OFF is structurally impossible while the root's axis is default-ON; the opt-OUT path is the achievable goal.)

## Verification
| | result |
|---|---|
| `cargo check --workspace --lib --bins` (the CI gate that failed last time) | ✅ clean |
| `cargo clippy --lib --bins -D warnings` | ✅ clean |
| `cargo fmt --check` | ✅ clean |
| `cargo check -p proximadb-embedded --no-default-features` (axis-free) | ✅ compiles; axis genuinely OFF (confirmed at rustc-cfg level) |
| default embedded (`-p proximadb-embedded`) | ✅ compiles (axis-ON) |
| ADR guards (`check_td_adr_unique`, `check_design_status_index`) | ✅ 85 ADRs, 0 errors |

Also corrects the **ADR-082** embedded paragraph (it still described the reverted default-OFF cut).