### PR TITLE
chore(build): dev-fast profile + advisory CI fast lane + shape validation (L2/D4/D5)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,6 +38,10 @@ test-coverage-safe = "tarpaulin --skip-clean --timeout 600 --avoid-cfg-tarpaulin
 # Fast check (syntax only, no codegen) — typed-syntax loop, no linking
 check-fast = "check --all-targets --jobs 3"
 check-lib  = "check --lib --jobs 3"   # even tighter; library-only
+# L2 dev-fast lane: check with deps at -O1 (opt-in profile, see Cargo.toml
+# [profile.dev-fast]). Faster than the default dev/test check for dep-heavy
+# edits; artifacts are NOT shared with the test profile, so toggling recompiles.
+check-dev-fast = "check --profile dev-fast"
 
 # Parallel test run (for unit tests that don't share state).
 # Overrides the RUST_TEST_THREADS=1 from [env] via the inner --test-threads flag.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1524,6 +1524,76 @@ jobs:
             cargo test ${{ matrix.args }} -- --test-threads=${{ matrix.threads }}
           fi
 
+  # ============================================================================
+  # TOUCHED-CRATE FAST LANE (D4 / TD-DECOMP-1 follow-up) — ADVISORY, never a gate.
+  # Gives seconds-to-minutes-scale unit-test feedback for LEAF / workspace-member
+  # edits by compiling only the crates whose source changed vs origin/develop
+  # (scripts/affected_crates.py — DIRECT crates only, no reverse-dependents). The
+  # required `rust-test` job still runs the full suite; this is the early signal.
+  # Advisory (continue-on-error) AND not in ci-success.needs, so a misfire can
+  # never block a merge. The root `proximadb` crate is deliberately SKIPPED here:
+  # a src/** edit maps to it, and compiling the ~850K-LOC monolith's lib would be
+  # both redundant with rust-test and OOM-prone (the #920 scenario rust-test works
+  # around with 12G swap + CARGO_BUILD_JOBS=1). This lane targets leaf edits,
+  # where it pays off — more so as TD-DECOMP-1 follow-ups move logic DOWN into
+  # leaf crates. rust-cache only (no sccache): leaf crates are small, and sccache
+  # adds the #920 OOM risk for no gain at this scale.
+  # ============================================================================
+  rust-affected-fast:
+    name: Rust touched-crate fast check (advisory)
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true        # advisory — never a merge gate (also not in ci-success.needs)
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so affected_crates.py's `git diff origin/develop...HEAD`
+          # (three-dot, merge-base) resolves across a large develop→main gap.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-affected-fast"
+          shared-key: "build"
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Affected-only fast unit check
+        run: |
+          set -euo pipefail
+          pkgs="$(python3 scripts/affected_crates.py origin/develop)"
+          [ -n "$pkgs" ] || { echo 'No crate source changed — skipping.'; exit 0; }
+          # Bare positionals to cargo/nextest are TEST-NAME FILTERS, not package
+          # selectors — turn the space-separated list into -p args. Skip the root
+          # crate (proximadb): a src/** edit maps to it, but compiling its lib is
+          # redundant with rust-test and OOM-prone here (see job header).
+          root_seen=no
+          pkg_args=""
+          for p in $pkgs; do
+            if [ "$p" = "proximadb" ]; then
+              root_seen=yes
+            else
+              pkg_args="$pkg_args -p $p"
+            fi
+          done
+          [ "$root_seen" = "yes" ] && echo "Root crate 'proximadb' changed — covered by the required rust-test job; not re-run in this fast lane."
+          if [ -z "$pkg_args" ]; then
+            echo 'Only the root crate (or nothing leaf) changed — nothing fast to check here.'
+            exit 0
+          fi
+          echo "Affected leaf crates:$pkg_args"
+          cargo nextest run --lib --profile unit $pkg_args
+
   # TD-168 develop early-detection: run the CHEAP object-store Cool-tier tests
   # (scripts/run_cloud_emulator_tests.sh --fast — compiles only the small
   # object-store crate, ~3-5m; no main-crate compile / no OOM risk) whenever the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1000,6 +1000,29 @@ overflow-checks = true
 incremental = true
 split-debuginfo = "unpacked"
 
