### PR TITLE
feat(storage): catalog-driven storage-URL resolution for SstEngine; retire placeholder

### DIFF
--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1231,6 +1231,29 @@ impl SharedServices {
                 engine = engine.with_freshness_lsn_source(src);
             }
 
+            // Catalog-driven storage-URL resolution: attach the catalog/config
+            // resolver so `get_collection_storage_url` resolves the real
+            // per-collection location (retires the `/data/collections/{id}`
+            // placeholder; the catalog is the single source of truth). Catalog
+            // first → `ConfigFallbackResolver` default, wrapped in `CachedResolver`.
+            // (WAL injection deferred: the WAL's fallback returns the base-location
+            // PREFIX, while these resolvers return the ROOT `{base}/{id}`;
+            // reconciling those contracts is a follow-up. SstEngine resolving
+            // correctly already achieves write/read agreement.)
+            {
+                use crate::storage::trait_components::path_resolver::{
+                    CachedResolver, CatalogResolver, CollectionPathResolver, CompositeResolver,
+                    ConfigFallbackResolver,
+                };
+                let chain: Vec<Arc<dyn CollectionPathResolver>> = vec![
+                    Arc::new(CatalogResolver::new()),
+                    Arc::new(ConfigFallbackResolver::default()),
+                ];
+                engine = engine.with_path_resolver(Arc::new(CachedResolver::new(Arc::new(
+                    CompositeResolver::new(chain),
+                ))));
+            }
+
             // Attach tier-migration integration when configured. Reads
             // the `[storage.sst_config.tiering]` block; defaults to
             // disabled. When `enabled = true`, the engine's

--- a/src/storage/engines/sst/collections.rs
+++ b/src/storage/engines/sst/collections.rs
@@ -310,15 +310,26 @@ impl SstEngine {
         Ok(results)
     }
 
-    /// Get storage URL for a collection
+    /// Get storage URL for a collection — resolved via the injected
+    /// `CollectionPathResolver` (catalog → config fallback; the single source of
+    /// truth), retiring the `/data/collections/{id}` placeholder. The resolver
+    /// returns the collection ROOT (`{base}/{collection_id}`); `/data` is the
+    /// segment subdirectory (matches `StoragePath::collection_data_path` + the
+    /// flush's `get_collection_storage_url_from_params`). When no resolver is
+    /// injected (un-wired deployment / test), a `ConfigFallbackResolver` is
+    /// default-constructed so the URL is still well-formed. Production wires the
+    /// catalog-coupled resolver via `SharedServices::new`.
     async fn get_collection_storage_url(&self, collection_id: &str) -> Result<String> {
-        // In a real implementation, this would:
-        // 1. Look up the collection's storage assignment
-        // 2. Return the appropriate storage URL
-
-        // For now, use a default path structure
-        let storage_url = format!("/data/collections/{}", collection_id);
-
+        use crate::storage::trait_components::path_resolver::CollectionPathResolver;
+        let root = match self.path_resolver.as_ref() {
+            Some(resolver) => resolver.resolve_base_location(collection_id).await?,
+            None => {
+                crate::storage::trait_components::path_resolver::ConfigFallbackResolver::default()
+                    .resolve_base_location(collection_id)
+                    .await?
+            }
+        };
+        let storage_url = format!("{root}/data");
         debug!(
             "📂 Storage URL for collection {}: {}",
             collection_id, storage_url

--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -400,6 +400,14 @@ pub struct SstEngine {
         Arc<dyn crate::storage::engines::sst::object_economy_directory::FreshnessLsnSource>,
     >,
 
+    /// DIP storage-URL resolver (optional). When set, `get_collection_storage_url`
+    /// resolves the collection's real `base_location` through it (catalog → config
+    /// fallback chain); the `/data/collections/{id}` placeholder is retired.
+    /// Mirrors the WAL's `path_resolver` + this struct's `freshness_lsn_source`.
+    /// Wired by `SharedServices::new`.
+    pub(crate) path_resolver:
+        Option<Arc<dyn crate::storage::trait_components::path_resolver::CollectionPathResolver>>,
+
     /// ADR-081 regression hook: rejected preflights must not reach the
     /// vector-proportional sort boundary.
     #[cfg(test)]
@@ -731,6 +739,7 @@ impl SstEngine {
             deletion_vector_store,
             tiering_integration: None,
             freshness_lsn_source: None,
+            path_resolver: None,
             #[cfg(test)]
             flush_sort_invocations: std::sync::atomic::AtomicU64::new(0),
         })
@@ -824,6 +833,18 @@ impl SstEngine {
         source: Arc<dyn crate::storage::engines::sst::object_economy_directory::FreshnessLsnSource>,
     ) -> Self {
         self.freshness_lsn_source = Some(source);
+        self
+    }
+
+    /// Attach the catalog/config storage-URL resolver. When set,
+    /// `get_collection_storage_url` resolves the real `base_location` through it
+    /// (retiring the `/data/collections/{id}` placeholder). When unset, the
+    /// method default-constructs a `ConfigFallbackResolver`.
+    pub fn with_path_resolver(
+        mut self,
+        resolver: Arc<dyn crate::storage::trait_components::path_resolver::CollectionPathResolver>,
+    ) -> Self {
+        self.path_resolver = Some(resolver);
         self
     }
 

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -128,6 +128,80 @@ impl CollectionPathResolver for ConfigFallbackResolver {
     }
 }
 
+/// Catalog-backed resolver: resolves a collection's base storage location from
+/// the **catalog** (the metadata authority), reusing the storage-layer
+/// `resolve_collection_from_catalog` (UUID→catalog scan) the WAL already uses.
+/// Returns `Err` when the collection isn't in the catalog or has no
+/// `storage_assignment`, so a `CompositeResolver` chain can fall through to a
+/// config default. This is the resolver that retires the `SstEngine`
+/// `get_collection_storage_url` placeholder — the catalog as the single source
+/// of truth for storage location. (No `CollectionService` dependency: the
+/// schema→assignment mapping `collection_from_catalog_schema` is storage-layer.)
+pub struct CatalogResolver;
+
+impl CatalogResolver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CatalogResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl CollectionPathResolver for CatalogResolver {
+    fn name(&self) -> &'static str {
+        "Catalog"
+    }
+
+    async fn resolve_base_location(&self, collection_id: &str) -> Result<String> {
+        let collection =
+            crate::storage::persistence::write_ahead_log::resolve_collection_from_catalog(
+                collection_id,
+            )
+            .await
+            .ok_or_else(|| {
+                anyhow::anyhow!("CatalogResolver: collection {collection_id} not found in catalog")
+            })?;
+        let base = collection
+            .storage_assignment
+            .as_ref()
+            .map(|a| a.base_location.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "CatalogResolver: collection {collection_id} has no storage_assignment"
+                )
+            })?;
+        // The catalog stores the base-location PREFIX (no collection_id); return
+        // the collection ROOT (prefix + collection_id), matching
+        // `ConfigFallbackResolver`'s contract — callers append `/data`, `/wal`, …
+        Ok(format!("{base}/{collection_id}"))
+    }
+
+    async fn resolve_storage_assignment(&self, collection_id: &str) -> Result<StorageAssignment> {
+        let base = self.resolve_base_location(collection_id).await?;
+        Ok(StorageAssignment {
+            primary_url: base,
+            weight: 1,
+            available: true,
+            replica_urls: Vec::new(),
+        })
+    }
+
+    async fn collection_exists(&self, collection_id: &str) -> Result<bool> {
+        Ok(
+            crate::storage::persistence::write_ahead_log::resolve_collection_from_catalog(
+                collection_id,
+            )
+            .await
+            .is_some(),
+        )
+    }
+}
+
 /// Caching resolver wrapper (for performance)
 ///
 /// Caches resolved paths to avoid repeated metadata lookups.


