### PR TITLE
feat(abac): wire TenantStableIdResolver for REST — unblock live ABAC (TD-TENANT-1 PR1)

### DIFF
--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -4503,6 +4503,14 @@ pub trait Catalog: Send + Sync {
     async fn account_id_u32(&self, _account: &str) -> anyhow::Result<Option<u32>> {
         Ok(None)
     }
+    /// TD-TENANT-1 item 3: SYNC lookup of the account u32 — no mint, no I/O.
+    /// For the request-hot `TenantStableIdResolver` (which is sync). Returns the
+    /// already-minted u32 for an account/tenant string, or `None` when unminted
+    /// (fail-closed deny). Default `None` — only the native catalog has a
+    /// registry; federated/external catalogs stay `None` (legacy-safe).
+    fn account_id_u32_lookup(&self, _account: &str) -> Option<u32> {
+        None
+    }
     /// ADR-031 allocator unification: the highest persisted `object_id` across
     /// all tables (from the durable `object_name_index`). The root startup path
     /// uses this to raise the collection-id allocator floor above every existing

--- a/crates/control/proximadb-catalog/src/manager.rs
+++ b/crates/control/proximadb-catalog/src/manager.rs
@@ -608,6 +608,22 @@ impl CatalogManager {
         self.get_catalog(name).await
     }
 
+    /// TD-TENANT-1 item 3: SYNC best-effort lookup of the account u32 via the
+    /// default catalog's registry (no mint, no I/O) — for the request-hot
+    /// `TenantStableIdResolver`. Uses `try_read` on the two backing RwLocks and
+    /// returns `None` on (rare) contention — callers treat `None` as fail-closed
+    /// deny (safe; the next request retries). Also `None` when no default
+    /// catalog is configured or the account is unminted.
+    pub fn account_id_u32_lookup(&self, account: &str) -> Option<u32> {
+        let name = self
+            .default_catalog
+            .try_read()
+            .ok()
+            .and_then(|n| n.as_ref().cloned())?;
+        let catalogs = self.catalogs.try_read().ok()?;
+        catalogs.get(&name)?.account_id_u32_lookup(account)
+    }
+
     /// Set the default catalog
     pub async fn set_default_catalog(&self, name: &str) -> Result<()> {
         // Verify catalog exists

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -1397,6 +1397,15 @@ impl Catalog for NativeCatalog {
         Ok(self.account_u32(account).await)
     }
 
+    fn account_id_u32_lookup(&self, account: &str) -> Option<u32> {
+        // TD-TENANT-1 item 3: sync read-only lookup (no mint, no persist) for the
+        // request-hot TenantStableIdResolver. None when unminted/empty.
+        if account.is_empty() {
+            return None;
+        }
+        self.account_registry.get(account).map(|v| *v.value())
+    }
+
     async fn max_object_id(&self) -> Result<Option<u64>> {
         // Max persisted object_id from the durable forward index (name→oid),
         // loaded eagerly at startup. Used by the root to raise the collection-id
@@ -2110,6 +2119,14 @@ mod tests {
         // A genuinely new account mints above the recovered floor (2, not 1).
         let new_acct = cat2.account_u32("other").await.expect("mint new");
         assert_eq!(new_acct, 2, "new account mints above recovered floor");
+
+        // TD-TENANT-1 item 3: the SYNC account_id_u32_lookup returns the minted
+        // u32 (no mint, no I/O) — the TenantStableIdResolver contract. None for
+        // unknown/empty (fail-closed deny).
+        assert_eq!(cat2.account_id_u32_lookup("acct"), Some(1));
+        assert_eq!(cat2.account_id_u32_lookup("other"), Some(2));
+        assert_eq!(cat2.account_id_u32_lookup("never"), None);
+        assert_eq!(cat2.account_id_u32_lookup(""), None);
     }
 
     #[tokio::test]

--- a/docs/12-design/adr/ADR-0083-consolidated-catalog-identity-model.adoc
+++ b/docs/12-design/adr/ADR-0083-consolidated-catalog-identity-model.adoc
@@ -151,3 +151,23 @@ second system; it is retired.
   a sequence separate from identity (not a key).
 * **Namespace `u16` wrap (ADR-074 D4):** 65,536 namespaces/account is a hard
   cap, not a silent wrap — fence it. Tracked separately.
+
+== Addendum: ABAC `tenant_stable_id` (TD-TENANT-1 item 3)
+
+The ABAC layer keys enforcement on `tenant_stable_id: u64` (the binding filter
+`b.tenant_stable_id == tenant_stable_id`; ABAC/ADR-075). This u64 is **the
+ADR-0083 account u32 widened** — the composite's tenant component
+(`{account(u32), namespace(u16), collection(u32)}`; Phase 5: tenant≡account).
+The catalog does **not** mint a separate tenant u64.
+
+Rationale: ADR-0083 retired the global u64-as-identity; a fresh `IdAllocator` u64
+tenant space would reintroduce it. Reusing the account u32 (the existing durable
+`account_registry`, with its sidecar + floor recovery) is ADR-consistent and
+structurally guarantees binding consistency — there is exactly one minting
+authority for the tenant u64, consumed by both the request path
+(`TenantStableIdResolver`) and the (future) ABAC binding-provisioning path.
+
+* `TenantStableIdResolver::stable_id_of(tenant)` returns `account_u32(tenant)
+  as u64` (lookup-only, no mint).
+* `None` (unminted / brief lock contention) ⇒ fail-closed deny — the id is an
+optimization, never a second source of truth (ADR-075).

--- a/src/network/rest/server.rs
+++ b/src/network/rest/server.rs
@@ -422,6 +422,14 @@ impl RestServer {
             query_adapter.clone(),
             llm_engine,
         );
+        // TD-TENANT-1 item 3: build the tenant-stable-id resolver from the
+        // catalog handle before it's moved into base_state below, so the tenant
+        // middleware can stamp tenant_stable_id for ABAC enforcement.
+        let tenant_stable_id_resolver = catalog_manager.as_ref().map(|cm| {
+            Arc::new(crate::security::CatalogTenantStableIdResolver::new(
+                cm.clone(),
+            )) as Arc<dyn proximadb_tenant::TenantStableIdResolver>
+        });
         if let Some(manager) = catalog_manager {
             base_state = base_state.with_catalog_manager(manager);
         }
@@ -559,8 +567,11 @@ impl RestServer {
         // Tenant extraction layer for multi-tenant isolation.
         // Env overrides (PROXIMADB_TENANT_HEADER_TRUST) are applied here — at
         // server construction, never inside constructors — so tests stay hermetic.
-        let tenant_extractor =
+        let mut tenant_extractor =
             TenantExtractor::with_config(security_config.tenant.clone().apply_env_overrides());
+        if let Some(resolver) = &tenant_stable_id_resolver {
+            tenant_extractor = tenant_extractor.with_stable_id_resolver(resolver.clone());
+        }
         let tenant_layer = middleware::from_fn_with_state(tenant_extractor, tenant_middleware);
 
         // Log security configuration
@@ -747,6 +758,13 @@ impl RestServer {
         if let Some(reg) = segment_registry {
             base_state = base_state.with_segment_registry(reg);
         }
+        // TD-TENANT-1 item 3: build the tenant-stable-id resolver from the
+        // catalog handle before it's moved into base_state below.
+        let tenant_stable_id_resolver = catalog_manager.as_ref().map(|cm| {
+            Arc::new(crate::security::CatalogTenantStableIdResolver::new(
+                cm.clone(),
+            )) as Arc<dyn proximadb_tenant::TenantStableIdResolver>
+        });
         if let Some(manager) = catalog_manager {
             base_state = base_state.with_catalog_manager(manager);
         }
@@ -877,7 +895,11 @@ impl RestServer {
         // unified path must apply it too (it is NOT wrapped by the caller).
         // The caller supplies the same deployment-derived policy used by the
         // multi-port path. Environment overrides are applied once here.
-        let tenant_extractor = TenantExtractor::with_config(tenant_config.apply_env_overrides());
+        let mut tenant_extractor =
+            TenantExtractor::with_config(tenant_config.apply_env_overrides());
+        if let Some(resolver) = &tenant_stable_id_resolver {
+            tenant_extractor = tenant_extractor.with_stable_id_resolver(resolver.clone());
+        }
         let tenant_layer = middleware::from_fn_with_state(tenant_extractor, tenant_middleware);
 
         // Auth layer — convergent with the multi-port `start_with_security`

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -12,6 +12,7 @@ pub mod rbac_service;
 pub mod request_identity;
 pub mod rls;
 pub mod security_coordinator;
+pub mod tenant_stable_id;
 pub mod validation;
 
 pub use rbac_service::{
@@ -33,6 +34,8 @@ pub use advanced_features::{
     IPAccessConfig, IPAccessControlService, IPAccessResult, MFAChallenge, MFAConfig, MFAProvider,
     MFAService, MFAVerificationResult, RateLimitConfig, RateLimitResult, RateLimitingService,
 };
+
+pub use tenant_stable_id::CatalogTenantStableIdResolver;
 
 pub use rls::{
     CollectionRLS, Operation as RLSOperation, RLSConfig, RLSFilterResult, RLSPolicy,

--- a/src/security/tenant_stable_id.rs
+++ b/src/security/tenant_stable_id.rs
@@ -1,0 +1,42 @@
+//! TD-TENANT-1 item 3: the production [`TenantStableIdResolver`] — a root-layer
+//! adapter over the catalog's account registry.
+//!
+//! The ABAC `tenant_stable_id` (u64) IS the ADR-0083 account u32 widened (the
+//! composite identity's tenant component); the catalog does NOT mint a separate
+//! tenant u64. See the ADR-0083 addendum. This resolver is held by the request
+//! middleware (REST `TenantExtractor::with_stable_id_resolver`) so every
+//! authenticated request carries a real `tenant_stable_id` for ABAC enforcement.
+//!
+//! Lookup-only + authoritative: exactly ONE place derives the tenant u64 (the
+//! account registry), so the request path and the (future) ABAC binding-
+//! provisioning path can never disagree. `None` (unminted / brief lock
+//! contention) ⇒ fail-closed deny — the id is an optimization, never a second
+//! source of truth.
+
+use std::sync::Arc;
+
+use proximadb_tenant::TenantStableIdResolver;
+
+use crate::catalog::CatalogManager;
+
+/// Resolve a tenant's stable id (u64) by looking up its ADR-0083 account u32 in
+/// the catalog's account registry (via [`CatalogManager::account_id_u32_lookup`]),
+/// widened to u64.
+#[derive(Clone)]
+pub struct CatalogTenantStableIdResolver {
+    catalog_manager: Arc<CatalogManager>,
+}
+
+impl CatalogTenantStableIdResolver {
+    pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
+        Self { catalog_manager }
+    }
+}
+
+impl TenantStableIdResolver for CatalogTenantStableIdResolver {
+    fn stable_id_of(&self, tenant_id: &str) -> Option<u64> {
+        self.catalog_manager
+            .account_id_u32_lookup(tenant_id)
+            .map(|id| id as u64)
+    }
+}


### PR DESCRIPTION
## Summary

ABAC enforcement is substrate-complete (PR-D1/D2/D3 merged) but **inert in prod**: `tenant_stable_id` is `None` everywhere (no resolver wired) and the seam ran on a hardcoded `7`. TD-TENANT-1 item 3 names the gap. This PR1 wires the resolver for **REST**, so `tenant_stable_id` is populated on requests — unblocking REST + relational ABAC when `abac-policy` is enabled (still default-OFF, config-gated). **No behavior change unless ABAC is on.**

**Key decision (ADR-0083):** `tenant_stable_id` (u64) IS the ADR-0083 account u32 widened — the composite's tenant component (Phase 5: tenant≡account). **Not** a fresh u64 space (that would reintroduce the global u64 ADR-0083 retired). An ADR-0083 addendum records this.

## Changes
- `Catalog` trait += sync `account_id_u32_lookup` (default `None`, lookup-only). `NativeCatalog` override (DashMap get) + `CatalogManager` sync delegate (best-effort `try_read`; `None` on rare contention ⇒ fail-closed deny, retried).
- `CatalogTenantStableIdResolver` adapter (`src/security`) impls `TenantStableIdResolver` → widened u64. **Lookup-only + authoritative**: one minting authority ⇒ request path + future binding-provisioning can never disagree.
- REST wiring at both extractor sites (`server.rs`): `.with_stable_id_resolver`. The dormant `tenant.rs:621` stamp + `From`-bridge become live.
- Test: `account_id_u32_lookup` returns the minted u32 + `None` for unknown/empty.

## Verification
- `cargo clippy -p proximadb-catalog -- -D warnings` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo clippy -p proximadb --features abac-policy --lib -- -D warnings` ✅
- `cargo nextest run -p proximadb-catalog -E 'test(account_registry)'` ✅ (incl. new lookup assertions)
- `cargo fmt --check` ✅ · `make work-commit-check` (panic +0, layering, tenant-path, env-gate) ✅

## Follow-ups (separate PRs)
- **PR2**: gRPC wiring (`GrpcAuthContext`/`GrpcAuthLayer` += resolver; 3 multi_server sites).
- **PR3**: binding-provisioning admin path (key by tenant **string**, resolve at write) + pre-mint `DEFAULT_TENANT`. End-to-end (binding for "acme" admits an "acme" read).

Plan: the approved design lives in the linked TD-TENANT-1 planning doc.