### PR TITLE
feat(flight): wire TenantStableIdResolver into Flight search (TD-FLIGHT-1 final)

### DIFF
--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -184,6 +184,11 @@ pub struct ProximaFlightService {
     /// Whether missing request identity may resolve to a configured default.
     tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
     catalog_manager: Option<Arc<CatalogManager>>,
+    /// TD-TENANT-1: catalog-backed tenant stable-id resolver, mirroring the
+    /// REST `TenantExtractor::with_stable_id_resolver` seam. When present,
+    /// `handle_v2_search` stamps the resolved stable u64 into the io_trace
+    /// boundary (so Flight search is attributable per-tenant like REST).
+    stable_id_resolver: Option<Arc<dyn proximadb_tenant::TenantStableIdResolver>>,
     /// R-7c.4b: when present, the `rank_features_export` Flight action
     /// drives the multi-phase ranking pipeline through this singleton.
     /// Absent means the action returns `Unimplemented` (deployments that
@@ -287,6 +292,7 @@ impl ProximaFlightService {
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
             tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
             catalog_manager: None,
+            stable_id_resolver: None,
             rank_services: None,
             primary_pod_gate: None,
             graph_service: None,
@@ -408,6 +414,17 @@ impl ProximaFlightService {
     /// Attach xCatalog metadata for relational/table Flight schema resolution.
     pub fn with_catalog_manager(mut self, catalog_manager: Option<Arc<CatalogManager>>) -> Self {
         self.catalog_manager = catalog_manager;
+        self
+    }
+
+    /// Wire the catalog-backed tenant stable-id resolver (TD-TENANT-1), mirroring
+    /// REST's `TenantExtractor::with_stable_id_resolver`. When set, Flight search
+    /// stamps the resolved stable id into the io_trace boundary.
+    pub fn with_stable_id_resolver(
+        mut self,
+        resolver: Option<Arc<dyn proximadb_tenant::TenantStableIdResolver>>,
+    ) -> Self {
+        self.stable_id_resolver = resolver;
         self
     }
 
@@ -1175,8 +1192,8 @@ impl ProximaFlightService {
     /// behavior, and the tenant-collection-access check. Wrapped in the same
     /// query-scoped I/O-trace boundary as REST v2 (route
     /// `arrow_flight.v2.records.search`) so object GETs/bytes stay attributable
-    /// per query. Flight has no tenant-stable-id resolver yet, so the stable id
-    /// is `None` (matches the `instrument()` fallback).
+    /// per query. The tenant stable id (TD-TENANT-1) is resolved via the wired
+    /// `TenantStableIdResolver` when present, else `None`.
     async fn handle_v2_search(
         &self,
         ticket: FlightSearchTicket,
@@ -1191,9 +1208,18 @@ impl ProximaFlightService {
             "Arrow Flight canonical v2 vector search"
         );
 
+        // TD-TENANT-1: resolve the tenant's stable u64 (catalog-backed) so the
+        // io_trace record is attributable per-tenant, mirroring REST v2. `None`
+        // when no resolver is wired or the tenant is unminted (fail-open for
+        // attribution, never for access).
+        let tenant_stable_id = self
+            .stable_id_resolver
+            .as_ref()
+            .and_then(|r| r.stable_id_of(tenant_id));
+
         let response = crate::observability::io_trace::instrument_with_stable_tenant(
             Some(tenant_id.to_string()),
-            None,
+            tenant_stable_id,
             "arrow_flight.v2.records.search",
             crate::observability::predicate_diagnostics::scope(async {
                 self.record_search_port

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -737,7 +737,11 @@ impl MultiServer {
                     arrow_graph,
                 )
                 .with_tenant_header_trust(tenant_header_trust)
-                .with_tenant_deployment_mode(tenant_deployment_mode);
+                .with_tenant_deployment_mode(tenant_deployment_mode)
+                .with_stable_id_resolver(Some(Arc::new(
+                    crate::security::CatalogTenantStableIdResolver::new(catalog_manager.clone()),
+                )
+                    as Arc<dyn proximadb_tenant::TenantStableIdResolver>));
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))
@@ -1145,7 +1149,13 @@ impl MultiServer {
                 })
                 .with_tenant_header_trust(self.tenant_header_trust)
                 .with_tenant_deployment_mode(self.tenant_deployment_mode.clone())
-                .with_catalog_manager(Some(services.catalog_manager.clone()));
+                .with_catalog_manager(Some(services.catalog_manager.clone()))
+                .with_stable_id_resolver(Some(Arc::new(
+                    crate::security::CatalogTenantStableIdResolver::new(
+                        services.catalog_manager.clone(),
+                    ),
+                )
+                    as Arc<dyn proximadb_tenant::TenantStableIdResolver>));
             let flight_server =
                 arrow_flight::flight_service_server::FlightServiceServer::new(flight_service)
                     .max_encoding_message_size(512 * 1024 * 1024)
@@ -1662,7 +1672,11 @@ impl MultiServer {
                     arrow_graph,
                 )
                 .with_tenant_header_trust(tenant_header_trust)
-                .with_tenant_deployment_mode(tenant_deployment_mode);
+                .with_tenant_deployment_mode(tenant_deployment_mode)
+                .with_stable_id_resolver(Some(Arc::new(
+                    crate::security::CatalogTenantStableIdResolver::new(catalog_manager.clone()),
+                )
+                    as Arc<dyn proximadb_tenant::TenantStableIdResolver>));
                 match ArrowFlightServer::new(arrow_bind_target, flight_service)
                     .with_security_coordinator(security_coordinator)
                     .with_catalog_manager(Some(catalog_manager))


### PR DESCRIPTION
## Summary
The last TD-FLIGHT-1 follow-up. #1357 wired the catalog-backed `TenantStableIdResolver` (`CatalogTenantStableIdResolver` over `CatalogManager::account_id_u32_lookup`) into REST — this mirrors it for Arrow Flight.

- Add `stable_id_resolver: Option<Arc<dyn TenantStableIdResolver>>` + `with_stable_id_resolver` builder to `ProximaFlightService`.
- Wire it at all 3 Flight boot sites in `multi_server.rs`, reusing the exact resolver construction REST uses (`server.rs`).
- In `handle_v2_search`, resolve the tenant stable u64 and pass it to `instrument_with_stable_tenant` (route `arrow_flight.v2.records.search`) — so Flight search io_trace records are attributable per-tenant like REST v2. `None` when no resolver is wired or the tenant is unminted (fail-open for **attribution**, never for access).

## Why now
This was blocked until #1357 landed the resolver impl. Flight wasn't in TD-TENANT-1's REST→gRPC→binding-provisioning sequence, so it's unclaimed — this PR closes it.

## Test plan
- `cargo nextest run` focused: all 3 flight e2e tests pass (do_get ≡ REST, bulk_search order, unknown-ticket rejection) — the resolver returns `None` for the unminted test tenant, so search behavior is unchanged.
- `cargo clippy -p proximadb --lib -- -D warnings` clean.
- `cargo fmt --check` clean.
- `make work-commit-check` — panic-policy, layering, boundaries, env-gate, hygiene all pass.

This completes the TD-FLIGHT-1 handoff: #1351 (core) + #1355 (api_port cleanup) + #1356 (bulk_search e2e) + #1358 (benchmark harness) + this (stable-id attribution).