### PR TITLE
feat(recovery): re-mark stranded DV bits post-recovery (TD-DELVEC-1 WI-5 P1)

### DIFF
--- a/crates/storage/proximadb-storage-traits/src/lib.rs
+++ b/crates/storage/proximadb-storage-traits/src/lib.rs
@@ -545,6 +545,23 @@ pub trait UnifiedStorageFormat: Send + Sync {
         Ok(())
     }
 
+    /// TD-DELVEC-1 WI-5 P1: re-mark deletion-vector bits for tombstones a crash
+    /// may have stranded between the WAL append (the commit) and `mark_deleted`.
+    /// Recovery calls this after the materialization flush with the just-replayed
+    /// tombstones — `(oid, manifest_lsn)`, where `manifest_lsn` is the durable
+    /// per-batch WAL `global_lsn` (the same space as the read side's
+    /// `snapshot_lsn`). Default no-op; the `SstEngine` impl (under
+    /// `cold-deletion-vectors`) resolves each oid → (segment, position) and marks
+    /// the DV bit. Disk-authoritative: the mark persists to `{segment}.dv`, which
+    /// the canonical serving engine `load`s on read.
+    async fn reconcile_deletion_vectors(
+        &self,
+        _collection_id: &str,
+        _tombstones: &[(String, u64)],
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Core compaction operation - engine-specific implementation (required)
     async fn do_compact(&self, params: &CompactionParameters) -> Result<CompactionResult>;
 

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -271,6 +271,13 @@ mod cold_read_merge_test;
 #[cfg(all(test, feature = "cold-deletion-vectors"))]
 #[path = "tests/cold_cascade_merge_test.rs"]
 mod cold_cascade_merge_test;
+// TD-DELVEC-1 WI-5 P1: post-recovery DV-bit reconciliation —
+// `reconcile_deletion_vectors` re-marks a tombstone's bit (the crash-strand
+// resurface fix). In-crate (#[path]) to call the feature-gated trait override
+// + read the pub(crate) DV store/discovery.
+#[cfg(all(test, feature = "cold-deletion-vectors"))]
+#[path = "tests/cold_recovery_reconcile_test.rs"]
+mod cold_recovery_reconcile_test;
 pub mod flush;
 pub mod manifest;
 #[cfg(feature = "cold-deletion-vectors")]

--- a/src/storage/engines/sst/tests/cold_recovery_reconcile_test.rs
+++ b/src/storage/engines/sst/tests/cold_recovery_reconcile_test.rs
@@ -7,9 +7,11 @@
 //! the replayed tombstones; the `SstEngine` impl resolves each oid → (segment,
 //! position) and `mark_deleted`s at the tombstone's `manifest_lsn`. This test
 //! drives that method directly: flush rows to a cold `.pax` → confirm no DV bit →
-//! reconcile one oid → that row's position is deleted, the others are not. In-crate
-//! so it can read the `pub(crate)` DV store + discovery, and call the feature-gated
-//! trait override.
+//! reconcile one oid → that row is deleted (MVCC snapshot-correct), the others are
+//! not. In-crate so it can read the `pub(crate)` DV store + call the feature-gated
+//! trait override. The engine's path resolver is wired to the flush's data dir so
+//! `reconcile` → `resolve_oid_positions` → `get_collection_storage_url` finds the
+//! segment.
 
 #[cfg(test)]
 mod tests {
@@ -24,6 +26,7 @@ mod tests {
     };
     use crate::storage::engines::sst::{SstConfig, core::SstEngine};
     use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use crate::storage::trait_components::path_resolver::ConfigFallbackResolver;
     use crate::storage::traits::{FlushParameters, UnifiedStorageFormat};
     use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
@@ -62,9 +65,15 @@ mod tests {
         fs_config.default_fs = Some(format!("file://{base_path}"));
         let filesystem = Arc::new(FilesystemFactory::create(fs_config).await.unwrap());
         let distance_compute = Arc::new(UnifiedDistanceCompute::default());
+        // Wire the path resolver to the flush's data dir so
+        // `get_collection_storage_url` (used by `resolve_oid_positions`) resolves
+        // the collection_id → the tempdir the flush wrote to.
         SstEngine::new_with_config(SstConfig::default(), filesystem, distance_compute)
             .await
             .unwrap()
+            .with_path_resolver(Arc::new(ConfigFallbackResolver::new(format!(
+                "file://{base_path}"
+            ))))
     }
 
     #[tokio::test]
@@ -74,7 +83,8 @@ mod tests {
         let collection = collection("cold_recovery_reconcile", &temp_dir);
         let engine = make_engine(&base).await;
 
-        // Flush 3 records → an immutable cold `.pax` (OID resolver embedded).
+        // Flush 3 records → an immutable cold `.pax` (OID resolver embedded under
+        // the feature).
         let records: Vec<VectorRecord> = ["r0", "r1", "r2"]
             .iter()
             .copied()
@@ -96,48 +106,23 @@ mod tests {
         let res = engine.do_flush(&flush).await?;
         assert!(res.success, "flush should produce a cold segment");
 
-        // Resolve the segment path + the on-disk row positions (the same space the
-        // DV keys on).
-        let storage_url = crate::storage::traits::StorageQueryContext::new(
-            std::sync::Arc::new(crate::core::search::SearchParams::default()),
-            std::sync::Arc::new(collection.clone()),
-        )
-        .collection_storage_path()
-        .expect("ctx has a storage assignment");
-        let files = engine.discover_sstable_files(&storage_url).await?;
-        let seg = files
-            .iter()
-            .find(|f| f.ends_with(".pax"))
-            .cloned()
-            .expect("flush should have produced a .pax segment");
-        let pax_local = seg.strip_prefix("file://").unwrap_or(&seg);
-        let bytes = std::fs::read(pax_local)?;
-        let on_disk = crate::storage::engines::sst::segment_format::read_segment_records(
-            &bytes,
-            &[],
-            &[],
-            None,
-        )?;
-        assert_eq!(on_disk.len(), 3, "segment should hold all 3 records");
-        // Map oid -> on-disk position (the same space the DV keys on).
-        let p0 = on_disk
-            .iter()
-            .position(|r| r.oid == "r0")
-            .expect("r0 in segment") as u32;
-        let p1 = on_disk
-            .iter()
-            .position(|r| r.oid == "r1")
-            .expect("r1 in segment") as u32;
+        // Resolve r1 → (segment, position) — the exact path reconcile uses.
+        let r1 = engine.resolve_oid_positions(&collection.id, "r1").await?;
+        assert!(
+            !r1.is_empty(),
+            "r1 must resolve (OID resolver embedded + path resolver wired)"
+        );
+        let (r1_seg, r1_pos) = r1[0].clone();
 
         let dv = engine
             .deletion_vector_store
             .as_ref()
             .expect("DV store is armed under cold-deletion-vectors");
 
-        // Precondition: no DV bits set yet (the "stranded" state — the live
-        // mark_deleted never ran, e.g. a crash stranded it).
+        // Precondition: no DV bit (the "stranded" state — the live mark_deleted
+        // never ran, e.g. a crash stranded it).
         assert!(
-            !dv.is_deleted_as_of(&seg, p1, u64::MAX).await,
+            !dv.is_deleted_as_of(&r1_seg, r1_pos, u64::MAX).await,
             "r1 must not be deleted before reconciliation"
         );
 
@@ -146,23 +131,27 @@ mod tests {
             .reconcile_deletion_vectors(&collection.id, &[("r1".to_string(), 100)])
             .await?;
 
-        // r1 is now deleted at gen 100 (visible at snapshot >= 100, invisible before
-        // — correct MVCC, since the key is the durable manifest_lsn space).
+        // r1 is now deleted at gen 100 — visible at snapshot >= 100, invisible
+        // before (correct MVCC, since the key is the durable manifest_lsn space).
         assert!(
-            dv.is_deleted_as_of(&seg, p1, 100).await,
+            dv.is_deleted_as_of(&r1_seg, r1_pos, 100).await,
             "reconciliation must mark r1 @ gen 100"
         );
         assert!(
-            dv.is_deleted_as_of(&seg, p1, u64::MAX).await,
+            dv.is_deleted_as_of(&r1_seg, r1_pos, u64::MAX).await,
             "r1 visible at a later snapshot"
         );
         assert!(
-            !dv.is_deleted_as_of(&seg, p1, 99).await,
+            !dv.is_deleted_as_of(&r1_seg, r1_pos, 99).await,
             "r1 invisible before its delete (MVCC snapshot-correct)"
         );
+
         // r0 (not reconciled) is untouched.
+        let r0 = engine.resolve_oid_positions(&collection.id, "r0").await?;
+        assert!(!r0.is_empty(), "r0 must resolve");
+        let (r0_seg, r0_pos) = r0[0].clone();
         assert!(
-            !dv.is_deleted_as_of(&seg, p0, u64::MAX).await,
+            !dv.is_deleted_as_of(&r0_seg, r0_pos, u64::MAX).await,
             "r0 must remain live (only r1 was reconciled)"
         );
         Ok(())

--- a/src/storage/engines/sst/tests/cold_recovery_reconcile_test.rs
+++ b/src/storage/engines/sst/tests/cold_recovery_reconcile_test.rs
@@ -1,0 +1,170 @@
+//! TD-DELVEC-1 WI-5 P1 integration test: the post-recovery DV-bit reconciliation
+//! (`UnifiedStorageFormat::reconcile_deletion_vectors`) re-marks a deletion-vector
+//! bit for a tombstone — closing the crash-strand resurface window.
+//!
+//! A crash between the WAL append (commit) and `mark_deleted` strands the DV bit.
+//! Recovery calls `reconcile_deletion_vectors` after the materialization flush with
+//! the replayed tombstones; the `SstEngine` impl resolves each oid → (segment,
+//! position) and `mark_deleted`s at the tombstone's `manifest_lsn`. This test
+//! drives that method directly: flush rows to a cold `.pax` → confirm no DV bit →
+//! reconcile one oid → that row's position is deleted, the others are not. In-crate
+//! so it can read the `pub(crate)` DV store + discovery, and call the feature-gated
+//! trait override.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    use crate::proto::proximadb_v1::{
+        Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
+    };
+    use crate::storage::engines::sst::{SstConfig, core::SstEngine};
+    use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use crate::storage::traits::{FlushParameters, UnifiedStorageFormat};
+    use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
+
+    fn collection(id: &str, temp_dir: &TempDir) -> Collection {
+        Collection {
+            id: id.to_string(),
+            config: Some(CollectionConfig {
+                name: id.to_string(),
+                dimension: 4,
+                storage_engine: Some(StorageEngine::Sst as i32),
+                ..Default::default()
+            }),
+            storage_assignment: Some(StorageAssignment {
+                base_location: temp_dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn record(oid: &str, i: usize) -> VectorRecord {
+        VectorRecord {
+            id: oid.to_string(),
+            vector: vec![i as f32, 0.0, 0.0, 0.0],
+            metadata: HashMap::new(),
+            version: Some(1),
+            timestamp: Some(i as i64),
+            updated_at: None,
+            expires_at: None,
+            source: None,
+        }
+    }
+
+    async fn make_engine(base_path: &str) -> SstEngine {
+        let mut fs_config = FilesystemConfig::default();
+        fs_config.default_fs = Some(format!("file://{base_path}"));
+        let filesystem = Arc::new(FilesystemFactory::create(fs_config).await.unwrap());
+        let distance_compute = Arc::new(UnifiedDistanceCompute::default());
+        SstEngine::new_with_config(SstConfig::default(), filesystem, distance_compute)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn reconcile_deletion_vectors_marks_the_target_row_only() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let base = temp_dir.path().to_str().unwrap().to_string();
+        let collection = collection("cold_recovery_reconcile", &temp_dir);
+        let engine = make_engine(&base).await;
+
+        // Flush 3 records → an immutable cold `.pax` (OID resolver embedded).
+        let records: Vec<VectorRecord> = ["r0", "r1", "r2"]
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(i, o)| record(o, i))
+            .collect();
+        let flush = FlushParameters {
+            collection_id: Some(collection.id.clone()),
+            vector_records: records.into_iter().map(Into::into).collect(),
+            force: true,
+            synchronous: true,
+            hints: HashMap::new(),
+            timeout_ms: None,
+            trigger_compaction: false,
+            batch_ids: vec![],
+            collection_config: Some(collection.clone()),
+            estimated_size: 0,
+        };
+        let res = engine.do_flush(&flush).await?;
+        assert!(res.success, "flush should produce a cold segment");
+
+        // Resolve the segment path + the on-disk row positions (the same space the
+        // DV keys on).
+        let storage_url = crate::storage::traits::StorageQueryContext::new(
+            std::sync::Arc::new(crate::core::search::SearchParams::default()),
+            std::sync::Arc::new(collection.clone()),
+        )
+        .collection_storage_path()
+        .expect("ctx has a storage assignment");
+        let files = engine.discover_sstable_files(&storage_url).await?;
+        let seg = files
+            .iter()
+            .find(|f| f.ends_with(".pax"))
+            .cloned()
+            .expect("flush should have produced a .pax segment");
+        let pax_local = seg.strip_prefix("file://").unwrap_or(&seg);
+        let bytes = std::fs::read(pax_local)?;
+        let on_disk = crate::storage::engines::sst::segment_format::read_segment_records(
+            &bytes,
+            &[],
+            &[],
+            None,
+        )?;
+        assert_eq!(on_disk.len(), 3, "segment should hold all 3 records");
+        // Map oid -> on-disk position (the same space the DV keys on).
+        let p0 = on_disk
+            .iter()
+            .position(|r| r.oid == "r0")
+            .expect("r0 in segment") as u32;
+        let p1 = on_disk
+            .iter()
+            .position(|r| r.oid == "r1")
+            .expect("r1 in segment") as u32;
+
+        let dv = engine
+            .deletion_vector_store
+            .as_ref()
+            .expect("DV store is armed under cold-deletion-vectors");
+
+        // Precondition: no DV bits set yet (the "stranded" state — the live
+        // mark_deleted never ran, e.g. a crash stranded it).
+        assert!(
+            !dv.is_deleted_as_of(&seg, p1, u64::MAX).await,
+            "r1 must not be deleted before reconciliation"
+        );
+
+        // Recovery reconciliation: re-mark r1's bit at its manifest_lsn (100).
+        engine
+            .reconcile_deletion_vectors(&collection.id, &[("r1".to_string(), 100)])
+            .await?;
+
+        // r1 is now deleted at gen 100 (visible at snapshot >= 100, invisible before
+        // — correct MVCC, since the key is the durable manifest_lsn space).
+        assert!(
+            dv.is_deleted_as_of(&seg, p1, 100).await,
+            "reconciliation must mark r1 @ gen 100"
+        );
+        assert!(
+            dv.is_deleted_as_of(&seg, p1, u64::MAX).await,
+            "r1 visible at a later snapshot"
+        );
+        assert!(
+            !dv.is_deleted_as_of(&seg, p1, 99).await,
+            "r1 invisible before its delete (MVCC snapshot-correct)"
+        );
+        // r0 (not reconciled) is untouched.
+        assert!(
+            !dv.is_deleted_as_of(&seg, p0, u64::MAX).await,
+            "r0 must remain live (only r1 was reconciled)"
+        );
+        Ok(())
+    }
+}

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -55,6 +55,40 @@ impl UnifiedStorageFormat for SstEngine {
         self.flush_implementation(params).await
     }
 
+    /// TD-DELVEC-1 WI-5 P1: re-mark deletion-vector bits for recovery tombstones
+    /// (see `UnifiedStorageFormat::reconcile_deletion_vectors`). The just-flushed
+    /// `L0_recovery_*` segments exist on disk, so `resolve_oid_positions` can find
+    /// each tombstone's target row; the mark persists to `{segment}.dv` (disk-
+    /// authoritative, read by the canonical serving engine). Best-effort — a
+    /// resolve/mark failure logs + continues; the tombstone stays coherent.
+    #[cfg(feature = "cold-deletion-vectors")]
+    async fn reconcile_deletion_vectors(
+        &self,
+        collection_id: &str,
+        tombstones: &[(String, u64)],
+    ) -> Result<()> {
+        let Some(dv_store) = self.deletion_vector_store.as_ref() else {
+            return Ok(());
+        };
+        for (oid, lsn) in tombstones {
+            let hits = match self.resolve_oid_positions(collection_id, oid).await {
+                Ok(hits) => hits,
+                Err(e) => {
+                    tracing::warn!("recovery DV reconcile: resolve failed for {oid}: {e:?}");
+                    continue;
+                }
+            };
+            for (seg, pos) in hits {
+                if let Err(e) = dv_store.mark_deleted(&seg, pos, *lsn).await {
+                    tracing::warn!(
+                        "recovery DV reconcile: mark failed for {oid} @ {seg}:{pos} (gen {lsn}): {e:?}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// SST's LSM bulk-load override (Phase 2F-b).
     ///
     /// Same shape as NOVA's override — SST's `flush_implementation`

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -592,6 +592,11 @@ impl RecoveryManager {
         let mut latest_by_oid: HashMap<String, (usize, proximadb_records::ProximaRecord)> =
             HashMap::new();
         let mut order = 0usize;
+        // TD-DELVEC-1 WI-5 P1: retain each record's durable per-batch manifest_lsn
+        // (the dedup map drops the batch→record association) so the post-flush
+        // reconciliation pass can re-mark DV bits at the correct generation.
+        #[cfg(feature = "cold-deletion-vectors")]
+        let mut oid_to_lsn: HashMap<String, u64> = HashMap::new();
         for object in &replay {
             if let Some(token) = &object.token {
                 digest.update(token.epoch.to_be_bytes());
@@ -604,6 +609,10 @@ impl RecoveryManager {
                 // Latest mutation wins in durable token order. Tombstones remain
                 // materialized so they continue suppressing values in older segments.
                 latest_by_oid.insert(record.oid.clone(), (order, record.clone()));
+                #[cfg(feature = "cold-deletion-vectors")]
+                if let Some(lsn) = object.manifest_lsn {
+                    oid_to_lsn.insert(record.oid.clone(), lsn);
+                }
                 order = order.saturating_add(1);
             }
         }
@@ -613,6 +622,15 @@ impl RecoveryManager {
             .into_iter()
             .map(|(_, record)| record)
             .collect::<Vec<_>>();
+        // TD-DELVEC-1 WI-5 P1: collect the recovery tombstones (with their durable
+        // manifest_lsn) so the post-flush pass can re-mark any DV bits a crash
+        // stranded between the WAL append and mark_deleted.
+        #[cfg(feature = "cold-deletion-vectors")]
+        let recovery_tombstones: Vec<(String, u64)> = vectors
+            .iter()
+            .filter(|r| r.valid_to_ns == Some(0) && r.origin.as_deref() == Some("delete"))
+            .filter_map(|r| oid_to_lsn.get(&r.oid).map(|&lsn| (r.oid.clone(), lsn)))
+            .collect();
         let digest = format!("{:x}", digest.finalize());
         let range = match (
             replay.first().and_then(|object| object.token.as_ref()),
@@ -638,6 +656,23 @@ impl RecoveryManager {
         .await?;
         if !result.success {
             anyhow::bail!("recovery materialization failed for collection {collection_id}");
+        }
+
+        // TD-DELVEC-1 WI-5 P1: re-mark deletion-vector bits for the recovery
+        // tombstones (a crash may have stranded them between the WAL append and
+        // mark_deleted). The just-flushed `L0_recovery_*` segments now exist on
+        // disk, so resolve_oid_positions can find the target rows. Disk-authoritative:
+        // the recovery engine's marks persist to `{segment}.dv`, which the canonical
+        // serving engine reads. Best-effort — failure logs + continues.
+        #[cfg(feature = "cold-deletion-vectors")]
+        if !recovery_tombstones.is_empty() {
+            if let Some(engine) = storage_engines.read().await.get(collection_id).cloned()
+                && let Err(e) = engine
+                    .reconcile_deletion_vectors(collection_id, &recovery_tombstones)
+                    .await
+            {
+                tracing::warn!("recovery DV reconcile failed for {collection_id}: {e:?}");
+            }
         }
 
         // Test-only crash-point seam (default unset ⇒ normal retirement, no runtime cost

--- a/src/storage/persistence/write_ahead_log/recovery_manager.rs
+++ b/src/storage/persistence/write_ahead_log/recovery_manager.rs
@@ -665,14 +665,13 @@ impl RecoveryManager {
         // the recovery engine's marks persist to `{segment}.dv`, which the canonical
         // serving engine reads. Best-effort — failure logs + continues.
         #[cfg(feature = "cold-deletion-vectors")]
-        if !recovery_tombstones.is_empty() {
-            if let Some(engine) = storage_engines.read().await.get(collection_id).cloned()
-                && let Err(e) = engine
-                    .reconcile_deletion_vectors(collection_id, &recovery_tombstones)
-                    .await
-            {
-                tracing::warn!("recovery DV reconcile failed for {collection_id}: {e:?}");
-            }
+        if !recovery_tombstones.is_empty()
+            && let Some(engine) = storage_engines.read().await.get(collection_id).cloned()
+            && let Err(e) = engine
+                .reconcile_deletion_vectors(collection_id, &recovery_tombstones)
+                .await
+        {
+            tracing::warn!("recovery DV reconcile failed for {collection_id}: {e:?}");
         }
 
         // Test-only crash-point seam (default unset ⇒ normal retirement, no runtime cost


### PR DESCRIPTION
## What

TD-DELVEC-1 **WI-5 P1** — closes the crash-strand resurface window. A crash between the WAL append (commit) and `mark_deleted` strands the deletion-vector bit; the delete then survives only as the WAL tombstone, which compaction drops after ~1h → the row resurfaces. P1 makes recovery re-mark the bits after the materialization flush.

Builds on **WI-5 P0 (#1365)**, which made the DV generation durable + recoverable.

## Change (trait-method seam)

The blocker: at the recovery hook point the only engine handle is `Arc<dyn UnifiedStorageFormat>`, which doesn't expose `deletion_vector_store`/`resolve_oid_positions` (downcast is an explicit known gap). So:

- **`UnifiedStorageFormat::reconcile_deletion_vectors(collection_id, &[(oid, manifest_lsn)])`** — new trait method with a **default no-op** (engines without `cold-deletion-vectors` do nothing; default builds unchanged).
- **`recover_collection_authoritative`** threads each record's durable per-batch `manifest_lsn` through the dedup loop (the dedup map drops the batch→record association), collects the recovery tombstones (`valid_to_ns==Some(0) && origin=="delete"`), and calls `reconcile_deletion_vectors` after the flush succeeds (the `L0_recovery_*` segments now exist on disk, so resolve can find the rows).
- **`SstEngine` impl (feature-gated):** `resolve_oid_positions` → `mark_deleted` at the tombstone's `manifest_lsn` — the **same generation the live delete path keys on** (post-P0), so MVCC visibility is correct, not a coarse approximation. Disk-authoritative: the recovery engine's marks persist to `{segment}.dv`, which the canonical serving engine `load`s on read.

The whole call site is `#[cfg(feature="cold-deletion-vectors")]`; the default path is byte-for-byte unchanged.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default — CI-gated) ✅
- `cargo build`/`test --features cold-deletion-vectors cold_recovery_reconcile` → `1 passed` ✅ (resolves + marks at `manifest_lsn`, MVCC snapshot-correct, targets only the reconciled row)
- `cargo clippy -p proximadb --lib --features cold-deletion-vectors -- -D warnings` ✅

## Remaining arc

- **WI-6**: compaction DV-awareness + carry (the retire layer — `DeletionVectorStore::remove`, `OidResolverCache::invalidate` — is still fully unwired; compaction ignores DVs).
- **WI-5 retire-side + WI-7**: publish-before-retire ordering + conservative purge (blocked on WI-6).
- A full end-to-end crash-recovery test (the recovery manager path) is a follow-up; this PR's test drives `reconcile_deletion_vectors` directly.