### PR TITLE
refactor(decomp): extract cluster consensus → runtime (TD-DECOMP-6)

### DIFF
--- a/crates/platform/proximadb-runtime/Cargo.toml
+++ b/crates/platform/proximadb-runtime/Cargo.toml
@@ -44,8 +44,9 @@ sysinfo = "0.30"
 thiserror.workspace = true
 tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1"
-# Only used by the `cluster`-gated `ClusterServerConfig::default` (node-id generation).
-uuid = { version = "1.0", features = ["v4"], optional = true }
+# Node-id generation: used unconditionally by `cluster::consensus` (TD-DECOMP-6) and by
+# the `cluster`-gated `ClusterServerConfig::default`.
+uuid = { version = "1.0", features = ["v4"] }
 
 [features]
 default = []
@@ -53,7 +54,6 @@ default = []
 # `ClusterServerConfig` re-export and the cluster-related fields on
 # `MultiServerConfig`. The root `proximadb` crate forwards its own
 # `cluster` feature here. Without this, `#[cfg(feature = "cluster")]`
-# in `bootstrap_config.rs` would unexpected-cfg-condition-value lint.
-# Pulls in `uuid` because the cluster-gated `ClusterServerConfig::default`
-# generates a node id via `uuid::Uuid::new_v4()`.
-cluster = ["dep:uuid"]
+# in `bootstrap_config.rs` would unexpected-cfg-condition-value lint. (`uuid` is now
+# unconditional — see [dependencies] — so this feature enables only the cfg gate, not a dep.)
+cluster = []

