### PR TITLE
feat(sst): merge-on-read on the RaBitQ cascade path (TD-DELVEC-1 WI-4 slice 2)

### DIFF
--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -265,6 +265,12 @@ mod cold_delete_dv_test;
 #[cfg(all(test, feature = "cold-deletion-vectors"))]
 #[path = "tests/cold_read_merge_test.rs"]
 mod cold_read_merge_test;
+// TD-DELVEC-1 WI-4 (slice 2): merge-on-read on the RaBitQ ANN cascade path — a
+// cold delete is invisible in an unfiltered Cosine scan over a coalesced RaBitQ
+// segment (`try_pax_cascade` filters hits by `CascadeHit::position`).
+#[cfg(all(test, feature = "cold-deletion-vectors"))]
+#[path = "tests/cold_cascade_merge_test.rs"]
+mod cold_cascade_merge_test;
 pub mod flush;
 pub mod manifest;
 #[cfg(feature = "cold-deletion-vectors")]

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -371,6 +371,7 @@ impl SstEngine {
     /// L2-validated (recall 0.932 @ N=100k). Other metrics stay on the generic scan
     /// until the cascade is metric-generalized + re-validated (follow-up).
     #[allow(clippy::too_many_arguments)]
+    #[cfg_attr(not(feature = "cold-deletion-vectors"), allow(unused_variables))]
     async fn try_pax_cascade(
         &self,
         sstable_path: &str,
@@ -380,6 +381,7 @@ impl SstEngine {
         distance_metric: DistanceMetric,
         collection_id: &str,
         collection_root: &str,
+        snapshot_lsn: u64,
     ) -> anyhow::Result<Option<Vec<OptimizedSearchRecord>>> {
         use proximadb_block_format::RankMetric;
         // Map the query metric to a cascade rank metric. Dot/max-IP and exotic
@@ -427,6 +429,30 @@ impl SstEngine {
                 )
                 .await?;
                 if let Some(hits) = coalesced_hits {
+                    // TD-DELVEC-1 WI-4 slice 2: merge-on-read on the RaBitQ ANN
+                    // path — warm this segment's deletion vector, then drop hits
+                    // whose row position (`CascadeHit::position`, the global row
+                    // index the coalesced scan scored = the space the DV keys on)
+                    // is deleted as of the scan's snapshot LSN. A cold delete is
+                    // invisible on the cascade path too. Best-effort: no DV store
+                    // or a load failure ⇒ no skipping (degraded, not a query
+                    // failure). Under the default build this filter is cfg'd out.
+                    #[cfg(feature = "cold-deletion-vectors")]
+                    let hits = if let Some(dv) = self.deletion_vector_store.as_ref() {
+                        let _ = dv.load(sstable_path).await;
+                        let mut kept = Vec::with_capacity(hits.len());
+                        for h in hits {
+                            if !dv
+                                .is_deleted_as_of(sstable_path, h.position, snapshot_lsn)
+                                .await
+                            {
+                                kept.push(h);
+                            }
+                        }
+                        kept
+                    } else {
+                        hits
+                    };
                     let records = hits
                         .into_iter()
                         .map(|h| {
@@ -1240,6 +1266,7 @@ impl SstEngine {
                                     distance_metric,
                                     collection_id,
                                     storage_url,
+                                    snapshot_lsn,
                                 )
                                 .await
                             {
@@ -1347,6 +1374,7 @@ impl SstEngine {
                             distance_metric,
                             collection_id,
                             storage_url,
+                            snapshot_lsn,
                         )
                         .await
                     {
@@ -1628,6 +1656,7 @@ impl SstEngine {
                     distance_metric,
                     collection_id,
                     storage_url,
+                    snapshot_lsn,
                 )
                 .await
             {

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -657,6 +657,12 @@ pub struct CascadeHit {
     /// materialization. `None` when no f32 tier is present (the caller gets
     /// id+score only, as before). Populated lazily for the top-k rows only.
     pub vector: Option<Vec<f32>>,
+    /// TD-DELVEC-1 WI-4 slice 2: the hit's global row position in the segment
+    /// (the index `read_segment_records` reconstructs positionally — the same
+    /// space the deletion vector keys on). Set at coalesced-scan hit construction
+    /// from the ranked row index `g`; consumed by `try_pax_cascade`'s merge-on-read
+    /// filter so a cold delete is invisible on the RaBitQ ANN path too.
+    pub position: u32,
 }
 
 /// Canonical resolver from a filter field name to its PAX column id for
@@ -2584,6 +2590,7 @@ pub async fn rabitq_search_segment_coalesced(
             oid: oid_of.get(g).cloned().unwrap_or_default(),
             distance: *dist,
             vector: None,
+            position: *g as u32,
         });
     }
 

--- a/src/storage/engines/sst/tests/cold_cascade_merge_test.rs
+++ b/src/storage/engines/sst/tests/cold_cascade_merge_test.rs
@@ -1,0 +1,177 @@
+//! TD-DELVEC-1 WI-4 **slice 2** integration test: a cold-resident delete is
+//! invisible on the **RaBitQ ANN cascade path** (`try_pax_cascade`), not only the
+//! exact scan (slice 1).
+//!
+//! Slice 1 (`cold_read_merge_test`) covers filtered/exact reads through
+//! `search_pax_file_exact`. The coalesced RaBitQ→SQ8 cascade
+//! (`rabitq_search_segment_coalesced`) serves *unfiltered* ANN queries itself and
+//! never reached that exact reader, so its hits also need merge-on-read. Slice 2
+//! threads each cascade hit's global row position (`CascadeHit::position`) into a
+//! DV filter inside `try_pax_cascade`.
+//!
+//! This test writes a coalesced RaBitQ `.pax` straight into the engine's data dir
+//! (via `write_pax_segment`, the same helper the coalesced-cascade unit tests use
+//! — `coalesced_rabitq_enabled()` is default-ON, so a `RaBitQ` write is coalesced),
+//! maps an oid → its on-disk row position with `read_segment_records` (the same
+//! positional space the DV and the cascade's row index `g` key on), marks that
+//! position deleted, and asserts an unfiltered Cosine scan (which the cascade
+//! serves for a coalesced RaBitQ segment) omits the deleted row.
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    use crate::core::search::SearchParams;
+    use crate::proto::proximadb_v1::{
+        Collection, CollectionConfig, StorageAssignment, StorageEngine,
+    };
+    use crate::storage::engines::sst::SstConfig;
+    use crate::storage::engines::sst::core::SstEngine;
+    use crate::storage::engines::sst::segment_format::{read_segment_records, write_pax_segment};
+    use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use crate::storage::traits::StorageQueryContext;
+    use proximadb_block_format::VectorQuant;
+    use proximadb_distance_kernel::DistanceMetric;
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+    use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
+
+    /// RaBitQ needs a non-trivial dimension to avoid degenerate random
+    /// projections; 64 mirrors the coalesced-cascade unit tests.
+    const DIM: usize = 64;
+
+    fn collection(id: &str, temp_dir: &TempDir) -> Collection {
+        Collection {
+            id: id.to_string(),
+            config: Some(CollectionConfig {
+                name: id.to_string(),
+                dimension: DIM as u32,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: temp_dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn rec(oid: &str, i: usize) -> ProximaRecord {
+        let ts = 1_700_000_000_000_000_000 + i as i64;
+        let mut r = ProximaRecord {
+            oid: oid.into(),
+            tenant_id: "t".into(),
+            created_at_ns: ts,
+            updated_at_ns: ts,
+            ..Default::default()
+        };
+        let vec: Vec<f32> = (0..DIM).map(|d| (i as f32 + d as f32) * 0.1).collect();
+        r.embeddings.push(EmbeddingCell {
+            modality: "dense".into(),
+            dim: DIM as u32,
+            values: EmbeddingValues::Fp32(vec),
+            ..Default::default()
+        });
+        r
+    }
+
+    async fn make_engine(base_path: &str) -> SstEngine {
+        let mut fs_config = FilesystemConfig::default();
+        fs_config.default_fs = Some(format!("file://{base_path}"));
+        let filesystem = Arc::new(FilesystemFactory::create(fs_config).await.unwrap());
+        let distance_compute = Arc::new(UnifiedDistanceCompute::default());
+        SstEngine::new_with_config(SstConfig::default(), filesystem, distance_compute)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn cold_delete_is_invisible_on_rabitq_cascade() -> Result<()> {
+        let n: usize = 8;
+        let temp_dir = TempDir::new()?;
+        let base = temp_dir.path().to_str().unwrap().to_string();
+        let collection = collection("cold_cascade_merge", &temp_dir);
+        let engine = make_engine(&base).await;
+
+        let records: Vec<ProximaRecord> = (0..n).map(|i| rec(&format!("r{i}"), i)).collect();
+
+        // Unfiltered Cosine query — the cascade serves coalesced RaBitQ segments
+        // for Euclidean/Cosine/DotProduct. top_k = n so every row is surfaced.
+        let query: Vec<f32> = (0..DIM).map(|d| d as f32 * 0.1).collect();
+        let search_params = Arc::new(SearchParams {
+            vector: Some(query),
+            top_k: Some(n as u16),
+            distance_metric: Some(DistanceMetric::Cosine),
+            ..Default::default()
+        });
+        let ctx = StorageQueryContext::new(search_params, Arc::new(collection.clone()));
+
+        // Write a coalesced RaBitQ `.pax` straight into the collection's data dir.
+        let storage_url = ctx
+            .collection_storage_path()
+            .expect("ctx has a storage assignment");
+        tokio::fs::create_dir_all(&storage_url).await?;
+        let pax_local = format!("{storage_url}/cascade.pax");
+        write_pax_segment(
+            Path::new(&pax_local),
+            &records,
+            &collection.id,
+            1,
+            VectorQuant::RaBitQ,
+            None,
+        )?;
+
+        // The exact `.pax` path the scan probes (the engine's discovered URL), so
+        // the DV key matches.
+        let files = engine.discover_sstable_files(&storage_url).await?;
+        let seg = files
+            .iter()
+            .find(|f| f.ends_with(".pax"))
+            .cloned()
+            .expect("the written .pax should be discoverable");
+
+        // Map oid → on-disk row position (read_segment_records reconstructs PAX
+        // positionally — the same space the DV and the cascade's row index key on).
+        let bytes = std::fs::read(&pax_local)?;
+        let on_disk = read_segment_records(&bytes, &[], &[], None)?;
+        assert!(!on_disk.is_empty(), "segment should decode to records");
+        let target_oid = on_disk[0].oid.clone();
+        let target_pos = 0u32;
+
+        // Baseline: the cascade returns the target row (among all n).
+        let baseline = engine.search_vectors_unified(&ctx).await?;
+        let baseline_ids: Vec<&str> = baseline.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            baseline_ids.contains(&target_oid.as_str()),
+            "baseline cascade scan should include the target, got {baseline_ids:?}"
+        );
+
+        // Mark the target's position deleted.
+        let dv = engine
+            .deletion_vector_store
+            .as_ref()
+            .expect("DV store is armed under cold-deletion-vectors");
+        assert!(dv.mark_deleted(&seg, target_pos, 100).await?, "target mark");
+
+        // Merge-on-read on the cascade path: the deleted row is now invisible, and
+        // exactly one row is removed.
+        let after = engine.search_vectors_unified(&ctx).await?;
+        let after_ids: Vec<&str> = after.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            !after_ids.contains(&target_oid.as_str()),
+            "deleted target must be absent on cascade merge-on-read, got {after_ids:?}"
+        );
+        assert_eq!(
+            after.len(),
+            baseline.len() - 1,
+            "exactly the deleted row should be removed; before={}, after={}",
+            baseline.len(),
+            after.len()
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

TD-DELVEC-1 **WI-4 slice 2** — completes WI-4: a cold delete is now invisible on **both** read paths. Slice 1 (#1362) covered the exact `.pax` scan (`search_pax_file_exact`). The coalesced RaBitQ→SQ8 cascade serves *unfiltered* ANN queries itself and never reached that exact reader, so its hits also need merge-on-read. This PR closes that gap.

## How

- **`CascadeHit::position: u32`** (segment_format.rs) — the hit's global row position, set at coalesced-scan construction from the ranked row index `g` (already in scope there). `g = block_start[bi] + local` is the same positional space the deletion vector and `read_segment_records` key on, so no resolver/remap is needed.
- **`try_pax_cascade`** now warms the segment's DV and drops hits whose position is deleted as of the scan's snapshot LSN — the same `snapshot_lsn` threaded in slice 1, passed through to `try_pax_cascade` at all 3 call sites (`scan_single_file` + the parallel/sequential `fallback_to_direct_search` paths).
- All DV logic is `#[cfg(feature = "cold-deletion-vectors")]`; the default build is unchanged (the `snapshot_lsn` param + `position` field are no-ops there, suppressed by `allow(unused_variables)`).

With slices 1 + 2, a cold delete is invisible to every cold read: exact scan, orchestrated AXIS fallback, direct search, parallel arc path, **and** the RaBitQ ANN cascade.

## Test

New in-crate feature-gated test `cold_cascade_merge_test` (declared via `#[path]` in `sst/mod.rs`): write a coalesced RaBitQ `.pax` via `write_pax_segment` (coalesced is default-ON) → map an oid → its on-disk position via `read_segment_records` → `mark_deleted` that position → unfiltered Cosine scan (served by the cascade) **omits the deleted row, exactly one removed**.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default — CI-gated) ✅
- `cargo build`/`test --features cold-deletion-vectors cold_cascade_merge` → `1 passed` ✅
- `cargo clippy -p proximadb --lib --features cold-deletion-vectors -- -D warnings` ✅

## Remaining F3v

WI-5/6/7 (publish-before-retire, compaction interlock, conservative purge) + non-blocking cleanups (inject shared `CatalogResolver` into the WAL; drop the WI-3b fs-walk bypass).