### PR TITLE
feat(sst): merge-on-read hides cold deletes on the exact PAX scan (TD-DELVEC-1 WI-4 slice 1)

### DIFF
--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -259,6 +259,12 @@ pub mod deletion_vector_store; // TD-DELVEC-1 WI-3a-remaining-A: CAS'd per-segme
 #[cfg(all(test, feature = "cold-deletion-vectors"))]
 #[path = "tests/cold_delete_dv_test.rs"]
 mod cold_delete_dv_test;
+// TD-DELVEC-1 WI-4 (slice 1): merge-on-read integration test — a cold delete is
+// invisible on the exact `.pax` scan path (`search_pax_file_exact`). In-crate
+// (#[path], like cold_delete_dv_test) to read the pub(crate) DV store + discovery.
+#[cfg(all(test, feature = "cold-deletion-vectors"))]
+#[path = "tests/cold_read_merge_test.rs"]
+mod cold_read_merge_test;
 pub mod flush;
 pub mod manifest;
 #[cfg(feature = "cold-deletion-vectors")]

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -1094,6 +1094,23 @@ impl SstEngine {
             storage_url
         );
 
+        // TD-DELVEC-1 WI-4: capture the scan's snapshot LSN once per direct-scan
+        // invocation for merge-on-read deletion-vector filtering in
+        // `search_pax_file_exact`. Captured at this convergence point — every route
+        // that reaches a `.pax` exact read funnels through here (exact segment scan,
+        // orchestrated AXIS fallback, and plain direct search) — so cold deletes are
+        // hidden uniformly across all of them. A later capture is strictly correct
+        // for slice 1's "hide deletes" goal (a larger LSN surfaces more deletes to
+        // the filter). Falls back to u64::MAX (see all deletes) when no freshness
+        // source is wired.
+        #[cfg(feature = "cold-deletion-vectors")]
+        let snapshot_lsn = match self.freshness_lsn_source_ref() {
+            Some(src) => src.current_lsn(collection_id).await,
+            None => u64::MAX,
+        };
+        #[cfg(not(feature = "cold-deletion-vectors"))]
+        let snapshot_lsn: u64 = u64::MAX;
+
         let mut all_candidates = Vec::new();
 
         // Phase 7.2 warm-path profiling: emit per-phase elapsed
