### PR TITLE
docs(design): build/CI acceleration plan + measured baseline (TD-DECOMP-1 follow-up)

### DIFF
--- a/docs/12-design/BUILD_CI_ACCELERATION_2026_07_31.adoc
+++ b/docs/12-design/BUILD_CI_ACCELERATION_2026_07_31.adoc
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Build / CI Acceleration — behavior-neutral plan + evidence (2026-07-31)
+
+:toc: macro
+:icons: font
+
+*Status:* L1 landed (TD-DECOMP-1 / PR #1344); L2–L4 are the implementation backlog.
+*Goal:* faster + more memory-predictable compile / link / CI, with **zero** API,
+wire, on-disk-format, feature-default, or recall changes.
+
+toc::[]
+
+== The problem, measured (D1 baseline)
+
+The root `proximadb` crate is an **850K-LOC monolith**; `src/storage` alone is
+**325K LOC (38%)**. 113 crates are already extracted; the root is the laggard.
+
+A single filtered root-library test recompiles + links the whole root in one rustc:
+
+[cols="1,3", options="header"]
+|===
+| Metric | Value (this branch, default features, sccache-warm)
+| Wall | **13.45 min** (`cargo test --lib <filter> --no-run` — compile + link)
+| Peak RSS | **26.68 GB** @ `jobs=3` (sampler summing rustc/cargo/linker PIDs)
+| sccache | 73 Rust misses / 1410 requests — deps cached; **the root crate is the uncached bottleneck**
+|===
+
+Compounding taxes (all dev/CI, not release): dev/test profiles compile deps at
+`opt-level=2` (arrow/parquet at `opt-level=3`); `codegen-units=4`;
+`.cargo/config.toml` caps `jobs=3`; CI hard-pins `CARGO_BUILD_JOBS=1` (serial) to
+bound memory — the 26.68 GB peak is *why*. Leaf-crate tests, by contrast, compile
+in seconds.
+
+== Levers
+
+=== L1 — move self-contained leaf logic DOWN  ✅ landed
+
+TD-DECOMP-1 / PR #1344: `SegmentFormat`/`detect`/`is_pax_segment` + the PAX-decode
+body moved root → `proximadb-storage-common`; root keeps a re-export + thin router
+(signature unchanged → 4 call sites untouched, no injected trait, cycle-free).
+Detection + PAX-decode are now unit-testable in the leaf crate (storage-common's
+465-test suite runs without the root).
+
+*Follow-up (not started):* move the heavier write/search/probe half of
+`segment_format` (reaches 8 root service surfaces → needs several injected traits).
+
+=== L2 — dev-loop profile lever  (proposed; build-free edit, locally verifiable)
+
+Add an *opt-in* `dev-fast` profile so iteration checks don't pay the dep
+`opt-level=2/3` tax:
+
+```toml
+# Cargo.toml — additive; default dev/test/release UNCHANGED (release stays the perf authority)
+[profile.dev-fast]
+inherits = "dev"
+[profile.dev-fast.package."*"]
+opt-level = 1          # deps at -O1, not -O2 (arrow/parquet not -O3) — faster dev check/test
+```
+
+Use: `cargo check --profile dev-fast`, wire into `worktree.sh check`/`test`.
+*Trade-off (documented):* dev-fast artifacts are NOT shared with the `test`
+profile (the mandate keeps `dev`/`test` opt-level equal for reuse), so toggling
+between them recompiles — acceptable for a fast-iteration lane. Behavior-neutral:
+release/production builds are untouched.
+
+=== L3 / D4 — CI lanes  (proposed; `ci.yml` edit — verify on push)
+
+The repo already has `rust-compile` (jobs=1), `rust-test`, integration jobs,
+release build, and `scripts/affected_crates.py` (prints touched crate names vs
+`origin/develop`). Gap: no **touched-crate fast lane**. Add an *advisory*
+(non-required, `continue-on-error`) job:
+
+```yaml
+rust-affected-fast:
+  needs: [changes]
+  if: needs.changes.outputs.rust == 'true'
+  runs-on: ubuntu-latest
+  steps:
+    - checkout (fetch-depth 0 so the origin/develop merge-base resolves)
+    - install toolchain + nextest + sccache/rust-cache
+    - name: affected-only fast check
+      run: |
+        pkgs="$(python3 scripts/affected_crates.py origin/develop)"
+        [ -n "$pkgs" ] || { echo 'no crate source changed'; exit 0; }
+        cargo nextest run --lib --profile unit $pkgs
+```
+
+Advisory so a misfire never blocks a merge; gives seconds-scale feedback for
+leaf-crate edits (more hits as L1/L1-follow-up move logic down). Companion:
+derive `CARGO_BUILD_JOBS` from runner RAM per lane (leaf lanes can raise it above
+the monolith's jobs=1 — small crates don't OOM).
+
+=== L4 / D5 — deployment shapes  (additive feature bundles — document + validate)
+
+The shapes already exist as Cargo feature bundles (no cfg-divergent impls). This
+item documents + validates each with `cargo check --no-default-features --features …`
+(builds — defer to a quiet machine).
+
+[cols="1,3", options="header"]
+|===
+| Shape | Feature set (exact)
+| **embedded** | `proximadb-embedded`, `--no-default-features`, + one binding (`python`\|`java`\|`nodejs`\|`c_ffi`)
+| **on-prem full** | root `default` (optionally `+cluster`,`+rocksdb`,`+enterprise-catalogs`)
+| **cloud** | root `default` + `cloud-full` (`aws`,`azure`,`gcp`) + `otlp-metering`
+| **exact-scan-only (no-axis)** | `--no-default-features --features sql_frontend,graph-first-sks,unified-facade-routing,canonical-document-store,datafusion-integration,otlp-metering`
+|===
+
+The no-axis row is already in CI's `feature-matrix`; the embedded/cloud rows are
+the validation targets. All compile from shared behavior — no semantic forks.
+
+== Sequencing
+
+. L2 (dev-fast profile) — build-free, locally verifiable when the machine is quiet.
+. D5 validation builds (the four shape checks) — capture pass/fail + timing.
+. D4 `ci.yml` fast lane — implement carefully (high blast radius; advisory).
+. One consolidated PR (L2 + D5 + D4) with before/after timings in
+  `BENCHMARK_EVIDENCE.toml`; update TD-DECOMP-1's follow-up section.
+
+== Out of scope / rejected
+
+Duplicated implementations; env-specific semantics; cfg-divergent engine forks;
+new public APIs; new on-disk/wire formats; recall-ratchet reductions; runtime
+perf claims from debug builds.


### PR DESCRIPTION
## What

Consolidated design record for the build/CI-acceleration effort: the measured problem (D1), the landed first lever (L1 / TD-DECOMP-1 / #1344), and the spec for the remaining levers (L2 dev-fast profile, L3/D4 CI touched-crate fast lane, L4/D5 deployment-shape matrix).

## Why

Anchored to the measured baseline (this branch, default features, sccache-warm): a single filtered root-library test is **13.45 min wall / 26.68 GB peak RSS @ `jobs=3`** — the root crate is the 850K-LOC uncached bottleneck. This doc captures the plan + evidence in one reviewable place so the remaining levers land coherently.

## Status of the levers

- **L1 — ✅ landed** (PR #1344 / TD-DECOMP-1): `SegmentFormat` detection + PAX-decode moved root → `proximadb-storage-common`; leaf-testable, behavior-neutral.
- **L2 — dev-fast profile** (proposed): additive opt-in profile cutting the dev/test dep `opt-level=2/3` tax; default profiles + release untouched.
- **L3 / D4 — CI touched-crate fast lane** (proposed): advisory `rust-affected-fast` job via `affected_crates.py` + nextest; seconds-scale feedback for leaf edits. RAM-derived `jobs` per lane.
- **L4 / D5 — deployment shapes** (proposed): document + validate the embedded / on-prem / cloud / no-axis feature bundles (already additive — no cfg forks).

## Why a docs PR now (vs bundled)

L2/D4/D5 are code changes that need build/CI verification; this design record is landing first so the plan + measured baseline are reviewable in parallel. The code levers follow as a companion PR. Build-time numbers are framed as the D1 baseline (not runtime perf claims).

## Verification
- [x] `make work-commit-check` green
- [x] no AI attribution