+# dev-fast — opt-in fast-iteration lane (L2 / TD-DECOMP-1 follow-up). The default
+# dev/test/release profiles are UNCHANGED; release remains the perf authority.
+# Use for a quick `cargo check`/test loop where you don't want to pay the dep
+# opt-level=2/3 tax that dev/test carry:
+#   cargo check --profile dev-fast      (alias: cargo check-dev-fast)
+# Trade-off: dev-fast artifacts are NOT shared with the `test` profile (dev==test
+# opt-level is the artifact-reuse invariant — see the dev/test blocks above), so
+# toggling between dev/test and dev-fast recompiles. Acceptable for a fast lane.
+# Behavior-neutral: no runtime code path selects this profile.
+[profile.dev-fast]
+inherits = "dev"
+[profile.dev-fast.package."*"]
+# Broad deps at -O1 instead of dev's -O2. Profile `inherits` DOES carry the base
+# profile's per-package override tables, and a more-specific match wins over this
+# wildcard — so the four arrow-family crates (arrow/parquet/arrow-array/arrow-buffer,
+# pinned to -O3 in [profile.dev.package.*] above) STAY at -O3 under dev-fast; every
+# OTHER dep (the datafusion stack, tokio, serde, …) drops -O2 → -O1, and workspace
+# code stays at the inherited dev top-level opt-level=0. Verified empirically:
+# `cargo check --profile dev-fast -p arrow-buffer -v` emits `-C opt-level=3` for
+# arrow-buffer while generic deps emit `-C opt-level=1`. The build-time lever is the
+# broad -O1 dep mass (NOT arrow/parquet); see the PR body for the measured delta.
+opt-level = 1
+
 # Benchmark configuration - Organized by functional categories
 
 # 1. COMPUTE & DISTANCE BENCHMARKS (01-03)

--- a/docs/10-quality/td/TD-DECOMP-1-segment-format-to-storage-common.adoc
+++ b/docs/10-quality/td/TD-DECOMP-1-segment-format-to-storage-common.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | Landing (delivered by this slice)
+| Status | Landed (PR #1344). Build/CI-acceleration follow-up levers (L2/D4/D5) landed in PR #1360.
 | Severity | Low — build/dev-loop only; zero runtime, API, or on-disk-format impact
 | Component | `crates/storage/proximadb-storage-common` (`segment_layout`, `pax_block`); root `src/storage/engines/sst/segment_format.rs`
 | Relates to | `roadmap/techdebt/P2_GOD_CRATE_TEST_DECOMPOSITION.md` (god-crate decomposition); the build/CI-shape effort (D1 evidence: root monolith = 850K LOC, filtered root-lib test = 13.45 min / 26.68 GB peak)
@@ -61,6 +61,26 @@ dependency on the root crate (verified) — so no cycle is possible.
   observability, metrics, `block_cluster`, `survivor_range_cache`,
   `sst_query_engine`, `search`); needs several injected traits, so it is a later
   slice once this read/detection seam is established.
