### PR TITLE
refactor(flight): remove dead api_port from ProximaFlightService (TD-FLIGHT-1 followup)

### DIFF
--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -169,14 +169,9 @@ pub struct ProximaFlightService {
     // concrete services it actually uses, not a monolithic handler. Canonical
     // v2 vector search goes through `RecordSearchPort`, record-batch ingest
     // through `RecordOpsPort`; the vector-ops/collection services are held
-    // directly (same Arcs as before). `api_port` is retained for the v1
-    // surface still used elsewhere (deprecated for Flight search — TD-FLIGHT-1).
-    // TD-FLIGHT-1: `api_port` (the v1 search contract) is no longer used by
-    // Flight search — both DoGet and bulk_search now route through
-    // `record_search_port`. Retained (rather than ripped out) to keep this PR
-    // off the constructor/boot-wiring cascade; a follow-up TD removes it.
-    #[allow(dead_code)]
-    api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
+    // directly (same Arcs as before). (TD-FLIGHT-2: the deprecated v1
+    // `api_port`/`ApiHandlersPort` search field was removed once #1351 landed —
+    // the v1 method stays on `ApiHandlersPort` for REST `/progressive/search`.)
     record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
     record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
     vector_operations_service: Arc<crate::services::VectorOperationsService>,
@@ -277,7 +272,6 @@ impl ProximaFlightService {
     /// routes through ROOT). The vector-ops/collection services and the storage
     /// locations are passed in by the boot wiring (multi_server / ArrowFlightServer).
     pub fn new(
-        api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
         record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
         record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
         vector_operations_service: Arc<crate::services::VectorOperationsService>,
@@ -285,7 +279,6 @@ impl ProximaFlightService {
         storage_locations: Vec<String>,
     ) -> Self {
         Self {
-            api_port,
             record_port,
             record_search_port,
             vector_operations_service,
@@ -314,12 +307,11 @@ impl ProximaFlightService {
     }
 
     /// Boot adapter (TD-104 S3-c/S3-e): build a `ProximaFlightService` from the
-    /// runtime `api_port` plus the concrete services it needs, all passed
-    /// directly (no root `UnifiedHandlers` indirection). `storage_locations` is
-    /// derived from the collection service's storage config — the same read the
-    /// former root `storage_config()` delegated to.
+    /// runtime ports plus the concrete services it needs, all passed directly
+    /// (no root `UnifiedHandlers` indirection). `storage_locations` is derived
+    /// from the collection service's storage config — the same read the former
+    /// root `storage_config()` delegated to.
     pub fn from_services(
-        api_port: Arc<dyn proximadb_runtime::ApiHandlersPort>,
         record_port: Arc<dyn proximadb_runtime::RecordOpsPort>,
         record_search_port: Arc<dyn proximadb_runtime::RecordSearchPort>,
         vector_operations_service: Arc<crate::services::VectorOperationsService>,
@@ -334,7 +326,6 @@ impl ProximaFlightService {
             .collect();
 
         Self::new(
-            api_port,
             record_port,
             record_search_port,
             vector_operations_service,

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -723,7 +723,6 @@ impl MultiServer {
             // three see identical routing decisions.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
-            let api_handlers = services.api_handlers.clone();
             let tenant_header_trust = self.tenant_header_trust;
             let tenant_deployment_mode = self.tenant_deployment_mode.clone();
 
@@ -731,7 +730,6 @@ impl MultiServer {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
                 let flight_service = ProximaFlightService::from_services(
-                    api_handlers,
                     arrow_record_ops,
                     arrow_record_search,
                     arrow_vector_ops,
@@ -1133,7 +1131,6 @@ impl MultiServer {
             // Arrow Flight service (HTTP/2-based, shares internal gRPC server)
             let flight_service =
                 crate::network::arrow_ipc::service::ProximaFlightService::from_services(
-                    services.api_handlers.clone(),
                     services.record_ops.clone(),
                     // same RecordOpsService Arc, coerced to the v2 search port (TD-FLIGHT-1)
                     services.record_ops.clone(),
@@ -1651,7 +1648,6 @@ impl MultiServer {
             // three see identical routing decisions.
             let primary_pod_registry = services.primary_pod_registry.clone();
             let self_pod_id = services.self_pod_id.clone();
-            let api_handlers = services.api_handlers.clone();
             let tenant_header_trust = self.tenant_header_trust;
             let tenant_deployment_mode = self.tenant_deployment_mode.clone();
 
@@ -1659,7 +1655,6 @@ impl MultiServer {
                 use crate::network::arrow_ipc::{ArrowFlightServer, service::ProximaFlightService};
 
                 let flight_service = ProximaFlightService::from_services(
-                    api_handlers,
                     arrow_record_ops,
                     arrow_record_search,
                     arrow_vector_ops,


### PR DESCRIPTION
## Summary
Follow-up cleanup to #1351 (TD-FLIGHT-1). Now that both Flight `DoGet` and `bulk_search` route through `RecordSearchPort`, the v1 `api_port: Arc<dyn ApiHandlersPort>` field on `ProximaFlightService` is unused (it carried `#[allow(dead_code)]` in #1351 to avoid the constructor/boot-wiring cascade there).

This removes it cleanly:
- Drop the `api_port` field + its params in `new()` / `from_services()`.
- Drop the matching `api_handlers` capture at all three Flight boot sites in `multi_server.rs`.
- The v1 `handle_vector_search_v1_for_tenant` method **stays** on `ApiHandlersPort` — REST's `/progressive/search` route still uses it.

Pure dead-code removal — **no behavior change**.

## Test plan
- `cargo nextest run` focused: 5 codec unit + 2 flight e2e pass (the e2e boots the server, confirming the boot-wiring change).
- `cargo clippy -p proximadb --lib -- -D warnings` clean.
- `cargo fmt --check` clean.
- `make work-commit-check` — panic-policy, layering, boundaries, env-gate, hygiene all pass.