### PR TITLE
feat(abac): share durable ABAC stores for hot-reload provisioning (TD-ABAC control-plane PR-A)

### DIFF
--- a/crates/control/proximadb-abac/src/authority.rs
+++ b/crates/control/proximadb-abac/src/authority.rs
@@ -468,6 +468,7 @@ mod tests {
 // ===========================================================================
 
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 /// A [`AttributeAuthority`] backed by an atomic-rename JSON snapshot on the
 /// filesystem — modeled on `FileSystemCorpusVersionStore`
@@ -481,9 +482,12 @@ use std::path::{Path, PathBuf};
 /// Writes are **synchronous and atomic**: `upsert`/`revoke` immediately persist
 /// the full binding set via a temp-file + rename. This is the same trade-off
 /// `FileSystemCorpusVersionStore` makes — simple, correct, adequate for
-/// development; a production impl might use per-binding rows.
+/// development; a production impl might use per-binding rows. The in-memory cache
+/// is behind a [`RwLock`] so an admin write through a shared `Arc` handle is
+/// visible to the live enforcer without a restart (hot-reload): writes take the
+/// write-lock and persist; reads take the read-lock.
 pub struct FileSystemAttributeAuthority {
-    inner: InMemoryAttributeAuthority,
+    inner: RwLock<InMemoryAttributeAuthority>,
     path: PathBuf,
 }
 
@@ -505,24 +509,45 @@ impl FileSystemAttributeAuthority {
                 inner.upsert(b);
             }
         }
-        Ok(Self { inner, path })
+        Ok(Self {
+            inner: RwLock::new(inner),
+            path,
+        })
     }
 
     /// Insert or replace a binding and persist immediately (atomic rename).
-    pub fn upsert(&mut self, binding: AttributeBinding) {
-        self.inner.upsert(binding);
+    ///
+    /// Takes `&self` (not `&mut self`): the in-memory cache lives behind a
+    /// [`RwLock`], so a shared `Arc<FileSystemAttributeAuthority>` handle can
+    /// mutate the authority — the admin-provisioning path (TD-ABAC control-plane)
+    /// writes through the same instance the live enforcer reads, and the change
+    /// is visible without a restart.
+    pub fn upsert(&self, binding: AttributeBinding) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.upsert(binding);
+        }
         let _ = self.persist();
     }
 
-    /// Remove a binding and persist immediately.
-    pub fn revoke(&mut self, subject: &SubjectId, tenant_stable_id: TenantStableId) {
-        self.inner.revoke(subject, tenant_stable_id);
+    /// Remove a binding and persist immediately. `&self` for the same hot-reload
+    /// reason as [`upsert`](Self::upsert).
+    pub fn revoke(&self, subject: &SubjectId, tenant_stable_id: TenantStableId) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.revoke(subject, tenant_stable_id);
+        }
         let _ = self.persist();
     }
 
-    /// Write the full binding set atomically (temp + rename).
+    /// Write the full binding set atomically (temp + rename). Re-reads the live
+    /// cache under the read-lock — so it always reflects the latest committed
+    /// state (no lost update under concurrent admin writes).
     fn persist(&self) -> Result<(), AuthorityError> {
-        let bindings: Vec<AttributeBinding> = self.inner.bindings().cloned().collect();
+        let bindings: Vec<AttributeBinding> = {
+            let guard = self.inner.read().unwrap_or_else(|p| p.into_inner());
+            guard.bindings().cloned().collect()
+        };
         let json = serde_json::to_vec(&bindings).map_err(|e| AuthorityError::Unavailable {
             detail: format!("serialize bindings: {e}"),
         })?;
@@ -544,6 +569,8 @@ impl AttributeAuthority for FileSystemAttributeAuthority {
         tenant_stable_id: TenantStableId,
     ) -> Result<ResolvedSubject, AuthorityError> {
         self.inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
             .resolve_effective_attributes(subject, tenant_stable_id)
     }
 }
@@ -566,7 +593,7 @@ mod fs_authority_tests {
 
         // Write phase: create authority, add alice, drop it.
         {
-            let mut auth = FileSystemAttributeAuthority::open(&path).unwrap();
+            let auth = FileSystemAttributeAuthority::open(&path).unwrap();
             auth.upsert(
                 AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())),
             );
@@ -610,7 +637,7 @@ mod fs_authority_tests {
 
         // Add alice, then revoke.
         {
-            let mut auth = FileSystemAttributeAuthority::open(&path).unwrap();
+            let auth = FileSystemAttributeAuthority::open(&path).unwrap();
             auth.upsert(
                 AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())),
             );

--- a/crates/control/proximadb-abac/src/compile.rs
+++ b/crates/control/proximadb-abac/src/compile.rs
@@ -30,6 +30,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use proximadb_catalog::fc_metamodel::ObjectId;
 use proximadb_filter_expression::{ComparisonOperator, FilterExpression};
@@ -65,7 +66,13 @@ pub trait PredicateObjectStore {
     /// Look up the predicate object registered under `id`. Returns `None` when
     /// unknown, revoked, or in another tenant's scope — [`compile_security_filter`]
     /// treats `None` as fail-closed.
-    fn get(&self, id: ObjectId) -> Option<&FilterExpression>;
+    ///
+    /// Returns an **owned** `FilterExpression` (not a borrow) so a durable
+    /// implementation can hold its cache behind a lock — a reference could not
+    /// escape the read guard. The single consumer
+    /// ([`compile_security_filter`]) already cloned the borrow, so this removes a
+    /// clone rather than adding one.
+    fn get(&self, id: ObjectId) -> Option<FilterExpression>;
 }
 
 /// An in-memory [`PredicateObjectStore`] — the reference implementation.
