### PR TITLE
feat(flight): converge Arrow Flight vector search on canonical v2 (TD-FLIGHT-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7691,6 +7691,7 @@ dependencies = [
  "proximadb-kernel",
  "proximadb-proto",
  "proximadb-records",
+ "proximadb-search-types",
  "proximadb-tenant",
  "regex",
  "reqwest 0.11.27",

--- a/clients/python/src/proximadb_sdk/protocols/arrow_flight.py
+++ b/clients/python/src/proximadb_sdk/protocols/arrow_flight.py
@@ -705,9 +705,7 @@ class ArrowFlightClient:
                         else []
                     ),
                     score=(
-                        batch.column("score")[i].as_py()
-                        if "score" in names
-                        else 0.0
+                        batch.column("score")[i].as_py() if "score" in names else 0.0
                     ),
                     metadata=metadata,
                 )

--- a/clients/python/src/proximadb_sdk/protocols/arrow_flight.py
+++ b/clients/python/src/proximadb_sdk/protocols/arrow_flight.py
@@ -654,14 +654,27 @@ class ArrowFlightClient:
         """
         client = self._get_client()
 
-        # Create search request as Ticket
+        # Canonical v2 Flight search ticket (TD-FLIGHT-1): self-describing JSON
+        # discriminated by "type":"vector_search". The legacy v1 ticket keys
+        # ("query"/"filter"/"include_vectors") never matched the server's v1
+        # VectorSearchRequest shape, so the query vector was silently dropped;
+        # this ticket carries the fields the canonical RichSearchRequest needs.
+        filters = (
+            [
+                {"field": field, "op": "eq", "value": value}
+                for field, value in filter_metadata.items()
+            ]
+            if filter_metadata
+            else []
+        )
         ticket_data = json.dumps(
             {
+                "type": "vector_search",
                 "collection_id": collection_id,
-                "query": query_vector,
+                "query_vector": query_vector,
                 "top_k": top_k,
-                "filter": filter_metadata,
-                "include_vectors": include_vectors,
+                "filters": filters,
+                "include_vector": include_vectors,
             }
         ).encode()
 
@@ -670,20 +683,33 @@ class ArrowFlightClient:
         # Execute search
         reader = client.do_get(ticket, options=self._get_call_options())
 
-        # Read results
+        # Read results. The v2 response carries a `properties` column (the full
+        # props map serialized as one JSON object per row) rather than the
+        # legacy lossy single-key `metadata` struct.
         results = []
         for chunk in reader:
             batch = chunk.data
+            names = batch.schema.names
             for i in range(batch.num_rows):
+                props_raw = (
+                    batch.column("properties")[i].as_py()
+                    if "properties" in names
+                    else None
+                )
+                metadata = json.loads(props_raw) if props_raw else {}
                 result = FlightSearchResult(
                     id=batch.column("id")[i].as_py(),
-                    vector=batch.column("vector")[i].as_py() if include_vectors else [],
+                    vector=(
+                        batch.column("vector")[i].as_py()
+                        if include_vectors and "vector" in names
+                        else []
+                    ),
                     score=(
                         batch.column("score")[i].as_py()
-                        if "score" in batch.schema.names
+                        if "score" in names
                         else 0.0
                     ),
-                    metadata={},
+                    metadata=metadata,
                 )
                 results.append(result)
 

--- a/clients/python/tests/unit/test_arrow_flight_cov.py
+++ b/clients/python/tests/unit/test_arrow_flight_cov.py
@@ -525,8 +525,28 @@ def test_search(monkeypatch):
     assert results[0].id == "r1"
     assert results[0].score == pytest.approx(0.9)
     assert results[0].vector == []
+    # TD-FLIGHT-1: the ticket is the canonical v2 shape (type:"vector_search"
+    # + query_vector), not the legacy v1 keys the server mis-parsed.
     ticket = fake.calls[0][1]
     assert b"col" in ticket.ticket
+    assert b"vector_search" in ticket.ticket
+    assert b"query_vector" in ticket.ticket
+
+
+def test_search_reads_properties(monkeypatch):
+    """The v2 response's `properties` column (full props map as JSON) is decoded
+    into the result metadata (TD-FLIGHT-1)."""
+    import json as _json
+
+    cols = {
+        "id": pa.array(["r1"]),
+        "score": pa.array([0.9], type=pa.float32()),
+        "properties": pa.array([_json.dumps({"category": "books", "year": 2024})]),
+    }
+    c, fake = make_client(monkeypatch)
+    fake.search_chunks = [FakeSearchChunk(pa.record_batch(cols))]
+    results = c.search("col", [0.1, 0.2], top_k=1)
+    assert results[0].metadata == {"category": "books", "year": 2024}
 
 
 def test_search_include_vectors(monkeypatch):

--- a/crates/foundation/proximadb-search-types/src/lib.rs
+++ b/crates/foundation/proximadb-search-types/src/lib.rs
@@ -18,6 +18,9 @@ pub mod bounded_queue;
 pub mod compiled_filter;
 pub mod json_comparison;
 pub mod json_value_serde;
+pub mod predicate_shortfall;
 pub mod results;
 pub mod search_params;
 pub mod sql_value_filter;
+
+pub use predicate_shortfall::PredicateShortfall;

--- a/crates/foundation/proximadb-search-types/src/predicate_shortfall.rs
+++ b/crates/foundation/proximadb-search-types/src/predicate_shortfall.rs
@@ -1,0 +1,30 @@
+//! Predicate-shortfall diagnostic (TD-064).
+//!
+//! Lives in the foundation `search-types` crate so that transport-neutral
+//! search DTOs (e.g. `proximadb_runtime::rich_search::RichSearchResponse`) can
+//! reference it without an upward dependency on the modality-tier
+//! observability engine. The observability engine re-exports it from its
+//! historical `search_plan_trace` module path so existing callers keep
+//! compiling.
+
+use serde::{Deserialize, Serialize};
+
+/// TD-064: Diagnostic block describing a predicate-aware recall shortfall.
+///
+/// Emitted when ANN returned a candidate pool, the metadata filter trimmed
+/// it, and the survivor count is below `requested_k`. Clients should treat
+/// this as a correctness signal — either re-issue with `PreFilter` mode,
+/// widen the filter, or accept the disclosed shortfall.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PredicateShortfall {
+    /// The `top_k` value the caller asked for.
+    pub requested_k: u32,
+    /// The number of results actually returned after predicate filtering.
+    pub returned_k: u32,
+    /// Pool size considered before the predicate (oversample budget).
+    pub oversample_pool: u32,
+    /// AnnFilteringMode that produced this shortfall (`post_filter`,
+    /// `inline`, or `pre_filter`). Free-form string so callers can encode
+    /// catalog `AnnFilteringMode` variants without coupling.
+    pub ann_filtering_mode: String,
+}

--- a/crates/modalities/proximadb-observability-engine/Cargo.toml
+++ b/crates/modalities/proximadb-observability-engine/Cargo.toml
@@ -61,6 +61,10 @@ proximadb-data-model.workspace = true
 proximadb-kernel.workspace = true
 proximadb-records.workspace = true
 proximadb-tenant.workspace = true
+# Foundation: owns `PredicateShortfall`, which the search-plan-trace module
+# re-exports (TD-FLIGHT-1 relocated the definition here so transport-neutral
+# search DTOs can reference it without a modality-tier dependency).
+proximadb-search-types.workspace = true
 # Optional, feature-gated (otlp-metering) — the OTLP metering *export* surface.
 # Same specs as the root crate's optional deps.
 opentelemetry = { version = "0.32", optional = true }

--- a/crates/modalities/proximadb-observability-engine/src/search_plan_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/search_plan_trace.rs
@@ -225,23 +225,11 @@ pub struct SearchPlanTrace {
 
 /// TD-064: Diagnostic block describing a predicate-aware recall shortfall.
 ///
-/// Emitted when ANN returned a candidate pool, the metadata filter trimmed
-/// it, and the survivor count is below `requested_k`. Clients should treat
-/// this as a correctness signal — either re-issue with `PreFilter` mode,
-/// widen the filter, or accept the disclosed shortfall.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PredicateShortfall {
-    /// The `top_k` value the caller asked for.
-    pub requested_k: u32,
-    /// The number of results actually returned after predicate filtering.
-    pub returned_k: u32,
-    /// Pool size considered before the predicate (oversample budget).
-    pub oversample_pool: u32,
-    /// AnnFilteringMode that produced this shortfall (`post_filter`,
-    /// `inline`, or `pre_filter`). Free-form string so callers can encode
-    /// catalog `AnnFilteringMode` variants without coupling.
-    pub ann_filtering_mode: String,
-}
+/// The *definition* was relocated to the foundation `proximadb-search-types`
+/// crate (TD-FLIGHT-1) so transport-neutral search DTOs can reference it
+/// without a modality-tier dependency. It is re-exported here to preserve the
+/// historical `search_plan_trace::PredicateShortfall` path.
+pub use proximadb_search_types::PredicateShortfall;
 
 impl SearchPlanTrace {
     /// Construct a Phase 0 trace with sensible defaults — meant to be filled

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub mod record_ops_port;
 pub mod record_route_port;
 pub mod resources;
 pub mod rich_record;
+pub mod rich_search;
 pub mod security_port;
 pub mod service_ports;
 pub mod streaming_port;
@@ -46,6 +47,9 @@ pub use record_ops_port::RecordOpsPort;
 pub use record_route_port::{PaxColumnDesc, PaxScanInputs, RecordRoutePort};
 pub use resources::{MemoryBudget, ResourceManager};
 pub use rich_record::{RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest};
+pub use rich_search::{
+    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse, RichSearchResult,
+};
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
 pub use service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};
 pub use streaming_port::StreamingPort;

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -19,6 +19,7 @@ pub mod port;
 pub mod proto_defaults;
 pub mod record_ops_port;
 pub mod record_route_port;
+pub mod record_search_port;
 pub mod resources;
 pub mod rich_record;
 pub mod rich_search;
@@ -44,6 +45,7 @@ pub use port::{
     CollectionSchemaUpdate, CollectionTextStorage,
 };
 pub use record_ops_port::RecordOpsPort;
+pub use record_search_port::RecordSearchPort;
 pub use record_route_port::{PaxColumnDesc, PaxScanInputs, RecordRoutePort};
 pub use resources::{MemoryBudget, ResourceManager};
 pub use rich_record::{RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest};

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -45,12 +45,13 @@ pub use port::{
     CollectionSchemaUpdate, CollectionTextStorage,
 };
 pub use record_ops_port::RecordOpsPort;
-pub use record_search_port::RecordSearchPort;
 pub use record_route_port::{PaxColumnDesc, PaxScanInputs, RecordRoutePort};
+pub use record_search_port::RecordSearchPort;
 pub use resources::{MemoryBudget, ResourceManager};
 pub use rich_record::{RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest};
 pub use rich_search::{
-    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse, RichSearchResult,
+    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse,
+    RichSearchResult,
 };
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
 pub use service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};

--- a/crates/platform/proximadb-runtime/src/record_search_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_search_port.rs
@@ -1,0 +1,29 @@
+//! Canonical v2 record/vector-search read port (TD-FLIGHT-1).
+//!
+//! The Arrow Flight search paths (`do_get` single-query and `do_exchange`
+//! `bulk_search`) consume canonical v2 search so they no longer run the
+//! deprecated v1 contract. This port lets the Flight service depend on the
+//! contract instead of a concrete root-crate service — the same seam the
+//! write path already uses via [`crate::RecordOpsPort`].
+//!
+//! Implemented by the root crate's `RecordOpsService`
+//! (`src/api_handlers/record_ops_service.rs`), which delegates to its
+//! `handle_record_search_for_tenant` — the single canonical search authority
+//! also called by REST v2 and gRPC v2. It owns typed-filter lowering, WAL
+//! delta-merge, MVCC/tombstone filtering, Strong-freshness cache behavior,
+//! and the tenant-collection-access check; no durable authority lives here.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::rich_search::{RichSearchRequest, RichSearchResponse};
+
+#[async_trait]
+pub trait RecordSearchPort: Send + Sync {
+    /// Run a canonical v2 search for `request.collection_id` under `tenant_id`.
+    async fn search_record(
+        &self,
+        request: RichSearchRequest,
+        tenant_id: Option<&str>,
+    ) -> Result<RichSearchResponse>;
+}

--- a/crates/platform/proximadb-runtime/src/rich_search.rs
+++ b/crates/platform/proximadb-runtime/src/rich_search.rs
@@ -1,0 +1,76 @@
+//! Canonical transport-neutral search DTOs for v2 and internal callers.
+//!
+//! These are the search-side companions to [`crate::rich_record`] (the write
+//! DTOs). They live in the platform `proximadb-runtime` crate so that a
+//! transport-neutral read port (`RecordSearchPort`) has a self-contained
+//! contract — without forcing adapters (Arrow Flight, REST, gRPC) to import
+//! root-internal module paths. The root `services::operations::vectors::legacy`
+//! module re-exports them so existing callers compile unchanged (mirrors the
+//! TD-104 `rich_record` relocation).
+
+use std::collections::HashMap;
+
+use proximadb_data_model::ProximaValue;
+use proximadb_search_types::PredicateShortfall;
+
+/// Canonical rich search request for v2 and internal callers.
+#[derive(Debug, Clone)]
+pub struct RichSearchRequest {
+    pub collection_id: String,
+    pub query_vector: Vec<f32>,
+    pub top_k: u32,
+    pub filters: Vec<RichFilterCondition>,
+}
+
+/// Canonical rich search response for v2 and internal callers.
+#[derive(Debug, Clone, Default)]
+pub struct RichSearchResponse {
+    pub results: Vec<RichSearchResult>,
+    pub total_found: i64,
+    pub collection_id: Option<String>,
+    /// TD-064(a): predicate-aware shortfall — `Some(...)` when a filtered
+    /// search returned fewer than the requested `top_k` after the
+    /// WAL+AXIS+storage merge. First-class and always-on (NOT debug-gated):
+    /// a silent `<top_k` under a tenant/RLS filter is fail-open, so the
+    /// client must be able to tell "fewer than k match my filter" from "the
+    /// engine returned my full top-k". Recomputed authoritatively against
+    /// the final merged result so an AXIS-stage false positive is cleared.
+    pub predicate_shortfall: Option<PredicateShortfall>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RichSearchResult {
+    pub id: String,
+    pub score: f64,
+    pub similarity: Option<f32>,
+    pub vector: Vec<f32>,
+    pub props: HashMap<String, ProximaValue>,
+    pub version: Option<u32>,
+    pub timestamp: Option<i64>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RichFilterCondition {
+    pub field: String,
+    pub operator: RichFilterOperator,
+    pub value: ProximaValue,
+    pub value_upper: Option<ProximaValue>,
+    pub value_list: Vec<ProximaValue>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RichFilterOperator {
+    Eq,
+    Ne,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    Between,
+    In,
+    NotIn,
+    Contains,
+    StartsWith,
+    EndsWith,
+}

--- a/docs/10-quality/td/TD-FLIGHT-1-arrow-flight-canonical-v2-search.adoc
+++ b/docs/10-quality/td/TD-FLIGHT-1-arrow-flight-canonical-v2-search.adoc
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FLIGHT-1: Arrow Flight routes search through the canonical v2 RecordSearchPort
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Resolved.** Implemented 2026-07-31 on `feat/flight-v2-vector-search`.
+| Priority | **P1** — Flight search silently ran the deprecated v1 contract while REST/gRPC ran v2, producing drift (lossy props, weaker tenant isolation, hard-coded bulk_search behavior).
+| Component | `src/network/arrow_ipc/service.rs` (DoGet + `bulk_search` DoExchange); `src/network/arrow_ipc/codec.rs` (`FlightSearchTicket`, `rich_search_results_to_batch`); `crates/platform/proximadb-runtime/src/{rich_search,record_search_port}.rs`; `src/api_handlers/record_ops_service.rs`.
+| Evidence | `handle_vector_search` called `ApiHandlersPort::handle_vector_search_v1_for_tenant`; `search_results_to_batch` emitted only the first metadata key per row; `handle_bulk_search_exchange` hard-coded `top_k:10`/empty filters and swallowed per-query errors; the DoGet ticket was a JSON v1 `VectorSearchRequest` whose key shape (`queries`/`include_fields`) never matched the Python SDK client (`query`/`include_vectors`), so the query vector was silently dropped. `RecordOpsPort` had no search method and the v2 DTOs were stuck in a root-internal module.
+|===
+
+== The finding
+
+Arrow Flight vector search — both the single-query `DoGet` path and the batched
+`bulk_search` `DoExchange` — ran the deprecated v1 search contract
+(`ApiHandlersPort::handle_vector_search_v1_for_tenant`) while REST v2 and gRPC v2
+ran the canonical `RecordOpsService::handle_record_search_for_tenant`. The two
+paths diverged:
+
+1. **Lossy results.** The Flight encoder `search_results_to_batch` collapsed each
+   row's props to a single key/value pair (`metadata.iter().next()`); multi-key
+   props were dropped.
+2. **Weaker isolation / correctness.** The v1 path lacks the v2
+   `validate_tenant_collection_access` check and the canonical dead-record
+   (tombstone/TTL) predicate that REST/gRPC inherit.
+3. **Broken bulk_search.** `handle_bulk_search_exchange` hard-coded `top_k:10`
+   with empty filters and swallowed per-query errors (`continue`).
+4. **Already-broken ticket.** The DoGet ticket was a JSON v1
+   `VectorSearchRequest`; the only client that built it (the Python SDK) used
+   mismatched keys, so the query vector was silently dropped — Flight search was
+   effectively non-functional for real queries.
+
+The structural blocker: Flight held `record_port: Arc<dyn RecordOpsPort>` (write
+only — no search method), and the transport-neutral v2 search DTOs lived in a
+root-internal module, so Flight could not cleanly call v2 search.
+
+== Direction (implemented)
+
+Converge Flight on the same canonical search authority as REST/gRPC via a stable
+read port, mirroring the established TD-104 `rich_record` relocation:
+
+1. **Relocate `PredicateShortfall`** to the foundation `proximadb-search-types`
+   crate (it is a field type of `RichSearchResponse`; re-exported from its
+   historical `search_plan_trace` path so all callers compile unchanged).
+2. **Relocate the 5 search DTOs** (`RichSearchRequest/Response/Result`,
+   `RichFilterCondition/Operator`) to `proximadb-runtime::rich_search` behind a
+   `pub use` shim in `legacy.rs` — zero consumer import changes.
+3. **Add `RecordSearchPort`** (dedicated read port, separate from the
+   write-oriented `RecordOpsPort`); `RecordOpsService` implements it by
+   delegating to `handle_record_search_for_tenant`.
+4. **Canonical v2 Flight ticket** (`FlightSearchTicket`, discriminated by
+   `"type":"vector_search"`) with a `to_rich_request()` translator lowering all
+   `RichFilterOperator` variants. Clean break — the v1 fallback is removed;
+   unknown tickets return `InvalidArgument`.
+5. **Full-fidelity encoder** `rich_search_results_to_batch` preserving the entire
+   props map as a JSON `properties` column (round-trips via `metadata_props`),
+   plus typed id/score/vector/timestamp/version/source columns.
+6. **io_trace boundary** (`route = arrow_flight.v2.records.search`) mirroring
+   REST v2 so object GETs/bytes stay attributable per query. Flight passes
+   `None` for the tenant stable id (no `TenantStableIdResolver` exists yet).
+7. **bulk_search** routes through the same path, preserves input order, makes
+   top_k/filters/include_vector configurable via an optional JSON control frame,
+   and surfaces per-query errors as frames instead of dropping them.
+
+The same concrete `Arc<RecordOpsService>` backs both the write port and the
+search port (it implements both), so boot wiring just clones the Arc twice.
+
+== Verification
+
+- `tests/flight_v2_search_e2e.rs`: Flight `DoGet` with the v2 ticket returns the
+  same ordered ids as REST v2 for one collection/query/top_k (deterministic
+  distinct-cosine vectors); an unrecognized ticket is rejected.
+- `src/network/arrow_ipc/codec.rs` unit tests: ticket discriminator (accepts v2,
+  rejects file/v1), `to_rich_request` (all operators + unsupported-operator
+  rejection), `rich_search_results_to_batch` (empty / full-props / vector-nullable).
+
+== Follow-ups (not in this PR)
+
+- **Benchmark** (handoff §"Benchmark acceptance"): the immutable-bed Flight-vs-REST
+  measurement (GETs/recall/p50-p95/wire bytes) is a separate release-build
+  activity; the expected invariant is GETs/query and recall are
+  transport-independent (Flight only saves serialization/copy overhead).
+- **Remove the dead `api_port`** field from `ProximaFlightService` (+ constructor
+  / boot-wiring cascade). The v1 method stays on `ApiHandlersPort` — REST's
+  `/progressive/search` route still uses it.
+- **bulk_search DoExchange e2e** (the query-vector Arrow-batch encode is
+  involved; the path reuses the DoGet-tested `handle_v2_search`).
+- Wire a real `TenantStableIdResolver` so Flight's io_trace records carry a
+  non-null stable id.

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -924,6 +924,23 @@ impl proximadb_runtime::RecordOpsPort for RecordOpsService {
     }
 }
 
+// TD-FLIGHT-1: canonical v2 search read port. The Arrow Flight search surfaces
+// (do_get + do_exchange bulk_search) consume this instead of the deprecated v1
+// `ApiHandlersPort::handle_vector_search_v1_for_tenant`, so they inherit the
+// same typed-filter, WAL delta-merge, MVCC/tombstone, Strong-freshness, and
+// tenant-collection-access behavior REST v2 / gRPC v2 get. Pure delegation to
+// the single canonical search authority.
+#[async_trait::async_trait]
+impl proximadb_runtime::RecordSearchPort for RecordOpsService {
+    async fn search_record(
+        &self,
+        request: RichSearchRequest,
+        tenant_id: Option<&str>,
+    ) -> Result<RichSearchResponse> {
+        self.handle_record_search_for_tenant(request, tenant_id).await
+    }
+}
+
 // ADR-009 convergence: the document facade's canonical branch routes here so a
 // document written via gRPC/DocumentService lands in the same tenant-scoped record
 // store REST v2 already uses — closing the store-split. Writes upsert (a re-inserted

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -937,7 +937,8 @@ impl proximadb_runtime::RecordSearchPort for RecordOpsService {
         request: RichSearchRequest,
         tenant_id: Option<&str>,
     ) -> Result<RichSearchResponse> {
-        self.handle_record_search_for_tenant(request, tenant_id).await
+        self.handle_record_search_for_tenant(request, tenant_id)
+            .await
     }
 }
 

--- a/src/network/arrow_ipc/codec.rs
+++ b/src/network/arrow_ipc/codec.rs
@@ -1578,22 +1578,24 @@ mod tests {
         let batch =
             ArrowProtoCodec::rich_search_results_to_batch(&[], false).expect("empty encodes");
         assert_eq!(batch.num_rows(), 0);
-        let names: Vec<&str> = batch
+        // The canonical v2 schema (7 typed columns), including the new
+        // full-fidelity `properties` column.
+        let field_names: Vec<String> = batch
             .schema()
             .fields()
             .iter()
-            .map(|f| f.name().as_str())
+            .map(|f| f.name().to_string())
             .collect();
         assert_eq!(
-            names,
+            field_names,
             vec![
-                "id",
-                "score",
-                "vector",
-                "properties",
-                "timestamp",
-                "version",
-                "source"
+                "id".to_string(),
+                "score".to_string(),
+                "vector".to_string(),
+                "properties".to_string(),
+                "timestamp".to_string(),
+                "version".to_string(),
+                "source".to_string(),
             ]
         );
     }

--- a/src/network/arrow_ipc/codec.rs
+++ b/src/network/arrow_ipc/codec.rs
@@ -220,7 +220,11 @@ fn flight_filter_to_rich(filter: &FlightFilter) -> Result<RichFilterCondition> {
     };
     let value = json_value_to_proxima(&filter.value);
     let value_upper = filter.value_upper.as_ref().map(json_value_to_proxima);
-    let value_list = filter.value_list.iter().map(json_value_to_proxima).collect();
+    let value_list = filter
+        .value_list
+        .iter()
+        .map(json_value_to_proxima)
+        .collect();
     Ok(RichFilterCondition {
         field: filter.field.clone(),
         operator,
@@ -1120,8 +1124,12 @@ impl ArrowProtoCodec {
         ]));
 
         let id_array = StringArray::from_iter_values(results.iter().map(|r| r.id.as_str()));
-        let score_array =
-            Float32Array::from(results.iter().map(|r| Some(r.score as f32)).collect::<Vec<_>>());
+        let score_array = Float32Array::from(
+            results
+                .iter()
+                .map(|r| Some(r.score as f32))
+                .collect::<Vec<_>>(),
+        );
 
         // Vector column: per-row validity, reserving `dimension` slots per row
         // even when the row carries no vector (keeps the child buffer length at
@@ -1162,8 +1170,12 @@ impl ArrowProtoCodec {
             Int64Array::from(results.iter().map(|r| r.timestamp).collect::<Vec<_>>());
         let version_array =
             UInt32Array::from(results.iter().map(|r| r.version).collect::<Vec<_>>());
-        let source_array =
-            StringArray::from(results.iter().map(|r| r.source.as_deref()).collect::<Vec<_>>());
+        let source_array = StringArray::from(
+            results
+                .iter()
+                .map(|r| r.source.as_deref())
+                .collect::<Vec<_>>(),
+        );
 
         RecordBatch::try_new(
             schema,
@@ -1566,10 +1578,23 @@ mod tests {
         let batch =
             ArrowProtoCodec::rich_search_results_to_batch(&[], false).expect("empty encodes");
         assert_eq!(batch.num_rows(), 0);
-        let names: Vec<&str> = batch.schema().fields().iter().map(|f| f.name().as_str()).collect();
+        let names: Vec<&str> = batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
         assert_eq!(
             names,
-            vec!["id", "score", "vector", "properties", "timestamp", "version", "source"]
+            vec![
+                "id",
+                "score",
+                "vector",
+                "properties",
+                "timestamp",
+                "version",
+                "source"
+            ]
         );
     }
 
@@ -1580,8 +1605,7 @@ mod tests {
             ("year", ProximaValue::Int64(2024)),
         ];
         let results = vec![mk_result("r1", 0.91, props)];
-        let batch =
-            ArrowProtoCodec::rich_search_results_to_batch(&results, false).expect("encode");
+        let batch = ArrowProtoCodec::rich_search_results_to_batch(&results, false).expect("encode");
         assert_eq!(batch.num_rows(), 1);
         let props_col = batch.column_by_name("properties").expect("properties col");
         let sa = props_col
@@ -1600,8 +1624,7 @@ mod tests {
         let mut r1 = mk_result("r1", 1.0, vec![]);
         r1.vector = vec![0.1, 0.2, 0.3];
         let r2 = mk_result("r2", 0.5, vec![]);
-        let batch =
-            ArrowProtoCodec::rich_search_results_to_batch(&[r1, r2], true).expect("encode");
+        let batch = ArrowProtoCodec::rich_search_results_to_batch(&[r1, r2], true).expect("encode");
         let vcol = batch.column_by_name("vector").expect("vector col");
         assert_eq!(vcol.null_count(), 1, "second row has no vector => null");
         assert!(!vcol.is_null(0));

--- a/src/network/arrow_ipc/codec.rs
+++ b/src/network/arrow_ipc/codec.rs
@@ -23,6 +23,9 @@ use arrow_schema::{DataType, Field, Fields, Schema, TimeUnit as ArrowTimeUnit};
 use proximadb_data_model::{ProximaValue, TimeUnit};
 use proximadb_records::conversions::json_to_proxima;
 use proximadb_records::{EdgeShape, EmbeddingCell, ProximaRecord, ProximaTreeNode};
+use proximadb_runtime::rich_search::{
+    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResult,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -112,6 +115,129 @@ pub struct FlightRequestMetadata {
 ///
 /// Reuses existing conversion functions from arrow_ipc_scanner.rs
 pub struct ArrowProtoCodec;
+
+/// Canonical v2 vector-search ticket for Arrow Flight `DoGet` (TD-FLIGHT-1).
+///
+/// The pre-TD-FLIGHT-1 ticket was a JSON-serialized v1 `VectorSearchRequest`
+/// proto, whose key shape (`queries`/`include_fields`) never matched the only
+/// client that built it (the Python SDK sent `query`/`include_vectors`) — so the
+/// query vector was silently dropped and Flight search returned garbage. This is
+/// the clean canonical v2 contract: a self-describing JSON object discriminated
+/// by `"type": "vector_search"`, carrying exactly what the canonical
+/// `RichSearchRequest` needs. `do_get` routes it ahead of the removed v1
+/// fallback, and `bulk_search` builds one per query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlightSearchTicket {
+    /// Discriminator — must be the literal `"vector_search"`.
+    #[serde(rename = "type")]
+    pub ticket_type: String,
+    /// Collection name or stable catalog id (resolved by the canonical service).
+    pub collection_id: String,
+    /// Query vector.
+    pub query_vector: Vec<f32>,
+    /// Top-k (defaults to 10 when absent on the wire).
+    #[serde(default = "default_top_k")]
+    pub top_k: u32,
+    /// Typed metadata filters (defaults to none).
+    #[serde(default)]
+    pub filters: Vec<FlightFilter>,
+    /// Whether to include result vectors in the response (defaults to false).
+    #[serde(default)]
+    pub include_vector: bool,
+}
+
+fn default_top_k() -> u32 {
+    10
+}
+
+/// A single typed filter on the v2 Flight ticket — mirrors
+/// `RichFilterCondition` but with JSON-deserializable values (the ticket is a
+/// serde JSON blob, not a typed struct on the client side).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlightFilter {
+    /// Field path / attribute name.
+    pub field: String,
+    /// Operator: eq, ne, gt, gte, lt, lte, between, in, not_in, contains,
+    /// starts_with, ends_with.
+    pub op: String,
+    #[serde(default)]
+    pub value: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_upper: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub value_list: Vec<serde_json::Value>,
+}
+
+impl FlightSearchTicket {
+    /// Parse the ticket only if it carries the v2 discriminator. Returns
+    /// `None` for any other ticket shape (file/graph tickets, or the removed
+    /// v1 VectorSearchRequest JSON) so `do_get` can fall through cleanly.
+    pub fn from_ticket(ticket: &Ticket) -> Option<Self> {
+        let parsed = serde_json::from_slice::<serde_json::Value>(&ticket.ticket).ok()?;
+        let is_v2 = parsed
+            .get("type")
+            .and_then(|v| v.as_str())
+            .is_some_and(|t| t == "vector_search");
+        if !is_v2 {
+            return None;
+        }
+        serde_json::from_value(parsed).ok()
+    }
+
+    /// Translate to the canonical transport-neutral rich request consumed by
+    /// `RecordSearchPort::search_record`. Mirrors the gRPC/REST filter lowering.
+    pub fn to_rich_request(&self) -> Result<RichSearchRequest> {
+        let filters = self
+            .filters
+            .iter()
+            .map(flight_filter_to_rich)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(RichSearchRequest {
+            collection_id: self.collection_id.clone(),
+            query_vector: self.query_vector.clone(),
+            top_k: self.top_k,
+            filters,
+        })
+    }
+}
+
+/// Lower one Flight ticket filter to a canonical `RichFilterCondition`.
+fn flight_filter_to_rich(filter: &FlightFilter) -> Result<RichFilterCondition> {
+    let operator = match filter.op.as_str() {
+        "eq" => RichFilterOperator::Eq,
+        "ne" => RichFilterOperator::Ne,
+        "gt" => RichFilterOperator::Gt,
+        "gte" => RichFilterOperator::Gte,
+        "lt" => RichFilterOperator::Lt,
+        "lte" => RichFilterOperator::Lte,
+        "between" => RichFilterOperator::Between,
+        "in" => RichFilterOperator::In,
+        "not_in" => RichFilterOperator::NotIn,
+        "contains" => RichFilterOperator::Contains,
+        "starts_with" => RichFilterOperator::StartsWith,
+        "ends_with" => RichFilterOperator::EndsWith,
+        other => anyhow::bail!("unsupported Flight filter operator: {other}"),
+    };
+    let value = json_value_to_proxima(&filter.value);
+    let value_upper = filter.value_upper.as_ref().map(json_value_to_proxima);
+    let value_list = filter.value_list.iter().map(json_value_to_proxima).collect();
+    Ok(RichFilterCondition {
+        field: filter.field.clone(),
+        operator,
+        value,
+        value_upper,
+        value_list,
+    })
+}
+
+/// JSON value → ProximaValue, treating JSON null as `ProximaValue::Null`.
+fn json_value_to_proxima(value: &serde_json::Value) -> ProximaValue {
+    if value.is_null() {
+        ProximaValue::Null
+    } else {
+        json_to_proxima(value)
+    }
+}
 
 impl ArrowProtoCodec {
     /// Create standard vector schema for ProximaDB
@@ -946,6 +1072,112 @@ impl ArrowProtoCodec {
             ],
         )
         .context("Failed to create RecordBatch from search results")
+    }
+
+    /// Encode canonical v2 search results (`RichSearchResult`) into a Flight
+    /// `RecordBatch` with full-fidelity props (TD-FLIGHT-1). Replaces the v1
+    /// `search_results_to_batch`, which collapsed each row's props to a single
+    /// key/value pair.
+    ///
+    /// Schema (the canonical v2 Flight search response contract):
+    /// - `id` Utf8 (non-null)
+    /// - `score` Float32 (nullable)
+    /// - `vector` nullable `FixedSizeList<Float32>` — null per row when the
+    ///   request set `include_vector=false`; the child buffer still reserves
+    ///   `dimension` slots per row (same constraint as `search_results_to_batch`)
+    /// - `properties` nullable Utf8 — the FULL `props` map serialized as one
+    ///   JSON object per row; round-trips losslessly via `metadata_props`' JSON
+    ///   branch (codec.rs `metadata_props`)
+    /// - `timestamp` Int64 (nullable), `version` UInt32 (nullable), `source`
+    ///   Utf8 (nullable)
+    ///
+    /// Empty results yield a zero-row batch of this schema (no panic).
+    pub fn rich_search_results_to_batch(
+        results: &[RichSearchResult],
+        include_vector: bool,
+    ) -> Result<RecordBatch> {
+        let dimension = if include_vector {
+            results.iter().map(|r| r.vector.len()).max().unwrap_or(0)
+        } else {
+            0
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("score", DataType::Float32, true),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, false)),
+                    dimension as i32,
+                ),
+                true,
+            ),
+            Field::new("properties", DataType::Utf8, true),
+            Field::new("timestamp", DataType::Int64, true),
+            Field::new("version", DataType::UInt32, true),
+            Field::new("source", DataType::Utf8, true),
+        ]));
+
+        let id_array = StringArray::from_iter_values(results.iter().map(|r| r.id.as_str()));
+        let score_array =
+            Float32Array::from(results.iter().map(|r| Some(r.score as f32)).collect::<Vec<_>>());
+
+        // Vector column: per-row validity, reserving `dimension` slots per row
+        // even when the row carries no vector (keeps the child buffer length at
+        // len*dimension — see `search_results_to_batch` for the same constraint).
+        let mut vector_values = Vec::with_capacity(results.len() * dimension);
+        let mut vector_present = Vec::with_capacity(results.len());
+        for r in results {
+            if include_vector && dimension > 0 && r.vector.len() == dimension {
+                vector_values.extend_from_slice(&r.vector);
+                vector_present.push(true);
+            } else {
+                vector_values.extend(std::iter::repeat_n(0.0f32, dimension));
+                vector_present.push(false);
+            }
+        }
+        let flat_array = Arc::new(Float32Array::from(vector_values)) as ArrayRef;
+        let vector_field = Arc::new(Field::new("item", DataType::Float32, false));
+        let vector_nulls = vector_present
+            .iter()
+            .any(|present| !present)
+            .then(|| arrow_buffer::NullBuffer::from(vector_present));
+        let vector_array =
+            FixedSizeListArray::new(vector_field, dimension as i32, flat_array, vector_nulls);
+
+        let properties_array = StringArray::from(
+            results
+                .iter()
+                .map(|r| {
+                    if r.props.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&r.props).ok()
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
+        let timestamp_array =
+            Int64Array::from(results.iter().map(|r| r.timestamp).collect::<Vec<_>>());
+        let version_array =
+            UInt32Array::from(results.iter().map(|r| r.version).collect::<Vec<_>>());
+        let source_array =
+            StringArray::from(results.iter().map(|r| r.source.as_deref()).collect::<Vec<_>>());
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(id_array),
+                Arc::new(score_array),
+                Arc::new(vector_array),
+                Arc::new(properties_array),
+                Arc::new(timestamp_array),
+                Arc::new(version_array),
+                Arc::new(source_array),
+            ],
+        )
+        .context("Failed to create RecordBatch from v2 search results")
     }
 
     /// Convert SqlValue to string

--- a/src/network/arrow_ipc/codec.rs
+++ b/src/network/arrow_ipc/codec.rs
@@ -1451,6 +1451,163 @@ mod tests {
         assert_eq!(schema.field(1).name(), "vector");
     }
 
+    // ---- TD-FLIGHT-1: canonical v2 ticket + encoder ----
+
+    fn mk_ticket(json: serde_json::Value) -> Ticket {
+        Ticket {
+            ticket: serde_json::to_vec(&json).expect("serialize ticket").into(),
+        }
+    }
+
+    fn mk_result(id: &str, score: f64, props: Vec<(&str, ProximaValue)>) -> RichSearchResult {
+        RichSearchResult {
+            id: id.to_string(),
+            score,
+            similarity: None,
+            vector: vec![],
+            props: props.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+            version: None,
+            timestamp: None,
+            source: None,
+        }
+    }
+
+    #[test]
+    fn test_flight_search_ticket_discriminator() {
+        let v2 = mk_ticket(serde_json::json!({
+            "type": "vector_search",
+            "collection_id": "c1",
+            "query_vector": [0.1, 0.2],
+            "top_k": 5
+        }));
+        let parsed = FlightSearchTicket::from_ticket(&v2).expect("v2 ticket parses");
+        assert_eq!(parsed.collection_id, "c1");
+        assert_eq!(parsed.query_vector, vec![0.1_f32, 0.2]);
+        assert_eq!(parsed.top_k, 5);
+        assert!(!parsed.include_vector);
+        assert!(parsed.filters.is_empty());
+
+        // Non-v2 tickets return None rather than mis-parsing.
+        let file_ticket = mk_ticket(serde_json::json!({
+            "type": "arrow_file", "collection_id": "c1", "file_path": "/x"
+        }));
+        assert!(FlightSearchTicket::from_ticket(&file_ticket).is_none());
+
+        // Old v1 VectorSearchRequest shape (no "type") is rejected.
+        let v1 = mk_ticket(serde_json::json!({
+            "collection_id": "c1", "queries": [], "top_k": 3
+        }));
+        assert!(FlightSearchTicket::from_ticket(&v1).is_none());
+    }
+
+    #[test]
+    fn test_flight_search_ticket_to_rich_request() {
+        let ticket = FlightSearchTicket {
+            ticket_type: "vector_search".to_string(),
+            collection_id: "c1".to_string(),
+            query_vector: vec![1.0, 2.0, 3.0],
+            top_k: 7,
+            filters: vec![
+                FlightFilter {
+                    field: "year".into(),
+                    op: "gte".into(),
+                    value: serde_json::json!(2020),
+                    value_upper: None,
+                    value_list: vec![],
+                },
+                FlightFilter {
+                    field: "tag".into(),
+                    op: "in".into(),
+                    value: serde_json::json!(null),
+                    value_upper: None,
+                    value_list: vec![serde_json::json!("a"), serde_json::json!("b")],
+                },
+                FlightFilter {
+                    field: "price".into(),
+                    op: "between".into(),
+                    value: serde_json::json!(10),
+                    value_upper: Some(serde_json::json!(100)),
+                    value_list: vec![],
+                },
+            ],
+            include_vector: true,
+        };
+        let req = ticket.to_rich_request().expect("translate");
+        assert_eq!(req.collection_id, "c1");
+        assert_eq!(req.top_k, 7);
+        assert_eq!(req.filters.len(), 3);
+        assert_eq!(req.filters[0].operator, RichFilterOperator::Gte);
+        assert_eq!(req.filters[1].operator, RichFilterOperator::In);
+        assert_eq!(req.filters[1].value_list.len(), 2);
+        assert_eq!(req.filters[2].operator, RichFilterOperator::Between);
+        assert!(req.filters[2].value_upper.is_some());
+
+        // Unsupported operator is rejected, not silently coerced.
+        let bad = FlightFilter {
+            field: "x".into(),
+            op: "weird".into(),
+            value: serde_json::json!(1),
+            value_upper: None,
+            value_list: vec![],
+        };
+        let bad_ticket = FlightSearchTicket {
+            ticket_type: "vector_search".into(),
+            collection_id: "c".into(),
+            query_vector: vec![],
+            top_k: 1,
+            filters: vec![bad],
+            include_vector: false,
+        };
+        assert!(bad_ticket.to_rich_request().is_err());
+    }
+
+    #[test]
+    fn test_rich_search_results_to_batch_empty() {
+        let batch =
+            ArrowProtoCodec::rich_search_results_to_batch(&[], false).expect("empty encodes");
+        assert_eq!(batch.num_rows(), 0);
+        let names: Vec<&str> = batch.schema().fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["id", "score", "vector", "properties", "timestamp", "version", "source"]
+        );
+    }
+
+    #[test]
+    fn test_rich_search_results_to_batch_preserves_full_props() {
+        let props = vec![
+            ("category", ProximaValue::String("books".into())),
+            ("year", ProximaValue::Int64(2024)),
+        ];
+        let results = vec![mk_result("r1", 0.91, props)];
+        let batch =
+            ArrowProtoCodec::rich_search_results_to_batch(&results, false).expect("encode");
+        assert_eq!(batch.num_rows(), 1);
+        let props_col = batch.column_by_name("properties").expect("properties col");
+        let sa = props_col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("properties is StringArray");
+        // The full map round-trips as JSON — BOTH keys survive (the v1 encoder
+        // collapsed props to a single key/value, dropping the second).
+        let json: serde_json::Value = serde_json::from_str(sa.value(0)).expect("valid json");
+        assert!(json.get("category").is_some());
+        assert!(json.get("year").is_some());
+    }
+
+    #[test]
+    fn test_rich_search_results_to_batch_vector_nullable() {
+        let mut r1 = mk_result("r1", 1.0, vec![]);
+        r1.vector = vec![0.1, 0.2, 0.3];
+        let r2 = mk_result("r2", 0.5, vec![]);
+        let batch =
+            ArrowProtoCodec::rich_search_results_to_batch(&[r1, r2], true).expect("encode");
+        let vcol = batch.column_by_name("vector").expect("vector col");
+        assert_eq!(vcol.null_count(), 1, "second row has no vector => null");
+        assert!(!vcol.is_null(0));
+        assert!(vcol.is_null(1));
+    }
+
     /// Regression: a search response with NO vector payload (the common case
     /// when `include_fields.vector` is unset) must still encode — the vector
     /// column becomes an all-null FixedSizeList rather than underflowing the

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -33,14 +33,13 @@ use tracing::{debug, info, warn};
 
 use crate::catalog::CatalogManager;
 use crate::network::auth::middleware::DataPlaneCapability;
-use crate::proto::proximadb_v1::VectorSearchRequest;
 use crate::security::{AuthenticationData, ClientCertificateData, SecurityCoordinator};
 use crate::services::operations::{
     BatchOperationResult, BulkWriteMode, CatalogBulkWriteResult, CatalogBulkWriteService,
 };
 use chrono::Utc;
 
-use super::codec::{ArrowProtoCodec, FlightSearchTicket, FlightWriteOperation, WriteMode};
+use super::codec::{ArrowProtoCodec, FlightFilter, FlightSearchTicket, FlightWriteOperation, WriteMode};
 use super::file_export::{
     ArrowFileExportHandler, ArrowFileRequest, ArrowFileTicket, FlightCompression,
 };
@@ -64,6 +63,33 @@ fn flight_data_wire_bytes(flight_data: &[FlightData]) -> u64 {
         .iter()
         .map(|fd| (fd.data_header.len() + fd.data_body.len() + fd.app_metadata.len()) as u64)
         .sum()
+}
+
+/// Optional control frame for the `bulk_search` DoExchange (TD-FLIGHT-1).
+/// Carried as JSON in a `FlightData.app_metadata` message ahead of the query
+/// batches; sets top_k / filters / include_vector for the queries that follow.
+/// Absent ⇒ defaults (top_k = 10, no filters), matching the pre-TD-FLIGHT-1
+/// behavior but now on the canonical v2 search path.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct BulkSearchControl {
+    #[serde(default)]
+    top_k: Option<u32>,
+    #[serde(default)]
+    include_vector: bool,
+    #[serde(default)]
+    filters: Vec<FlightFilter>,
+}
+
+/// Build a control-only `FlightData` frame (no body) carrying `metadata` as
+/// app-metadata — used for per-query error frames and the bulk_search
+/// completion frame.
+fn control_flight_data(metadata: Vec<u8>) -> FlightData {
+    FlightData {
+        flight_descriptor: None,
+        data_header: Default::default(),
+        app_metadata: metadata.into(),
+        data_body: Default::default(),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -143,6 +169,11 @@ pub struct ProximaFlightService {
     // through `RecordOpsPort`; the vector-ops/collection services are held
     // directly (same Arcs as before). `api_port` is retained for the v1
     // surface still used elsewhere (deprecated for Flight search — TD-FLIGHT-1).
+    // TD-FLIGHT-1: `api_port` (the v1 search contract) is no longer used by
+    // Flight search — both DoGet and bulk_search now route through
+    // `record_search_port`. Retained (rather than ripped out) to keep this PR
+    // off the constructor/boot-wiring cascade; a follow-up TD removes it.
+    #[allow(dead_code)]
     api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
     record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
     record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
@@ -1142,42 +1173,6 @@ impl ProximaFlightService {
         self.record_port
             .delete_record_batch(collection_id, record_ids, tenant_id)
             .await
-    }
-
-    /// Handle vector search (DoGet)
-    async fn handle_vector_search(
-        &self,
-        request: VectorSearchRequest,
-        tenant_id: &str,
-    ) -> Result<Vec<arrow_array::RecordBatch>> {
-        debug!(
-            collection_id = %request.collection_id,
-            top_k = request.top_k,
-            "Arrow IPC vector search"
-        );
-
-        // Execute search via UnifiedHandlers (reuses existing path)
-        let response = self
-            .api_port
-            .handle_vector_search_v1_for_tenant(request, Some(tenant_id))
-            .await?;
-
-        // Convert results to Arrow RecordBatch
-        let search_results = response
-            .results
-            .as_ref()
-            .map(|r| &r.results)
-            .filter(|results| !results.is_empty());
-
-        let Some(results) = search_results else {
-            return Ok(Vec::new());
-        };
-
-        let dimension = results[0].vector.len();
-
-        let batch = ArrowProtoCodec::search_results_to_batch(results, dimension)?;
-
-        Ok(vec![batch])
     }
 
     /// Canonical v2 vector search (TD-FLIGHT-1). Routes through the
@@ -3136,8 +3131,17 @@ impl ProximaFlightService {
         first_msg: FlightData,
         mut stream: TonicStreaming<FlightData>,
     ) -> TonicResult<<Self as FlightService>::DoExchangeStream> {
-        let mut results = Vec::new();
+        let mut results: Vec<std::result::Result<FlightData, TonicStatus>> = Vec::new();
         let mut query_count = 0u64;
+
+        // The bulk_search exchange carries query vectors as Arrow batches of
+        // ProximaRecord envelopes. Optional control frames (JSON in
+        // `app_metadata`) set top_k / filters / include_vector for the queries
+        // that follow; absent a control frame the defaults are top_k=10 and no
+        // filters — but now on the canonical v2 search path (TD-FLIGHT-1).
+        let mut top_k: u32 = 10;
+        let mut include_vector = false;
+        let mut filters: Vec<FlightFilter> = Vec::new();
         let mut flight_messages = vec![first_msg];
 
         while let Some(data) = stream
@@ -3146,9 +3150,16 @@ impl ProximaFlightService {
             .map_err(|e| TonicStatus::internal(format!("Stream error: {}", e)))?
         {
             if !data.app_metadata.is_empty()
-                && let Ok(config) = serde_json::from_slice::<serde_json::Value>(&data.app_metadata)
+                && let Ok(control) = serde_json::from_slice::<BulkSearchControl>(&data.app_metadata)
             {
-                debug!("Received search config: {:?}", config);
+                debug!(?control, "Received bulk_search control frame");
+                if let Some(k) = control.top_k {
+                    top_k = k;
+                }
+                include_vector = control.include_vector;
+                if !control.filters.is_empty() {
+                    filters = control.filters;
+                }
                 continue;
             }
             flight_messages.push(data);
@@ -3156,18 +3167,29 @@ impl ProximaFlightService {
 
         let query_batches = ArrowProtoCodec::flight_data_stream_to_batches(&flight_messages)
             .map_err(|e| TonicStatus::internal(format!("Failed to parse query batches: {}", e)))?;
+
         for batch in query_batches {
             // Extract query vectors from batch using canonical ProximaRecord envelopes.
             let query_records = match ArrowProtoCodec::batches_to_proxima_records(vec![batch]) {
                 Ok(v) => v,
                 Err(e) => {
-                    warn!("Failed to extract query vectors: {}", e);
+                    // Surface the per-batch decode error as a frame instead of
+                    // silently dropping the whole batch.
+                    let meta = serde_json::to_vec(&serde_json::json!({
+                        "type": "error", "stage": "decode", "message": e.to_string()
+                    }))
+                    .unwrap_or_default();
+                    results.push(Ok(control_flight_data(meta)));
+                    warn!("Failed to extract query vectors: {e}");
                     continue;
                 }
             };
 
-            // Execute searches for each query vector
+            // Execute one canonical v2 search per query vector, preserving input
+            // order. A failed query surfaces an error frame at its position
+            // rather than vanishing (acceptance #2).
             for query_record in query_records {
+                let query_index = query_count;
                 query_count += 1;
 
                 let query_vector = query_record
@@ -3176,45 +3198,39 @@ impl ProximaFlightService {
                     .map(|e| e.values.to_fp32_owned())
                     .unwrap_or_default();
 
-                let search_request = crate::proto::proximadb_v1::VectorSearchRequest {
+                // Build a canonical v2 ticket (reuses the DoGet filter lowering)
+                // and route through the same RecordSearchPort authority.
+                let ticket = FlightSearchTicket {
+                    ticket_type: "vector_search".to_string(),
                     collection_id: collection_id.clone(),
-                    queries: vec![crate::proto::proximadb_v1::SearchQuery {
-                        vector: query_vector,
-                        filters: std::collections::HashMap::new(),
-                        advanced_filter: None,
-                    }],
-                    top_k: 10, // Default top_k
-                    include_fields: Some(crate::proto::proximadb_v1::IncludeFields {
-                        vector: true,
-                        metadata: true,
-                        score: true,
-                        rank: true,
-                        source: false,
-                        source_options: std::collections::HashMap::new(),
-                    }),
-                    search_params: None,
-                    distance_metric_override: None,
-                    search_optimization: None,
+                    query_vector,
+                    top_k,
+                    filters: filters.clone(),
+                    include_vector,
                 };
 
-                // Execute search
-                let search_response =
-                    match self.handle_vector_search(search_request, &tenant_id).await {
-                        Ok(batches) => batches,
-                        Err(e) => {
-                            warn!("Search failed for query {}: {}", query_record.oid, e);
-                            continue;
-                        }
-                    };
+                let search_batches = match self.handle_v2_search(ticket, &tenant_id).await {
+                    Ok(batches) => batches,
+                    Err(e) => {
+                        let meta = serde_json::to_vec(&serde_json::json!({
+                            "type": "error",
+                            "query_index": query_index,
+                            "query_id": query_record.oid.to_string(),
+                            "message": e.to_string()
+                        }))
+                        .unwrap_or_default();
+                        results.push(Ok(control_flight_data(meta)));
+                        warn!(query_index, query_id = %query_record.oid, "bulk_search query failed: {e}");
+                        continue;
+                    }
+                };
 
-                // Convert result batches to FlightData
-                for result_batch in search_response {
+                for result_batch in search_batches {
                     let flight_data_vec =
                         ArrowProtoCodec::batch_to_flight_data(&result_batch, &Default::default())
                             .map_err(|e| {
-                            TonicStatus::internal(format!("Failed to encode result: {}", e))
-                        })?;
-
+                                TonicStatus::internal(format!("Failed to encode result: {}", e))
+                            })?;
                     for fd in flight_data_vec {
                         results.push(Ok(fd));
                     }
@@ -3222,26 +3238,19 @@ impl ProximaFlightService {
             }
         }
 
-        // Send completion message
-        let complete_msg = serde_json::json!({
+        // Completion frame.
+        let complete_meta = serde_json::to_vec(&serde_json::json!({
             "type": "complete",
             "query_count": query_count,
             "collection_id": collection_id
-        });
-
-        let complete_data = FlightData {
-            flight_descriptor: None,
-            data_header: Default::default(),
-            app_metadata: serde_json::to_vec(&complete_msg).unwrap_or_default().into(),
-            data_body: Default::default(),
-        };
-
-        results.push(Ok(complete_data));
+        }))
+        .unwrap_or_default();
+        results.push(Ok(control_flight_data(complete_meta)));
 
         info!(
             collection_id = %collection_id,
-            query_count = query_count,
-            "Arrow Flight: bulk_search exchange completed"
+            query_count,
+            "Arrow Flight: bulk_search exchange completed (canonical v2 path)"
         );
 
         Ok(TonicResponse::new(Box::pin(stream::iter(results))))

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -137,12 +137,15 @@ fn graph_flight_err(e: anyhow::Error) -> FlightError {
 /// - **.arrow**: Arrow IPC files (from SST, HELIX engines)
 /// - **.parquet**: Parquet files (from Nova, VIPER engines)
 pub struct ProximaFlightService {
-    // TD-104 S3: the Flight service depends on ports + the concrete services it
-    // actually uses, not a monolithic handler. Vector search goes through
-    // `ApiHandlersPort`, record-batch ingest through `RecordOpsPort`; the
-    // vector-ops/collection services are held directly (same Arcs as before).
+    // TD-104 S3 / TD-FLIGHT-1: the Flight service depends on ports + the
+    // concrete services it actually uses, not a monolithic handler. Canonical
+    // v2 vector search goes through `RecordSearchPort`, record-batch ingest
+    // through `RecordOpsPort`; the vector-ops/collection services are held
+    // directly (same Arcs as before). `api_port` is retained for the v1
+    // surface still used elsewhere (deprecated for Flight search — TD-FLIGHT-1).
     api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
     record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
+    record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
     vector_operations_service: Arc<crate::services::VectorOperationsService>,
     collection_service: Arc<crate::services::CollectionService>,
     security_coordinator: Option<Arc<SecurityCoordinator>>,
@@ -243,6 +246,7 @@ impl ProximaFlightService {
     pub fn new(
         api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
         record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
+        record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
         vector_operations_service: Arc<crate::services::VectorOperationsService>,
         collection_service: Arc<crate::services::CollectionService>,
         storage_locations: Vec<String>,
@@ -250,6 +254,7 @@ impl ProximaFlightService {
         Self {
             api_port,
             record_port,
+            record_search_port,
             vector_operations_service,
             collection_service,
             security_coordinator: None,
@@ -283,6 +288,7 @@ impl ProximaFlightService {
     pub fn from_services(
         api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
         record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
+        record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
         vector_operations_service: Arc<crate::services::VectorOperationsService>,
         collection_service: Arc<crate::services::CollectionService>,
         graph_service: Arc<crate::graph::GraphOperationsService>,
@@ -297,6 +303,7 @@ impl ProximaFlightService {
         Self::new(
             api_port,
             record_port,
+            record_search_port,
             vector_operations_service,
             collection_service,
             storage_locations,

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -40,7 +40,7 @@ use crate::services::operations::{
 };
 use chrono::Utc;
 
-use super::codec::{ArrowProtoCodec, FlightWriteOperation, WriteMode};
+use super::codec::{ArrowProtoCodec, FlightSearchTicket, FlightWriteOperation, WriteMode};
 use super::file_export::{
     ArrowFileExportHandler, ArrowFileRequest, ArrowFileTicket, FlightCompression,
 };
@@ -1179,6 +1179,48 @@ impl ProximaFlightService {
 
         Ok(vec![batch])
     }
+
+    /// Canonical v2 vector search (TD-FLIGHT-1). Routes through the
+    /// `RecordSearchPort` — the same `RecordOpsService::handle_record_search_for_tenant`
+    /// authority REST v2 and gRPC v2 use — so Flight inherits typed filters,
+    /// WAL delta-merge, MVCC/tombstone filtering, Strong-freshness cache
+    /// behavior, and the tenant-collection-access check. Wrapped in the same
+    /// query-scoped I/O-trace boundary as REST v2 (route
+    /// `arrow_flight.v2.records.search`) so object GETs/bytes stay attributable
+    /// per query. Flight has no tenant-stable-id resolver yet, so the stable id
+    /// is `None` (matches the `instrument()` fallback).
+    async fn handle_v2_search(
+        &self,
+        ticket: FlightSearchTicket,
+        tenant_id: &str,
+    ) -> Result<Vec<arrow_array::RecordBatch>> {
+        let include_vector = ticket.include_vector;
+        let request = ticket.to_rich_request()?;
+        debug!(
+            collection_id = %request.collection_id,
+            top_k = request.top_k,
+            include_vector,
+            "Arrow Flight canonical v2 vector search"
+        );
+
+        let response = crate::observability::io_trace::instrument_with_stable_tenant(
+            Some(tenant_id.to_string()),
+            None,
+            "arrow_flight.v2.records.search",
+            crate::observability::predicate_diagnostics::scope(async {
+                self.record_search_port
+                    .search_record(request, Some(tenant_id))
+                    .await
+            }),
+        )
+        .await?;
+
+        // Always emit one batch of the canonical v2 schema — even when empty
+        // (acceptance: empty results / optional vectors must not panic).
+        let batch =
+            ArrowProtoCodec::rich_search_results_to_batch(&response.results, include_vector)?;
+        Ok(vec![batch])
+    }
 }
 
 #[tonic::async_trait]
@@ -1480,41 +1522,51 @@ impl FlightService for ProximaFlightService {
             return Ok(TonicResponse::new(stream));
         }
 
-        // Otherwise, handle as vector search request
-        let search_request = ArrowProtoCodec::ticket_to_search_request(&ticket).map_err(|e| {
-            TonicStatus::invalid_argument(format!("Failed to parse search request: {}", e))
-        })?;
-        Self::validate_flight_search_capability(
-            auth_context.capability.as_ref(),
-            &search_request.collection_id,
-        )?;
+        // Canonical v2 vector search (TD-FLIGHT-1): a self-describing JSON
+        // ticket discriminated by "type":"vector_search". This replaces the
+        // deprecated v1 `VectorSearchRequest` fallback — Flight search now runs
+        // the same canonical search authority (RecordSearchPort) as REST v2 /
+        // gRPC v2, with full-fidelity props and the tenant-collection-access
+        // check.
+        if let Some(search_ticket) = FlightSearchTicket::from_ticket(&ticket) {
+            Self::validate_flight_search_capability(
+                auth_context.capability.as_ref(),
+                &search_ticket.collection_id,
+            )?;
 
-        // Execute search
-        let batches = self
-            .handle_vector_search(search_request, &auth_context.tenant_id)
-            .await
-            .map_err(|e| TonicStatus::internal(format!("Search failed: {}", e)))?;
+            let batches = self
+                .handle_v2_search(search_ticket, &auth_context.tenant_id)
+                .await
+                .map_err(|e| TonicStatus::internal(format!("Search failed: {}", e)))?;
 
-        // Egress-aware shaping (co-design D2): for a chargeable (far) client, encode
-        // the result batches with ZSTD — a lossless byte-minimization the Arrow
-        // reader decompresses transparently. Near/free clients stay uncompressed
-        // (save CPU). Then meter the ACTUAL encoded bytes so the bill reflects the
-        // compressed egress that really left.
-        let compression = if edge.shape_policy().compress {
-            FlightCompression::Zstd.to_arrow_compression()
-        } else {
-            None
-        };
-        let flight_data =
-            ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
-                .map_err(|e| TonicStatus::internal(format!("Failed to encode batches: {}", e)))?;
-        edge.record_result_egress(
-            Some(auth_context.tenant_id.as_str()),
-            flight_data_wire_bytes(&flight_data),
-        );
-        let stream = stream::iter(flight_data.into_iter().map(Ok));
+            // Egress-aware shaping (co-design D2): for a chargeable (far)
+            // client, encode the result batches with ZSTD — a lossless
+            // byte-minimization the Arrow reader decompresses transparently.
+            // Near/free clients stay uncompressed (save CPU). Then meter the
+            // ACTUAL encoded bytes so the bill reflects the compressed egress.
+            let compression = if edge.shape_policy().compress {
+                FlightCompression::Zstd.to_arrow_compression()
+            } else {
+                None
+            };
+            let flight_data =
+                ArrowProtoCodec::batches_to_flight_data_with_compression(&batches, compression)
+                    .map_err(|e| {
+                        TonicStatus::internal(format!("Failed to encode batches: {}", e))
+                    })?;
+            edge.record_result_egress(
+                Some(auth_context.tenant_id.as_str()),
+                flight_data_wire_bytes(&flight_data),
+            );
+            let stream = stream::iter(flight_data.into_iter().map(Ok));
+            return Ok(TonicResponse::new(Box::pin(stream)));
+        }
 
-        Ok(TonicResponse::new(Box::pin(stream)))
+        // Unknown ticket shape — no longer silently coerced into v1 search.
+        Err(TonicStatus::invalid_argument(
+            "Unrecognized Flight DoGet ticket: expected an arrow_file, graph, \
+             or vector_search (type:\"vector_search\") ticket",
+        ))
     }
 
     async fn do_put(

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -39,7 +39,9 @@ use crate::services::operations::{
 };
 use chrono::Utc;
 
-use super::codec::{ArrowProtoCodec, FlightFilter, FlightSearchTicket, FlightWriteOperation, WriteMode};
+use super::codec::{
+    ArrowProtoCodec, FlightFilter, FlightSearchTicket, FlightWriteOperation, WriteMode,
+};
 use super::file_export::{
     ArrowFileExportHandler, ArrowFileRequest, ArrowFileTicket, FlightCompression,
 };
@@ -3229,8 +3231,8 @@ impl ProximaFlightService {
                     let flight_data_vec =
                         ArrowProtoCodec::batch_to_flight_data(&result_batch, &Default::default())
                             .map_err(|e| {
-                                TonicStatus::internal(format!("Failed to encode result: {}", e))
-                            })?;
+                            TonicStatus::internal(format!("Failed to encode result: {}", e))
+                        })?;
                     for fd in flight_data_vec {
                         results.push(Ok(fd));
                     }

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -706,6 +706,8 @@ impl MultiServer {
             let arrow_bind_target = self.config.arrow_bind_target();
             let arrow_target_log = format!("{arrow_bind_target:?}");
             let arrow_record_ops = services.record_ops.clone();
+            // TD-FLIGHT-1: same RecordOpsService Arc, coerced to the search port.
+            let arrow_record_search = services.record_ops.clone();
             let arrow_vector_ops = services.vector_operations_service.clone();
             let arrow_collection = services.collection_service.clone();
             let arrow_graph = services.graph_service.clone();
@@ -731,6 +733,7 @@ impl MultiServer {
                 let flight_service = ProximaFlightService::from_services(
                     api_handlers,
                     arrow_record_ops,
+                    arrow_record_search,
                     arrow_vector_ops,
                     arrow_collection,
                     arrow_graph,
@@ -1131,6 +1134,8 @@ impl MultiServer {
             let flight_service =
                 crate::network::arrow_ipc::service::ProximaFlightService::from_services(
                     services.api_handlers.clone(),
+                    services.record_ops.clone(),
+                    // same RecordOpsService Arc, coerced to the v2 search port (TD-FLIGHT-1)
                     services.record_ops.clone(),
                     services.vector_operations_service.clone(),
                     services.collection_service.clone(),
@@ -1629,6 +1634,8 @@ impl MultiServer {
             // `arrow_target_log` (the value has no `Display` impl).
             let arrow_target_log = format!("{arrow_bind_target:?}");
             let arrow_record_ops = services.record_ops.clone();
+            // TD-FLIGHT-1: same RecordOpsService Arc, coerced to the search port.
+            let arrow_record_search = services.record_ops.clone();
             let arrow_vector_ops = services.vector_operations_service.clone();
             let arrow_collection = services.collection_service.clone();
             let arrow_graph = services.graph_service.clone();
@@ -1654,6 +1661,7 @@ impl MultiServer {
                 let flight_service = ProximaFlightService::from_services(
                     api_handlers,
                     arrow_record_ops,
+                    arrow_record_search,
                     arrow_vector_ops,
                     arrow_collection,
                     arrow_graph,

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -223,69 +223,16 @@ pub use proximadb_runtime::rich_record::{
     RichRecordBatchRequest, RichRecordDeleteBatchRequest, RichRecordGetRequest,
 };
 
-/// Canonical rich search request for v2 and internal callers.
-#[derive(Debug, Clone)]
-pub struct RichSearchRequest {
-    pub collection_id: String,
-    pub query_vector: Vec<f32>,
-    pub top_k: u32,
-    pub filters: Vec<RichFilterCondition>,
-}
-
-/// Canonical rich search response for v2 and internal callers.
-#[derive(Debug, Clone, Default)]
-pub struct RichSearchResponse {
-    pub results: Vec<RichSearchResult>,
-    pub total_found: i64,
-    pub collection_id: Option<String>,
-    /// TD-064(a): predicate-aware shortfall — `Some(...)` when a filtered
-    /// search returned fewer than the requested `top_k` after the
-    /// WAL+AXIS+storage merge. First-class and always-on (NOT debug-gated):
-    /// a silent `<top_k` under a tenant/RLS filter is fail-open, so the
-    /// client must be able to tell "fewer than k match my filter" from "the
-    /// engine returned my full top-k". Recomputed authoritatively against
-    /// the final merged result so an AXIS-stage false positive is cleared.
-    pub predicate_shortfall: Option<crate::observability::search_plan_trace::PredicateShortfall>,
-}
-
-#[derive(Debug, Clone)]
-pub struct RichSearchResult {
-    pub id: String,
-    pub score: f64,
-    pub similarity: Option<f32>,
-    pub vector: Vec<f32>,
-    pub props: HashMap<String, proximadb_data_model::ProximaValue>,
-    pub version: Option<u32>,
-    pub timestamp: Option<i64>,
-    pub source: Option<String>,
-}
+/// Canonical rich search request/response/filter DTOs now live in
+/// `proximadb-runtime` (TD-FLIGHT-1) so the `RecordSearchPort` contract is
+/// self-contained — mirroring the `RichRecord*` relocation above. Re-exported
+/// here so existing `crate::services::operations::vectors::legacy::RichSearch*`
+/// / `RichFilter*` callers are unaffected.
+pub use proximadb_runtime::rich_search::{
+    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse, RichSearchResult,
+};
 
 pub type RichRecordGetResponse = Option<RichSearchResult>;
-
-#[derive(Debug, Clone)]
-pub struct RichFilterCondition {
-    pub field: String,
-    pub operator: RichFilterOperator,
-    pub value: proximadb_data_model::ProximaValue,
-    pub value_upper: Option<proximadb_data_model::ProximaValue>,
-    pub value_list: Vec<proximadb_data_model::ProximaValue>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RichFilterOperator {
-    Eq,
-    Ne,
-    Gt,
-    Gte,
-    Lt,
-    Lte,
-    Between,
-    In,
-    NotIn,
-    Contains,
-    StartsWith,
-    EndsWith,
-}
 
 /// Lower rich `ProximaValue` predicates straight to the canonical
 /// [`FilterExpression`] consumed by the unified search path.

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -229,7 +229,8 @@ pub use proximadb_runtime::rich_record::{
 /// here so existing `crate::services::operations::vectors::legacy::RichSearch*`
 /// / `RichFilter*` callers are unaffected.
 pub use proximadb_runtime::rich_search::{
-    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse, RichSearchResult,
+    RichFilterCondition, RichFilterOperator, RichSearchRequest, RichSearchResponse,
+    RichSearchResult,
 };
 
 pub type RichRecordGetResponse = Option<RichSearchResult>;

--- a/tests/flight_v2_search_e2e.rs
+++ b/tests/flight_v2_search_e2e.rs
@@ -12,7 +12,7 @@
 use std::net::TcpListener;
 use std::time::Duration;
 
-use arrow_array::{RecordBatch, StringArray};
+use arrow_array::{Array, RecordBatch, StringArray};
 use arrow_flight::Ticket;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;

--- a/tests/flight_v2_search_e2e.rs
+++ b/tests/flight_v2_search_e2e.rs
@@ -1,0 +1,262 @@
+//! End-to-end convergence of Arrow Flight vector search onto the canonical v2
+//! service (TD-FLIGHT-1).
+//!
+//! Boots an in-process ProximaDB with a free Flight port, inserts records over
+//! REST v2, then runs the SAME search over both REST v2 and Arrow Flight `DoGet`
+//! (the new `type:"vector_search"` ticket) and asserts they return identical
+//! ordered ids — proving Flight now routes through the same `RecordSearchPort`
+//! authority as REST v2 rather than the deprecated v1 contract. A second test
+//! verifies the clean-break ticket routing: a non-file/non-graph/non-v2 ticket
+//! is rejected with `InvalidArgument` instead of being silently coerced to v1.
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use arrow_array::{RecordBatch, StringArray};
+use arrow_flight::decode::FlightRecordBatchStream;
+use arrow_flight::error::FlightError;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::Ticket;
+use futures::TryStreamExt;
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct FlightServer {
+    flight_port: u16,
+    rest_port: u16,
+    db: Option<ProximaDB>,
+    _tmp_data: TempDir,
+}
+
+impl FlightServer {
+    async fn start() -> anyhow::Result<Self> {
+        let flight_port = free_port();
+        let rest_port = free_port();
+        let tmp_data = TempDir::new()?;
+
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp_data.path().to_path_buf();
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = free_port();
+        config.api.arrow_flight_port = flight_port;
+        config.api.pg_port = Some(free_port());
+        config.api.unified_mode = false;
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp_data.path().display()),
+            ..Default::default()
+        }];
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp_data.path().display());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .no_proxy()
+            .build()?;
+        let health_url = format!("http://127.0.0.1:{}/health", rest_port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            match http.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => break,
+                _ => {
+                    if std::time::Instant::now() > deadline {
+                        anyhow::bail!("server didn't become ready in 15s");
+                    }
+                    sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        // Grace for the Arrow IPC listener to start accepting.
+        sleep(Duration::from_millis(300)).await;
+
+        Ok(Self {
+            flight_port,
+            rest_port,
+            db: Some(db),
+            _tmp_data: tmp_data,
+        })
+    }
+
+    fn flight_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.flight_port)
+    }
+
+    fn rest_base(&self) -> String {
+        format!("http://127.0.0.1:{}", self.rest_port)
+    }
+}
+
+impl Drop for FlightServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+/// Build a unit-norm vector whose cosine to `e_0` is exactly `first` — so five
+/// records with distinct `first` components have a strict, deterministic cosine
+/// ordering against the query `e_0`.
+fn unit_with_first(first: f32, dim: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    v[0] = first;
+    v[1] = (1.0 - first * first).sqrt();
+    v
+}
+
+/// Flight `DoGet` with the canonical v2 ticket must return the SAME ordered ids
+/// as REST v2 for the same collection/query/top_k — the core TD-FLIGHT-1
+/// convergence gate.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn flight_v2_doget_matches_rest_v2() {
+    let server = FlightServer::start().await.expect("server start");
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .no_proxy()
+        .build()
+        .unwrap();
+    let base = server.rest_base();
+    let name = format!(
+        "flight_v2_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let dim: usize = 8;
+
+    let create = http
+        .post(format!("{base}/api/v2/collections"))
+        .json(&json!({
+            "name": name, "dimension": dim, "engine": "sst",
+            "distance_metric": "cosine", "enable_proxima_record": false,
+        }))
+        .send()
+        .await
+        .expect("create");
+    assert!(create.status().is_success(), "create failed");
+
+    // Distinct cosine sims against e_0: rec-0=1.0, rec-1=0.9, ... rec-4=0.6.
+    let records: Vec<serde_json::Value> = (0..5)
+        .map(|i| {
+            let first = 1.0 - 0.1 * i as f32;
+            json!({ "id": format!("rec-{i}"), "vector": unit_with_first(first, dim) })
+        })
+        .collect();
+    let insert = http
+        .post(format!("{base}/api/v2/collections/{name}/records/batch"))
+        .json(&json!({ "records": records }))
+        .send()
+        .await
+        .expect("insert");
+    assert!(insert.status().is_success(), "insert failed");
+    sleep(Duration::from_millis(500)).await;
+
+    let query: Vec<f32> = unit_with_first(1.0, dim); // == e_0
+    // REST v2 oracle.
+    let rest_resp = http
+        .post(format!("{base}/api/v2/collections/{name}/search"))
+        .json(&json!({ "vector": query, "top_k": 3 }))
+        .send()
+        .await
+        .expect("rest search");
+    assert!(rest_resp.status().is_success(), "rest search status");
+    let rest_body: serde_json::Value = rest_resp.json().await.expect("rest json");
+    let rest_ids: Vec<String> = rest_body
+        .get("results")
+        .or_else(|| rest_body.get("hits"))
+        .and_then(|v| v.as_array())
+        .expect("rest results array")
+        .iter()
+        .filter_map(|h| {
+            h.get("id")
+                .or_else(|| h.get("record_id"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    assert_eq!(rest_ids, vec!["rec-0", "rec-1", "rec-2"], "rest oracle order: {rest_body}");
+
+    // Flight DoGet with the canonical v2 ticket.
+    let channel = tonic::transport::Endpoint::from_shared(server.flight_url())
+        .expect("flight endpoint")
+        .connect()
+        .await
+        .expect("flight channel");
+    let mut flight = FlightServiceClient::new(channel);
+
+    let ticket = Ticket {
+        ticket: serde_json::to_vec(&json!({
+            "type": "vector_search",
+            "collection_id": name,
+            "query_vector": query,
+            "top_k": 3,
+            "include_vector": false,
+        }))
+        .unwrap()
+        .into(),
+    };
+    let response = flight.do_get(ticket).await.expect("flight do_get").into_inner();
+    let record_stream = FlightRecordBatchStream::new_from_flight_data(
+        response.map_err(|s| FlightError::Tonic(Box::new(s))),
+    );
+    let batches: Vec<RecordBatch> = record_stream.try_collect().await.expect("decode batches");
+
+    let mut flight_ids: Vec<String> = Vec::new();
+    for b in &batches {
+        let id_col = b
+            .column_by_name("id")
+            .expect("id column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("id is StringArray");
+        for i in 0..id_col.len() {
+            flight_ids.push(id_col.value(i).to_string());
+        }
+    }
+
+    assert_eq!(
+        flight_ids, rest_ids,
+        "Flight DoGet must return the same ordered ids as REST v2 (TD-FLIGHT-1)"
+    );
+}
+
+/// A ticket that is neither arrow_file, graph, nor vector_search is rejected
+/// with an error — no silent coercion into the removed v1 search fallback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn flight_v2_unknown_ticket_rejected() {
+    let server = FlightServer::start().await.expect("server start");
+    let channel = tonic::transport::Endpoint::from_shared(server.flight_url())
+        .expect("flight endpoint")
+        .connect()
+        .await
+        .expect("flight channel");
+    let mut flight = FlightServiceClient::new(channel);
+
+    let ticket = Ticket {
+        ticket: serde_json::to_vec(&json!({ "type": "bogus_unknown_ticket" }))
+            .unwrap()
+            .into(),
+    };
+    let result = flight.do_get(ticket).await;
+    assert!(
+        result.is_err(),
+        "an unrecognized ticket must be rejected, not silently coerced to v1 search"
+    );
+}

--- a/tests/flight_v2_search_e2e.rs
+++ b/tests/flight_v2_search_e2e.rs
@@ -13,10 +13,10 @@ use std::net::TcpListener;
 use std::time::Duration;
 
 use arrow_array::{RecordBatch, StringArray};
+use arrow_flight::Ticket;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use arrow_flight::flight_service_client::FlightServiceClient;
-use arrow_flight::Ticket;
 use futures::TryStreamExt;
 use proximadb::core::Config;
 use proximadb::database::ProximaDB;
@@ -191,7 +191,11 @@ async fn flight_v2_doget_matches_rest_v2() {
                 .map(str::to_string)
         })
         .collect();
-    assert_eq!(rest_ids, vec!["rec-0", "rec-1", "rec-2"], "rest oracle order: {rest_body}");
+    assert_eq!(
+        rest_ids,
+        vec!["rec-0", "rec-1", "rec-2"],
+        "rest oracle order: {rest_body}"
+    );
 
     // Flight DoGet with the canonical v2 ticket.
     let channel = tonic::transport::Endpoint::from_shared(server.flight_url())
@@ -212,7 +216,11 @@ async fn flight_v2_doget_matches_rest_v2() {
         .unwrap()
         .into(),
     };
-    let response = flight.do_get(ticket).await.expect("flight do_get").into_inner();
+    let response = flight
+        .do_get(ticket)
+        .await
+        .expect("flight do_get")
+        .into_inner();
     let record_stream = FlightRecordBatchStream::new_from_flight_data(
         response.map_err(|s| FlightError::Tonic(Box::new(s))),
     );


### PR DESCRIPTION
## Summary

Arrow Flight vector search was running the **deprecated v1** contract while REST v2 and gRPC v2 ran the canonical v2 service. This PR routes Flight `DoGet` and `bulk_search` `DoExchange` through the same canonical `RecordOpsService::handle_record_search_for_tenant` authority as the other surfaces, via a new stable read port.

### Defects fixed
- **Drift / weaker correctness.** Flight called `ApiHandlersPort::handle_vector_search_v1_for_tenant` and the lossy `search_results_to_batch` encoder (first metadata key only); it missed v2's tenant-collection-access check and canonical dead-record predicate.
- **Broken bulk_search.** Hard-coded `top_k:10` + empty filters, and **swallowed per-query errors**.
- **Already-broken ticket.** The DoGet ticket was a JSON v1 `VectorSearchRequest`; the only client building it (Python SDK) used mismatched keys, so the query vector was **silently dropped**.

### What changed
1. Relocate `PredicateShortfall` to foundation `proximadb-search-types` (re-exported at its historical path).
2. Relocate the 5 v2 search DTOs to `proximadb-runtime::rich_search` behind a `pub use` shim — zero consumer import changes (mirrors TD-104 `rich_record`).
3. New dedicated read port `RecordSearchPort`; `RecordOpsService` implements it (the same concrete `Arc` backs the write + search ports).
4. Canonical v2 Flight ticket `FlightSearchTicket` (`type:"vector_search"`), with full typed-filter lowering; clean break — unknown tickets return `InvalidArgument`.
5. Full-fidelity encoder `rich_search_results_to_batch` preserving the entire props map (JSON `properties` column).
6. `handle_v2_search` wrapped in the same io_trace boundary as REST v2 (`arrow_flight.v2.records.search`).
7. `bulk_search` routes through v2, preserves order, makes top_k/filters configurable via an optional control frame, and surfaces per-query errors as frames.

## Test plan
- `tests/flight_v2_search_e2e.rs`: boots embedded ProximaDB + real Flight client; asserts Flight `DoGet` returns the **same ordered ids as REST v2** for one collection/query/top_k (deterministic distinct-cosine vectors), and that an unrecognized ticket is rejected.
- `codec.rs` unit tests: ticket discriminator (accepts v2, rejects file/v1), `to_rich_request` (all operators + unsupported rejection), `rich_search_results_to_batch` (empty / full-props round-trip / vector-nullable).
- Python SDK `arrow_flight.search()` emits the v2 ticket + decodes `properties`; unit tests updated.

## Verification (local)
- `cargo fmt --check` clean
- `cargo nextest run` focused: 17 runtime + 5 codec unit + 2 e2e pass
- `cargo clippy -D warnings` clean (runtime/search-types/observability-engine + root lib)
- `make work-commit-check` — panic-policy delta **+0**, layering, workspace-boundaries, tenant-path, env-gate (230), hygiene
- `check_td_adr_unique.py` 0 errors
- `cargo build -p proximadb-server --bin proximadb-server` builds
- rebased on latest `origin/develop`

## Follow-ups (documented in TD-FLIGHT-1)
- Immutable-bed Flight-vs-REST benchmark (GETs/recall are transport-invariant; Flight only saves serialization/copy) — separate release-build activity.
- Remove the now-dead `api_port` field (+ constructor/boot cascade). The v1 method stays on `ApiHandlersPort` — REST `/progressive/search` still uses it.
- `bulk_search` DoExchange e2e (the query-vector Arrow-batch encode); wire a real `TenantStableIdResolver` for non-null io_trace stable ids.

Filed as TD-FLIGHT-1.