### PR TITLE
feat(abac): read (GET) endpoints for policy inspection (TD-ABAC control-plane)

### DIFF
--- a/crates/control/proximadb-abac/src/authority.rs
+++ b/crates/control/proximadb-abac/src/authority.rs
@@ -540,6 +540,19 @@ impl FileSystemAttributeAuthority {
         let _ = self.persist();
     }
 
+    /// A snapshot of every attribute binding — for inspection/audit (the GET
+    /// admin endpoints). Owned (not an iterator borrowing `&self`) because the
+    /// cache is behind a [`RwLock`]; mirrors
+    /// [`FileSystemPredicateObjectStore::objects`](crate::FileSystemPredicateObjectStore::objects).
+    pub fn bindings(&self) -> Vec<AttributeBinding> {
+        self.inner
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .bindings()
+            .cloned()
+            .collect()
+    }
+
     /// Write the full binding set atomically (temp + rename). Re-reads the live
     /// cache under the read-lock — so it always reflects the latest committed
     /// state (no lost update under concurrent admin writes).

--- a/src/network/rest/canonical/abac_admin.rs
+++ b/src/network/rest/canonical/abac_admin.rs
@@ -64,7 +64,7 @@ use serde::{Deserialize, Serialize};
 
 use proximadb_abac::{
     AttributeBinding, FileSystemAttributeAuthority, FileSystemPolicyBindingStore,
-    FileSystemPredicateObjectStore,
+    FileSystemPredicateObjectStore, PolicyBindingStore, PredicateObjectStore,
 };
 use proximadb_catalog::fc_metamodel::{
     AttrValue, Effect, FieldMask, ObjectId, PolicyBinding, Scope, SubjectId,
@@ -259,6 +259,34 @@ pub struct PredicateObjectResponse {
     pub expression: FilterExpression,
 }
 
+// ── Read (GET) response DTOs ──
+
+/// Response for `GET /api/v2/abac/policy-bindings/{tenant}` — the tenant's live
+/// policy (the same set the enforcer composes for every read).
+#[derive(Debug, Serialize)]
+pub struct PolicyBindingsResponse {
+    pub tenant: String,
+    pub tenant_stable_id: u64,
+    pub count: usize,
+    pub bindings: Vec<PolicyBinding>,
+}
+
+/// Response for `GET /api/v2/abac/attribute-bindings` — every authority binding
+/// (cluster-operator scope; cross-tenant by design).
+#[derive(Debug, Serialize)]
+pub struct AttributeBindingsResponse {
+    pub count: usize,
+    pub bindings: Vec<AttributeBinding>,
+}
+
+/// Response for `GET /api/v2/abac/predicate-objects` — every registered
+/// predicate object.
+#[derive(Debug, Serialize)]
+pub struct PredicateObjectsResponse {
+    pub count: usize,
+    pub objects: Vec<PredicateObjectResponse>,
+}
+
 // ===========================================================================
 // Testable provisioning cores (sync; take the shared handles + a resolver)
 // ===========================================================================
@@ -444,6 +472,89 @@ pub async fn delete_predicate_object(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ===========================================================================
+// Read (GET) handlers — operator inspection of the live policy
+// ===========================================================================
+
+/// `GET /api/v2/abac/policy-bindings/{tenant}` — the tenant's live policy
+/// bindings (the set the enforcer composes per read). Resolve-at-read, same as
+/// write: 422 if the tenant has no stable id.
+pub async fn get_policy_bindings(
+    user_context: Option<Extension<UnifiedUserContext>>,
+    State(state): State<AppState>,
+    Path(tenant): Path<String>,
+) -> Result<Json<PolicyBindingsResponse>, (StatusCode, Json<OperatorErrorResponse>)> {
+    authorize_operator(user_context.as_ref().map(|e| &e.0))?;
+    let store = require_binding_store(&state)?;
+    let resolver = CatalogTenantStableIdResolver::new(state.catalog_manager.clone());
+    let tenant_stable_id = resolve_tenant(&resolver, &tenant).map_err(map_provision_err)?;
+    let bindings = store.bindings_for(tenant_stable_id);
+    let count = bindings.len();
+    Ok(Json(PolicyBindingsResponse {
+        tenant,
+        tenant_stable_id,
+        count,
+        bindings,
+    }))
+}
+
+/// `GET /api/v2/abac/attribute-bindings` — every authority binding
+/// (cluster-operator scope; cross-tenant by design).
+pub async fn list_attribute_bindings(
+    user_context: Option<Extension<UnifiedUserContext>>,
+    State(state): State<AppState>,
+) -> Result<Json<AttributeBindingsResponse>, (StatusCode, Json<OperatorErrorResponse>)> {
+    authorize_operator(user_context.as_ref().map(|e| &e.0))?;
+    let authority = require_authority(&state)?;
+    let bindings = authority.bindings();
+    let count = bindings.len();
+    Ok(Json(AttributeBindingsResponse { count, bindings }))
+}
+
+/// `GET /api/v2/abac/predicate-objects` — every registered predicate object.
+pub async fn list_predicate_objects(
+    user_context: Option<Extension<UnifiedUserContext>>,
+    State(state): State<AppState>,
+) -> Result<Json<PredicateObjectsResponse>, (StatusCode, Json<OperatorErrorResponse>)> {
+    authorize_operator(user_context.as_ref().map(|e| &e.0))?;
+    let store = require_predicate_store(&state)?;
+    let objects = store
+        .objects()
+        .into_iter()
+        .map(|(object_id, expression)| PredicateObjectResponse {
+            object_id,
+            expression,
+        })
+        .collect::<Vec<_>>();
+    let count = objects.len();
+    Ok(Json(PredicateObjectsResponse { count, objects }))
+}
+
+/// `GET /api/v2/abac/predicate-objects/{object_id}` — one predicate object.
+/// 404 if unknown (a dangling ref resolves fail-closed regardless).
+pub async fn get_predicate_object(
+    user_context: Option<Extension<UnifiedUserContext>>,
+    State(state): State<AppState>,
+    Path(object_id): Path<ObjectId>,
+) -> Result<Json<PredicateObjectResponse>, (StatusCode, Json<OperatorErrorResponse>)> {
+    authorize_operator(user_context.as_ref().map(|e| &e.0))?;
+    let store = require_predicate_store(&state)?;
+    match store.get(object_id) {
+        Some(expression) => Ok(Json(PredicateObjectResponse {
+            object_id,
+            expression,
+        })),
+        None => Err((
+            StatusCode::NOT_FOUND,
+            Json(OperatorErrorResponse {
+                error: "predicate_object_not_found",
+                message: format!("no predicate object registered under object_id {object_id}"),
+                code: 404,
+            }),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -451,7 +562,6 @@ mod tests {
     use crate::security::rls::AbacEnforcer;
     use chrono::Utc;
     use proximadb_abac::InMemoryPolicyEpochs;
-    use proximadb_abac::PolicyBindingStore;
     use proximadb_catalog::fc_metamodel::Target;
     use proximadb_filter_expression::ComparisonOperator;
     use serde_json::json;
@@ -707,6 +817,71 @@ mod tests {
                 tenant: "ghost".into()
             }
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_endpoints_reflect_provisioned_policy() {
+        // Round-trip: provision via the write cores, then read back through the
+        // SAME accessors the GET handlers use — `authority.bindings()` (the new
+        // accessor), `bindings_for`, `objects`, `get`. Proves the read surface
+        // observes the live, hot-reloaded policy (and validates PR-B's writes).
+        let dir = unique_dir("reads");
+        let binding_store =
+            Arc::new(FileSystemPolicyBindingStore::open(dir.join("policy.json")).unwrap());
+        let authority =
+            Arc::new(FileSystemAttributeAuthority::open(dir.join("attrs.json")).unwrap());
+        let predicate_store =
+            Arc::new(FileSystemPredicateObjectStore::open(dir.join("preds.json")).unwrap());
+        let resolver = TestResolver;
+
+        // Provision one of each.
+        let mut attrs = BTreeMap::new();
+        attrs.insert("dept".to_string(), AttrValue::Str("eng".into()));
+        provision_attribute_binding(&authority, &resolver, "alice", "acme", attrs).unwrap();
+        provision_policy_binding(
+            &binding_store,
+            &resolver,
+            "acme",
+            1,
+            PutPolicyBindingRequest {
+                scope: Scope::Table(200),
+                effect: Effect::Permit,
+                predicate_ref: Some(42),
+                field_mask: None,
+            },
+        )
+        .unwrap();
+        register_predicate_object(
+            &predicate_store,
+            42,
+            FilterExpression::Comparison {
+                field: "dept".to_string(),
+                operator: ComparisonOperator::Equals,
+                value: json!("eng"),
+            },
+        );
+
+        // GET /policy-bindings/{tenant} path → bindings_for.
+        let acme_bindings = binding_store.bindings_for(7);
+        assert_eq!(acme_bindings.len(), 1);
+        assert_eq!(acme_bindings[0].object_id, 1);
+
+        // GET /attribute-bindings path → authority.bindings() (the new accessor).
+        let attr_bindings = authority.bindings();
+        assert_eq!(attr_bindings.len(), 1);
+        assert_eq!(attr_bindings[0].subject_id.0, "alice");
+        assert_eq!(attr_bindings[0].tenant_stable_id, 7);
+
+        // GET /predicate-objects path → objects().
+        let pred_objects = predicate_store.objects();
+        assert_eq!(pred_objects.len(), 1);
+        assert_eq!(pred_objects[0].0, 42);
+
+        // GET /predicate-objects/{object_id} path → get() (Some) or 404 (None).
+        assert!(predicate_store.get(42).is_some());
+        assert!(predicate_store.get(999).is_none());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/network/rest/canonical/handlers.rs
+++ b/src/network/rest/canonical/handlers.rs
@@ -1540,10 +1540,11 @@ fn operator_and_control_v2_routes() -> axum::Router<AppState> {
             get(crate::network::rest::canonical::primary_pod::list_primary_pods),
         );
 
-    // TD-ABAC control-plane (PR-B): ABAC policy-provisioning admin API. Each
-    // handler writes through the shared enforcer stores (hot-reload), resolves
-    // the tenant string→u64 at write time, and is auth-gated to the operator
-    // role. `abac-policy`-only — default builds omit these routes entirely.
+    // TD-ABAC control-plane (PR-B writes + read endpoints): the ABAC
+    // policy-provisioning admin API. Write handlers go through the shared
+    // enforcer stores (hot-reload), resolve tenant string→u64 at write time, and
+    // are auth-gated to the operator role; read handlers inspect the live policy.
+    // `abac-policy`-only — default builds omit these routes entirely.
     #[cfg(feature = "abac-policy")]
     let router = router
         .route(
@@ -1552,14 +1553,24 @@ fn operator_and_control_v2_routes() -> axum::Router<AppState> {
                 .delete(crate::network::rest::canonical::abac_admin::delete_policy_binding),
         )
         .route(
+            "/api/v2/abac/policy-bindings/{tenant}",
+            axum::routing::get(crate::network::rest::canonical::abac_admin::get_policy_bindings),
+        )
+        .route(
             "/api/v2/abac/attribute-bindings",
-            axum::routing::post(
-                crate::network::rest::canonical::abac_admin::post_attribute_binding,
-            ),
+            axum::routing::get(
+                crate::network::rest::canonical::abac_admin::list_attribute_bindings,
+            )
+            .post(crate::network::rest::canonical::abac_admin::post_attribute_binding),
+        )
+        .route(
+            "/api/v2/abac/predicate-objects",
+            axum::routing::get(crate::network::rest::canonical::abac_admin::list_predicate_objects),
         )
         .route(
             "/api/v2/abac/predicate-objects/{object_id}",
-            axum::routing::put(crate::network::rest::canonical::abac_admin::put_predicate_object)
+            axum::routing::get(crate::network::rest::canonical::abac_admin::get_predicate_object)
+                .put(crate::network::rest::canonical::abac_admin::put_predicate_object)
                 .delete(crate::network::rest::canonical::abac_admin::delete_predicate_object),
         );
 


### PR DESCRIPTION
Builds on PR-B (#1367, merged) — the policy-provisioning write surface. This adds the matching **read** surface so operators can inspect the live policy: "did my provision take effect?" and "what policy is enforced for tenant X?".

## Endpoints (all `authorize_operator`-gated, `abac-policy`-only)

| Method + Path | → read |
|---|---|
| `GET /api/v2/abac/policy-bindings/{tenant}` | the tenant's live bindings (the set the enforcer composes per read); resolve-at-read (422 on unminted tenant) |
| `GET /api/v2/abac/attribute-bindings` | every authority binding |
| `GET /api/v2/abac/predicate-objects` | every registered predicate object |
| `GET /api/v2/abac/predicate-objects/{object_id}` | one predicate object (404 if unknown; a dangling ref resolves fail-closed regardless) |

The handlers reuse PR-B's gate / resolver / 503 patterns and read through the **same** shared `Arc<FileSystem*>` instances the enforcer + write handlers use — so a read always reflects the live, hot-reloaded policy. Native serde (zero drift). Adds a small read accessor `FileSystemAttributeAuthority::bindings()` (mirroring `FileSystemPredicateObjectStore::objects()`; the in-memory authority already had it).

## Verification

- `cargo clippy -p proximadb-abac --all-targets -- -D warnings` ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- abac crate: 58/58 ✅; `abac_admin` (abac-policy): **10/10 pass** — incl. the new `read_endpoints_reflect_provisioned_policy` round-trip (provision → read back via the GET accessors) ✅
- `cargo fmt --check` ✅; `make work-commit-check` ✅ (panic-policy delta +0, env-gate 230, hygiene clean)

Default builds omit the module + routes entirely (cfg-gated).