-* The complementary compile-time levers (dev/test dep `opt-level` tax, RAM-derived
-  CI job parallelism, touched-crate fast lane) and the embedded/on-prem/cloud
-  deployment-shape documentation are tracked separately under the build/CI-shape effort.
+* The complementary compile-time levers and deployment-shape validation landed in
+  PR #1360 (behavior-neutral; design doc `BUILD_CI_ACCELERATION_2026_07_31`).
+  Measured evidence (quiet machine):
++
+--
+** *L2* — opt-in `[profile.dev-fast]` (inherits `dev`; broad deps `-O2→-O1`, alias
+   `cargo check-dev-fast`). Cold `cargo test --lib … --no-run` (sccache OFF,
+   `jobs=3`): default dev **1245s** vs dev-fast **1069s** → **−176s (~14%)**.
+   Profile `inherits` carries the base profile's per-package overrides, so the
+   arrow-family crates (arrow/parquet/arrow-array/arrow-buffer, pinned `-O3`) STAY
+   at `-O3`; only the broad dep mass drops to `-O1`; workspace code stays at `-O0`
+   (verified: `cargo check --profile dev-fast -p arrow-buffer -v` → `-C opt-level=3`).
+   The win is on cold/CI builds — in the sccache-warm hot loop deps are cached and
+   the `-O0` root recompile dominates.
+** *D4* — advisory `rust-affected-fast` CI lane (`continue-on-error: true`, NOT in
+   `ci-success.needs` → can never block a merge): `cargo nextest run --lib` only on
+   crates touched vs `origin/develop` (`scripts/affected_crates.py`), skipping the
+   root monolith (redundant with `rust-test` + the #920 OOM risk). Seconds-scale
+   feedback for leaf edits; value grows as more logic moves DOWN.
+** *D5* — deployment-shape validation (confirmatory; CI's feature-matrix covers it):
+   on-prem / cloud (`cloud-full,otlp-metering`) / no-axis (default minus `axis`) /
+   embedded (`--no-default-features`) all `cargo check` clean.
+--


### PR DESCRIPTION
## What

Behavior-neutral build/CI-acceleration levers — design doc
`docs/12-design/BUILD_CI_ACCELERATION_2026_07_31.adoc`; TD-DECOMP-1 follow-up.
**No API, wire/on-disk-format, feature-default, or recall changes.** Default
dev/test/release profiles are UNCHANGED; release remains the perf authority.

### L2 — opt-in `dev-fast` profile
- `[profile.dev-fast]` (inherits `dev`) + `[profile.dev-fast.package."*"] opt-level = 1`, plus a `cargo check-dev-fast` alias.
- **Measured** cold (`cargo test --lib segment_format_detect --no-run`, sccache OFF, `jobs=3`, quiet machine — both runs identical conditions):

  | profile | wall | exit |
  |---|---|---|
  | default dev (deps `-O2`) | 1245s | 0 |
  | dev-fast (deps `-O1`) | 1069s | 0 |
  | **delta** | **−176s (~14%)** | |

- **Inheritance finding:** `inherits = "dev"` DOES carry the base profile's per-package override tables, and a more-specific match beats the wildcard — so arrow/parquet/arrow-array/arrow-buffer STAY at `-O3` under dev-fast; only the broad dep mass (datafusion, tokio, …) drops `-O2→-O1`; workspace code stays at `-O0`. Verified: `cargo check --profile dev-fast -p arrow-buffer -v` → `-C opt-level=3`; generic deps → `-C opt-level=1`.
- **Honest scope:** the win is on cold/CI builds. In the sccache-warm hot loop, deps are cached and the `-O0` root recompile dominates, so per-iteration benefit is limited to dep-recompile cases (Cargo.lock change, clean build, CI).

### D4 — advisory touched-crate CI fast lane
- New `rust-affected-fast` job in `.github/workflows/ci.yml`: `continue-on-error: true` AND **not** in `ci-success.needs` → a misfire can never block a merge.
- Runs `cargo nextest run --lib --profile unit` only on crates whose source changed vs `origin/develop` (`scripts/affected_crates.py`).
- Fixes two skeleton bugs: (1) bare positionals are test-name *filters*, not package selectors → built `-p <crate>` args; (2) skips the root `proximadb` crate (redundant with `rust-test` + the #920 OOM risk that job works around with swap + `CARGO_BUILD_JOBS=1`). Seconds-scale feedback for leaf/workspace-member edits; value grows as TD-DECOMP-1 follow-ups move logic DOWN into leaf crates.

### D5 — deployment-shape validation (confirmatory; CI feature-matrix covers these)

  | Shape | Features | Result |
  |---|---|---|
  | on-prem | root `default` | ✅ pass |
  | cloud | `default` + `cloud-full,otlp-metering` | ✅ pass |
  | no-axis | `default` minus `axis` | ✅ pass |
  | embedded | `--no-default-features` | ✅ pass |
  | embedded | `--no-default-features --features c_ffi` | ✅ pass |

## Verification (quiet machine)
- `cargo build -p proximadb-server` ✅ (dev, 12m20s)
- `cargo clippy --lib --bins -- -D warnings` ✅ (the CI clippy gate, 6m15s)
- `cargo fmt --check` ✅
- `make work-commit-check` ✅ (fmt, docs-claim, capability-matrix, workspace-boundaries, tenant-path, panic-policy +0 delta, env-gates)
- L2 cold-cold timing + D5 shape table above.

## Not in scope / rejected
Runtime perf claims from debug builds; lowering arrow/parquet opt-level (kept at `-O3`); bumping sccache size (live CI `sccache --show-stats`: 306 MiB / 10 GiB cap, 100% hits, 0 misses — size isn't the constraint; the GHA repo cache quota and the uncached root monolith on root-touching PRs are).