--- a/crates/platform/proximadb-runtime/src/cluster/consensus.rs
+++ b/crates/platform/proximadb-runtime/src/cluster/consensus.rs
@@ -30,13 +30,13 @@ use tokio::sync::RwLock;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use super::rpc::{
+use crate::cluster_rpc::{
     AppendEntriesRequest, AppendEntriesResponse, CircuitBreaker, ConnectionManager,
     ConnectionPoolConfig, ConsensusTransport, LogEntryType, NodeEndpoint, RequestVoteRequest,
     RetryPolicy, RpcLogEntry,
 };
 // Re-export for external use
-pub use super::rpc::{RequestVoteResponse, RpcResult};
+pub use crate::cluster_rpc::{RequestVoteResponse, RpcResult};
 
 // Config consolidated into proximadb-config (TD-107, seam S4); re-exported
 // so existing `crate::cluster::...` import paths keep resolving.
@@ -1607,9 +1607,9 @@ mod tests {
         async fn install_snapshot(
             &self,
             _target: &NodeEndpoint,
-            _req: super::super::rpc::InstallSnapshotRequest,
-        ) -> RpcResult<super::super::rpc::InstallSnapshotResponse> {
-            Ok(super::super::rpc::InstallSnapshotResponse {
+            _req: crate::cluster_rpc::InstallSnapshotRequest,
+        ) -> RpcResult<crate::cluster_rpc::InstallSnapshotResponse> {
+            Ok(crate::cluster_rpc::InstallSnapshotResponse {
                 term: 1,
                 bytes_stored: 0,
             })

--- a/crates/platform/proximadb-runtime/src/cluster/mod.rs
+++ b/crates/platform/proximadb-runtime/src/cluster/mod.rs
@@ -12,6 +12,7 @@
 //! except root/application/binding.
 
 pub mod cache_affinity;
+pub mod consensus;
 pub mod metadata_service;
 pub mod node_registry;
 pub mod shard;

--- a/crates/platform/proximadb-runtime/src/cluster_rpc/mod.rs
+++ b/crates/platform/proximadb-runtime/src/cluster_rpc/mod.rs
@@ -20,3 +20,7 @@ pub mod grpc_client;
 pub mod retry;
 pub mod traits;
 pub mod types;
+
+// Convenience re-exports (mirror root src/cluster/rpc/mod.rs) so moved callers
+// (e.g. `cluster::consensus`) can name rpc items at the cluster_rpc root.
+pub use {connection::*, error::*, retry::*, traits::*, types::*};

--- a/docs/10-quality/td/TD-DECOMP-6-extract-cluster-consensus-to-runtime.adoc
+++ b/docs/10-quality/td/TD-DECOMP-6-extract-cluster-consensus-to-runtime.adoc
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-6: Extract cluster consensus root → proximadb-runtime (god-crate decomposition)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing (delivered by this slice)
+| Severity | Low — build/dev-loop only; zero runtime, API, or on-disk-format impact (behavior-neutral re-export)
+| Component | `crates/platform/proximadb-runtime` (`cluster::consensus`); root `src/cluster/mod.rs` (re-export shim)
+| Relates to | `roadmap/techdebt/P2_GOD_CRATE_TEST_DECOMPOSITION.md`; [[TD-DECOMP-1]] (recipe); [[TD-DECOMP-3]]/[[TD-DECOMP-4]]/[[TD-DECOMP-5]] (prior cluster moves)
+|===
+
+== Why
+
+Continues the cluster extraction. `consensus` (the Raft consensus engine, **17 tests**) was
+deferred in TD-DECOMP-5 because it imports `ConnectionManager`/`ConnectionPoolConfig` from
+`rpc/connection` — which only landed in the runtime via TD-DECOMP-4 (#1371). With that merged,
+`consensus` is now unblocked and is the next clean cluster file (its only non-self deps are
+`proximadb-config` + the runtime's `cluster_rpc` layer + `uuid`; no `crate::` climb-out into
+storage/network/catalog).
+
+== What moved (behavior-neutral)
+
+* `src/cluster/consensus.rs` → `crates/platform/proximadb-runtime/src/cluster/consensus.rs`.
+  The only rewrite is its rpc refs: `super::rpc::` and `super::super::rpc::` →
+  `crate::cluster_rpc::` (5 sites). No other `crate::` climb-out.
+* `proximadb-runtime/src/cluster_rpc/mod.rs` gains convenience re-exports
+  (`pub use {connection::*, error::*, retry::*, traits::*, types::*};`) mirroring the root
+  `src/cluster/rpc/mod.rs`, so the moved `consensus` can name rpc items at the `cluster_rpc`
+  root exactly as before.
+* `proximadb-runtime/src/cluster/mod.rs` declares `pub mod consensus;`.
+* `proximadb-runtime/Cargo.toml`: `uuid` is now **unconditional** (was optional behind the
+  `cluster` feature) — `consensus` uses it for node-id generation and compiles unconditionally
+  (matching the root's unconditional cluster module). The `cluster` feature becomes `[]`
+  (empty) — it still cfg-gates `ClusterServerConfig` in `bootstrap_config.rs` but no longer
+  gates the `uuid` dep.
+* Root `src/cluster/mod.rs` replaces `pub mod consensus;` with
+  `pub use proximadb_runtime::cluster::consensus;` — so `grpc_server`/`distributed_ops`/
+  `replication` and external callers resolve `RaftConsensus`/etc. unchanged.
+
+== Verification
+
+* `cargo check -p proximadb-runtime` green (moved consensus + re-exports + unconditional uuid).
+* `cargo check -p proximadb` green (root compiles through the re-export).
+* `cargo nextest run -p proximadb-runtime --lib` — runtime gains the 17 tests (111→128).
+* `cargo nextest run -p proximadb --lib` green — root lib test binary shed the 17 tests.
+* `python3 scripts/check_workspace_boundaries.py` + `scripts/check-layering.sh` green.
+* `cargo build -p proximadb-server` + `cargo clippy --lib --bins -- -D warnings` +
+  `cargo fmt --check` + `make work-commit-check` green.
+
+== Follow-ups (out of scope here)
+
+* `grpc_server` (root-side) is now the last piece coupling to a moved cluster module — it
+  references `consensus::RaftConsensus` + `replication::EngineReplication` via the re-export.
+  `grpc_server` itself moves once `replication` does (it's tangled with `distributed_ops`→
+  `routing`→`crate::catalog`).
+* The remaining cluster residue (`distributed_ops`/`replication` + climbers
+  `partition_lease`/`routing`/`primary_pod_registry`) needs the structural enabler — extract
+  `catalog`/`network`/`storage` to crates — before it can follow.

--- a/docs/_internal/roadmap/CAPABILITY_MATRIX.toml
+++ b/docs/_internal/roadmap/CAPABILITY_MATRIX.toml
@@ -312,7 +312,7 @@ status = "partial"
 notes = "Raft internals, shard planning, snapshot/restore, routing foundations exist (~5,491 LOC, src/cluster/, behind the `cluster` flag). RPC transport + remote execution + failover are placeholder/partial (TD-077, support tier Experimental). PULSAR/QUASAR engines retired."
 controlling_td = ["TD-077"]
 evidence = [
-  "src/cluster/consensus.rs:17",
+  "crates/platform/proximadb-runtime/src/cluster/consensus.rs:17",
   "src/cluster/mod.rs:1",
 ]
 

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -53,7 +53,10 @@
 // edge. Re-exported here so `crate::cluster::*` paths (incl. distributed_ops/
 // replication/consensus) resolve unchanged.
 pub use proximadb_runtime::cluster::{cache_affinity, metadata_service, node_registry, shard};
-pub mod consensus;
+// `consensus` now lives in `proximadb-runtime::cluster` (TD-DECOMP-6); re-exported so
+// `crate::cluster::consensus::*` paths (grpc_server/distributed_ops/replication/external
+// callers) resolve unchanged.
+pub use proximadb_runtime::cluster::consensus;
 pub mod distributed_ops;
 /// Generation-fenced per-partition write leases over object storage (Phase 7):
 /// a peer holds a durable, fenced lease over one (tenant, collection) for


### PR DESCRIPTION
## What
Continues the cluster extraction (after #1366/#1369/#1371/#1374). Extracts **`consensus`** (the Raft consensus engine, **17 tests**) → `proximadb-runtime/cluster`. Behavior-neutral. This was deferred in TD-DECOMP-5 because it imports `connection.rs` types that #1371 relocated — now unblocked.

## Change
- `git mv src/cluster/consensus.rs` → `proximadb-runtime/src/cluster/consensus.rs`; only rewrite is `super::rpc::`/`super::super::rpc::` → `crate::cluster_rpc::` (5 sites). No other `crate::` climb-out.
- `cluster_rpc/mod.rs`: convenience re-exports `pub use {connection::*, error::*, retry::*, traits::*, types::*};` (mirror of root `rpc/mod.rs`) so consensus names rpc items at the `cluster_rpc` root as before.
- Runtime `Cargo.toml`: `uuid` → unconditional (consensus uses it for node-id gen; compiles unconditionally matching the root's cluster module); `cluster` feature → `[]` (still cfg-gates `ClusterServerConfig`, no longer gates the `uuid` dep).
- Root `src/cluster/mod.rs`: `pub mod consensus;` → `pub use proximadb_runtime::cluster::consensus;` — `grpc_server`/`distributed_ops`/`replication` + external callers resolve `RaftConsensus` unchanged.

## Verification (quiet machine)
| check | result |
|---|---|
| `cargo check -p proximadb` | ✅ |
| `nextest -p proximadb-runtime` | ✅ **128 passed** (111→128: +17 consensus tests) |
| `check_workspace_boundaries.py` | ✅ no findings |
| `check-layering.sh` | ✅ |
| `cargo build -p proximadb-server` | ✅ |
| `cargo clippy --lib --bins -D warnings` | ✅ |
| `cargo fmt --check` + `make work-commit-check` + td-unique | ✅ |

**Running total once merged: 125 tests out of the root lib binary** (14+37+19+38+17), 5 cluster slices.

## Follow-ups (TD-DECOMP-6)
`grpc_server` (root-side) is the last piece coupling to a moved cluster module (refs `consensus::RaftConsensus` + `replication::EngineReplication` via re-export). It + the remaining residue (`distributed_ops`/`replication`/climbers) need the structural enabler — extract `catalog`/`network`/`storage` to crates.
