### PR TITLE
fix(wal): key cold-delete DV bits on the durable WAL global_lsn (TD-DELVEC-1 WI-5 P0)

### DIFF
--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1206,12 +1206,13 @@ impl VectorOperationsService {
             ensure_tenant_on_records(&mut tombstones, &tenant_context.tenant_id)?;
         }
 
-        // TD-DELVEC-1 WI-3b: under `cold-deletion-vectors`, a delete that lands on
-        // a row already in an immutable cold segment sets a deletion-vector bit
-        // (keyed by the delete's real WAL LSN) in addition to the tombstone. The
-        // tombstone still carries read-after-write coherence (`is_record_dead`,
-        // valid_to_ns=0 in olap_delta_merge) until WI-4 wires merge-on-read to
-        // consult the DV.
+        // TD-DELVEC-1 WI-3b / WI-5 P0: under `cold-deletion-vectors`, a delete that
+        // lands on a row already in an immutable cold segment sets a deletion-vector
+        // bit keyed by the delete's durable per-batch WAL `global_lsn` (returned by
+        // `insert_vectors_via_wal_returning_lsns`), in addition to the tombstone.
+        // The durable keying (WI-5 P0) puts the generation in the read side's
+        // `snapshot_lsn` number space for correct MVCC; WI-4 wires merge-on-read to
+        // consult the DV. The tombstone still provides read-after-write coherence.
         #[cfg(feature = "cold-deletion-vectors")]
         let (result, lsns) = self
             .insert_vectors_via_wal_returning_lsns(&collection_id, tombstones)

--- a/src/services/operations/vectors/write.rs
+++ b/src/services/operations/vectors/write.rs
@@ -312,9 +312,12 @@ impl VectorWriteCoordinator {
     }
 
     /// Insert records via the standard WAL path, returning the per-record WAL/MVCC
