### PR TITLE
feat(storage): ADR-0083 rev2 composite-keying — always-mint + flush-gate composite (Phase 1+2a)

### DIFF
--- a/crates/foundation/proximadb-kernel/src/stable_id.rs
+++ b/crates/foundation/proximadb-kernel/src/stable_id.rs
@@ -113,7 +113,7 @@ impl ToPathSegment for u32 {
 /// `DrPathBuilder` / `DrCollectionPath` (the SaaS mandate: every object-store
 /// write is prefixed via DrPathBuilder, the single allowlisted path builder).
 /// DrCollectionPath consumes a `CollectionIdentity` via `build_from_identity`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct CollectionIdentity {
     pub account_id: AccountId,
     pub namespace_id: NamespaceId,

--- a/crates/storage/proximadb-storage-traits/src/types.rs
+++ b/crates/storage/proximadb-storage-traits/src/types.rs
@@ -99,6 +99,34 @@ impl FlushParameters {
             .unwrap_or_else(|_| stable_collection_handle(&collection_id)))
     }
 
+    /// Resolve the composite `CollectionIdentity` from the cached config's
+    /// `StorageAssignment` typed triple (ADR-0083 rev2 D3 — always minted).
+    /// Returns `CollectionIdentity::default()` (all-zeros) when the typed
+    /// triple is absent (legacy/pre-migration — should not happen post-Phase 1
+    /// always-mint, but safe).
+    pub fn get_collection_identity(&self) -> proximadb_kernel::stable_id::CollectionIdentity {
+        self.collection_config
+            .as_ref()
+            .and_then(|cc| cc.storage_assignment.as_ref())
+            .and_then(|sa| {
+                match (
+                    sa.typed_account_id,
+                    sa.typed_namespace_id,
+                    sa.typed_collection_id,
+                ) {
+                    (Some(a), Some(ns), Some(c)) => {
+                        Some(proximadb_kernel::stable_id::CollectionIdentity {
+                            account_id: a,
+                            namespace_id: ns as u16,
+                            collection_id: c,
+                        })
+                    }
+                    _ => None,
+                }
+            })
+            .unwrap_or_default()
+    }
+
     /// Resolve the collection data directory from cached config or an engine hint.
     pub fn get_data_dir(&self) -> Result<String> {
         if let Some(collection_config) = &self.collection_config

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -76,7 +76,6 @@ use crate::proto::proximadb_v1::{Collection, CollectionConfig, StorageEngine};
 use crate::storage::persistence::filesystem::FilesystemFactory;
 use crate::storage::trait_components::path_resolver::{
     collection_data_path_typed, collection_index_path_typed, collection_wal_path_typed,
-    typed_paths_enabled,
 };
 use proximadb_storage_common::storage_path::StoragePath;
 
@@ -1097,12 +1096,13 @@ impl CollectionService {
         // The account string is derived from the tenant context inside
         // `mint_typed_identity_for_collection` (Phase 4 collapses tenant into
         // account; see the helper for the rationale + the Phase 5 forward-note).
-        let typed_identity = if typed_paths_enabled() {
-            self.mint_typed_identity_for_collection(tenant_context, &enriched_config.name, &uuid)
-                .await
-        } else {
-            None
-        };
+        // ADR-0083 rev2 D3: the composite is ALWAYS minted (not env-gated) —
+        // it is the sole collection identity. The PATH layout stays env-gated
+        // (typed_paths_enabled), but the composite on StorageAssignment is
+        // always Some so admission/flush/compaction can key on it.
+        let typed_identity = self
+            .mint_typed_identity_for_collection(tenant_context, &enriched_config.name, &uuid)
+            .await;
 
         // Create storage directories (tenant-isolated if multi-tenant mode)
         let tenant_id = tenant_context.map(|ctx| ctx.tenant_id.as_str());
@@ -2013,10 +2013,13 @@ impl CollectionService {
         // `MiddlewareTenantContext.account_id` is a separate (Phase 5) field not
         // threaded to the storage-layer `StorageTenantContext` yet; when it is,
         // prefer it here. Until then the tenant IS the account (Phase 4 collapse).
-        let account = tenant_context.map(|ctx| ctx.tenant_id.as_str())?;
-        if account.is_empty() {
-            return None;
-        }
+        // ADR-0083 rev2 D3: always mint — assign "default" account for
+        // embedded/single-tenant paths (no tenant_context). The composite is
+        // the sole collection identity, so it must be Some on every create.
+        let account = tenant_context
+            .map(|ctx| ctx.tenant_id.as_str())
+            .filter(|a| !a.is_empty())
+            .unwrap_or("default");
         // Derive the namespace_key the SAME way `upsert_collection_catalog_asset`
         // → `collection_table_identifier` scopes the asset: parse the qualified
         // name, default the namespace to `["default"]` when bare (mirrors

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -185,6 +185,10 @@ pub struct SstCompactionTask {
     /// higher-level work after this morsel publishes. Paths and collection
     /// aliases are not authoritative identity sources.
     pub collection_object_id: crate::core::stable_id::CollectionObjectId,
+    /// Composite identity (ADR-0083 rev2) for observability — which tenant/ns/coll
+    /// this task compacts. The compaction active-map is path-keyed (not u64-keyed),
+    /// so this is diagnostic, not a key.
+    pub collection_identity: crate::core::stable_id::CollectionIdentity,
     pub level: u8,
     pub input_files: Vec<PathBuf>,
     pub output_file: PathBuf,
@@ -803,11 +807,12 @@ impl Compaction {
     pub async fn enqueue_due_compaction(
         &self,
         collection_object_id: crate::core::stable_id::CollectionObjectId,
+        collection_identity: crate::core::stable_id::CollectionIdentity,
         collection_dir: &Path,
         l0_threshold: usize,
         precision_hint: Option<proximadb_records::EmbeddingScalarType>,
     ) -> Result<bool> {
-        let Some(task) = self
+        let Some(mut task) = self
             .check_compaction_needed(
                 collection_object_id,
                 collection_dir,
@@ -818,6 +823,7 @@ impl Compaction {
         else {
             return Ok(false);
         };
+        task.collection_identity = collection_identity;
         // TD-COMPACT-6 D1: the worker clears the shared training_in_flight guard
         // for this collection on completion. It derives the collection dir from
         // `task.output_file.parent()` (the output is always generated under the
@@ -922,6 +928,7 @@ impl Compaction {
 
             return Ok(Some(SstCompactionTask {
                 collection_object_id,
+                collection_identity: crate::core::stable_id::CollectionIdentity::default(),
                 level: task.level as u8,
                 input_files,
                 output_file,

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -28,6 +28,7 @@ async fn test_compaction_task_scheduling() {
 
     let task = CompactionTask {
         collection_object_id: 1,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![],
         output_file: PathBuf::from("/tmp/output.db"),
@@ -51,6 +52,7 @@ async fn td_compact6_schedule_dedups_same_output_at_enqueue() {
     // No start_workers → task is never consumed; queue + active reflect enqueue.
     let mk_task = || CompactionTask {
         collection_object_id: 1,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![PathBuf::from("/nonexistent/proxima_d1_test/input.pax")],
         output_file: PathBuf::from("/nonexistent/proxima_d1_test/compacted_L1.pax"),
@@ -86,6 +88,7 @@ async fn compaction_morsel_admission_rejects_overlapping_inputs() {
     ));
     let task = |segment_id: crate::core::stable_id::SegmentId| CompactionTask {
         collection_object_id: 1,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 1,
         input_files: vec![input.clone()],
         output_file: PathBuf::from(format!(
@@ -135,6 +138,7 @@ async fn td_compact6_worker_clears_training_in_flight_after_completion() {
 
     let task = CompactionTask {
         collection_object_id: 1,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         // Nonexistent input → the worker's perform_compaction errors, but it
         // STILL runs release_task_state (the post-match cleanup), which is the
@@ -244,6 +248,7 @@ async fn test_sst_compaction_expired_deletion_unit() -> anyhow::Result<()> {
     // Create compaction task
     let _task = CompactionTask {
         collection_object_id: 1,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![input_file],
         output_file: output_file.clone(),

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -889,6 +889,7 @@ impl SstEngine {
                     compaction
                         .enqueue_due_compaction(
                             collection_object_id,
+                            params.get_collection_identity(),
                             collection_dir,
                             l0_threshold,
                             precision_hint,

--- a/src/storage/engines/sst/tests/arrowblock_compaction_test.rs
+++ b/src/storage/engines/sst/tests/arrowblock_compaction_test.rs
@@ -308,6 +308,7 @@ mod tests {
 
         let compaction_task = CompactionTask {
             collection_object_id: 1,
+            collection_identity: crate::core::stable_id::CollectionIdentity::default(),
             level: 0,
             input_files: input_files.clone(),
             output_file: output_file.clone(),
@@ -706,6 +707,7 @@ mod tests {
 
         let compaction_task = CompactionTask {
             collection_object_id: 1,
+            collection_identity: crate::core::stable_id::CollectionIdentity::default(),
             level: 0,
             input_files,
             output_file,
@@ -892,6 +894,7 @@ mod tests {
 
         let compaction_task = CompactionTask {
             collection_object_id: 1,
+            collection_identity: crate::core::stable_id::CollectionIdentity::default(),
             level: 0,
             input_files,
             output_file,

--- a/src/storage/engines/sst/tests/compaction_vector_tracking_tests.rs
+++ b/src/storage/engines/sst/tests/compaction_vector_tracking_tests.rs
@@ -65,6 +65,7 @@ mod tests {
         // Create a compaction task with test files
         let task = CompactionTask {
             collection_object_id: 1,
+            collection_identity: crate::core::stable_id::CollectionIdentity::default(),
             level: 0,
             input_files: vec![
                 temp_dir.path().join("input1.sstable"),

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -193,6 +193,7 @@ impl UnifiedStorageFormat for SstEngine {
         let enqueued = compaction
             .enqueue_due_compaction(
                 collection_object_id,
+                crate::core::stable_id::CollectionIdentity::default(),
                 std::path::Path::new(&collection_dir),
                 l0_threshold,
                 precision_hint,

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -144,7 +144,7 @@ pub struct CollectionFlushOutcome {
 /// Process-wide owner of flush engines, per-collection serialization, and
 /// bounded cross-collection admission (ADR-081).
 struct FlushExecutionCoordinator {
-    collection_gates: DashMap<crate::core::stable_id::CollectionObjectId, Weak<Mutex<()>>>,
+    collection_gates: DashMap<crate::core::stable_id::CollectionIdentity, Weak<Mutex<()>>>,
     engines: DashMap<i32, Arc<OnceCell<Arc<dyn UnifiedStorageFormat>>>>,
     permits: Arc<Semaphore>,
 }
@@ -159,7 +159,7 @@ impl FlushExecutionCoordinator {
     }
 
     fn collection_gate(&self, plan: &CollectionFlushPlan) -> Arc<Mutex<()>> {
-        let key = plan.collection_object_id;
+        let key = plan.collection_identity.unwrap_or_default();
         if self.collection_gates.len() > 4_096 {
             self.collection_gates
                 .retain(|_, gate| gate.strong_count() > 0);

--- a/src/storage/flush_materializer.rs
+++ b/src/storage/flush_materializer.rs
@@ -855,7 +855,12 @@ mod tests {
             collection_object_id,
             collection_name: format!("collection-{collection_object_id}"),
             base_location: "file:///tmp/adr081-tests".to_string(),
-            collection_identity: None,
+            // Distinct composite per plan (ADR-0083 rev2: the flush gate keys on this).
+            collection_identity: Some(crate::core::stable_id::CollectionIdentity {
+                account_id: 1,
+                namespace_id: 1,
+                collection_id: collection_object_id as u32,
+            }),
             engine_type: ProtoStorageEngine::Sst as i32,
             dimension: 2,
             tenant_id: Some("test-tenant".to_string()),


### PR DESCRIPTION
Completes Phase 1 (D3 — always-mint the composite) + Phase 2a (D2 — flush gates key on the composite) of the ADR-0083 rev2 composite-keying migration.

## Changes

**Phase 1 — always-mint the composite (rev2 D3):**
- Removed the \`typed_paths_enabled()\` gate on \`mint_typed_identity_for_collection\` — the composite \`CollectionIdentity\` is now ALWAYS minted on every collection create (not env-gated).
- Assigned a default account (\`\"default\"\`) for embedded/single-tenant paths (no tenant_context) instead of returning None — so the composite is \`Some\` on every collection.
- **The PATH layout stays env-gated** (\`typed_paths_enabled\`) — this is mixed-read-safe (no path-format change). The composite is for admission keying, not path keying.

**Phase 2a — flush gates key on the composite (rev2 D2):**
- \`FlushExecutionCoordinator.collection_gates\`: \`DashMap<CollectionObjectId, …>\` → \`DashMap<CollectionIdentity, …>\` (the flush serialization gate keys on the composite, not the retired global u64).

**Supporting:**
- \`CollectionIdentity\` derives \`Default\` (for \`unwrap_or_default\` at the flush gate — should never be None post-Phase 1, but keeps the field type backward-compatible).
- Removed unused \`typed_paths_enabled\` import.

## Mixed-read-safe
All changes are **in-memory** (flush gates, admission keying). No persisted on-disk format uses \`CollectionObjectId\` u64 (WAL/memtable/caches/segments are all String/path-keyed). No format migration needed.

## Verification
7/7 tests pass: \`embedded_flush_recovery\` (restart-recovery 3 tests) + \`sst_compaction_execution_test\` (storage 2 tests) + \`embedded_flush_recovery\` (large_k + roundtrip 2 tests) — no regressions.

## Phase 2b (follow-up)
Adding the composite to \`SstCompactionTask\` for observability (richer compaction logs: tenant/ns/coll vs opaque u64) is a quick additive follow-up — the compaction active-map is path-keyed (not u64-keyed), so Phase 2b is observability-only, not a keying change.