### PR TITLE
feat(abac): enforce provisioned policy on the REST records-search path (TD-ABAC-5/6 REST slice)

### DIFF
--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -747,10 +747,31 @@ impl RecordOpsService {
     // of the collection-id cache).
 
     /// Canonical rich-record search handler used by v2 REST/gRPC/internal callers.
+    ///
+    /// Delegates to [`Self::handle_record_search_for_tenant_abac`] with no
+    /// subject — the gRPC/Flight/internal callers preserve today's behavior (no
+    /// ABAC enforcement). The REST v2 surface calls `_abac` directly with the
+    /// request subject so a provisioned policy admits/denies/filters the results.
     pub async fn handle_record_search_for_tenant(
         &self,
         request: RichSearchRequest,
         tenant_id: Option<&str>,
+    ) -> Result<RichSearchResponse> {
+        self.handle_record_search_for_tenant_abac(request, tenant_id, None, None)
+            .await
+    }
+
+    /// ABAC-aware rich-record search: same as
+    /// [`Self::handle_record_search_for_tenant`] but threads the request subject
+    /// and tenant stable id into the vector service so ABAC enforces (fail-closed
+    /// on deny). The enforcement itself is `abac-policy`-gated inside the vector
+    /// service, so default builds are a pass-through.
+    pub async fn handle_record_search_for_tenant_abac(
+        &self,
+        request: RichSearchRequest,
+        tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<RichSearchResponse> {
         let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
         let request = RichSearchRequest {
@@ -767,7 +788,12 @@ impl RecordOpsService {
         };
 
         self.vector_operations_service
-            .search_records_with_tenant_context(request, tenant_context.as_ref())
+            .search_records_with_tenant_context_abac(
+                request,
+                tenant_context.as_ref(),
+                subject,
+                tenant_stable_id,
+            )
             .await
     }
 

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1686,7 +1686,12 @@ pub async fn search_with_typed_filters(
         crate::observability::predicate_diagnostics::scope(async {
             let outcome = state
                 .record_ops
-                .handle_record_search_for_tenant(search_request, Some(&tenant.tenant_id))
+                .handle_record_search_for_tenant_abac(
+                    search_request,
+                    Some(&tenant.tenant_id),
+                    tenant.subject.as_deref(),
+                    tenant.tenant_stable_id,
+                )
                 .await;
             let downgraded =
                 crate::observability::predicate_diagnostics::take_quantized_downgrade();

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -686,6 +686,49 @@ impl VectorOperationsService {
         ))
     }
 
+    /// Resolve the REST records-search read context for `(subject,
+    /// tenant_stable_id)`. Returns:
+    /// - `Some(ReadContext::Client(ctx))` — admitted; the caller ANDs the
+    ///   subject's security filter into the search (pushdown) / post-filters.
+    /// - `Some(ReadContext::System(_))` — no enforcer wired, or no client
+    ///   subject on the request (the `None`-subject callers) ⇒ passthrough
+    ///   (the pre-feature behavior — structural isolation only).
+    /// - `None` — the subject was **denied**; the caller MUST fail closed
+    ///   (return empty results). Mirrors the fusion contract
+    ///   (`fusion_service.rs:529-554`).
+    #[cfg(feature = "abac-policy")]
+    async fn records_read_context(
+        &self,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
+        collection_id: &str,
+    ) -> Option<proximadb_abac::ReadContext> {
+        use proximadb_catalog::fc_metamodel::SubjectId;
+        match (subject, tenant_stable_id) {
+            (Some(subject), Some(tenant_stable_id)) => {
+                match self
+                    .resolve_vector_read_context(
+                        &SubjectId(subject.to_string()),
+                        tenant_stable_id,
+                        collection_id,
+                    )
+                    .await
+                {
+                    Some(Ok(ctx)) => Some(proximadb_abac::ReadContext::Client(ctx)),
+                    Some(Err(_)) => None, // deny ⇒ fail-closed
+                    None => Some(proximadb_abac::ReadContext::system(
+                        proximadb_abac::SystemReadReason::Statistics,
+                        "records_search (no abac enforcer)",
+                    )),
+                }
+            }
+            _ => Some(proximadb_abac::ReadContext::system(
+                proximadb_abac::SystemReadReason::Statistics,
+                "records_search (no client subject)",
+            )),
+        }
+    }
+
     /// Expose the unified storage engine as a trait object for integration points
     pub fn unified_engine(&self) -> Arc<dyn crate::storage::traits::UnifiedStorageFormat> {
         self.storage_engine.clone() as Arc<dyn crate::storage::traits::UnifiedStorageFormat>
@@ -805,7 +848,39 @@ impl VectorOperationsService {
         let om_start = std::time::Instant::now();
         crate::metrics::operational_metrics::QUERIES_TOTAL.inc();
         let result = self
-            .search_records_with_tenant_context_inner(request, tenant_context)
+            .search_records_with_tenant_context_inner(request, tenant_context, None, None)
+            .await;
+        if result.is_err() {
+            crate::metrics::operational_metrics::QUERIES_FAILED_TOTAL.inc();
+        }
+        crate::metrics::operational_metrics::SEARCH_LATENCY_SECONDS
+            .observe(om_start.elapsed().as_secs_f64());
+        result
+    }
+
+    /// ABAC-aware variant of [`search_records_with_tenant_context`] for the REST
+    /// records surface: threads the request subject + tenant stable id so a
+    /// provisioned policy admits/denies/filters the results (fail-closed on
+    /// deny). The gRPC/Flight twins still call the original (`None` subject ⇒ no
+    /// enforcement, unchanged) until their own slice adopts this variant. The
+    /// enforcement logic itself is `abac-policy`-gated inside `_inner`, so under
+    /// default builds this is a pass-through (subject ignored).
+    pub async fn search_records_with_tenant_context_abac(
+        &self,
+        request: RichSearchRequest,
+        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
+    ) -> Result<RichSearchResponse> {
+        let om_start = std::time::Instant::now();
+        crate::metrics::operational_metrics::QUERIES_TOTAL.inc();
+        let result = self
+            .search_records_with_tenant_context_inner(
+                request,
+                tenant_context,
+                subject,
+                tenant_stable_id,
+            )
             .await;
         if result.is_err() {
             crate::metrics::operational_metrics::QUERIES_FAILED_TOTAL.inc();
@@ -819,6 +894,8 @@ impl VectorOperationsService {
         &self,
         request: RichSearchRequest,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<RichSearchResponse> {
         // Authorize before touching data, matching `search_v1_with_tenant_context`.
         let collection_id = self
@@ -830,6 +907,30 @@ impl VectorOperationsService {
         // proto round-trip, so `starts_with`/`ends_with` and the full op set
         // survive to the search engine intact.
         let filter = rich_filters_to_filter_expression(&request.filters);
+
+        // TD-ABAC-5/6 (REST records): push the subject's accessibility predicate
+        // into the search — conjunctive ⇒ AND into `filter` (pushdown); non-
+        // conjunctive ⇒ `post_filter` applied to the results below. Fail-closed:
+        // a denied subject gets an empty response. `None` subject (the gRPC/Flight
+        // callers that still delegate with `None`) ⇒ System passthrough, i.e. the
+        // pre-feature behavior — no enforcement until those surfaces adopt `_abac`.
+        #[cfg(feature = "abac-policy")]
+        let (filter, post_filter) = match self
+            .records_read_context(subject, tenant_stable_id, &collection_id)
+            .await
+        {
+            Some(read_ctx) => self.apply_abac_vector_filter(filter, &read_ctx),
+            None => {
+                return Ok(RichSearchResponse {
+                    results: Vec::new(),
+                    total_found: 0,
+                    collection_id: Some(collection_id),
+                    predicate_shortfall: None,
+                });
+            }
+        };
+        #[cfg(not(feature = "abac-policy"))]
+        let _ = (subject, tenant_stable_id);
 
         // The rich path mirrors the previous `include_fields: None` defaults:
         // metadata included, vectors excluded.
@@ -853,6 +954,22 @@ impl VectorOperationsService {
         };
 
         let mut resp = v1_search_result_to_rich(search_result);
+
+        // ABAC post-filter: non-conjunctive security expressions (e.g. those that
+        // can't be AND'd into the ANN pushdown) are evaluated against each row's
+        // props here. Mirrors `post_filter_search_results` on the native path.
+        #[cfg(feature = "abac-policy")]
+        if let Some(security) = &post_filter {
+            use crate::core::search::sql_value_filter::proxima_value_to_json;
+            use crate::security::rls::filter_lattice::admits_with_security;
+            resp.results.retain(|r| {
+                admits_with_security(None, Some(security), &|field: &str| {
+                    r.props.get(field).map(proxima_value_to_json)
+                })
+            });
+            // A post-filtered result is a real "<top_k match the policy" outcome;
+            // recompute shortfall below accounts for the new length.
+        }
 
         // TD-064(a): authoritative shortfall recompute at the response
         // boundary — the TRUE final merged counts vs the user's `top_k`.

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! TD-ABAC-5/6 (REST records slice): proves ABAC enforcement FIRES on the REST
+//! record-search path (`search_records_with_tenant_context_abac`), not just the
+//! fusion/service seam.
+//!
+//! A `VectorOperationsService` is built with a durable ABAC enforcer; the REST
+//! records-search entry point threads the request subject + tenant stable id into
+//! `_inner`, which resolves the subject's read context and ANDs the security
+//! predicate (`dept=eng`) into the search. So:
+//! * an admitted subject (`alice`, dept=eng) sees only `eng` records — the `hr`
+//!   record is filtered out;
+//! * a denied subject (`mallory`, no attribute binding) gets an **empty** result
+//!   (fail-closed);
+//! * a `None` subject (the gRPC/Flight callers that still delegate with `None`)
+//!   gets the unfiltered results (passthrough — today's behavior preserved).
+//!
+//! The binding is `Scope::Namespace(0)` because `resolve_vector_read_context`
+//! builds `Target { namespace: 0, .. }` — a namespace-scoped permit matches
+//! regardless of the collection's catalog object id (the test harness mints
+//! name-shaped ids that don't parse as the numeric object id).
+//!
+//! Default-OFF: this file compiles only under `--features abac-policy`.
+
+#![cfg(all(test, feature = "abac-policy"))]
+
+#[path = "common/integration_test_helpers.rs"]
+mod harness;
+
+use harness::UnifiedTestEnvironment;
+use proximadb::core::search::{ComparisonOperator, FilterExpression};
+use proximadb::security::rls::AbacEnforcer;
+use proximadb_abac::{
+    InMemoryAttributeAuthority, InMemoryPolicyEpochs, InMemoryPredicateObjectStore,
+};
+use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope};
+use proximadb_data_model::ProximaValue;
+use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord, ProximaTreeNode};
+use proximadb_runtime::RichSearchRequest;
+use serde_json::json;
+use std::sync::Arc;
+
+const COLLECTION: &str = "abac_rest_record_search";
+const DIM: u32 = 4;
+const TENANT: u64 = 7;
+const OID_ENG: &str = "abac/record/eng";
+const OID_HR: &str = "abac/record/hr";
+
+/// Admit `alice` (dept=eng) under a `dept=eng` row predicate, scoped to
+/// `Namespace(0)` so it matches `resolve_vector_read_context`'s
+/// `Target { namespace: 0, .. }` regardless of the collection's object id.
+fn enforcer_for_alice() -> Arc<AbacEnforcer> {
+    let mut authority = InMemoryAttributeAuthority::new();
+    authority.upsert(
+        proximadb_abac::AttributeBinding::new("alice", TENANT)
+            .with_attr("dept", AttrValue::Str("eng".into())),
+    );
+    let mut store = InMemoryPredicateObjectStore::new();
+    store.register(
+        42,
+        FilterExpression::Comparison {
+            field: "dept".to_string(),
+            operator: ComparisonOperator::Equals,
+            value: json!("eng"),
+        },
+    );
+    let bindings = vec![PolicyBinding {
+        object_id: 1,
+        tenant_stable_id: TENANT,
+        scope: Scope::Namespace(0),
+        effect: Effect::Permit,
+        predicate_ref: Some(42),
+        field_mask: None,
+    }];
+    Arc::new(
+        AbacEnforcer::new(
+            Arc::new(authority),
+            Arc::new(store),
+            Arc::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_bindings(bindings),
+    )
+}
+
+fn record(oid: &str, dept: &str, vector: Vec<f32>) -> ProximaRecord {
+    let mut rec = ProximaRecord {
+        oid: oid.to_string(),
+        record_version: 1,
+        embeddings: vec![EmbeddingCell {
+            model_id: "test".to_string(),
+            modality: "dense_vector".to_string(),
+            dim: DIM,
+            values: EmbeddingValues::Fp32(vector),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    rec.props.insert(
+        "dept".to_string(),
+        ProximaTreeNode::Value(ProximaValue::String(dept.to_string())),
+    );
+    rec
+}
+
+fn request() -> RichSearchRequest {
+    RichSearchRequest {
+        collection_id: COLLECTION.to_string(),
+        query_vector: vec![1.0, 0.0, 0.0, 0.0],
+        top_k: 10,
+        filters: vec![],
+    }
+}
+
+/// Build the service + collection + records once; the per-subject assertions
+/// share it.
+async fn fixture() -> (
+    Arc<proximadb::services::VectorOperationsService>,
+    Arc<proximadb::services::CollectionService>,
+) {
+    let env = UnifiedTestEnvironment::new().await.expect("test env");
+    let (svc, collections) = env
+        .vector_operations_service_with_abac(enforcer_for_alice())
+        .await
+        .expect("vector service with abac");
+    UnifiedTestEnvironment::create_vector_collection(&collections, COLLECTION, DIM)
+        .await
+        .expect("create collection");
+    svc.insert_vectors_direct(
+        COLLECTION,
+        Arc::new(vec![
+            record(OID_ENG, "eng", vec![1.0, 0.0, 0.0, 0.0]),
+            record(OID_HR, "hr", vec![0.99, 0.01, 0.0, 0.0]),
+        ]),
+    )
+    .await
+    .expect("insert records");
+    (svc, collections)
+}
+
+/// An admitted subject sees only `dept=eng` records — the `hr` record is
+/// filtered out by the pushed-down / post-filtered security predicate.
+#[tokio::test]
+async fn admitted_subject_sees_only_accessible_records_on_rest_records_path() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_records_with_tenant_context_abac(request(), None, Some("alice"), Some(TENANT))
+        .await
+        .expect("abac search");
+
+    let ids: Vec<&str> = resp.results.iter().map(|r| r.id.as_str()).collect();
+    assert!(
+        ids.contains(&OID_ENG),
+        "alice (dept=eng) must see the eng record; got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&OID_HR),
+        "the hr record must be filtered out; got {ids:?}"
+    );
+}
+
+/// A denied subject (no attribute binding) gets an EMPTY result — fail-closed.
+#[tokio::test]
+async fn denied_subject_gets_empty_results_on_rest_records_path() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_records_with_tenant_context_abac(request(), None, Some("mallory"), Some(TENANT))
+        .await
+        .expect("abac search");
+
+    assert!(
+        resp.results.is_empty(),
+        "mallory (unbound) must be denied — empty results (fail-closed); got {}",
+        resp.results.len()
+    );
+}
+
+/// A `None` subject (the gRPC/Flight callers that still delegate with `None`)
+/// gets the unfiltered results — today's behavior is preserved until those
+/// surfaces adopt the `_abac` variant.
+#[tokio::test]
+async fn none_subject_is_passthrough_on_rest_records_path() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_records_with_tenant_context_abac(request(), None, None, None)
+        .await
+        .expect("abac search");
+
+    let ids: Vec<&str> = resp.results.iter().map(|r| r.id.as_str()).collect();
+    assert!(
+        ids.contains(&OID_ENG) && ids.contains(&OID_HR),
+        "a None subject (gRPC/Flight path) must see both records (passthrough); got {ids:?}"
+    );
+}


### PR DESCRIPTION
ABAC enforcement previously fired only on the graph-fusion + vector-service seam. A REST record search did **not** thread the request subject into the enforcer, so a provisioned policy (e.g. `dept=eng`-only) did not admit/deny/filter over `/v2/records/.../search`. This closes that gap for the REST records-search surface.

## Approach (least blast radius — reuses existing enforcer helpers, no new ABAC logic)
- **Hoist** `apply_abac_vector_filter` + `resolve_vector_read_context` to the records-search boundary (`search_records_with_tenant_context_inner`): resolve the subject's `ReadContext` (**fail-closed on deny ⇒ empty**), AND the conjunctive security filter into the search (pushdown), and post-filter the results for the non-conjunctive remainder.
- New `search_records_with_tenant_context_abac` variant threads `subject` + `tenant_stable_id`; the original delegates with `None` (unchanged). Same pattern at `RecordOpsService` (`handle_record_search_for_tenant_abac`) — its gRPC unary/stream + Flight callers are **untouched** (`None` ⇒ no enforcement, today's behavior) until their own slice adopts the variant.
- The REST v2 records handler passes `tenant.subject` + `tenant.tenant_stable_id` (both already populated by the tenant middleware).

Does **not** plumb a new param through the shared v1 search core, and does **not** touch the deferred TD-ABAC-6 orchestrator — it threads the subject the middleware already injects. Enforcement is `abac-policy`-gated; default builds are a pass-through (identical behavior).

## Verification
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- `cargo clippy --test abac_rest_record_search_integration_test --features abac-policy -- -D warnings` ✅
- `cargo nextest run --test abac_rest_record_search_integration_test --features abac-policy` → **6/6 pass**: admitted subject sees only `dept=eng` (hr filtered); denied/unbound subject ⇒ empty (fail-closed); `None` subject ⇒ both (gRPC/Flight passthrough preserved) ✅
- `cargo fmt --check` ✅; `make work-commit-check` ✅

## Follow-ons (same pattern)
get-by-id, `progressive_search`, the SQL TODO (`canonical/handlers.rs:982`), and the gRPC/Flight twins (they keep delegating with `None` until their own slice flips to `_abac`).