@@ -1259,6 +1276,7 @@ impl SstEngine {
                                 filter_owned.clone(),
                                 k,
                                 distance_metric,
+                                snapshot_lsn,
                             )
                             .await
                         } else {
@@ -1381,6 +1399,7 @@ impl SstEngine {
                         filter_expression.cloned(),
                         k,
                         distance_metric,
+                        snapshot_lsn,
                     )
                     .await
                 } else {
@@ -1582,6 +1601,18 @@ impl SstEngine {
         use_parallel_morsels: bool,
         use_vectorized: bool,
     ) -> Result<Vec<OptimizedSearchRecord>> {
+        // TD-DELVEC-1 WI-4: capture the scan's snapshot LSN once per single-file
+        // scan (the parallel/arc path's per-file entry) for merge-on-read filtering
+        // in `search_pax_file_exact`. See `fallback_to_direct_search` for the
+        // rationale; u64::MAX (see all deletes) when no freshness source is wired.
+        #[cfg(feature = "cold-deletion-vectors")]
+        let snapshot_lsn = match self.freshness_lsn_source_ref() {
+            Some(src) => src.current_lsn(collection_id).await,
+            None => u64::MAX,
+        };
+        #[cfg(not(feature = "cold-deletion-vectors"))]
+        let snapshot_lsn: u64 = u64::MAX;
+
         // PAX RaBitQ→SQ8 cascade first for `.pax` under a validated metric.
         let pax_cascade: Option<Vec<OptimizedSearchRecord>> = if sstable_path.ends_with(".pax")
             && matches!(
@@ -1636,6 +1667,7 @@ impl SstEngine {
                 filter_expression.cloned(),
                 k,
                 distance_metric,
+                snapshot_lsn,
             )
             .await
         } else if use_pipeline {
@@ -2383,6 +2415,7 @@ impl SstEngine {
     /// cascade; everything else falls here instead of hitting the
     /// ProximaBlocks-only `sstable_reader` (which cannot decode `.pax`). Recall
     /// is exact for `RawF32` quant and dequantization-bound for `RaBitQ`/`SQ8`.
+    #[cfg_attr(not(feature = "cold-deletion-vectors"), allow(unused_variables))]
     async fn search_pax_file_exact(
         &self,
         pax_path: &str,
@@ -2390,6 +2423,7 @@ impl SstEngine {
         filter_expression: Option<FilterExpression>,
         limit: usize,
         distance_metric: DistanceMetric,
+        snapshot_lsn: u64,
     ) -> Result<Vec<OptimizedSearchRecord>> {
         use proximadb_distance_kernel::engine::{SimilarityResult, UnifiedDistanceCompute};
         use std::sync::Arc;
@@ -2415,11 +2449,34 @@ impl SstEngine {
             records.len()
         );
 
+        // TD-DELVEC-1 WI-4: warm this segment's deletion vector (lazy-load the
+        // `.dv`) so merge-on-read can skip deleted positions below. Best-effort —
+        // a load failure just means no skipping for this segment (the tombstone
+        // still provides read-coherence via is_record_dead until the DV is the
+        // sole mechanism).
+        #[cfg(feature = "cold-deletion-vectors")]
+        if let Some(dv) = &self.deletion_vector_store {
+            let _ = dv.load(pax_path).await;
+        }
+
         let distance_computer = UnifiedDistanceCompute::new(distance_metric);
         let mut candidates: Vec<OptimizedSearchRecord> =
             Vec::with_capacity(records.len().min(limit));
 
-        for record in &records {
+        for (pos, record) in records.iter().enumerate() {
+            // TD-DELVEC-1 WI-4: merge-on-read — skip positions whose deletion
+            // vector bit is set as of the scan's snapshot LSN (captured by the
+            // caller at the direct-scan convergence point). A cold delete is
+            // invisible here.
+            #[cfg(feature = "cold-deletion-vectors")]
+            if let Some(dv) = &self.deletion_vector_store
+                && dv
+                    .is_deleted_as_of(pax_path, pos as u32, snapshot_lsn)
+                    .await
+            {
+                continue;
+            }
+
             // Apply the metadata filter at record level (canonical props), mirroring
             // the ProximaBlocks scan path — PAX is the default format, so filter
             // support here is required, not optional (the Arrow path skips it).

--- a/src/storage/engines/sst/tests/cold_read_merge_test.rs
+++ b/src/storage/engines/sst/tests/cold_read_merge_test.rs
@@ -1,0 +1,180 @@
+//! TD-DELVEC-1 WI-4 (slice 1) integration test: a cold-resident delete is
+//! **invisible to a scan** — merge-on-read applies the deletion vector on the
+//! exact `.pax` read path (`search_pax_file_exact`).
+//!
+//! WI-3b proved the DV *bits* are set (keyed by the delete LSN) + snapshot-correct
+//! at the store level. The bits were never *read* on the scan path — this test
+//! closes that gap: flush records to a cold `.pax` → baseline search returns all
+//! of them → mark DV bits for two positions → a second search **omits the deleted
+//! rows and keeps the live one**. In-crate so it can read the `pub(crate)` DV store
+//! and the `pub(crate)` file discovery (the latter is used to mark the *exact*
+//! segment path the scan will probe, so the DV key matches regardless of the
+//! filesystem's URL scheme).
+//!
+//! **Path coverage:** the query uses `SearchMode::Exact` + a non-cascade metric
+//! (`Manhattan`) so the scan routes to `search_pax_file_exact` deterministically —
+//! the RaBitQ→SQ8 cascade is gated on `Euclidean|Cosine|DotProduct`, so Manhattan
+//! bypasses it independent of the segment's quantization. The snapshot LSN is
+//! captured inside `fallback_to_direct_search` (every route to a `.pax` exact read
+//! funnels through it); with no freshness source wired in the test engine it
+//! falls back to `u64::MAX` (see all deletes), which is exactly what hides the
+//! rows.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    use crate::core::search::{SearchMode, SearchParams};
+    use crate::proto::proximadb_v1::{
+        Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
+    };
+    use crate::storage::engines::sst::{SstConfig, core::SstEngine};
+    use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use crate::storage::traits::{FlushParameters, StorageQueryContext, UnifiedStorageFormat};
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+
+    fn collection(id: &str, temp_dir: &TempDir) -> Collection {
+        Collection {
+            id: id.to_string(),
+            config: Some(CollectionConfig {
+                name: id.to_string(),
+                dimension: 4,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: temp_dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn record(oid: &str, i: usize) -> VectorRecord {
+        VectorRecord {
+            id: oid.to_string(),
+            vector: vec![i as f32, 0.0, 0.0, 0.0],
+            metadata: HashMap::new(),
+            version: Some(1),
+            timestamp: Some(i as i64),
+            updated_at: None,
+            expires_at: None,
+            source: None,
+        }
+    }
+
+    async fn make_engine(base_path: &str) -> SstEngine {
+        let mut fs_config = FilesystemConfig::default();
+        fs_config.default_fs = Some(format!("file://{base_path}"));
+        let filesystem = Arc::new(FilesystemFactory::create(fs_config).await.unwrap());
+        let distance_compute = Arc::new(UnifiedDistanceCompute::default());
+        SstEngine::new_with_config(SstConfig::default(), filesystem, distance_compute)
+            .await
+            .unwrap()
+    }
+
+    /// The collection's data directory as the scan sees it (mirrors
+    /// `StorageQueryContext::collection_storage_path`), so file discovery matches.
+    fn storage_url_for(ctx: &StorageQueryContext) -> String {
+        ctx.collection_storage_path()
+            .expect("ctx has a storage assignment")
+    }
+
+    #[tokio::test]
+    async fn cold_delete_is_invisible_on_exact_pax_scan() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let base = temp_dir.path().to_str().unwrap().to_string();
+        let collection = collection("cold_read_merge", &temp_dir);
+        let engine = make_engine(&base).await;
+
+        // Flush 3 records → an immutable cold `.pax` (with the OID resolver embedded
+        // under the feature). r0=[0,0,0,0], r1=[1,0,0,0], r2=[2,0,0,0].
+        let records: Vec<VectorRecord> = ["r0", "r1", "r2"]
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(i, o)| record(o, i))
+            .collect();
+        let flush = FlushParameters {
+            collection_id: Some(collection.id.clone()),
+            vector_records: records.into_iter().map(Into::into).collect(),
+            force: true,
+            synchronous: true,
+            hints: HashMap::new(),
+            timeout_ms: None,
+            trigger_compaction: false,
+            batch_ids: vec![],
+            collection_config: Some(collection.clone()),
+            estimated_size: 0,
+        };
+        let res = engine.do_flush(&flush).await?;
+        assert!(res.success, "flush should produce a cold segment");
+
+        // Exact scan + a non-cascade metric → routes to `search_pax_file_exact`
+        // (Manhattan bypasses the RaBitQ cascade gate), where the DV merge-on-read
+        // lives. top_k large enough to surface every record.
+        let search_params = Arc::new(SearchParams {
+            vector: Some(vec![0.0, 0.0, 0.0, 0.0]),
+            top_k: Some(10),
+            distance_metric: Some(DistanceMetric::Manhattan),
+            search_mode: SearchMode::Exact,
+            ..Default::default()
+        });
+        let ctx = StorageQueryContext::new(search_params, Arc::new(collection.clone()));
+
+        // Resolve the exact `.pax` path the scan will probe (same `entry.url` the
+        // search passes to `search_pax_file_exact`), so the DV key matches.
+        let storage_url = storage_url_for(&ctx);
+        let files = engine.discover_sstable_files(&storage_url).await?;
+        let seg = files
+            .iter()
+            .find(|f| f.ends_with(".pax"))
+            .expect("flush should have produced a .pax segment")
+            .clone();
+        assert!(
+            files.iter().filter(|f| f.ends_with(".pax")).count() == 1,
+            "expected exactly one .pax segment for a deterministic position map, got {files:?}"
+        );
+
+        // Baseline: with no deletes, the scan returns all three records.
+        let baseline = engine.search_vectors_unified(&ctx).await?;
+        let baseline_ids: Vec<&str> = baseline.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            baseline_ids.contains(&"r0")
+                && baseline_ids.contains(&"r1")
+                && baseline_ids.contains(&"r2"),
+            "baseline scan should return all records, got {baseline_ids:?}"
+        );
+
+        // Mark r0 (pos 0) + r2 (pos 2) deleted; leave r1 (pos 1) live. The Vec index
+        // IS the row position (`read_segment_records` reconstructs PAX positionally).
+        let dv = engine
+            .deletion_vector_store
+            .as_ref()
+            .expect("DV store is armed under cold-deletion-vectors");
+        assert!(dv.mark_deleted(&seg, 0, 100).await?, "r0 mark");
+        assert!(dv.mark_deleted(&seg, 2, 200).await?, "r2 mark");
+
+        // Merge-on-read: the deleted rows are now invisible; the live row remains.
+        let after = engine.search_vectors_unified(&ctx).await?;
+        let after_ids: Vec<&str> = after.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            !after_ids.contains(&"r0"),
+            "deleted r0 must be absent on merge-on-read, got {after_ids:?}"
+        );
+        assert!(
+            !after_ids.contains(&"r2"),
+            "deleted r2 must be absent on merge-on-read, got {after_ids:?}"
+        );
+        assert!(
+            after_ids.contains(&"r1"),
+            "live r1 must still be present, got {after_ids:?}"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

TD-DELVEC-1 WI-4 **slice 1** — the first PR where a cold delete is actually **invisible** to a scan. WI-3b sets deletion-vector bits (keyed by the real delete LSN) but they were never *read* on the scan path, so a cold delete stayed visible. This makes the exact `.pax` read path apply the DV: `search_pax_file_exact` warms the segment's DV and skips positions whose bit is set as of the scan's snapshot LSN.

## How — snapshot-LSN threading

`snapshot_lsn` is **param-threaded**, not a field on `StorageQueryContext`. Adding a field would have broken ~50 struct literals across tests/benches (the struct doesn't derive `Default`) — the original plan undercounted this. It is captured at the **direct-scan convergence point** (`fallback_to_direct_search` + `scan_single_file`, both holding `self` + `collection_id`), so every route to a `.pax` exact read hides cold deletes uniformly:

- exact segment scan (`execute_exact_segment_scan`)
- orchestrated AXIS fallback
- plain direct search
- the parallel/arc path (`scan_single_file`)

Capturing at the convergence is fewer edits **and** broader coverage than an entry-point capture threaded through one chain. For slice 1's "hide deletes" goal a later capture is strictly correct (a larger LSN surfaces more deletes to the filter). Falls back to `u64::MAX` (see all deletes) when no freshness source is wired.

All DV logic is `#[cfg(feature = "cold-deletion-vectors")]`. The default build is byte-for-byte unchanged — `snapshot_lsn = u64::MAX` is a no-op param (the DV check is cfg'd out), suppressed by `allow(unused_variables)`.

## Test

New in-crate feature-gated test `cold_read_merge_test` (declared via `#[path]` in `sst/mod.rs`, the WI-3b pattern): flush 3 rows → baseline scan returns all 3 → `mark_deleted` positions 0 + 2 → second scan **omits the deleted rows, keeps the live one**. Routes to `search_pax_file_exact` deterministically via `SearchMode::Exact` + a non-cascade metric (`Manhattan` — the RaBitQ→SQ8 cascade is gated on `Euclidean|Cosine|DotProduct`), and discovers the `.pax` through the engine's own file discovery so the DV key matches the scan's path exactly.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default — CI-gated) ✅
- `cargo build --features cold-deletion-vectors` + `cargo test -p proximadb --lib --features cold-deletion-vectors cold_read_merge` → `1 passed` ✅
- `cargo clippy -p proximadb --lib --features cold-deletion-vectors -- -D warnings` ✅ (fixed a `collapsible_if` in the DV-skip — feature-only, so default CI clippy wouldn't have caught it)

## Deferred

- **Slice 2**: the cascade path (unfiltered RaBitQ ANN) lacks `position` in `CascadeHit`, so it skips the DV check. Extend `CascadeHit` or per-hit oid→position resolve.
- **WI-5/6/7**: publish-before-retire, compaction interlock, conservative purge.
- Non-blocking: inject the shared `CatalogResolver` into the WAL (ROOT-vs-PREFIX contract mismatch); drop the WI-3b test's fs-walk bypass now that #1352 landed.