### PR TITLE
feat(observability): TD-IOTRACE-4 — plumb persistent-L2 cache probes into the io-trace envelope and warehouse

### DIFF
--- a/crates/modalities/proximadb-observability-engine/src/io_trace.rs
+++ b/crates/modalities/proximadb-observability-engine/src/io_trace.rs
@@ -181,6 +181,13 @@ pub struct IoTrace {
     /// Footer/metadata cache outcomes (Dimension 3 — the highest-ROI cache).
     footer_hits: AtomicU64,
     footer_misses: AtomicU64,
+    /// Persistent local-disk L2 cache probe outcomes (ADR-085 / TD-IOTRACE-4).
+    /// Distinct from the in-memory footer cache: an L2 hit serves bytes that
+    /// survived process restart/L1 eviction without a billed ranged GET, so a
+    /// footer-cold query can still be physically warm — the cache-state signal
+    /// downstream priors aggregation needs alongside the footer ratio.
+    l2_hits: AtomicU64,
+    l2_misses: AtomicU64,
     /// Chargeable egress bytes — moved cross-region / to the internet off the
     /// free same-region path (Dimension 2 — KEU). Recorded only for chargeable
     /// localities; the route cost model's egress weight consumes this.
@@ -519,6 +526,12 @@ impl IoTrace {
         self.footer_misses.fetch_add(misses, Ordering::Relaxed);
     }
 
+    /// Record a batch of persistent-L2 cache probe outcomes (ADR-085 tier).
+    pub fn record_l2s(&self, hits: u64, misses: u64) {
+        self.l2_hits.fetch_add(hits, Ordering::Relaxed);
+        self.l2_misses.fetch_add(misses, Ordering::Relaxed);
+    }
+
     /// Add to chargeable egress bytes (cross-region / internet — KEU).
     pub fn record_egress_bytes(&self, bytes: u64) {
         self.egress_bytes.fetch_add(bytes, Ordering::Relaxed);
@@ -676,6 +689,8 @@ impl IoTrace {
             bytes_written: self.bytes_written.load(Ordering::Relaxed),
             footer_hits: self.footer_hits.load(Ordering::Relaxed),
             footer_misses: self.footer_misses.load(Ordering::Relaxed),
+            l2_hits: self.l2_hits.load(Ordering::Relaxed),
+            l2_misses: self.l2_misses.load(Ordering::Relaxed),
             egress_bytes: self.egress_bytes.load(Ordering::Relaxed),
             embedding_calls: self.embedding_calls.load(Ordering::Relaxed),
             embedding_input_tokens: self.embedding_input_tokens.load(Ordering::Relaxed),
@@ -779,6 +794,12 @@ pub struct IoTraceSnapshot {
     pub bytes_written: u64,
     pub footer_hits: u64,
     pub footer_misses: u64,
+    /// Persistent local-disk L2 cache probe outcomes (ADR-085 / TD-IOTRACE-4).
+    /// `serde(default)` keeps snapshots serialized before this field readable.
+    #[serde(default)]
+    pub l2_hits: u64,
+    #[serde(default)]
+    pub l2_misses: u64,
     pub egress_bytes: u64,
     pub embedding_calls: u64,
     pub embedding_input_tokens: u64,
@@ -896,6 +917,8 @@ impl IoTraceSnapshot {
             && self.bytes_written == 0
             && self.footer_hits == 0
             && self.footer_misses == 0
+            && self.l2_hits == 0
+            && self.l2_misses == 0
             && self.egress_bytes == 0
             && self.embedding_calls == 0
             && self.embedding_input_tokens == 0
@@ -939,6 +962,8 @@ impl IoTraceSnapshot {
             footer_hits = self.footer_hits,
             footer_misses = self.footer_misses,
             footer_hit_ratio = self.footer_hit_ratio().unwrap_or(f64::NAN),
+            l2_hits = self.l2_hits,
+            l2_misses = self.l2_misses,
             egress_bytes = self.egress_bytes,
             embedding_calls = self.embedding_calls,
             embedding_input_tokens = self.embedding_input_tokens,
@@ -1066,6 +1091,17 @@ pub fn record_footers(hits: u64, misses: u64) {
 #[cfg(not(feature = "io-trace"))]
 #[inline(always)]
 pub fn record_footers(_hits: u64, _misses: u64) {}
+
+/// Record a batch of persistent-L2 cache probe outcomes for the active query
+/// (ADR-085 / TD-IOTRACE-4). (TD-160: perf/geometry trace class —
+/// compile-time gated, same class as the footer-cache outcomes.)
+#[cfg(feature = "io-trace")]
+pub fn record_l2s(hits: u64, misses: u64) {
+    let _ = IO_TRACE.try_with(|t| t.record_l2s(hits, misses));
+}
+#[cfg(not(feature = "io-trace"))]
+#[inline(always)]
+pub fn record_l2s(_hits: u64, _misses: u64) {}
 
 /// Record chargeable egress bytes (cross-region / internet — KEU) for the
 /// active query.
@@ -1775,6 +1811,27 @@ mod tests {
         assert_eq!(s.embedding_input_tokens, 150);
         assert_eq!(s.embedding_output_tokens, 300);
         assert_eq!(s.total_embedding_tokens(), 450);
+    }
+
+    /// TD-IOTRACE-4: persistent-L2 probe outcomes accumulate into the snapshot,
+    /// count as trace activity, and a snapshot serialized BEFORE the fields
+    /// existed still deserializes with them defaulted (mixed-read-safe).
+    #[test]
+    fn l2_probes_record_snapshot_and_default_from_legacy_json() {
+        let t = IoTrace::new();
+        t.record_l2s(3, 1);
+        t.record_l2s(1, 0);
+        let s = t.snapshot();
+        assert_eq!(s.l2_hits, 4);
+        assert_eq!(s.l2_misses, 1);
+        assert!(!s.is_empty(), "an L2-only trace is not empty");
+
+        let mut v = serde_json::to_value(IoTraceSnapshot::default()).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("l2_hits");
+        obj.remove("l2_misses");
+        let legacy: IoTraceSnapshot = serde_json::from_value(v).unwrap();
+        assert_eq!((legacy.l2_hits, legacy.l2_misses), (0, 0));
     }
 
     #[tokio::test]

--- a/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
+++ b/crates/modalities/proximadb-observability-engine/src/trace_envelope.rs
@@ -92,6 +92,12 @@ pub struct TraceHeader {
     pub footer_hits: u64,
     #[serde(default)]
     pub footer_misses: u64,
+    /// Persistent local-disk L2 cache probe outcomes (ADR-085 / TD-IOTRACE-4).
+    /// `serde(default)` keeps pre-existing envelopes readable (mixed-read-safe).
+    #[serde(default)]
+    pub l2_hits: u64,
+    #[serde(default)]
+    pub l2_misses: u64,
     /// Compute wall ms attributed per engine (`datafusion`/`native`/`volcano`).
     /// A billing-class field — read verbatim by the KRU meter.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -248,6 +254,8 @@ impl TraceHeader {
             range_gets: snap.range_gets,
             footer_hits: snap.footer_hits,
             footer_misses: snap.footer_misses,
+            l2_hits: snap.l2_hits,
+            l2_misses: snap.l2_misses,
             compute_ms: snap.compute_ms.clone(),
             setup_ms: snap.setup_ms,
             open_ms: snap.open_ms,
@@ -359,6 +367,23 @@ impl TraceEnvelope {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TD-IOTRACE-4: the header carries the persistent-L2 probe counters, and
+    /// an envelope written BEFORE the fields existed still deserializes with
+    /// them defaulted to zero (mixed-read-safe — never a flag-day).
+    #[test]
+    fn header_carries_l2_probes_and_legacy_json_defaults_to_zero() {
+        let snap = IoTraceSnapshot {
+            l2_hits: 5,
+            l2_misses: 2,
+            ..Default::default()
+        };
+        let h = TraceHeader::from_snapshot(&snap, Some("t"), 1);
+        assert_eq!((h.l2_hits, h.l2_misses), (5, 2));
+
+        let legacy: TraceHeader = serde_json::from_str(r#"{"event_time_unix_ms":7}"#).unwrap();
+        assert_eq!((legacy.l2_hits, legacy.l2_misses), (0, 0));
+    }
 
     fn relational_snapshot() -> IoTraceSnapshot {
         IoTraceSnapshot {

--- a/docs/10-quality/td/TD-IOTRACE-4-persistent-l2-cache-counters-not-in-trace.adoc
+++ b/docs/10-quality/td/TD-IOTRACE-4-persistent-l2-cache-counters-not-in-trace.adoc
@@ -6,7 +6,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open** (filed 2026-07-31)
+| Status | **Resolved (2026-07-31, this PR).** `l2_hits`/`l2_misses` flow end-to-end: `IoTrace` → `IoTraceSnapshot` → `TraceHeader` (`serde(default)`) → nullable `trace_header` warehouse columns. Recording sites: the parent-region probe records inline in `SurvivorRangeCache::get_or_fetch_in_parent`, and the exact-key backend is wrapped by `TracedSurvivorL2` (engine-layer `L2ValueStore` adapter — the cache crate stays layering-clean). Gated behind the `io-trace` feature like the footer recorders (TD-160 perf-class). Acceptance test: `l2_probe_outcomes_reach_the_ambient_io_trace`. The downstream `aggregate.py` signal switch remains AnvaiOps TD-M1 scope.
 | Severity | Medium — cache-dimension observability/fidelity gap, not revenue-blocking (the KRU physical counters are TD-IOTRACE-2, Resolved #1091). Becomes higher-stakes as the persistent L2 tier (#1325) changes what "warm" means for real workloads.
 | Component | Observability — `crates/modalities/proximadb-observability-engine/src/{io_trace.rs,trace_envelope.rs}`, `src/observability/io_trace_warehouse.rs`
 | Introduced-by | PR #1325 (persistent L2 PAX warm tier, ADR-085) — the counters exist but stop at process-local stats

--- a/src/observability/io_trace_warehouse.rs
+++ b/src/observability/io_trace_warehouse.rs
@@ -538,6 +538,11 @@ fn header_schema() -> SchemaRef {
         req("table_open_misses", DataType::Int64),
         req("egress_bytes", DataType::Int64),
         req("compute_ms_total", DataType::Int64),
+        // Persistent-L2 cache probes (ADR-085 / TD-IOTRACE-4). Appended and
+        // NULLABLE: parquet segments written before these columns existed lack
+        // them, and readers must resolve the absence to NULL — never fail.
+        opt("l2_hits", DataType::Int64),
+        opt("l2_misses", DataType::Int64),
     ]))
 }
 
@@ -648,6 +653,8 @@ fn build_header_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
     let mut table_open_misses = Vec::with_capacity(n);
     let mut egress_bytes = Vec::with_capacity(n);
     let mut compute_ms_total = Vec::with_capacity(n);
+    let mut l2_hits = Vec::with_capacity(n);
+    let mut l2_misses = Vec::with_capacity(n);
     for e in envs {
         let h = &e.header;
         writer_uuid.push(e.writer_uuid.clone());
@@ -682,6 +689,8 @@ fn build_header_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
         table_open_misses.push(h.table_open_misses as i64);
         egress_bytes.push(h.egress_bytes as i64);
         compute_ms_total.push(h.compute_ms.values().sum::<u64>() as i64);
+        l2_hits.push(h.l2_hits as i64);
+        l2_misses.push(h.l2_misses as i64);
     }
     let cols: Vec<ArrayRef> = vec![
         str_arr(writer_uuid),
@@ -712,6 +721,8 @@ fn build_header_batch(envs: &[TraceEnvelope]) -> Result<Option<RecordBatch>, Sto
         i64_arr(table_open_misses),
         i64_arr(egress_bytes),
         i64_arr(compute_ms_total),
+        i64_arr(l2_hits),
+        i64_arr(l2_misses),
     ];
     RecordBatch::try_new(header_schema(), cols)
         .map(Some)
@@ -949,6 +960,34 @@ mod tests {
             header: header(writer, seq),
             payload,
         }
+    }
+
+    /// TD-IOTRACE-4: the header batch carries the persistent-L2 probe columns
+    /// (appended, nullable — pre-existing parquet segments lack them and read
+    /// as NULL).
+    #[test]
+    fn header_batch_carries_l2_probe_columns() {
+        let mut e = env("w", 1, TracePayload::Generic);
+        e.header.l2_hits = 9;
+        e.header.l2_misses = 3;
+        let batch = build_header_batch(&[e]).unwrap().unwrap();
+        let schema = batch.schema();
+        let (ih, im) = (
+            schema.index_of("l2_hits").unwrap(),
+            schema.index_of("l2_misses").unwrap(),
+        );
+        assert!(schema.field(ih).is_nullable() && schema.field(im).is_nullable());
+        let hits = batch
+            .column(ih)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let misses = batch
+            .column(im)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!((hits.value(0), misses.value(0)), (9, 3));
     }
 
     fn relational(writer: &str, seq: u64, n_exec: usize) -> TraceEnvelope {

--- a/src/storage/engines/sst/survivor_range_cache.rs
+++ b/src/storage/engines/sst/survivor_range_cache.rs
@@ -44,8 +44,8 @@ use std::future::Future;
 use std::sync::Arc;
 
 use proximadb_cache::{
-    CacheBudget, CacheKey, CacheKind, CacheScope, L2CacheStats, L2Class, PersistentArcBytesL2,
-    PersistentByteStore, TenantCache,
+    CacheBudget, CacheKey, CacheKind, CacheScope, L2CacheStats, L2Class, L2ValueStore,
+    PersistentArcBytesL2, PersistentByteStore, TenantCache,
 };
 use proximadb_storage_filesystem_types::{FilesystemError, FsResult};
 
@@ -65,6 +65,39 @@ fn request_cache_scope() -> CacheScope {
     crate::observability::io_trace::current_tenant_stable_id()
         .map(CacheScope::stable_tenant)
         .unwrap_or(CacheScope::Shared)
+}
+
+/// Persistent-L2 backend wrapper that forwards each exact-key probe outcome
+/// into the ambient per-query io_trace (TD-IOTRACE-4). It lives at the engine
+/// layer because the cache crate (foundation) must not depend on the
+/// observability engine; the probe runs inside the query task, so the
+/// task-local trace is in scope. Outcome semantics mirror `TenantCache`'s own
+/// global counters: `Ok(Some)` = hit, `Ok(None)`/`Err` = miss (fail-open).
+#[derive(Debug)]
+struct TracedSurvivorL2(PersistentArcBytesL2);
+
+#[async_trait::async_trait]
+impl L2ValueStore<Arc<[u8]>> for TracedSurvivorL2 {
+    async fn get(&self, key: &CacheKey) -> std::io::Result<Option<(Arc<[u8]>, u32)>> {
+        let result = self.0.get(key).await;
+        match &result {
+            Ok(Some(_)) => crate::observability::io_trace::record_l2s(1, 0),
+            Ok(None) | Err(_) => crate::observability::io_trace::record_l2s(0, 1),
+        }
+        result
+    }
+
+    async fn put(&self, key: &CacheKey, weight: u32, value: Arc<[u8]>) -> std::io::Result<()> {
+        self.0.put(key, weight, value).await
+    }
+
+    async fn remove(&self, key: &CacheKey) -> std::io::Result<bool> {
+        self.0.remove(key).await
+    }
+
+    fn resident_bytes(&self) -> u64 {
+        self.0.resident_bytes()
+    }
 }
 
 /// A byte-range cache for survivor (Region B SQ8) and OID (Region D) ranges of
@@ -157,11 +190,11 @@ impl SurvivorRangeCache {
             None => TenantCache::new(budget),
         };
         if let Some(store) = &l2_store {
-            cache = cache.with_l2_backend(Arc::new(PersistentArcBytesL2::new(
+            cache = cache.with_l2_backend(Arc::new(TracedSurvivorL2(PersistentArcBytesL2::new(
                 store.clone(),
                 "survivor-exact",
                 L2Class::Survivor,
-            )));
+            ))));
         }
         Self {
             inner: Arc::new(cache),
@@ -279,6 +312,7 @@ impl SurvivorRangeCache {
             if let Ok(Some(bytes)) = store.get_range(&persistent_key, relative_off, len).await {
                 self.parent_l2_hits
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                crate::observability::io_trace::record_l2s(1, 0);
                 // Promote only the demanded range. `insert_memory_only`
                 // deliberately avoids writing an exact-range duplicate
                 // beside the durable parent entry.
@@ -290,6 +324,7 @@ impl SurvivorRangeCache {
             }
             self.parent_l2_misses
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            crate::observability::io_trace::record_l2s(0, 1);
         }
         let result = self
             .inner
@@ -709,6 +744,68 @@ mod tests {
             },
         )
         .await;
+    }
+
+    /// TD-IOTRACE-4 acceptance: a query served from the persistent L2 tier
+    /// records a nonzero `l2_hits` in the ambient per-query io_trace — the
+    /// restart-cold DRAM tier is exactly the footer-cold-but-L2-warm state the
+    /// counters exist to make observable. (Gated like the recorder itself:
+    /// without the `io-trace` feature the free fns are no-ops.)
+    #[cfg(feature = "io-trace")]
+    #[tokio::test]
+    async fn l2_probe_outcomes_reach_the_ambient_io_trace() {
+        let dir = tempfile::tempdir().expect("test tempdir");
+        let store =
+            Arc::new(PersistentByteStore::open(dir.path(), 1 << 20).expect("open persistent L2"));
+        let cache = SurvivorRangeCache::with_resolver_and_l2(1 << 20, None, Some(store.clone()));
+        let parent: Arc<[u8]> = Arc::from((0u8..32).collect::<Vec<_>>());
+        cache
+            .seed_parent_region("seg.pax", 1_000, parent)
+            .await
+            .expect("seed parent");
+        drop(cache);
+        drop(store);
+
+        let reopened =
+            Arc::new(PersistentByteStore::open(dir.path(), 1 << 20).expect("reopen persistent L2"));
+        let restarted = SurvivorRangeCache::with_resolver_and_l2(1 << 20, None, Some(reopened));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let loads_in_scope = loads.clone();
+        let snap =
+            crate::observability::io_trace::instrument(Some("t".to_string()), "test", async move {
+                let bytes = restarted
+                    .get_or_fetch_in_parent(
+                        CacheKind::QuantizedCodes,
+                        "seg.pax",
+                        1_008,
+                        4,
+                        1_000,
+                        32,
+                        move || {
+                            let loads = loads_in_scope.clone();
+                            async move {
+                                loads.fetch_add(1, Ordering::SeqCst);
+                                Ok(vec![99; 4])
+                            }
+                        },
+                    )
+                    .await
+                    .expect("persistent parent slice");
+                assert_eq!(bytes.as_ref(), &[8, 9, 10, 11]);
+                crate::observability::io_trace::snapshot().expect("trace in scope")
+            })
+            .await;
+        assert_eq!(
+            loads.load(Ordering::SeqCst),
+            0,
+            "served from L2, not the GET"
+        );
+        assert!(
+            snap.l2_hits >= 1,
+            "parent-L2 hit must be recorded in the query trace: hits={} misses={}",
+            snap.l2_hits,
+            snap.l2_misses
+        );
     }
 
     /// TD-CACHE-1 S2: warm_set ranks by hit count, caps at top_k, and


### PR DESCRIPTION
## Summary
Resolves **TD-IOTRACE-4** (filed #1347): the ADR-085 persistent L2 warm tier (#1325) counted hits/misses only in process-local stats, leaving per-query L2 cache state invisible to every `trace_header` warehouse consumer. A footer-cold but **L2-warm** query — the restart case the tier exists for — read as cold downstream, skewing the fleet-priors cold/warm cell classification (AnvaiOps TD-M1).

The counters now flow end-to-end, mirroring the footer-cache pattern at every step:

- **`IoTrace` / `IoTraceSnapshot`** — `l2_hits`/`l2_misses` counters + `record_l2s` (the free fn is `io-trace`-feature-gated, same TD-160 perf class as `record_footers`; `serde(default)` on the snapshot fields).
- **`TraceHeader`** — `serde(default)` fields; envelopes written before this change deserialize with zeros (mixed-read-safe, never a flag-day).
- **`trace_header` warehouse** — two appended **nullable** Int64 columns; parquet segments written before them resolve to NULL, never fail.
- **Recording sites** — the parent-region probe records inline in `SurvivorRangeCache::get_or_fetch_in_parent` (next to the existing `parent_l2_*` atomics); the exact-key backend is wrapped by a new `TracedSurvivorL2` adapter implementing `L2ValueStore` at the engine layer, so the foundation cache crate keeps zero observability dependencies (layering-clean). Outcome semantics mirror `TenantCache`'s own counting: `Ok(Some)` = hit, `Ok(None)`/`Err` = miss (fail-open).

Downstream, the AnvaiOps `fleet-priors/aggregate.py` cache-state signal switch (footer ratio → L2 ratio) stays TD-M1 scope and can proceed once this reaches a deployed image.

## Test plan
- [x] `cargo nextest run -p proximadb-observability-engine` — 326/326 (includes new trace-accumulation + legacy-JSON-default tests for snapshot and envelope)
- [x] `cargo nextest run --lib -E 'test(survivor_range_cache) or test(io_trace_warehouse)'` — 12/12 (includes new warehouse column presence/nullability test)
- [x] `cargo nextest run --lib --features io-trace -E 'test(l2_probe_outcomes_reach_the_ambient_io_trace)'` — the TD's acceptance gate: a restart-cold query served from the persistent parent seed records `l2_hits ≥ 1` in the ambient per-query trace, loader never runs
- [x] `cargo check --all-targets` clean; `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean
- [x] `make work-commit-check` — all deterministic guards pass