@@ -99,8 +106,8 @@ impl Default for InMemoryPredicateObjectStore {
 }
 
 impl PredicateObjectStore for InMemoryPredicateObjectStore {
-    fn get(&self, id: ObjectId) -> Option<&FilterExpression> {
-        self.objects.get(&id)
+    fn get(&self, id: ObjectId) -> Option<FilterExpression> {
+        self.objects.get(&id).cloned()
     }
 }
 
@@ -129,10 +136,13 @@ impl PredicateObjectStore for InMemoryPredicateObjectStore {
 /// Predicate objects are keyed by global catalog `ObjectId` (not tenant-
 /// partitioned), matching [`InMemoryPredicateObjectStore`] and the enforcer's
 /// single shared store — a predicate ref resolves the same `FilterExpression`
-/// regardless of tenant. `Send + Sync` (held by the enforcer behind a
-/// `Box<dyn PredicateObjectStore + Send + Sync>`).
+/// regardless of tenant. `Send + Sync` (held by the enforcer behind a shared
+/// `Arc<dyn PredicateObjectStore + Send + Sync>`). The in-memory cache is behind
+/// a [`RwLock`] so an admin write through a shared `Arc` handle is visible to the
+/// live enforcer without a restart (hot-reload): writes take the write-lock and
+/// persist; reads take the read-lock.
 pub struct FileSystemPredicateObjectStore {
-    inner: InMemoryPredicateObjectStore,
+    inner: RwLock<InMemoryPredicateObjectStore>,
     path: PathBuf,
 }
 
@@ -155,31 +165,57 @@ impl FileSystemPredicateObjectStore {
                 inner.register(id, expr);
             }
         }
-        Ok(Self { inner, path })
+        Ok(Self {
+            inner: RwLock::new(inner),
+            path,
+        })
     }
 
     /// Register or replace a predicate object and persist immediately (atomic rename).
-    pub fn register(&mut self, id: ObjectId, expr: FilterExpression) {
-        self.inner.register(id, expr);
+    ///
+    /// Takes `&self` (not `&mut self`): the in-memory cache lives behind a
+    /// [`RwLock`], so a shared `Arc<FileSystemPredicateObjectStore>` handle can
+    /// mutate the store — the admin-provisioning path (TD-ABAC control-plane)
+    /// writes through the same instance the live enforcer reads, and the change
+    /// is visible without a restart.
+    pub fn register(&self, id: ObjectId, expr: FilterExpression) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.register(id, expr);
+        }
         let _ = self.persist();
     }
 
     /// Remove a predicate object and persist immediately. Subsequent resolves of
-    /// `id` fail-closed.
-    pub fn revoke(&mut self, id: ObjectId) {
-        self.inner.revoke(id);
+    /// `id` fail-closed. `&self` for the same hot-reload reason as [`register`](Self::register).
+    pub fn revoke(&self, id: ObjectId) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.revoke(id);
+        }
         let _ = self.persist();
     }
 
