### PR TITLE
feat(abac): activate vector ABAC on the fusion path — REST end-to-end (FA-2 PR-D3)

### DIFF
--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -3807,6 +3807,7 @@ impl EmbeddedProximaDB {
                 graph_id: graph_id.to_string(),
                 // Embedded stays single-tenant by default (unscoped, byte-identical legacy behavior).
                 tenant: None,
+                tenant_stable_id: None, // FA-2 PR-D3: embedded path — no client subject
                 vector_collection: vector_collection.to_string(),
                 query_vector,
                 max_depth,

--- a/src/network/grpc/v2/entity_service.rs
+++ b/src/network/grpc/v2/entity_service.rs
@@ -508,6 +508,7 @@ impl ProximaEntityService for ProximaEntityServiceImpl {
                 vector_collection: collection.clone(),
                 // Structural tenant boundary — scopes BOTH fusion legs (clean names in, TD-ENTITY-TENANT-1).
                 tenant: Some(tenant.clone()),
+                tenant_stable_id: None, // FA-2 PR-D3: gRPC resolver wiring deferred
                 query_vector,
                 // TD-146 scope B: graph-augmented entity fusion. Entity vectors live under the
                 // auxiliary `{node_id}/{model_id}` oid; `EntityNode` keying normalizes both the

--- a/src/network/grpc/v2/fusion_service.rs
+++ b/src/network/grpc/v2/fusion_service.rs
@@ -109,6 +109,9 @@ impl ProximaFusionService for ProximaFusionServiceImpl {
             graph_id: req.graph_id.clone(),
             // Structural tenant boundary — scopes both fusion legs (TD-ENTITY-TENANT-1).
             tenant: Some(tenant_id.clone()),
+            // FA-2 PR-D3: gRPC tenant_stable_id wiring deferred (resolver not on
+            // the gRPC auth layer) ⇒ None ⇒ no per-record ABAC here yet.
+            tenant_stable_id: None,
             vector_collection: req.vector_collection.clone(),
             query_vector: req.query_vector.clone(),
             max_depth: if req.max_depth == 0 {

--- a/src/network/rest/v2/graphs.rs
+++ b/src/network/rest/v2/graphs.rs
@@ -172,6 +172,9 @@ pub async fn fusion_search_v2(
         graph_id,
         // Structural tenant boundary — scopes both fusion legs (TD-ENTITY-TENANT-1).
         tenant: Some(tenant.tenant_id.clone()),
+        // FA-2 PR-D3: stable tenant id for ABAC per-record enforcement (binding
+        // filter key). `None` ⇒ structural isolation only.
+        tenant_stable_id: tenant.tenant_stable_id,
         vector_collection: request.vector_collection,
         query_vector: request.query_vector,
         max_depth: request.max_depth,

--- a/src/services/entity_orchestrator.rs
+++ b/src/services/entity_orchestrator.rs
@@ -383,6 +383,7 @@ impl EntityOrchestrator {
                 vector_collection: collection.to_string(),
                 // Structural tenant boundary — scopes BOTH fusion legs (clean names in, TD-ENTITY-TENANT-1).
                 tenant: Some(tenant.to_string()),
+                tenant_stable_id: None, // FA-2 PR-D3: internal path — no client subject
                 query_vector,
                 // TD-146 scope B: graph-augmented entity fusion. `EntityNode` keying normalizes
                 // the auxiliary vector oid + canonical graph oid to the entity `node_id` so the

--- a/src/services/fusion_service.rs
+++ b/src/services/fusion_service.rs
@@ -450,6 +450,12 @@ pub struct GraphFusionParams {
     /// `{tenant}/{graph_id}` (via `scoped_graph_id`) so reads + canonical oids match the graph write
     /// path. `None`/default tenant ⇒ bare graph_id + unscoped vector read (TD-ENTITY-TENANT-1).
     pub tenant: Option<String>,
+    /// FA-2 PR-D3: the request's STABLE tenant id — the ABAC binding-filter key
+    /// (`b.tenant_stable_id == tenant_stable_id`). Populated by the network layer
+    /// from the resolved identity (REST: `MiddlewareTenantContext.tenant_stable_id`).
+    /// `None` ⇒ no per-record ABAC enforcement (structural isolation only) — the
+    /// default for paths that haven't resolved a stable id (gRPC, embedded).
+    pub tenant_stable_id: Option<u64>,
 }
 
 /// Orchestrates the graph instance of the fusion seam over the live vector + graph engines.
@@ -520,10 +526,33 @@ impl FusionService {
         let limit = params.limit;
 
         #[cfg(feature = "abac-policy")]
-        let read_ctx = proximadb_abac::ReadContext::system(
-            proximadb_abac::SystemReadReason::Statistics,
-            "fusion_service [CLIENT-PLACEHOLDER]",
-        );
+        let read_ctx = match (&params.principal, params.tenant_stable_id) {
+            (Some(subject), Some(tenant_stable_id)) => {
+                match self
+                    .vector
+                    .resolve_vector_read_context(
+                        &proximadb_catalog::fc_metamodel::SubjectId(subject.clone()),
+                        tenant_stable_id,
+                        &collection,
+                    )
+                    .await
+                {
+                    Some(Ok(ctx)) => proximadb_abac::ReadContext::Client(ctx),
+                    Some(Err(_)) => {
+                        // Fail-closed: a denied subject gets an empty fusion result.
+                        return Ok((Vec::new(), FusionStats::default(), HashMap::new()));
+                    }
+                    None => proximadb_abac::ReadContext::system(
+                        proximadb_abac::SystemReadReason::Statistics,
+                        "fusion_service (no abac enforcer)",
+                    ),
+                }
+            }
+            _ => proximadb_abac::ReadContext::system(
+                proximadb_abac::SystemReadReason::Statistics,
+                "fusion_service (no client subject)",
+            ),
+        };
         let mut hits = retry_vector_search(
             &collection,
             || {

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -701,6 +701,43 @@ impl VectorOperationsService {
         self
     }
 
+    /// FA-2 PR-D3 (abac-policy): resolve `subject`'s read authorization for a
+    /// vector `collection_id` into the [`AuthorizedReadContext`] the push-down
+    /// path consumes. The fusion seam calls this to build a `ReadContext::Client`
+    /// from the request subject + tenant.
+    ///
+    /// Returns:
+    /// - `None` ⇒ no enforcer wired (or the collection can't be resolved — the
+    ///   search itself then fails with that error, so no unfiltered data is
+    ///   served); the caller uses a `System` (passthrough) context.
+    /// - `Some(Ok(ctx))` ⇒ admitted; wrap as `ReadContext::Client(ctx)`.
+    /// - `Some(Err(reason))` ⇒ DENY; the caller MUST fail closed (return empty).
+    ///
+    /// `Target.table` is the collection's catalog object id (resolved the same
+    /// way `unified_search_native` does, ADR-0083 D5). Table-scoped policies
+    /// match on it alone (`scope_covers` for `Scope::Table` checks `target.table`
+    /// only); `namespace` is irrelevant for the common per-collection RLS case.
+    #[cfg(feature = "abac-policy")]
+    pub async fn resolve_vector_read_context(
+        &self,
+        subject: &proximadb_catalog::fc_metamodel::SubjectId,
+        tenant_stable_id: u64,
+        collection_id: &str,
+    ) -> Option<Result<proximadb_abac::AuthorizedReadContext, proximadb_abac::DenyReason>> {
+        let enforcer = self.abac_enforcer.as_ref()?;
+        let collection = self.get_or_load_collection(collection_id).await.ok()?;
+        let object_id: crate::core::stable_id::CollectionObjectId = collection.id.parse().ok()?;
+        Some(enforcer.resolve_read_context(
+            subject,
+            tenant_stable_id,
+            proximadb_catalog::fc_metamodel::Target {
+                namespace: 0,
+                table: object_id as u32,
+                column: None,
+            },
+        ))
+    }
+
     /// Expose the unified storage engine as a trait object for integration points
     pub fn unified_engine(&self) -> Arc<dyn crate::storage::traits::UnifiedStorageFormat> {
         self.storage_engine.clone() as Arc<dyn crate::storage::traits::UnifiedStorageFormat>

--- a/tests/abac_vector_pushdown_integration_test.rs
+++ b/tests/abac_vector_pushdown_integration_test.rs
@@ -206,3 +206,61 @@ async fn system_context_does_not_filter() {
         "a System context must not filter — both records expected; got {ids:?}"
     );
 }
+
+/// FA-2 PR-D3: the centralized vector resolver (`resolve_vector_read_context`)
+/// resolves the collection and builds the `Target` the enforcer matches. An
+/// admitted subject ⇒ `Some(Ok(ctx))`; an unbound subject ⇒ `Some(Err(_))`
+/// (deny — the caller fail-closes). Uses a namespace-scoped binding (matches the
+/// resolver's `Target.namespace = 0`) so the assertion is independent of the
+/// collection's generated object id.
+#[tokio::test]
+async fn resolve_vector_read_context_admits_and_denies() {
+    let env = UnifiedTestEnvironment::new().await.expect("test env");
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        proximadb_abac::AttributeBinding::new("alice", TENANT)
+            .with_attr("dept", AttrValue::Str("eng".into())),
+    );
+    let bindings = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Namespace(0),
+        effect: Effect::Permit,
+        predicate_ref: None,
+        field_mask: None,
+    }];
+    let enforcer = Arc::new(
+        AbacEnforcer::new(
+            Box::new(authority),
+            Box::new(InMemoryPredicateObjectStore::new()),
+            Box::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_bindings(bindings),
+    );
+    let (svc, collections) = env
+        .vector_operations_service_with_abac(enforcer)
+        .await
+        .expect("vector service with abac");
+    UnifiedTestEnvironment::create_vector_collection(&collections, COLLECTION, DIM)
+        .await
+        .expect("create collection");
+
+    // alice (binding present) ⇒ admitted: the resolver found the collection and
+    // built a Target the enforcer matched.
+    let admitted = svc
+        .resolve_vector_read_context(&SubjectId("alice".into()), TENANT, COLLECTION)
+        .await;
+    assert!(
+        matches!(admitted, Some(Ok(_))),
+        "alice must be admitted (Some(Ok))"
+    );
+
+    // mallory (no attribute binding) ⇒ denied — caller must fail-closed.
+    let denied = svc
+        .resolve_vector_read_context(&SubjectId("mallory".into()), TENANT, COLLECTION)
+        .await;
+    assert!(
+        matches!(denied, Some(Err(_))),
+        "mallory (unbound) must be denied (Some(Err))"
+    );
+}


### PR DESCRIPTION
## Summary

PR-D2 (#1350) wired the enforcer and proved the enforcement kernel fires when a `Client` `ReadContext` reaches `unified_search_native`. This PR makes the **fusion path** construct that `Client` context from a live request, so per-record ABAC actually enforces on real fusion searches (not just the test harness).

## Changes

- **`VectorOperationsService::resolve_vector_read_context(subject, tenant_stable_id, collection_id)`**: the centralized resolver. Resolves the collection's catalog object id (ADR-0083 D5) and calls `resolve_read_context`. Table-scoped policies bind on the object id alone (`scope_covers` matches `target.table` only) — namespace is irrelevant for the common per-collection RLS case (this dissolves the namespace/catalog concern; see PR-D2 thread).
- **`FusionService` (`graph_fusion_search_with_labels`)**: replace the `System` placeholder with a resolved `Client` `ReadContext` from `params.principal` + `params.tenant_stable_id`; **Deny ⇒ empty fusion result (fail-closed)**. No subject/tenant, or no enforcer ⇒ `System` passthrough (structural isolation only).
- **`GraphFusionParams` += `tenant_stable_id`**; the REST fusion handler populates it from `MiddlewareTenantContext.tenant_stable_id` (the ABAC binding-filter key). All 6 construction sites updated (REST gets the real value; gRPC/internal/embedded set `None`).
- **Integration test**: `resolve_vector_read_context` admits an admitted subject and denies an unbound one (verifies collection resolution + `Target` construction).

## Verification (local)

- `cargo clippy -p proximadb --features abac-policy --lib -- -D warnings` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo nextest run -p proximadb --features abac-policy --test abac_vector_pushdown_integration_test` — 6/6 ✅ (incl. the new resolver test)
- `cargo fmt --check` ✅ · `make work-commit-check` (panic +0, layering, tenant-path, env-gate) ✅

## Scope / follow-up

- **REST fusion is wired end-to-end.** gRPC fusion sets `tenant_stable_id: None` for now — the gRPC auth layer (`GrpcAuthContext`) has no `tenant_stable_id` field and the `TenantStableIdResolver` is REST-middleware-only; threading the resolver into the gRPC interceptor is the next slice.
- **Plain gRPC/REST search (non-fusion)** still diverges to `execute_unified_plan` and does not route through the enforcement kernel — a separate, larger item.
- abac-policy remains default-OFF; default builds are unchanged.