### PR TITLE
feat(abac): enforce provisioned policy on the REST get-by-id path (TD-ABAC-5/6 REST slice)

### DIFF
--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -798,10 +798,31 @@ impl RecordOpsService {
     }
 
     /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
+    /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
+    ///
+    /// Delegates to [`Self::handle_record_get_for_tenant_abac`] with no subject
+    /// (the gRPC/internal callers preserve today's behavior — no ABAC). The REST
+    /// v2 surface calls `_abac` directly with the request subject.
     pub async fn handle_record_get_for_tenant(
         &self,
         request: RichRecordGetRequest,
         tenant_id: Option<&str>,
+    ) -> Result<RichRecordGetResponse> {
+        self.handle_record_get_for_tenant_abac(request, tenant_id, None, None)
+            .await
+    }
+
+    /// ABAC-aware rich-record get: same as
+    /// [`Self::handle_record_get_for_tenant`] but threads the request subject
+    /// and tenant stable id so a provisioned policy admit-checks the fetched
+    /// record (fail-closed on deny). Enforcement is `abac-policy`-gated inside
+    /// the vector service; default builds are a pass-through.
+    pub async fn handle_record_get_for_tenant_abac(
+        &self,
+        request: RichRecordGetRequest,
+        tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<RichRecordGetResponse> {
         let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
         let request = RichRecordGetRequest {
@@ -818,7 +839,12 @@ impl RecordOpsService {
         };
 
         self.vector_operations_service
-            .get_record_with_tenant_context(request, tenant_context.as_ref())
+            .get_record_with_tenant_context_abac(
+                request,
+                tenant_context.as_ref(),
+                subject,
+                tenant_stable_id,
+            )
             .await
     }
 

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -2099,7 +2099,7 @@ pub async fn get_record_v2(
 
     match state
         .record_ops
-        .handle_record_get_for_tenant(
+        .handle_record_get_for_tenant_abac(
             RichRecordGetRequest {
                 collection_id: collection_id.clone(),
                 record_id: record_id.clone(),
@@ -2107,6 +2107,8 @@ pub async fn get_record_v2(
                 include_props: true,
             },
             Some(&tenant.tenant_id),
+            tenant.subject.as_deref(),
+            tenant.tenant_stable_id,
         )
         .await
     {

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1000,29 +1000,95 @@ impl VectorOperationsService {
         request: RichRecordGetRequest,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
     ) -> Result<RichRecordGetResponse> {
+        self.get_record_with_tenant_context_abac(request, tenant_context, None, None)
+            .await
+    }
+
+    /// ABAC-aware rich-record get: fetches the record, then admit-checks the
+    /// single result against the subject's security predicate (fail-closed on
+    /// deny). The gRPC/internal callers keep the no-subject delegate (no
+    /// enforcement); the REST v2 surface passes the request subject. Enforcement
+    /// is `abac-policy`-gated; default builds pass the subject through ignored.
+    pub async fn get_record_with_tenant_context_abac(
+        &self,
+        request: RichRecordGetRequest,
+        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
+    ) -> Result<RichRecordGetResponse> {
         let collection_id = self
             .validate_tenant_collection_access(&request.collection_id, tenant_context)
             .await?
             .to_string();
 
-        self.vector(
-            &collection_id,
-            &request.record_id,
-            request.include_vector,
-            request.include_props,
-        )
-        .await
-        .map(|record| {
-            // Defense-in-depth: never return a dead (tombstone / TTL-expired)
-            // record from get-by-id, regardless of which backing store (WAL
-            // or SST point-lookup) produced it. The WAL memtable filters on
-            // its own, but the SST point-lookup path does not. Use the
-            // canonical is_visible_at(now_ns) on valid_to_ns.
-            let now_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
-            record
-                .filter(|r| r.is_visible_at(now_ns))
-                .map(vector_record_to_rich_result)
-        })
+        let record = self
+            .vector(
+                &collection_id,
+                &request.record_id,
+                request.include_vector,
+                request.include_props,
+            )
+            .await
+            .map(|record| {
+                // Defense-in-depth: never return a dead (tombstone / TTL-expired)
+                // record from get-by-id, regardless of which backing store (WAL
+                // or SST point-lookup) produced it. The WAL memtable filters on
+                // its own, but the SST point-lookup path does not. Use the
+                // canonical is_visible_at(now_ns) on valid_to_ns.
+                let now_ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+                record
+                    .filter(|r| r.is_visible_at(now_ns))
+                    .map(vector_record_to_rich_result)
+            })?;
+
+        #[cfg(feature = "abac-policy")]
+        let record = self
+            .admit_record_abac(record, subject, tenant_stable_id, &collection_id)
+            .await;
+        #[cfg(not(feature = "abac-policy"))]
+        let _ = (subject, tenant_stable_id);
+
+        Ok(record)
+    }
+
+    /// Admit-check a single fetched record against the subject's read context:
+    /// `None` (denied) ⇒ `None` (fail-closed); `System` ⇒ passthrough;
+    /// `Client(ctx)` ⇒ drop the record if it fails the ctx's security predicate.
+    /// (Point lookups have no filter slot to push into, so this is a post-check
+    /// on the one returned record.)
+    #[cfg(feature = "abac-policy")]
+    async fn admit_record_abac(
+        &self,
+        record: Option<RichSearchResult>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
+        collection_id: &str,
+    ) -> Option<RichSearchResult> {
+        use crate::core::search::sql_value_filter::proxima_value_to_json;
+        use crate::security::rls::filter_lattice::admits_with_security;
+
+        match self
+            .records_read_context(subject, tenant_stable_id, collection_id)
+            .await
+        {
+            // Denied ⇒ fail-closed: the record is not returned.
+            None => None,
+            // No client subject / no enforcer ⇒ structural isolation only.
+            Some(proximadb_abac::ReadContext::System(_)) => record,
+            Some(proximadb_abac::ReadContext::Client(ctx)) => {
+                let security = self
+                    .abac_enforcer
+                    .as_ref()
+                    .and_then(|enforcer| enforcer.security_filter_for_context(&ctx));
+                record.filter(|r| match &security {
+                    Some(security) => admits_with_security(None, Some(security), &|field: &str| {
+                        r.props.get(field).map(proxima_value_to_json)
+                    }),
+                    // Admitted with no row predicate ⇒ the record is visible.
+                    None => true,
+                })
+            }
+        }
     }
 
     /// Point-get a single FULL record by id, tenant-scoped (TD-DOC-CONV-1).

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -37,7 +37,7 @@ use proximadb_abac::{
 use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope};
 use proximadb_data_model::ProximaValue;
 use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord, ProximaTreeNode};
-use proximadb_runtime::RichSearchRequest;
+use proximadb_runtime::{RichRecordGetRequest, RichSearchRequest};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -193,5 +193,82 @@ async fn none_subject_is_passthrough_on_rest_records_path() {
     assert!(
         ids.contains(&OID_ENG) && ids.contains(&OID_HR),
         "a None subject (gRPC/Flight path) must see both records (passthrough); got {ids:?}"
+    );
+}
+
+// ── get-by-id path (`get_record_with_tenant_context_abac`) ──
+//
+// A point lookup has no filter slot to push into, so enforcement is a post-check
+// on the single fetched record: denied subject ⇒ None (fail-closed); admitted
+// subject ⇒ the record only if it satisfies the security predicate; None subject
+// ⇒ passthrough.
+
+fn get_request(record_id: &str) -> RichRecordGetRequest {
+    RichRecordGetRequest {
+        collection_id: COLLECTION.to_string(),
+        record_id: record_id.to_string(),
+        include_vector: false,
+        include_props: true,
+    }
+}
+
+/// An admitted subject (dept=eng) may GET the eng record, NOT the hr record.
+#[tokio::test]
+async fn admitted_subject_gets_only_accessible_record_on_getbyid_path() {
+    let (svc, _collections) = fixture().await;
+
+    let eng = svc
+        .get_record_with_tenant_context_abac(
+            get_request(OID_ENG),
+            None,
+            Some("alice"),
+            Some(TENANT),
+        )
+        .await
+        .expect("abac get");
+    assert!(eng.is_some(), "alice (dept=eng) may GET the eng record");
+
+    let hr = svc
+        .get_record_with_tenant_context_abac(get_request(OID_HR), None, Some("alice"), Some(TENANT))
+        .await
+        .expect("abac get");
+    assert!(
+        hr.is_none(),
+        "alice must NOT GET the hr record — it fails the dept=eng security predicate"
+    );
+}
+
+/// A denied subject (no attribute binding) gets NONE — fail-closed.
+#[tokio::test]
+async fn denied_subject_gets_no_record_on_getbyid_path() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .get_record_with_tenant_context_abac(
+            get_request(OID_ENG),
+            None,
+            Some("mallory"),
+            Some(TENANT),
+        )
+        .await
+        .expect("abac get");
+    assert!(
+        resp.is_none(),
+        "mallory (unbound) must be denied — no record (fail-closed)"
+    );
+}
+
+/// A `None` subject (the gRPC/internal callers) gets the record — passthrough.
+#[tokio::test]
+async fn none_subject_is_passthrough_on_getbyid_path() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .get_record_with_tenant_context_abac(get_request(OID_ENG), None, None, None)
+        .await
+        .expect("abac get");
+    assert!(
+        resp.is_some(),
+        "a None subject (gRPC/internal path) may GET the record (passthrough)"
     );
 }


### PR DESCRIPTION
Companion to #1373 (REST records-search enforcement): a provisioned policy now also admit/deny-checks a REST point lookup (`/v2/records/{id}`). A point get has no filter slot to push into, so enforcement is a **post-check on the single fetched record**.

## Change
- New `get_record_with_tenant_context_abac` (+ `handle_record_get_for_tenant_abac`) thread the subject + `tenant_stable_id`: a **denied** subject ⇒ `None` (fail-closed); an **admitted** subject ⇒ the record only if it satisfies the ctx's security predicate (`security_filter_for_context` + `admits_with_security` on its props); a `System`/`None` context ⇒ passthrough. Reuses #1373's `records_read_context`.
- The originals delegate with `None` — **gRPC/internal callers unchanged** (today's behavior) until their own slice adopts the variant.
- REST `get_record_v2` passes `tenant.subject` + `tenant.tenant_stable_id`.

`abac-policy`-gated; default builds pass the subject through ignored (identical behavior).

## Verification
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- `cargo clippy --test abac_rest_record_search_integration_test --features abac-policy -- -D warnings` ✅
- `cargo nextest run --test abac_rest_record_search_integration_test --features abac-policy` → **9/9 pass**: admitted subject GETs `eng` but not `hr`; denied/unbound ⇒ `None` (fail-closed); `None` ⇒ passthrough ✅
- `cargo fmt --check` ✅; `make work-commit-check` ✅

Completes the REST records surface (both search #1373 and get-by-id now enforce). Remaining follow-ons (same pattern): `progressive_search`, the SQL TODO (`handlers.rs:982`), gRPC/Flight twins.