-    /// An iterator over the stored predicate objects — for inspection/audit.
-    pub fn objects(&self) -> impl Iterator<Item = (&ObjectId, &FilterExpression)> {
-        self.inner.objects.iter()
+    /// A snapshot of the stored predicate objects — for inspection/audit. Owned
+    /// (not an iterator borrowing `&self`) because the cache is behind a [`RwLock`].
+    pub fn objects(&self) -> Vec<(ObjectId, FilterExpression)> {
+        self.inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .objects
+            .iter()
+            .map(|(k, v)| (*k, v.clone()))
+            .collect()
     }
 
-    /// Write the full predicate-object set atomically (temp + rename).
+    /// Write the full predicate-object set atomically (temp + rename). Re-reads
+    /// the live cache under the read-lock — so it always reflects the latest
+    /// committed state (no lost update under concurrent admin writes).
     fn persist(&self) -> Result<(), PredicateStoreError> {
         let objects: Vec<(ObjectId, FilterExpression)> = self
             .inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
             .objects
             .iter()
             .map(|(k, v)| (*k, v.clone()))
@@ -200,8 +236,13 @@ impl FileSystemPredicateObjectStore {
 }
 
 impl PredicateObjectStore for FileSystemPredicateObjectStore {
-    fn get(&self, id: ObjectId) -> Option<&FilterExpression> {
-        self.inner.get(id)
+    fn get(&self, id: ObjectId) -> Option<FilterExpression> {
+        self.inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .objects
+            .get(&id)
+            .cloned()
     }
 }
 
@@ -244,7 +285,7 @@ pub fn compile_security_filter(
     let mut resolved: Vec<FilterExpression> = Vec::with_capacity(refs.len());
     for id in refs {
         match store.get(*id) {
-            Some(expr) => resolved.push(expr.clone()),
+            Some(expr) => resolved.push(expr),
             None => {
                 // A missing predicate ref is a deny — the policy references
                 // something the store cannot find, and the safe answer is
@@ -412,7 +453,7 @@ mod tests {
 
         // Write phase: register predicate 42 (dept=eng) + 7 (clearance>=3), drop.
         {
-            let mut store = FileSystemPredicateObjectStore::open(&path).expect("open");
+            let store = FileSystemPredicateObjectStore::open(&path).expect("open");
             store.register(42, eq_dept("eng"));
             store.register(7, gt_clearance(3));
             assert!(path.exists(), "persist wrote the file");
@@ -420,8 +461,8 @@ mod tests {
 
         // Read phase: reopen — both predicates must survive, byte-identical.
         let store = FileSystemPredicateObjectStore::open(&path).expect("reopen");
-        assert_eq!(store.get(42), Some(&eq_dept("eng")));
-        assert_eq!(store.get(7), Some(&gt_clearance(3)));
+        assert_eq!(store.get(42), Some(eq_dept("eng")));
+        assert_eq!(store.get(7), Some(gt_clearance(3)));
         assert!(store.get(999).is_none(), "unknown ref resolves None (deny)");
 
         // compile_security_filter — the production enforcement path — resolves
@@ -442,7 +483,7 @@ mod tests {
         let path = dir.join("predicates.json");
 
         {
-            let mut store = FileSystemPredicateObjectStore::open(&path).expect("open");
+            let store = FileSystemPredicateObjectStore::open(&path).expect("open");
             store.register(42, eq_dept("eng"));
             store.revoke(42);
         }

--- a/crates/control/proximadb-abac/src/policy_binding_store.rs
+++ b/crates/control/proximadb-abac/src/policy_binding_store.rs
@@ -33,6 +33,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use proximadb_catalog::fc_metamodel::{PolicyBinding, TenantStableId};
 
@@ -45,8 +46,8 @@ use proximadb_catalog::fc_metamodel::{PolicyBinding, TenantStableId};
 /// `tenant_stable_id` field on every [`PolicyBinding`] is what keeps policy from
 /// crossing the tenant boundary). Implementations are `Send + Sync`: the
 /// [`AbacEnforcer`](crate::AbacEnforcer) (well, the adapter in the root crate)
-/// holds the store behind a `Box<dyn PolicyBindingStore + Send + Sync>` so it can
-/// be shared across the read-serving services.
+/// holds the store behind a shared `Arc<dyn PolicyBindingStore + Send + Sync>` so
+/// it can be shared across the read-serving services.
 pub trait PolicyBindingStore: Send + Sync {
     /// All policy bindings the store holds for `tenant_stable_id`. An empty
     /// `Vec` is the well-defined "deny everything" policy (deny-biased
@@ -160,9 +161,12 @@ impl PolicyBindingStore for InMemoryPolicyBindingStore {
 /// Writes are **synchronous and atomic**: `upsert`/`replace_tenant`/`remove`
 /// immediately persist the full binding set via a temp-file + rename — the same
 /// trade-off [`FileSystemAttributeAuthority`] makes (simple, correct, adequate
-/// for development; a production impl might use per-binding rows).
+/// for development; a production impl might use per-binding rows). The in-memory
+/// cache is behind a [`RwLock`] so an admin write through a shared `Arc` handle
+/// is visible to the live enforcer without a restart (hot-reload): writes take
+/// the write-lock and persist; reads take the read-lock.
 pub struct FileSystemPolicyBindingStore {
-    inner: InMemoryPolicyBindingStore,
+    inner: RwLock<InMemoryPolicyBindingStore>,
     path: PathBuf,
 }
 
@@ -185,37 +189,58 @@ impl FileSystemPolicyBindingStore {
                 inner.upsert(b);
             }
         }
-        Ok(Self { inner, path })
+        Ok(Self {
+            inner: RwLock::new(inner),
+            path,
+        })
     }
 
     /// Insert or replace a binding and persist immediately (atomic rename).
-    pub fn upsert(&mut self, binding: PolicyBinding) {
-        self.inner.upsert(binding);
+    ///
+    /// Takes `&self` (not `&mut self`): the in-memory cache lives behind a
+    /// [`RwLock`], so a shared `Arc<FileSystemPolicyBindingStore>` handle can
+    /// mutate the store — the admin-provisioning path (TD-ABAC control-plane)
+    /// writes through the same instance the live enforcer reads, and the change
+    /// is visible without a restart.
+    pub fn upsert(&self, binding: PolicyBinding) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.upsert(binding);
+        }
         let _ = self.persist();
     }
 
-    /// Replace a tenant's binding set and persist immediately.
-    pub fn replace_tenant(
-        &mut self,
-        tenant_stable_id: TenantStableId,
-        bindings: Vec<PolicyBinding>,
-    ) {
-        self.inner.replace_tenant(tenant_stable_id, bindings);
+    /// Replace a tenant's binding set and persist immediately. `&self` for the
+    /// same hot-reload reason as [`upsert`](Self::upsert).
+    pub fn replace_tenant(&self, tenant_stable_id: TenantStableId, bindings: Vec<PolicyBinding>) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.replace_tenant(tenant_stable_id, bindings);
+        }
         let _ = self.persist();
     }
 
-    /// Remove a binding and persist immediately.
-    pub fn remove(&mut self, tenant_stable_id: TenantStableId, object_id: u64) -> bool {
-        let removed = self.inner.remove(tenant_stable_id, object_id);
+    /// Remove a binding and persist immediately. `&self` for the same hot-reload
+    /// reason as [`upsert`](Self::upsert).
+    pub fn remove(&self, tenant_stable_id: TenantStableId, object_id: u64) -> bool {
+        let removed = {
+            let mut guard = self.inner.write().unwrap_or_else(|p| p.into_inner());
+            guard.remove(tenant_stable_id, object_id)
+        };
         if removed {
             let _ = self.persist();
         }
         removed
     }
 
-    /// Write the full binding set atomically (temp + rename).
+    /// Write the full binding set atomically (temp + rename). Re-reads the live
+    /// cache under the read-lock — so it always reflects the latest committed
+    /// state (no lost update under concurrent admin writes).
     fn persist(&self) -> Result<(), PolicyStoreError> {
-        let bindings: Vec<PolicyBinding> = self.inner.bindings().cloned().collect();
+        let bindings: Vec<PolicyBinding> = {
+            let guard = self.inner.read().unwrap_or_else(|p| p.into_inner());
+            guard.bindings().cloned().collect()
+        };
         let json =
             serde_json::to_vec_pretty(&bindings).map_err(|e| PolicyStoreError::Unavailable {
                 detail: format!("serialize bindings: {e}"),
@@ -233,7 +258,10 @@ impl FileSystemPolicyBindingStore {
 
 impl PolicyBindingStore for FileSystemPolicyBindingStore {
     fn bindings_for(&self, tenant_stable_id: TenantStableId) -> Vec<PolicyBinding> {
-        self.inner.bindings_for(tenant_stable_id)
+        self.inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .bindings_for(tenant_stable_id)
     }
 }
 
@@ -370,7 +398,7 @@ mod tests {
 
         // Write phase: create the store, publish tenant 7's policy, drop it.
         {
-            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            let store = FileSystemPolicyBindingStore::open(&path).expect("open");
             store.replace_tenant(
                 7,
                 vec![
@@ -411,7 +439,7 @@ mod tests {
         let path = dir.join("policy.json");
 
         {
-            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            let store = FileSystemPolicyBindingStore::open(&path).expect("open");
             store.upsert(permit_binding(1, 7, 200, Some(42)));
             assert!(store.remove(7, 1), "binding 1 was present");
             assert!(!store.remove(7, 1), "binding 1 is now gone");

--- a/src/network/rest/canonical/handlers.rs
+++ b/src/network/rest/canonical/handlers.rs
@@ -62,6 +62,21 @@ pub struct RestCoreServices {
     /// Port-backed API handler (the runtime `UnifiedHandlers`) — same `Arc` as
     /// `SharedServices.api_handlers`.
     pub api_handlers: Arc<dyn proximadb_runtime::ApiHandlersPort>,
+
+    /// Durable ABAC attribute-authority handle (TD-ABAC control-plane /
+    /// `abac-policy`). Same `Option<Arc>` as `SharedServices.abac_authority`; flows
+    /// into `AppState.abac_authority` so the admin endpoints share the enforcer's
+    /// instance (hot-reload). `None` when ABAC is off.
+    #[cfg(feature = "abac-policy")]
+    pub abac_authority: Option<Arc<proximadb_abac::FileSystemAttributeAuthority>>,
+    /// Durable ABAC policy-binding store handle. Same as
+    /// `SharedServices.abac_binding_store`.
+    #[cfg(feature = "abac-policy")]
+    pub abac_binding_store: Option<Arc<proximadb_abac::FileSystemPolicyBindingStore>>,
+    /// Durable ABAC predicate-object store handle. Same as
+    /// `SharedServices.abac_predicate_store`.
+    #[cfg(feature = "abac-policy")]
+    pub abac_predicate_store: Option<Arc<proximadb_abac::FileSystemPredicateObjectStore>>,
 }
 
 impl RestCoreServices {
@@ -82,6 +97,15 @@ impl RestCoreServices {
             observability_service: services.observability_service.clone(),
             event_log: services.event_log.clone(),
             api_handlers: services.api_handlers.clone(),
+            // TD-ABAC control-plane: carry the durable handles through so
+            // `AppState::new` can install them — the admin endpoints then share
+            // the SAME instances the live enforcer reads (hot-reload).
+            #[cfg(feature = "abac-policy")]
+            abac_authority: services.abac_authority.clone(),
+            #[cfg(feature = "abac-policy")]
+            abac_binding_store: services.abac_binding_store.clone(),
+            #[cfg(feature = "abac-policy")]
+            abac_predicate_store: services.abac_predicate_store.clone(),
         }
     }
 }
@@ -232,6 +256,32 @@ pub struct AppState {
     /// owns. `None` when the service is not enabled (handlers return 501).
     pub external_collection_service:
         Option<Arc<crate::services::external_collection::ExternalCollectionService>>,
+
+    /// Durable ABAC attribute-authority handle (TD-ABAC control-plane /
+    /// `abac-policy`). The SAME `Arc<FileSystemAttributeAuthority>` instance the
+    /// live enforcer reads, so an admin provision written through this handle is
+    /// visible without a restart (hot-reload). Wired from
+    /// `SharedServices.abac_authority` via `with_abac_authority` in
+    /// `src/network/multi_server.rs`. `None` when ABAC is off; the
+    /// attribute-binding admin endpoints return 503 in that case.
+    #[cfg(feature = "abac-policy")]
+    pub abac_authority: Option<Arc<proximadb_abac::FileSystemAttributeAuthority>>,
+
+    /// Durable ABAC policy-binding store handle (TD-ABAC control-plane /
+    /// `abac-policy`). Shared with the live enforcer; the admin policy-binding
+    /// endpoints write (upsert/remove) through this handle. Wired from
+    /// `SharedServices.abac_binding_store` via `with_abac_binding_store`.
+    /// `None` when ABAC is off.
+    #[cfg(feature = "abac-policy")]
+    pub abac_binding_store: Option<Arc<proximadb_abac::FileSystemPolicyBindingStore>>,
+
+    /// Durable ABAC predicate-object store handle (TD-ABAC control-plane /
+    /// `abac-policy`). Shared with the live enforcer; the admin predicate-object
+    /// endpoints register/revoke through this handle. Wired from
+    /// `SharedServices.abac_predicate_store` via `with_abac_predicate_store`.
+    /// `None` when ABAC is off.
+    #[cfg(feature = "abac-policy")]
+    pub abac_predicate_store: Option<Arc<proximadb_abac::FileSystemPredicateObjectStore>>,
 }
 
 impl AppState {
@@ -257,6 +307,12 @@ impl AppState {
             observability_service,
             event_log,
             api_handlers,
+            #[cfg(feature = "abac-policy")]
+            abac_authority,
+            #[cfg(feature = "abac-policy")]
+            abac_binding_store,
+            #[cfg(feature = "abac-policy")]
+            abac_predicate_store,
         } = core;
         // Cross-modal fusion port — built once at boot from the vector + graph services and the
         // shared full-text index map (search-surface contract: one retrieval engine, shared port).
@@ -319,6 +375,16 @@ impl AppState {
             recall_probe_gate: None,
             discovery_service: None,
             external_collection_service: None,
+            // TD-ABAC control-plane: carried through `RestCoreServices` from
+            // `SharedServices.abac_*` (built once, shared with the live enforcer
+            // so an admin provision is hot-visible). `None` when ABAC is off; the
+            // `with_abac_*` builders remain for test overrides.
+            #[cfg(feature = "abac-policy")]
+            abac_authority,
+            #[cfg(feature = "abac-policy")]
+            abac_binding_store,
+            #[cfg(feature = "abac-policy")]
+            abac_predicate_store,
         }
     }
 
@@ -356,6 +422,41 @@ impl AppState {
         registry: Arc<crate::cluster::primary_pod_registry::PrimaryPodRegistry>,
     ) -> Self {
         self.primary_pod_registry = registry;
+        self
+    }
+
+    /// Inject the shared durable ABAC attribute-authority handle (TD-ABAC
+    /// control-plane / `abac-policy`). Wired from `SharedServices.abac_authority`
+    /// in `src/network/multi_server.rs` so the admin attribute-binding endpoints
+    /// and the live enforcer share the SAME instance (hot-reload).
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_authority(
+        mut self,
+        authority: Arc<proximadb_abac::FileSystemAttributeAuthority>,
+    ) -> Self {
+        self.abac_authority = Some(authority);
+        self
+    }
+
+    /// Inject the shared durable ABAC policy-binding store handle (TD-ABAC
+    /// control-plane / `abac-policy`). Wired from `SharedServices.abac_binding_store`.
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_binding_store(
+        mut self,
+        store: Arc<proximadb_abac::FileSystemPolicyBindingStore>,
+    ) -> Self {
+        self.abac_binding_store = Some(store);
+        self
+    }
+
+    /// Inject the shared durable ABAC predicate-object store handle (TD-ABAC
+    /// control-plane / `abac-policy`). Wired from `SharedServices.abac_predicate_store`.
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_predicate_store(
+        mut self,
+        store: Arc<proximadb_abac::FileSystemPredicateObjectStore>,
+    ) -> Self {
+        self.abac_predicate_store = Some(store);
         self
     }
 

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -359,6 +359,27 @@ pub struct SharedServices {
     #[cfg(feature = "experimental-ledger")]
     pub ledger_store: Arc<proximadb_ledger::LedgerService<proximadb_ledger::DurableLedger>>,
 
+    /// Durable ABAC attribute-authority handle (TD-ABAC control-plane /
+    /// `abac-policy`). The SAME `Arc<FileSystemAttributeAuthority>` instance the
+    /// live enforcer reads — so an admin provision written through this handle is
+    /// visible without a restart (hot-reload). `None` unless `abac-policy` is on
+    /// and `<data_dir>/abac/attribute-bindings.json` opens cleanly.
+    #[cfg(feature = "abac-policy")]
+    pub abac_authority: Option<Arc<proximadb_abac::FileSystemAttributeAuthority>>,
+
+    /// Durable ABAC policy-binding store handle (TD-ABAC control-plane /
+    /// `abac-policy`). Shared with the live enforcer; the admin policy-binding
+    /// endpoints (TD-ABAC control-plane PR-B) write through this handle. `None`
+    /// when ABAC is off.
+    #[cfg(feature = "abac-policy")]
+    pub abac_binding_store: Option<Arc<proximadb_abac::FileSystemPolicyBindingStore>>,
+
+    /// Durable ABAC predicate-object store handle (TD-ABAC control-plane /
+    /// `abac-policy`). Shared with the live enforcer; the admin predicate-object
+    /// endpoints register/revoke through this handle. `None` when ABAC is off.
+    #[cfg(feature = "abac-policy")]
+    pub abac_predicate_store: Option<Arc<proximadb_abac::FileSystemPredicateObjectStore>>,
+
     /// The single canonical WAL-backed record store, built + WAL-recovered ONCE here and
     /// shared across ALL surfaces — the REST/gRPC `DmlService` and the pgwire direct-write
     /// path both route relational tables through this instance — so a write on any protocol
@@ -461,6 +482,18 @@ pub struct SharedServices {
     >,
 }
 
+/// The three durable ABAC substrate stores, each behind a shared `Arc` handle so
+/// the live `AbacEnforcer`(s) and the admin-provisioning writer observe the SAME
+/// instance — a runtime provision is visible to the enforcer without a restart
+/// (hot-reload, TD-ABAC control-plane). Opened once in
+/// [`SharedServices::open_abac_stores`].
+#[cfg(feature = "abac-policy")]
+struct AbacDurableStores {
+    authority: Arc<proximadb_abac::FileSystemAttributeAuthority>,
+    bindings: Arc<proximadb_abac::FileSystemPolicyBindingStore>,
+    predicate_objects: Arc<proximadb_abac::FileSystemPredicateObjectStore>,
+}
+
 impl SharedServices {
     /// Borrow the TurboQuant registry, if any. Convenience getter so call
     /// sites don't have to feature-gate the field access locally — this
@@ -523,26 +556,24 @@ impl SharedServices {
         }
     }
 
-    /// Build the process-shared ABAC [`AbacEnforcer`](crate::security::rls::AbacEnforcer)
-    /// from the **durable** substrate (TD-ABAC-2, Phase 5b): the
-    /// `FileSystemAttributeAuthority` (#1310) + the `FileSystemPolicyBindingStore`
-    /// (this change), both restart-recovered from `<data_dir>/abac/`. The
-    /// predicate-object store and the policy-epoch source are **in-memory** today
-    /// (follow-ons: durable predicates, durable epochs) — so an opt-in
-    /// `abac-policy` build can evaluate table-level permit/deny (predicate-free
-    /// bindings) but not yet row-predicates until the predicate store is durable.
+    /// Open the three durable ABAC substrate stores (`FileSystem*`) from
+    /// `<data_dir>/abac/` once at boot, each behind a shared `Arc` handle. The
+    /// live [`AbacEnforcer`](crate::security::rls::AbacEnforcer)(s) and the
+    /// admin-provisioning writer share these SAME instances, so a runtime
+    /// provision is visible to the enforcer without a restart (hot-reload,
+    /// TD-ABAC control-plane).
     ///
     /// Returns `None` on default builds (the feature is OFF) and when there is no
-    /// `data_dir` or a durable store cannot be opened — i.e. the status quo (no
+    /// `data_dir` or a store cannot be opened — i.e. the status quo (no
     /// enforcement). It never synthesizes an allow: absent ⇒ no enforcer ⇒ no
     /// filtering, the same state as today.
     #[cfg(feature = "abac-policy")]
-    fn build_abac_enforcer(
+    fn open_abac_stores(
         opt_config: Option<&crate::core::config::Config>,
-    ) -> Option<Arc<crate::security::rls::AbacEnforcer>> {
+    ) -> Option<AbacDurableStores> {
         use proximadb_abac::{
             FileSystemAttributeAuthority, FileSystemPolicyBindingStore,
-            FileSystemPredicateObjectStore, InMemoryPolicyEpochs,
+            FileSystemPredicateObjectStore,
         };
 
         let data_dir = opt_config?.server.data_dir.clone();
@@ -559,7 +590,7 @@ impl SharedServices {
 
         let authority =
             match FileSystemAttributeAuthority::open(abac_dir.join("attribute-bindings.json")) {
-                Ok(a) => a,
+                Ok(a) => Arc::new(a),
                 Err(e) => {
                     tracing::error!(
                         "abac-policy: failed to open attribute authority at {}: {e}; \
@@ -571,7 +602,7 @@ impl SharedServices {
             };
         let bindings =
             match FileSystemPolicyBindingStore::open(abac_dir.join("policy-bindings.json")) {
-                Ok(s) => s,
+                Ok(s) => Arc::new(s),
                 Err(e) => {
                     tracing::error!(
                         "abac-policy: failed to open policy binding store at {}: {e}; \
@@ -587,7 +618,7 @@ impl SharedServices {
         // production. Empty ⇒ every predicate ref resolves fail-closed.
         let predicate_objects =
             match FileSystemPredicateObjectStore::open(abac_dir.join("predicate-objects.json")) {
-                Ok(s) => s,
+                Ok(s) => Arc::new(s),
                 Err(e) => {
                     tracing::error!(
                         "abac-policy: failed to open predicate object store at {}: {e}; \
@@ -599,16 +630,45 @@ impl SharedServices {
             };
 
         tracing::info!(
-            "abac-policy: durable ABAC enforcer active at {} (authority + policy binding store + predicate object store)",
+            "abac-policy: durable ABAC stores active at {} (authority + policy binding store + predicate object store)",
             abac_dir.display()
         );
+        Some(AbacDurableStores {
+            authority,
+            bindings,
+            predicate_objects,
+        })
+    }
+
+    /// Build a process-shared [`AbacEnforcer`] from already-opened shared stores,
+    /// cloning the `Arc` handles so the enforcer reads the same instances an admin
+    /// writer mutates (hot-reload). The policy-epoch source is in-memory today
+    /// (follow-on: durable epochs).
+    #[cfg(feature = "abac-policy")]
+    fn build_enforcer_from_stores(
+        stores: &AbacDurableStores,
+    ) -> Arc<crate::security::rls::AbacEnforcer> {
+        use proximadb_abac::InMemoryPolicyEpochs;
         let enforcer = crate::security::rls::AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(predicate_objects),
-            Box::new(InMemoryPolicyEpochs::new()),
+            stores.authority.clone(),
+            stores.predicate_objects.clone(),
+            Arc::new(InMemoryPolicyEpochs::new()),
         )
-        .with_binding_store(Box::new(bindings));
-        Some(Arc::new(enforcer))
+        .with_binding_store(stores.bindings.clone());
+        Arc::new(enforcer)
+    }
+
+    /// Open the durable stores and build the enforcer in one shot. Test-only
+    /// convenience — production shares the opened stores across the vector/DML
+    /// enforcers AND `AppState` (see [`open_abac_stores`] +
+    /// [`build_enforcer_from_stores`]) so an admin provision is hot-visible to
+    /// every reader. Gated to `test` so it carries no dead-code weight in
+    /// `--lib` builds.
+    #[cfg(all(feature = "abac-policy", test))]
+    fn build_abac_enforcer(
+        opt_config: Option<&crate::core::config::Config>,
+    ) -> Option<Arc<crate::security::rls::AbacEnforcer>> {
+        Self::open_abac_stores(opt_config).map(|s| Self::build_enforcer_from_stores(&s))
     }
 
     /// Create shared services with full business logic configuration
@@ -1499,6 +1559,13 @@ impl SharedServices {
             }
         }
 
+        // Open the durable ABAC stores ONCE here (outer scope) so the
+        // vector-service enforcer, the DmlService enforcer, and the AppState
+        // admin handles all share the SAME store instances — a runtime provision
+        // is then hot-visible to every reader (TD-ABAC control-plane).
+        #[cfg(feature = "abac-policy")]
+        let abac_stores = Self::open_abac_stores(opt_config);
+
         // `directory_cache` constructed earlier (before SstEngine) so the
         // engine, the vector ops service, and the SharedServices public
         // field all share the same `Arc`.
@@ -1535,12 +1602,12 @@ impl SharedServices {
             // ⇒ no enforcer ⇒ no per-record filtering (the status quo). Mirrors the
             // DmlService wiring (`build_abac_enforcer`, TD-ABAC-2).
             #[cfg(feature = "abac-policy")]
-            let svc = match Self::build_abac_enforcer(opt_config) {
-                Some(enforcer) => {
+            let svc = match &abac_stores {
+                Some(stores) => {
                     debug!(
                         "✅ SharedServices::new - durable ABAC enforcer wired into VectorOperationsService"
                     );
-                    svc.with_abac_enforcer(enforcer)
+                    svc.with_abac_enforcer(Self::build_enforcer_from_stores(stores))
                 }
                 None => svc,
             };
@@ -2478,10 +2545,10 @@ impl SharedServices {
         // DML read funnel. Fully behind `abac-policy` (default-OFF) ⇒ default
         // builds are byte-for-byte unchanged; `None` ⇒ no enforcement (status quo).
         #[cfg(feature = "abac-policy")]
-        let base_dml = match Self::build_abac_enforcer(opt_config) {
-            Some(enforcer) => {
+        let base_dml = match &abac_stores {
+            Some(stores) => {
                 debug!("✅ SharedServices::new - durable ABAC enforcer wired into DmlService");
-                base_dml.with_abac_enforcer(enforcer)
+                base_dml.with_abac_enforcer(Self::build_enforcer_from_stores(stores))
             }
             None => base_dml,
         };
@@ -2867,6 +2934,16 @@ impl SharedServices {
                 conditional_key_store,
                 #[cfg(feature = "experimental-ledger")]
                 ledger_store,
+                // TD-ABAC control-plane: the three durable ABAC store handles,
+                // cloned from the single `abac_stores` trio opened above so the
+                // admin-provisioning endpoints share the SAME instances the live
+                // enforcer reads (hot-reload). `None` when ABAC is off.
+                #[cfg(feature = "abac-policy")]
+                abac_authority: abac_stores.as_ref().map(|s| s.authority.clone()),
+                #[cfg(feature = "abac-policy")]
+                abac_binding_store: abac_stores.as_ref().map(|s| s.bindings.clone()),
+                #[cfg(feature = "abac-policy")]
+                abac_predicate_store: abac_stores.as_ref().map(|s| s.predicate_objects.clone()),
                 // TD-064 / LLD §5: per-collection recall-probe gate. Empty
                 // at startup; populated as the stats refresher / search path
                 // observe probe outcomes. Route-health surfaces per-scope
@@ -3681,16 +3758,15 @@ mod abac_composition_root_tests {
 
         // 1. durable authority: alice → dept=eng in tenant 7.
         {
-            let mut auth =
-                FileSystemAttributeAuthority::open(abac_dir.join("attribute-bindings.json"))
-                    .expect("open authority");
+            let auth = FileSystemAttributeAuthority::open(abac_dir.join("attribute-bindings.json"))
+                .expect("open authority");
             auth.upsert(
                 AttributeBinding::new("alice", 7).with_attr("dept", AttrValue::Str("eng".into())),
             );
         }
         // 2. durable policy bindings: permit table 200 under predicate ref 42.
         {
-            let mut bindings =
+            let bindings =
                 FileSystemPolicyBindingStore::open(abac_dir.join("policy-bindings.json"))
                     .expect("open binding store");
             bindings.replace_tenant(
@@ -3707,7 +3783,7 @@ mod abac_composition_root_tests {
         }
         // 3. durable predicate objects: ref 42 → dept == "eng".
         {
-            let mut preds =
+            let preds =
                 FileSystemPredicateObjectStore::open(abac_dir.join("predicate-objects.json"))
                     .expect("open predicate store");
             preds.register(

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -10,6 +10,9 @@
 //! walker via [`admits_with_security`](super::filter_lattice::admits_with_security).
 
 #[cfg(feature = "abac-policy")]
+use std::sync::Arc;
+
+#[cfg(feature = "abac-policy")]
 use crate::core::search::{
     FilterExpression, OptimizedSearchRecord, sql_value_filter::proxima_value_to_json,
 };
@@ -82,9 +85,9 @@ pub enum AbacScanResult {
 #[cfg(feature = "abac-policy")]
 #[allow(dead_code)]
 pub struct AbacEnforcer {
-    authority: Box<dyn AttributeAuthority + Send + Sync>,
-    store: Box<dyn PredicateObjectStore + Send + Sync>,
-    epochs: Box<dyn PolicyEpochSource + Send + Sync>,
+    authority: Arc<dyn AttributeAuthority + Send + Sync>,
+    store: Arc<dyn PredicateObjectStore + Send + Sync>,
+    epochs: Arc<dyn PolicyEpochSource + Send + Sync>,
     /// The policy bindings this enforcer governs. Holding them makes the enforcer
     /// a self-contained policy a service can store once and call per-read
     /// (`predicate_for`); the per-call `scan_predicate_for(.., bindings)` variant
@@ -93,18 +96,25 @@ pub struct AbacEnforcer {
     /// The durable policy source (Phase 5b). When set, `predicate_for` loads the
     /// tenant's bindings from here per read — restart-surviving policy. When
     /// unset, it falls back to the held `bindings` (the in-memory/test path).
-    binding_store: Option<Box<dyn PolicyBindingStore + Send + Sync>>,
+    ///
+    /// Held as a shared `Arc<dyn PolicyBindingStore>` (not `Box`) so the same
+    /// durable store instance is shared between this enforcer and an
+    /// admin-provisioning writer: a write through the writer's `Arc` handle is
+    /// visible to the enforcer's next read without a restart (hot-reload,
+    /// TD-ABAC control-plane).
+    binding_store: Option<Arc<dyn PolicyBindingStore + Send + Sync>>,
 }
 
 #[cfg(feature = "abac-policy")]
 #[allow(dead_code)]
 impl AbacEnforcer {
     /// Construct from the three substrate stores. In production these are the
-    /// durable-backed impls; in tests, the in-memory ones.
+    /// durable-backed impls (shared `Arc` handles so an admin writer and the
+    /// enforcer observe the same instance); in tests, the in-memory ones.
     pub fn new(
-        authority: Box<dyn AttributeAuthority + Send + Sync>,
-        store: Box<dyn PredicateObjectStore + Send + Sync>,
-        epochs: Box<dyn PolicyEpochSource + Send + Sync>,
+        authority: Arc<dyn AttributeAuthority + Send + Sync>,
+        store: Arc<dyn PredicateObjectStore + Send + Sync>,
+        epochs: Arc<dyn PolicyEpochSource + Send + Sync>,
     ) -> Self {
         Self {
             authority,
@@ -127,7 +137,11 @@ impl AbacEnforcer {
     /// [`predicate_for`](Self::predicate_for) loads the tenant's bindings from the
     /// store on every read — a restart-surviving policy. This is the production
     /// path; [`with_bindings`](Self::with_bindings) remains for tests.
-    pub fn with_binding_store(mut self, store: Box<dyn PolicyBindingStore + Send + Sync>) -> Self {
+    ///
+    /// Takes a shared `Arc` so the caller (boot wiring) can retain its own clone
+    /// of the same durable store for the admin-provisioning writer — a provision
+    /// is then visible to this enforcer without a restart.
+    pub fn with_binding_store(mut self, store: Arc<dyn PolicyBindingStore + Send + Sync>) -> Self {
         self.binding_store = Some(store);
         self
     }
@@ -400,9 +414,9 @@ mod tests {
             field_mask: None,
         }];
         let enforcer = AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(store),
-            Box::new(InMemoryPolicyEpochs::new()),
+            Arc::new(authority),
+            Arc::new(store),
+            Arc::new(InMemoryPolicyEpochs::new()),
         );
         (enforcer, bindings)
     }
@@ -579,7 +593,7 @@ mod tests {
             proximadb_abac::AttributeBinding::new("alice", 7)
                 .with_attr("dept", AttrValue::Str("eng".into())),
         );
-        let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+        let store = FileSystemPolicyBindingStore::open(&path).expect("open");
         store.replace_tenant(
             7,
             vec![PolicyBinding {
@@ -593,12 +607,12 @@ mod tests {
         );
 
         let enforcer = AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(predicate_store_for_dept()),
-            Box::new(InMemoryPolicyEpochs::new()),
+            Arc::new(authority),
+            Arc::new(predicate_store_for_dept()),
+            Arc::new(InMemoryPolicyEpochs::new()),
         )
         // NOTE: no with_bindings — held bindings are empty by design.
-        .with_binding_store(Box::new(store));
+        .with_binding_store(Arc::new(store));
 
         match enforcer.predicate_for(
             &SubjectId("alice".into()),
@@ -646,7 +660,7 @@ mod tests {
 
         // Write phase: persist tenant 7's permit, then drop everything.
         {
-            let mut store = FileSystemPolicyBindingStore::open(&path).expect("open");
+            let store = FileSystemPolicyBindingStore::open(&path).expect("open");
             store.replace_tenant(
                 7,
                 vec![PolicyBinding {
@@ -670,11 +684,11 @@ mod tests {
                     .with_attr("dept", AttrValue::Str("eng".into())),
             );
             AbacEnforcer::new(
-                Box::new(authority),
-                Box::new(predicate_store_for_dept()),
-                Box::new(InMemoryPolicyEpochs::new()),
+                Arc::new(authority),
+                Arc::new(predicate_store_for_dept()),
+                Arc::new(InMemoryPolicyEpochs::new()),
             )
-            .with_binding_store(Box::new(store))
+            .with_binding_store(Arc::new(store))
         }
 
         let store = FileSystemPolicyBindingStore::open(&path).expect("reopen");
@@ -687,6 +701,90 @@ mod tests {
                 assert!(!pred(&record_with("hr")));
             }
             _ => panic!("alice must be Restricted after restart"),
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn enforcer_observes_a_binding_provisioned_after_construction_hot_reload() {
+        // PR-A hot-reload gate (TD-ABAC control-plane): the admin-provisioning
+        // path writes through a SHARED `Arc<FileSystemPolicyBindingStore>` — the
+        // SAME instance the live enforcer reads. A binding written AFTER the
+        // enforcer is constructed must be visible to the very next read, with no
+        // restart. This is the property that makes runtime policy provisioning
+        // usable in a running server.
+        let dir = std::env::temp_dir().join(format!(
+            "proximadb-abac-enforcer-hotreload-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("policy.json");
+        let target = Target {
+            namespace: 3,
+            table: 200,
+            column: None,
+        };
+
+        let mut authority = InMemoryAttributeAuthority::new();
+        authority.upsert(
+            proximadb_abac::AttributeBinding::new("alice", 7)
+                .with_attr("dept", AttrValue::Str("eng".into())),
+        );
+
+        // Build the durable store EMPTY, wrap it in an `Arc`, and hand a CLONE
+        // (the same instance) to the enforcer. The caller retains its own clone —
+        // the admin-provisioning handle.
+        let store = Arc::new(FileSystemPolicyBindingStore::open(&path).expect("open"));
+        let enforcer = AbacEnforcer::new(
+            Arc::new(authority),
+            Arc::new(predicate_store_for_dept()),
+            Arc::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_binding_store(store.clone());
+
+        // Before provisioning, alice has no applicable policy ⇒ deny-biased ⇒
+        // fail-closed DENY (also the unprovisioned-tenant behavior the admin API
+        // must not let through).
+        assert!(
+            matches!(
+                enforcer.predicate_for(&SubjectId("alice".into()), 7, target),
+                AbacScanResult::Denied(_)
+            ),
+            "no binding provisioned yet ⇒ alice is denied (fail-closed)"
+        );
+
+        // The admin provisions tenant 7's permit through the SAME shared handle —
+        // no restart, no re-open. This is the write the enforcer must observe.
+        store.replace_tenant(
+            7,
+            vec![PolicyBinding {
+                object_id: 1,
+                tenant_stable_id: 7,
+                scope: Scope::Table(200),
+                effect: Effect::Permit,
+                predicate_ref: Some(42),
+                field_mask: None,
+            }],
+        );
+
+        // The live enforcer observes the provisioned binding on the next read:
+        // alice is now admitted with her dept=eng row predicate.
+        match enforcer.predicate_for(&SubjectId("alice".into()), 7, target) {
+            AbacScanResult::Restricted(pred) => {
+                assert!(pred(&record_with("eng")), "dept=eng row admitted");
+                assert!(!pred(&record_with("hr")), "dept=hr row denied");
+            }
+            AbacScanResult::Unrestricted => {
+                panic!("alice must be Restricted (predicate ref 42), not Unrestricted")
+            }
+            AbacScanResult::Denied(_) => {
+                panic!("hot-reload failed: provisioned binding not visible to enforcer")
+            }
         }
 
         let _ = std::fs::remove_file(&path);

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -6101,9 +6101,9 @@ mod abac_relational_enforcement_tests {
             field_mask: None,
         }];
         AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(store),
-            Box::new(InMemoryPolicyEpochs::new()),
+            Arc::new(authority),
+            Arc::new(store),
+            Arc::new(InMemoryPolicyEpochs::new()),
         )
         .with_bindings(bindings)
     }

--- a/tests/abac_vector_pushdown_integration_test.rs
+++ b/tests/abac_vector_pushdown_integration_test.rs
@@ -70,9 +70,9 @@ fn enforcer_for_alice() -> Arc<AbacEnforcer> {
     }];
     Arc::new(
         AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(store),
-            Box::new(InMemoryPolicyEpochs::new()),
+            Arc::new(authority),
+            Arc::new(store),
+            Arc::new(InMemoryPolicyEpochs::new()),
         )
         .with_bindings(bindings),
     )
@@ -231,9 +231,9 @@ async fn resolve_vector_read_context_admits_and_denies() {
     }];
     let enforcer = Arc::new(
         AbacEnforcer::new(
-            Box::new(authority),
-            Box::new(InMemoryPredicateObjectStore::new()),
-            Box::new(InMemoryPolicyEpochs::new()),
+            Arc::new(authority),
+            Arc::new(InMemoryPredicateObjectStore::new()),
+            Arc::new(InMemoryPolicyEpochs::new()),
         )
         .with_bindings(bindings),
     );


### PR DESCRIPTION
## Summary

ABAC enforcement is wired on every surface (REST/gRPC/Flight), but the three durable stores were owned by the `AbacEnforcer` as read-only `Box<dyn>` loaded once at boot — so a correct admin write to the policy files was **invisible until restart**, and no production writer existed. This PR (PR-A) makes the stores **shareable** so a provision is hot-visible to the live enforcer. It is the substrate for the admin provisioning endpoints (PR-B).

## Changes

- **`FileSystem*` stores** (`crates/control/proximadb-abac/src/{authority,policy_binding_store,compile}.rs`): in-memory cache moves behind `std::sync::RwLock`; inherent write methods (`upsert`/`replace_tenant`/`remove`/`register`/`revoke`) become `&self` (internal write-lock + the unchanged atomic temp+rename persist). Poison recovery via the established `.unwrap_or_else(|p| p.into_inner())` idiom (no panics). `PredicateObjectStore::get` now returns an owned `FilterExpression` — a reference cannot escape a read guard (the single consumer, `compile_security_filter`, already cloned).
- **`AbacEnforcer`** (`src/security/rls/abac_adapter.rs`): holds `authority`/`store`/`epochs`/`binding_store` as `Arc<dyn …>` (was `Box<dyn>`); `new()`/`with_binding_store()` take `Arc<dyn>`.
- **`SharedServices`** (`src/network/shared_services.rs`): opens the three stores **once** (`open_abac_stores`) and shares `Arc` clones across the VectorOperationsService + DmlService enforcers **and** three new `Option<Arc<FileSystem*>>` fields — every reader now observes the same instance (previously each enforcer opened its own copy, so a shared provision would not have reached both).
- **`AppState`** (`src/network/rest/canonical/handlers.rs`): the handles ride through `RestCoreServices` into `AppState.abac_*` (cfg-gated, default `None`), mirroring the `primary_pod_registry` extraction pattern; `with_abac_*` builders remain for test overrides.

## Gate test

`enforcer_observes_a_binding_provisioned_after_construction_hot_reload` — builds the enforcer over a shared `Arc<FileSystemPolicyBindingStore>`, writes a binding through that handle **after** construction, and asserts `enforcer.predicate_for` observes it on the next read (no restart). Proves deny-before-write → admit-after-provision.

## Verification

- `cargo clippy -p proximadb-abac --all-targets -- -D warnings` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- `cargo clippy --test abac_vector_pushdown_integration_test --features abac-policy -- -D warnings` ✅
- abac crate: 58/58 tests ✅; root lib (abac-policy): 12/12 enforcer + composition-root tests ✅ (incl. hot-reload gate)
- `cargo fmt --check` ✅; `make work-commit-check` ✅ (panic-policy delta +0, env-gate 230, workspace/tenant/hygiene clean)

Default-OFF (`abac-policy`); default builds are unchanged. No new TD filed — this is plumbing executing the approved plan; PR-B (the three admin endpoints + resolve-at-write) follows.