-    /// LSNs alongside the batch result. TD-DELVEC-1 WI-3b: the cold-delete path
-    /// keys the deletion-vector bit on the delete's real LSN (`sequences`, one per
-    /// input record, in input order) instead of wall-clock time.
+    /// LSNs alongside the batch result. TD-DELVEC-1 WI-3b / WI-5 P0: these are the
+    /// durable per-batch manifest `global_lsn` (broadcast one-per-record, in input
+    /// order) when the batch is synced — the cold-delete path keys deletion-vector
+    /// bits on them so the generation shares the read side's `snapshot_lsn` number
+    /// space (correct MVCC). Falls back to ephemeral memtable sequences in
+    /// MemoryOnly mode (no durability to key on).
     #[cfg(feature = "cold-deletion-vectors")]
     pub(crate) async fn insert_vectors_via_wal_returning_lsns(
         &self,

--- a/src/storage/persistence/write_ahead_log/disk_manager.rs
+++ b/src/storage/persistence/write_ahead_log/disk_manager.rs
@@ -63,6 +63,10 @@ pub struct WalFileInfo {
     /// Ordered token parsed from the object name. The tenant is populated from
     /// the authenticated envelope when the object is read.
     pub recovery_token: Option<RecoveryToken>,
+    /// The durable manifest `global_lsn` allocated for this batch (TD-DELVEC-1
+    /// WI-5 P0). Set on the write path; `0` when parsed from a path (reads don't
+    /// need it — only the write path returns it for DV-bit keying).
+    pub global_lsn: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -328,6 +332,11 @@ impl WriteAheadLogDiskManager {
         let file_name = file_url.split('/').next_back().unwrap_or("").to_string();
 
         use crate::storage::persistence::write_ahead_log::manifest;
+        // TD-DELVEC-1 WI-5 P0: capture the durable `global_lsn` allocated for this
+        // batch (synchronous inside `append_async`) so the write path can return it
+        // for deletion-vector bit keying. Stays `0` if there is no manifest service
+        // or the (non-fatal) append failed — callers fall back to the memtable seq.
+        let mut global_lsn = 0u64;
         if let Some(manifest_service) = manifest::get_service() {
             let format_str = match format {
                 SerializationFormat::ProtocolBuffers => "proto",
@@ -348,8 +357,9 @@ impl WriteAheadLogDiskManager {
             );
             // Async append (non-blocking, high performance); non-fatal if manifest
             // channel is closed (e.g. singleton background worker from a prior run).
-            if let Err(e) = manifest_service.append_async(entry).await {
-                warn!("⚠️  Manifest append failed (non-fatal): {}", e);
+            match manifest_service.append_async(entry).await {
+                Ok(lsn) => global_lsn = lsn,
+                Err(e) => warn!("⚠️  Manifest append failed (non-fatal): {}", e),
             }
         }
 
@@ -368,6 +378,7 @@ impl WriteAheadLogDiskManager {
             format,
             encryption_metadata,
             recovery_token: Some(recovery_token),
+            global_lsn,
         };
 
         debug!("✅ Successfully wrote WAL batch to disk: {:?}", file_info);
@@ -710,6 +721,7 @@ impl WriteAheadLogDiskManager {
             format,
             encryption_metadata: None, // Path parsing doesn't have encryption metadata
             recovery_token,
+            global_lsn: 0, // Not recoverable from the path; reads don't need it.
         })
     }
 }

--- a/src/storage/persistence/write_ahead_log/manifest/service.rs
+++ b/src/storage/persistence/write_ahead_log/manifest/service.rs
@@ -476,10 +476,15 @@ impl GlobalManifestService {
         Ok(())
     }
 
-    /// Append an entry asynchronously (high performance, no blocking)
-    pub async fn append_async(&self, mut entry: GlobalManifestEntry) -> Result<()> {
+    /// Append an entry asynchronously (the LSN is allocated synchronously; the
+    /// entry is persisted by the background worker). Returns the allocated durable
+    /// `global_lsn` — TD-DELVEC-1 WI-5 P0 keys deletion-vector bits on this LSN so
+    /// the DV generation shares the read side's `snapshot_lsn` number space
+    /// (correct MVCC) and is recoverable.
+    pub async fn append_async(&self, mut entry: GlobalManifestEntry) -> Result<u64> {
         // Allocate global LSN
         entry.global_lsn = self.lsn_allocator.allocate().await;
+        let global_lsn = entry.global_lsn;
 
         // Send to background worker (non-blocking)
         self.append_tx
@@ -490,7 +495,7 @@ impl GlobalManifestService {
             .await
             .context("Failed to send append request")?;
 
-        Ok(())
+        Ok(global_lsn)
     }
 
     /// Append an entry synchronously (waits for disk write)
@@ -1200,6 +1205,66 @@ mod barrier_tests {
             entries[0].status,
             WalEntryStatus::Flushed,
             "freshly appended batch must be marked Flushed, not missed"
+        );
+    }
+
+    /// TD-DELVEC-1 WI-5 P0: `append_async` returns the durable per-batch
+    /// `global_lsn` it allocated (previously a discarded `()`), so the cold-delete
+    /// path can key deletion-vector bits on a generation in the read side's
+    /// `snapshot_lsn` number space. The LSN is allocated synchronously, monotonic
+    /// across appends, and matches `current_lsn`.
+    #[tokio::test]
+    async fn append_async_returns_durable_global_lsn() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let wal_url = format!("file://{}", temp_dir.path().display());
+        let fs_factory = Arc::new(
+            FilesystemFactory::create(FilesystemConfig::default())
+                .await
+                .expect("fs factory"),
+        );
+        let service = GlobalManifestService::new(
+            GlobalManifestServiceConfig::default(),
+            fs_factory,
+            wal_url.clone(),
+        )
+        .await
+        .expect("service");
+
+        let mk_entry = |batch_id: &str| GlobalManifestEntry {
+            global_lsn: 0, // allocated by append_async
+            collection_id: "c1".to_string(),
+            batch_id: batch_id.to_string(),
+            file_path: format!("c1/wal/{batch_id}.bcwal"),
+            storage_url: wal_url.clone(),
+            size_bytes: 42,
+            checksum_crc32: 0,
+            timestamp_ms: 1,
+            format: SerializationFormat::Bincode,
+            vector_count: 1,
+            status: WalEntryStatus::Active,
+            checkpoint_id: None,
+        };
+
+        let lsn1 = service
+            .append_async(mk_entry("b1"))
+            .await
+            .expect("append b1");
+        let lsn2 = service
+            .append_async(mk_entry("b2"))
+            .await
+            .expect("append b2");
+        assert!(
+            lsn1 > 0,
+            "append_async must return an allocated LSN, got {lsn1}"
+        );
+        assert!(
+            lsn2 > lsn1,
+            "returned LSNs must be monotonic: {lsn1} then {lsn2}"
+        );
+        assert_eq!(
+            service.current_lsn().await,
+            lsn2,
+            "the returned LSN must match the manifest's current_lsn"
         );
     }
 }

--- a/src/storage/persistence/write_ahead_log/manifest/singleton.rs
+++ b/src/storage/persistence/write_ahead_log/manifest/singleton.rs
@@ -159,8 +159,9 @@ pub async fn shutdown() -> Result<()> {
 
 // Convenience functions
 
-/// Append entry asynchronously (high performance)
-pub async fn append_async(entry: GlobalManifestEntry) -> Result<()> {
+/// Append entry asynchronously (high performance); returns the allocated
+/// durable `global_lsn` (see `GlobalManifestService::append_async`).
+pub async fn append_async(entry: GlobalManifestEntry) -> Result<u64> {
     let service = get_service().ok_or_else(|| anyhow!("Global manifest not initialized"))?;
     service.append_async(entry).await
 }

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -2201,6 +2201,10 @@ impl WriteAheadLogManager {
             }
         }
 
+        // TD-DELVEC-1 WI-5 P0: capture the durable per-batch `global_lsn` (when this
+        // batch is synced to disk + the manifest append succeeds) so it can be
+        // returned for DV-bit keying instead of the ephemeral memtable sequence.
+        let mut durable_lsn: Option<u64> = None;
         // Then, persist to disk if sync mode requires it
         if self.should_sync_to_disk(collection_id).await? {
             info!(
@@ -2373,6 +2377,7 @@ impl WriteAheadLogManager {
                 .await
             {
                 Ok(file_info) => {
+                    durable_lsn = Some(file_info.global_lsn);
                     trace!("WAL: write_batch_with_sync SUCCESS: {:?}", file_info);
                 }
                 Err(e) => {
@@ -2397,7 +2402,12 @@ impl WriteAheadLogManager {
             );
         }
 
-        Ok(sequences)
+        // Return the durable per-batch `global_lsn` (broadcast one-per-record) when
+        // the batch was synced + the manifest allocated one; otherwise the ephemeral
+        // memtable sequences (MemoryOnly / append failure — no durability to key on).
+        // TD-DELVEC-1 WI-3b/WI-5: the cold-delete path keys DV bits on these LSNs.
+        let n = sequences.len();
+        Ok(durable_lsn.map(|l| vec![l; n]).unwrap_or(sequences))
     }
 
     /// Insert multiple vectors efficiently (modern API)


### PR DESCRIPTION
## What

TD-DELVEC-1 **WI-5 P0** — a correctness fix to the landed WI-3b delete path, and the prerequisite for WI-5 P1 (the resurface fix).

The cold-delete path keyed deletion-vector bits on the per-record "LSN" from `insert_vectors_via_wal_returning_lsns`, documented as the "delete's real WAL LSN." Recon proved that value is an **ephemeral in-memtable sequence** (`global_partitioned.rs:858`, reset to 1 each boot, not persisted) — **not** the durable WAL `global_lsn`. The read side (`is_deleted_as_of`) compares it against `snapshot_lsn = manifest.current_lsn()` (the durable `global_lsn` space), so the number spaces disagreed: "hide deletes" worked (ephemeral gen ≤ durable snapshot_lsn almost always), but **MVCC snapshot isolation was broken** — a delete was visible to snapshots older than the delete.

## Change

Thread the durable per-batch `global_lsn` from the manifest append up to the delete path:
- `GlobalManifestService::append_async` now returns the `global_lsn` it allocates synchronously (`Result<()>` → `Result<u64>`).
- `disk_manager` surfaces it on `WalFileInfo.global_lsn` (new field; `0` when parsed from a path).
- `write_vector_batch_native_arc` returns it (broadcast one-per-record across the atomic batch) instead of the ephemeral sequence. MemoryOnly (no durability) falls back to the ephemeral sequence.

This puts the DV generation in the read side's `snapshot_lsn` number space (correct MVCC) and makes it **recoverable** — the prerequisite for **WI-5 P1** (the post-recovery DV-bit reconciliation pass that closes the crash-strand resurface window).

## Scope

Plumbing is default-visible; only the cold-delete path (feature-gated) consumes the LSN for DV keying, so **default builds are unchanged**. Corrects the two inaccurate "real WAL LSN" comments.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default — CI-gated) ✅
- `cargo build -p proximadb --lib --features cold-deletion-vectors` ✅
- `cargo test -p proximadb --lib append_async_returns_durable_global_lsn` → `1 passed` (returns a durable, monotonic `global_lsn` matching `current_lsn`) ✅

## Follow-ups

- **WI-5 P1**: the post-recovery DV-bit reconciliation pass (now unblocked — the generation is recoverable). Targets `canonical_sst_storage`'s DV store (not the transient recovery engine); rides the `boot_warm` background-pass template.
- A full MVCC snapshot-visibility integration test needs a controllable `FreshnessLsnSource` in test infra.
- The retire layer (`DeletionVectorStore::remove`, `OidResolverCache::invalidate`) is still fully unwired — WI-6 (compaction carry) territory.