### PR DESCRIPTION
## Catalog-driven storage-URL resolution for SstEngine

`SstEngine::get_collection_storage_url` was a **placeholder** (`/data/collections/{id}`, ignoring the collection's real `storage_assignment.base_location`) — the root of a two-sources-of-truth bug: the flush resolved the real location, but every read/maintenance path (`list_collection_files`, `contains_vector`, `cleanup`, `scan_all_vectors`, `compact_collection`, `collection_stats`, `ensure_staging_directory`) looked in the wrong place for any non-default base location (S3/Azure/GCS). That broke compaction/stats/scans/deletes for those collections and blocked F3v's WI-3b production `resolve_oid_positions` + WI-4.

### What
- New **`CatalogResolver`** (`CollectionPathResolver`) in `trait_components/path_resolver.rs` — resolves the base location from the **catalog** (the metadata authority), reusing the storage-layer `resolve_collection_from_catalog` (UUID→catalog scan). **No `CollectionService` dependency** — the schema→assignment mapping `collection_from_catalog_schema` is storage-layer.
- **`SstEngine`**: `path_resolver` field + `.with_path_resolver()` builder (mirrors `freshness_lsn_source`); `get_collection_storage_url` now routes through the resolver (`{root}/data`), with `ConfigFallbackResolver` default-constructed when unset. **Placeholder retired; all 7 callers fixed at once.**
- **`SharedServices::new`**: injects `CachedResolver(CompositeResolver([CatalogResolver, ConfigFallbackResolver]))` into `SstEngine`.

### Verification
- `cargo test --lib get_collection_storage_url` + the sst `collections` tests (4) pass — no regressions.
- `cargo fmt --all --check` clean; `cargo clippy --lib -- -D warnings` clean.

### Notes
- **General correctness fix** (not F3v-feature-gated); unblocks F3v (WI-3b production path + WI-4) as a side effect.
- **WAL injection (shared instance) deferred**: the WAL's fallback returns the base-location PREFIX while `ConfigFallbackResolver`/`CatalogResolver` return the ROOT `{base}/{id}`; reconciling those contracts is a follow-up. SstEngine resolving correctly already achieves write/read agreement.
- The **flush path is unaffected** (separate `get_collection_storage_url_from_params`).