### PR TITLE
feat(abac): wire vector ABAC enforcer + resolve_read_context; prove enforcement fires (FA-2 PR-D2)

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1479,8 +1479,8 @@ impl SharedServices {
         // `directory_cache` constructed earlier (before SstEngine) so the
         // engine, the vector ops service, and the SharedServices public
         // field all share the same `Arc`.
-        let vector_operations_service = Arc::new(
-            {
+        let vector_operations_service = {
+            let svc = {
                 #[cfg(feature = "axis")]
                 {
                     VectorOperationsService::new(
@@ -1504,8 +1504,25 @@ impl SharedServices {
             // Phase 7.2: thread the same affinity registry held by
             // the SharedServices field so search-path recordings and
             // operator inspection share state.
-            .with_affinity_registry(affinity_registry.clone()),
-        );
+            .with_affinity_registry(affinity_registry.clone());
+            // FA-2 (abac-policy): wire the durable ABAC enforcer into the vector
+            // service so `unified_search_native` enforces the subject's accessibility
+            // predicate on every search (push-down for conjunctive policies, post-filter
+            // otherwise). Default-OFF ⇒ default builds are byte-for-byte unchanged; `None`
+            // ⇒ no enforcer ⇒ no per-record filtering (the status quo). Mirrors the
+            // DmlService wiring (`build_abac_enforcer`, TD-ABAC-2).
+            #[cfg(feature = "abac-policy")]
+            let svc = match Self::build_abac_enforcer(opt_config) {
+                Some(enforcer) => {
+                    debug!(
+                        "✅ SharedServices::new - durable ABAC enforcer wired into VectorOperationsService"
+                    );
+                    svc.with_abac_enforcer(enforcer)
+                }
+                None => svc,
+            };
+            Arc::new(svc)
+        };
 
         info!(
             "✅ SharedServices: VectorOperationsService created successfully - 40-60% performance boost enabled"

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -154,6 +154,40 @@ impl AbacEnforcer {
         self.scan_predicate_for(subject, tenant, target, bindings)
     }
 
+    /// Resolve `subject`'s read authorization for `target`, returning the
+    /// admitted [`AuthorizedReadContext`] for the vector push-down path: the
+    /// caller wraps it in `ReadContext::Client(ctx)` and hands it to
+    /// `unified_search_native`. `Err(reason)` ⇒ DENY — the caller MUST fail
+    /// closed (return empty results) and MUST NOT collapse it to `None`/`System`
+    /// (that would be a fail-open hole). Mirrors `predicate_for`'s binding-store
+    /// selection so a durable store is consulted per read when present.
+    pub fn resolve_read_context(
+        &self,
+        subject: &SubjectId,
+        tenant: u64,
+        target: Target,
+    ) -> Result<AuthorizedReadContext, DenyReason> {
+        let owned;
+        let bindings: &[PolicyBinding] = match &self.binding_store {
+            Some(store) => {
+                owned = store.bindings_for(tenant);
+                &owned
+            }
+            None => &self.bindings,
+        };
+        match AuthorizedReadContext::resolve(
+            self.authority.as_ref(),
+            self.epochs.as_ref(),
+            bindings,
+            subject,
+            tenant,
+            target,
+        ) {
+            proximadb_abac::ReadDecision::Deny(reason) => Err(reason),
+            proximadb_abac::ReadDecision::Admit(ctx) => Ok(ctx),
+        }
+    }
+
     /// Resolve `subject`'s authorization for `target` and compile to a scan
     /// predicate. The caller provides the `bindings` (loaded from the policy
     /// store — Phase 5 makes that durable; today they are supplied directly).
@@ -442,6 +476,53 @@ mod tests {
             }
             _ => panic!("expected a single Eq(dept, eng) comparison"),
         }
+    }
+
+    #[test]
+    fn enforcer_resolves_admitted_read_context_for_vector_path() {
+        // resolve_read_context is the vector push-down seam: it returns the
+        // admitted AuthorizedReadContext for the caller to wrap as
+        // ReadContext::Client(ctx). Alice (dept=eng, binding present) is admitted
+        // with her row-predicate ref (42) intact — so security_filter_for_context
+        // would later compile the dept=eng filter for the ANN push-down.
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let enforcer = enforcer.with_bindings(bindings);
+        let ctx = enforcer
+            .resolve_read_context(
+                &SubjectId("alice".into()),
+                7,
+                Target {
+                    namespace: 3,
+                    table: 200,
+                    column: None,
+                },
+            )
+            .expect("alice (dept=eng, binding present) must be admitted");
+        assert!(
+            ctx.row_predicate_refs().contains(&42),
+            "admitted context carries alice's row-predicate ref"
+        );
+    }
+
+    #[test]
+    fn enforcer_resolve_read_context_denies_unbound_subject() {
+        // Fail-closed contract: an unbound subject (no attribute binding) denies,
+        // and the caller must map Err ⇒ empty results — never collapse to None.
+        let (enforcer, bindings) = enforcer_with_alice("eng");
+        let enforcer = enforcer.with_bindings(bindings);
+        let deny = enforcer.resolve_read_context(
+            &SubjectId("mallory".into()),
+            7,
+            Target {
+                namespace: 3,
+                table: 200,
+                column: None,
+            },
+        );
+        assert!(
+            deny.is_err(),
+            "mallory (unbound) must be denied, not admitted"
+        );
     }
 
     #[test]

--- a/tests/abac_vector_pushdown_integration_test.rs
+++ b/tests/abac_vector_pushdown_integration_test.rs
@@ -1,0 +1,208 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! FA-2 (abac-policy): proves vector-path ABAC enforcement FIRES end-to-end on
+//! the real search kernel.
+//!
+//! A `VectorOperationsService` is built with a durable ABAC enforcer (the
+//! composition wiring that `SharedServices` applies in production); an admitted
+//! `Client` `ReadContext` — resolved from the subject via `resolve_read_context`
+//! — is threaded into `unified_search_native_with_tenant_context`, the SAME seam
+//! the fusion vector leg uses. The subject's security predicate (`dept=eng`) is
+//! pushed DOWN into the ANN search, so an `eng` record is returned while an `hr`
+//! record (though nearest to the query) is excluded. A `System` context leaves
+//! the search untouched (normal search still works; enforcement is conditional
+//! on a `Client` context).
+//!
+//! Default-OFF: this file compiles only under `--features abac-policy`.
+
+#![cfg(all(test, feature = "abac-policy"))]
+
+#[path = "common/integration_test_helpers.rs"]
+mod harness;
+
+use harness::UnifiedTestEnvironment;
+use proximadb::core::search::{ComparisonOperator, FilterExpression};
+use proximadb::security::rls::AbacEnforcer;
+use proximadb_abac::{
+    InMemoryAttributeAuthority, InMemoryPolicyEpochs, InMemoryPredicateObjectStore, ReadContext,
+    SystemReadReason,
+};
+use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope, SubjectId, Target};
+use proximadb_data_model::ProximaValue;
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord, ProximaTreeNode};
+use serde_json::json;
+use std::sync::Arc;
+
+const COLLECTION: &str = "abac_vector_pushdown";
+const DIM: u32 = 4;
+const TENANT: u64 = 7;
+const NAMESPACE: u16 = 3;
+const TABLE: u32 = 200;
+const OID_ENG: &str = "abac/record/eng";
+const OID_HR: &str = "abac/record/hr";
+
+/// Build an enforcer that admits `alice` (dept=eng) with a `dept=eng` row
+/// predicate (mirrors the `abac_adapter` unit-test fixture). `with_bindings`
+/// installs the held binding set that `resolve_read_context` consults.
+fn enforcer_for_alice() -> Arc<AbacEnforcer> {
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        proximadb_abac::AttributeBinding::new("alice", TENANT)
+            .with_attr("dept", AttrValue::Str("eng".into())),
+    );
+    let mut store = InMemoryPredicateObjectStore::new();
+    store.register(
+        42,
+        FilterExpression::Comparison {
+            field: "dept".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!("eng"),
+        },
+    );
+    let bindings = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Table(TABLE),
+        effect: Effect::Permit,
+        predicate_ref: Some(42),
+        field_mask: None,
+    }];
+    Arc::new(
+        AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(store),
+            Box::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_bindings(bindings),
+    )
+}
+
+fn record(oid: &str, dept: &str, vector: Vec<f32>) -> ProximaRecord {
+    let mut rec = ProximaRecord {
+        oid: oid.to_string(),
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "test".to_string(),
+            modality: "dense_vector".to_string(),
+            dim: DIM,
+            values: EmbeddingValues::Fp32(vector),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    rec.props.insert(
+        "dept".to_string(),
+        ProximaTreeNode::Value(ProximaValue::String(dept.to_string())),
+    );
+    rec
+}
+
+/// An admitted subject sees only `dept=eng` records — the `hr` record, though
+/// nearest to the query, is filtered out by the pushed-down security predicate.
+#[tokio::test]
+async fn admitted_subject_sees_only_accessible_records() {
+    let env = UnifiedTestEnvironment::new().await.expect("test env");
+    let enforcer = enforcer_for_alice();
+    let (svc, collections) = env
+        .vector_operations_service_with_abac(enforcer.clone())
+        .await
+        .expect("vector service with abac");
+    UnifiedTestEnvironment::create_vector_collection(&collections, COLLECTION, DIM)
+        .await
+        .expect("create collection");
+
+    // Both records sit nearest the query; without ABAC both would be returned.
+    svc.insert_vectors_direct(
+        COLLECTION,
+        Arc::new(vec![
+            record(OID_ENG, "eng", vec![1.0, 0.0, 0.0, 0.0]),
+            record(OID_HR, "hr", vec![0.99, 0.01, 0.0, 0.0]),
+        ]),
+    )
+    .await
+    .expect("insert records");
+
+    // Resolve alice → admitted Client ReadContext (the fusion vector-leg seam).
+    let ctx = enforcer
+        .resolve_read_context(
+            &SubjectId("alice".into()),
+            TENANT,
+            Target {
+                namespace: NAMESPACE,
+                table: TABLE,
+                column: None,
+            },
+        )
+        .expect("alice is admitted");
+    let read_ctx = ReadContext::Client(ctx);
+
+    let results = svc
+        .unified_search_native_with_tenant_context(
+            COLLECTION,
+            vec![1.0, 0.0, 0.0, 0.0],
+            10,
+            None,
+            None,
+            None,
+            &read_ctx,
+        )
+        .await
+        .expect("search");
+
+    let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+    assert!(
+        ids.contains(&OID_ENG),
+        "alice (dept=eng) must see the eng record; got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&OID_HR),
+        "the hr record must be filtered out by the security predicate; got {ids:?}"
+    );
+}
+
+/// A `System` context (trusted-internal / unwired) leaves the search untouched —
+/// both records are returned. Proves enforcement is conditional on a `Client`
+/// context and that normal search is unaffected by the wired enforcer.
+#[tokio::test]
+async fn system_context_does_not_filter() {
+    let env = UnifiedTestEnvironment::new().await.expect("test env");
+    let enforcer = enforcer_for_alice();
+    let (svc, collections) = env
+        .vector_operations_service_with_abac(enforcer)
+        .await
+        .expect("vector service with abac");
+    UnifiedTestEnvironment::create_vector_collection(&collections, COLLECTION, DIM)
+        .await
+        .expect("create collection");
+
+    svc.insert_vectors_direct(
+        COLLECTION,
+        Arc::new(vec![
+            record(OID_ENG, "eng", vec![1.0, 0.0, 0.0, 0.0]),
+            record(OID_HR, "hr", vec![0.99, 0.01, 0.0, 0.0]),
+        ]),
+    )
+    .await
+    .expect("insert records");
+
+    let read_ctx = ReadContext::system(SystemReadReason::Statistics, "abac_system_test");
+    let results = svc
+        .unified_search_native_with_tenant_context(
+            COLLECTION,
+            vec![1.0, 0.0, 0.0, 0.0],
+            10,
+            None,
+            None,
+            None,
+            &read_ctx,
+        )
+        .await
+        .expect("search");
+
+    let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+    assert!(
+        ids.contains(&OID_ENG) && ids.contains(&OID_HR),
+        "a System context must not filter — both records expected; got {ids:?}"
+    );
+}

--- a/tests/common/integration_test_helpers.rs
+++ b/tests/common/integration_test_helpers.rs
@@ -202,6 +202,44 @@ impl UnifiedTestEnvironment {
         Ok((vector_ops, collection_service))
     }
 
+    /// FA-2 (abac-policy): like [`vector_operations_service`] but wires a vector
+    /// ABAC enforcer into the service so `unified_search_native` enforces the
+    /// subject's accessibility predicate on the real search path. For
+    /// integration tests that prove enforcement fires end-to-end.
+    #[cfg(feature = "abac-policy")]
+    pub async fn vector_operations_service_with_abac(
+        &self,
+        enforcer: Arc<proximadb::security::rls::AbacEnforcer>,
+    ) -> Result<(Arc<VectorOperationsService>, Arc<CollectionService>)> {
+        let metadata_url = format!("file://{}", self.persistent_dir.join("metadata").display());
+        let sst_engine = Arc::new(SstEngine::new().await?);
+        let wal_manager = Arc::new(WriteAheadLogManager::new(WALConfig::default()).await?);
+        let axis_manager = Arc::new(AxisManager::new(AxisConfig::default()).await?);
+        let catalog_manager = Arc::new(CatalogManager::new());
+        catalog_manager
+            .create_native_catalog("default", &metadata_url)
+            .await?;
+        let storage_config = StorageConfig {
+            metadata_url,
+            ..Default::default()
+        };
+        let collection_service = Arc::new(
+            CollectionService::new(storage_config)
+                .await?
+                .with_catalog_manager(catalog_manager),
+        );
+        let vector_ops = Arc::new(
+            VectorOperationsService::new(
+                sst_engine,
+                wal_manager,
+                axis_manager,
+                collection_service.clone() as Arc<dyn CollectionPort>,
+            )
+            .with_abac_enforcer(enforcer),
+        );
+        Ok((vector_ops, collection_service))
+    }
+
     /// Create a dense vector collection on the given `CollectionService`
     /// (cosine / SST), for use with the `vector_operations_service()` stack.
     pub async fn create_vector_collection(


### PR DESCRIPTION
## Summary

PR-D1 (#1346) added the vector ABAC substrate — the enforcer field/builder and `apply_abac_vector_filter` — but left it **inert**: the enforcer was never wired in production, and no caller could resolve a subject into the `Client` `ReadContext` the search kernel consumes. This PR completes the activation foundation and **proves enforcement fires end-to-end**.

## Changes

- **Composition** (`shared_services.rs`): `SharedServices` wires the durable ABAC enforcer into `VectorOperationsService` (`.with_abac_enforcer`), mirroring the `DmlService` pattern. `unified_search_native` now enforces when fed a `Client` context. Default-OFF (`abac-policy`); default builds unchanged.
- **`AbacEnforcer::resolve_read_context`** (`abac_adapter.rs`): the boundary resolver (admit → ctx, deny → `Err`) for the vector push-down path, mirroring `predicate_for`'s binding-store selection. The caller fail-closes on `Err` (→ empty) and must not collapse it to `None` (that would be a fail-open hole).
- **Integration test** (`abac_vector_pushdown_integration_test.rs`): on the fusion vector-leg seam (`unified_search_native_with_tenant_context`), an admitted subject (`dept=eng`) sees only the `eng` record — the `hr` record is excluded by the pushed-down security predicate; a `System` context leaves the search untouched. Plus unit tests for `resolve_read_context` admit/deny.

## Verification (local, abac-policy + default)

- `cargo clippy -p proximadb --features abac-policy --lib -- -D warnings` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo nextest run -p proximadb --features abac-policy --lib` — `resolve_read_context` admit/deny ✅
- `cargo nextest run -p proximadb --features abac-policy --test abac_vector_pushdown_integration_test` — **enforcement fires** (admitted→accessible only; System→unfiltered) ✅
- `cargo fmt --check` ✅
- `make work-commit-check` (panic delta +0, tenant-path, env-gate, hygiene, layering) ✅

## Scope / follow-up (PR-D3)

Production **handler wiring** — constructing the `Client` `ReadContext` from live REST/gRPC fusion requests — is the follow-up. Tracing the live paths showed it is sizable and separable from this activation core:
- the gRPC plain-search v1 chain diverges to `execute_unified_plan` and does **not** currently route through `unified_search_native` (the enforcement kernel);
- `tenant_stable_id` is absent on the service-layer `TenantContext` (only `MiddlewareTenantContext` carries it; gRPC `GrpcAuthContext` would need a new field);
- `stable_namespace_id` is not on the proto `Collection`/`CollectionPort` — only on `CatalogTableSchema` (via `CatalogManager::resolve_table_scoped`).

The enforcement core proven here is the foundation all of that handler wiring feeds into.