### PR TITLE
feat(sst): compaction drops DV-deleted rows + retires input .dv (TD-DELVEC-1 WI-6)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/deletion_vector.rs
+++ b/crates/storage/proximadb-storage-common/src/deletion_vector.rs
@@ -185,6 +185,17 @@ impl VersionedDeletionVector {
         total.saturating_sub(self.deleted_count_as_of(snapshot_lsn))
     }
 
+    /// All positions deleted at any generation (the union of every run's
+    /// bitmap). TD-DELVEC-1 WI-6: compaction consults this to physically drop
+    /// DV-deleted rows at the merge.
+    pub fn deleted_positions(&self) -> Vec<u32> {
+        let mut all = RoaringBitmap::new();
+        for bm in self.runs.values() {
+            all |= bm;
+        }
+        all.to_vec()
+    }
+
     /// Serialize as `[VDV_MAGIC | run_count u32 | (gen u64, body_len u32, roaring
     /// body)* ]`, all little-endian.
     pub fn serialize(&self) -> Result<Vec<u8>, BitmapError> {

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1243,8 +1243,8 @@ impl Compaction {
     /// footer region (position → oid). The merge dedup loses each record's source
     /// segment/position, so this is computed up front from the inputs. Feature-gated.
     #[cfg(feature = "cold-deletion-vectors")]
-    async fn build_deleted_oids(
-        &self,
+    pub(crate) async fn build_deleted_oids(
+        filesystem: &crate::storage::persistence::filesystem::FilesystemFactory,
         dv_store: &crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore,
         input_files: &[std::path::PathBuf],
     ) -> std::collections::HashSet<String> {
@@ -1261,8 +1261,7 @@ impl Compaction {
             if positions.is_empty() {
                 continue;
             }
-            let Ok(Some(resolver)) = read_segment_resolver(&self.filesystem_factory, &path).await
-            else {
+            let Ok(Some(resolver)) = read_segment_resolver(filesystem, &path).await else {
                 continue;
             };
             for pos in positions {
@@ -1443,7 +1442,8 @@ impl Compaction {
                 self.filesystem_factory.clone(),
             );
         #[cfg(feature = "cold-deletion-vectors")]
-        let deleted_oids = self.build_deleted_oids(&dv_store, &task.input_files).await;
+        let deleted_oids =
+            Self::build_deleted_oids(&self.filesystem_factory, &dv_store, &task.input_files).await;
 
         for vector_record in &resolved_records {
             // TD-DELVEC-1 WI-6: drop DV-deleted rows (checked before tombstone/

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1237,6 +1237,43 @@ impl Compaction {
     /// Original enhanced compaction implementation (now used as fallback)
     /// UNIFIED VectorRecord compaction (eliminates SstRecord conversions completely)
     /// OPTIMIZATION: Single streaming path, no dual conversions, fastest performance
+    /// TD-DELVEC-1 WI-6: collect the oids deleted (DV bit set) across the input
+    /// segments, so the compaction merge can physically drop them. Reads each
+    /// input's DV (`{input}.dv`, disk-authoritative) + the segment's OID resolver
+    /// footer region (position → oid). The merge dedup loses each record's source
+    /// segment/position, so this is computed up front from the inputs. Feature-gated.
+    #[cfg(feature = "cold-deletion-vectors")]
+    async fn build_deleted_oids(
+        &self,
+        dv_store: &crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore,
+        input_files: &[std::path::PathBuf],
+    ) -> std::collections::HashSet<String> {
+        use crate::storage::engines::sst::oid_resolve::read_segment_resolver;
+        let mut deleted = std::collections::HashSet::new();
+        for input in input_files {
+            let path = input.to_string_lossy().into_owned();
+            // Absent `.dv` → no deletes for this segment (load is a no-op).
+            let _ = dv_store.load(&path).await;
+            let Some(vdv) = dv_store.get(&path).await else {
+                continue;
+            };
+            let positions = vdv.deleted_positions();
+            if positions.is_empty() {
+                continue;
+            }
+            let Ok(Some(resolver)) = read_segment_resolver(&self.filesystem_factory, &path).await
+            else {
+                continue;
+            };
+            for pos in positions {
+                if let Some(oid) = resolver.oid_at(pos) {
+                    deleted.insert(oid.to_string());
+                }
+            }
+        }
+        deleted
+    }
+
     async fn perform_unified_vectorrecord_compaction(
         &self,
         task: &SstCompactionTask,
@@ -1394,7 +1431,28 @@ impl Compaction {
         let mut deleted_vector_ids = Vec::new();
         let mut merged_vectors = Vec::new();
 
+        // TD-DELVEC-1 WI-6: build the set of oids whose deletion-vector bit is
+        // set in any input segment, so the merge physically drops them (a DV-
+        // deleted row must not resurrect in the compacted output). The merge
+        // dedup loses each record's source segment/position, so this is computed
+        // up front from the input segments' DVs + OID resolvers. The `dv_store`
+        // is reused below to retire the inputs' `.dv` files.
+        #[cfg(feature = "cold-deletion-vectors")]
+        let dv_store =
+            crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore::new(
+                self.filesystem_factory.clone(),
+            );
+        #[cfg(feature = "cold-deletion-vectors")]
+        let deleted_oids = self.build_deleted_oids(&dv_store, &task.input_files).await;
+
         for vector_record in &resolved_records {
+            // TD-DELVEC-1 WI-6: drop DV-deleted rows (checked before tombstone/
+            // expiry so a DV delete always wins).
+            #[cfg(feature = "cold-deletion-vectors")]
+            if deleted_oids.contains(&vector_record.id) {
+                deleted_vector_ids.push(vector_record.id.clone());
+                continue;
+            }
             // Tombstone detection: empty vector + expires_at in past (including 0)
             // expires_at = 0 means "epoch time" which is always in the past = tombstone marker
             let is_tombstone = vector_record.vector.is_empty()
@@ -1980,6 +2038,14 @@ impl Compaction {
                     purged,
                     "evicted survivor-cache ranges for compacted-away file"
                 );
+            }
+
+            // TD-DELVEC-1 WI-6: retire the input segment's deletion vector — it
+            // referenced this now-compacted-away input. Best-effort (a missing
+            // `.dv` is already success).
+            #[cfg(feature = "cold-deletion-vectors")]
+            if let Err(e) = dv_store.remove(&input_path).await {
+                warn!("compaction DV retire: failed to remove {input_path}.dv: {e:?}");
             }
         }
         if !retirement_errors.is_empty() {

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -278,6 +278,12 @@ mod cold_cascade_merge_test;
 #[cfg(all(test, feature = "cold-deletion-vectors"))]
 #[path = "tests/cold_recovery_reconcile_test.rs"]
 mod cold_recovery_reconcile_test;
+// TD-DELVEC-1 WI-6: compaction DV-awareness — `build_deleted_oids` collects the
+// DV-deleted oids so the merge drops them. In-crate (#[path]) to call the
+// pub(crate) feature-gated associated fn + segment helpers.
+#[cfg(all(test, feature = "cold-deletion-vectors"))]
+#[path = "tests/cold_compaction_dv_test.rs"]
+mod cold_compaction_dv_test;
 pub mod flush;
 pub mod manifest;
 #[cfg(feature = "cold-deletion-vectors")]

--- a/src/storage/engines/sst/oid_resolve.rs
+++ b/src/storage/engines/sst/oid_resolve.rs
@@ -16,6 +16,7 @@ use proximadb_storage_common::pax_block::SEGMENT_MAGIC;
 use proximadb_storage_common::segment_layout::{SEG_TAIL_LEN, SegmentFooterIndex};
 
 use crate::storage::engines::sst::oid_resolver_cache::OidResolverCache;
+use crate::storage::persistence::filesystem::FilesystemFactory;
 
 impl super::core::SstEngine {
     /// TD-DELVEC-1 WI-3c: resolve an oid to all `(segment_path, position)` hits
@@ -67,60 +68,72 @@ impl super::core::SstEngine {
     /// (CRC-validated). Returns `None` if the segment has no resolver region
     /// (`opr_len == 0` → tombstone fallback) or isn't a coalesced PAX segment.
     async fn read_resolver(&self, path: &str) -> Result<Option<Arc<OidPositionResolver>>> {
-        let storage_url = path.to_string();
-        let fs = self
-            .filesystem()
-            .get_filesystem(&storage_url)
-            .map_err(|e| anyhow!("resolver load: filesystem for {storage_url}: {e:?}"))?;
-
-        // File size (to read the tail).
-        let metadata = fs
-            .metadata(&storage_url)
-            .await
-            .map_err(|e| anyhow!("resolver load: metadata for {storage_url}: {e:?}"))?;
-        let file_size = metadata.size as u64;
-        if file_size < SEG_TAIL_LEN as u64 {
-            return Ok(None); // too small
-        }
-
-        // Read the tail [footer_len u64 | SEGMENT_MAGIC 8B] to locate the footer.
-        let tail_off = file_size - SEG_TAIL_LEN as u64;
-        let tail = fs
-            .read_range(&storage_url, tail_off, SEG_TAIL_LEN as u64)
-            .await
-            .map_err(|e| anyhow!("resolver load: tail read for {storage_url}: {e:?}"))?;
-        if &tail[8..16] != SEGMENT_MAGIC {
-            return Ok(None); // not a coalesced PAX segment
-        }
-        let footer_len_bytes: [u8; 8] = tail[..8]
-            .try_into()
-            .map_err(|_| anyhow!("resolver load: bad tail for {storage_url}"))?;
-        let footer_len = u64::from_le_bytes(footer_len_bytes) as usize;
-        if footer_len == 0 || (tail_off as usize) < footer_len {
-            return Ok(None);
-        }
-
-        // Read + parse the footer.
-        let footer_off = tail_off - footer_len as u64;
-        let footer_bytes = fs
-            .read_range(&storage_url, footer_off, footer_len as u64)
-            .await
-            .map_err(|e| anyhow!("resolver load: footer read for {storage_url}: {e:?}"))?;
-        let footer = SegmentFooterIndex::parse(&footer_bytes)
-            .map_err(|e| anyhow!("resolver load: footer parse for {storage_url}: {e}"))?;
-
-        // No resolver region → None (tombstone fallback).
-        if footer.opr_len == 0 {
-            return Ok(None);
-        }
-
-        // Read + deserialize the resolver region (CRC-validated by deserialize).
-        let region = fs
-            .read_range(&storage_url, footer.opr_off, footer.opr_len)
-            .await
-            .map_err(|e| anyhow!("resolver load: region read for {storage_url}: {e:?}"))?;
-        let resolver = OidPositionResolver::deserialize(&region)
-            .map_err(|e| anyhow!("resolver load: deserialize for {storage_url}: {e}"))?;
-        Ok(Some(Arc::new(resolver)))
+        read_segment_resolver(self.filesystem(), path).await
     }
+}
+
+/// Lazy-load a resolver from the segment's footer region — a free fn usable by
+/// callers that don't hold an `SstEngine` (e.g. compaction, TD-DELVEC-1 WI-6).
+/// Reads the tail `[footer_len u64 | SEGMENT_MAGIC 8B]` to locate the footer,
+/// then the footer body (→ `opr_off`/`opr_len`), then the region bytes →
+/// deserialize (CRC-validated). Returns `None` if the segment has no resolver
+/// region (`opr_len == 0` → tombstone fallback) or isn't a coalesced PAX segment.
+pub async fn read_segment_resolver(
+    filesystem: &FilesystemFactory,
+    path: &str,
+) -> Result<Option<Arc<OidPositionResolver>>> {
+    let storage_url = path.to_string();
+    let fs = filesystem
+        .get_filesystem(&storage_url)
+        .map_err(|e| anyhow!("resolver load: filesystem for {storage_url}: {e:?}"))?;
+
+    // File size (to read the tail).
+    let metadata = fs
+        .metadata(&storage_url)
+        .await
+        .map_err(|e| anyhow!("resolver load: metadata for {storage_url}: {e:?}"))?;
+    let file_size = metadata.size as u64;
+    if file_size < SEG_TAIL_LEN as u64 {
+        return Ok(None); // too small
+    }
+
+    // Read the tail [footer_len u64 | SEGMENT_MAGIC 8B] to locate the footer.
+    let tail_off = file_size - SEG_TAIL_LEN as u64;
+    let tail = fs
+        .read_range(&storage_url, tail_off, SEG_TAIL_LEN as u64)
+        .await
+        .map_err(|e| anyhow!("resolver load: tail read for {storage_url}: {e:?}"))?;
+    if &tail[8..16] != SEGMENT_MAGIC {
+        return Ok(None); // not a coalesced PAX segment
+    }
+    let footer_len_bytes: [u8; 8] = tail[..8]
+        .try_into()
+        .map_err(|_| anyhow!("resolver load: bad tail for {storage_url}"))?;
+    let footer_len = u64::from_le_bytes(footer_len_bytes) as usize;
+    if footer_len == 0 || (tail_off as usize) < footer_len {
+        return Ok(None);
+    }
+
+    // Read + parse the footer.
+    let footer_off = tail_off - footer_len as u64;
+    let footer_bytes = fs
+        .read_range(&storage_url, footer_off, footer_len as u64)
+        .await
+        .map_err(|e| anyhow!("resolver load: footer read for {storage_url}: {e:?}"))?;
+    let footer = SegmentFooterIndex::parse(&footer_bytes)
+        .map_err(|e| anyhow!("resolver load: footer parse for {storage_url}: {e}"))?;
+
+    // No resolver region → None (tombstone fallback).
+    if footer.opr_len == 0 {
+        return Ok(None);
+    }
+
+    // Read + deserialize the resolver region (CRC-validated by deserialize).
+    let region = fs
+        .read_range(&storage_url, footer.opr_off, footer.opr_len)
+        .await
+        .map_err(|e| anyhow!("resolver load: region read for {storage_url}: {e:?}"))?;
+    let resolver = OidPositionResolver::deserialize(&region)
+        .map_err(|e| anyhow!("resolver load: deserialize for {storage_url}: {e}"))?;
+    Ok(Some(Arc::new(resolver)))
 }

--- a/src/storage/engines/sst/tests/cold_compaction_dv_test.rs
+++ b/src/storage/engines/sst/tests/cold_compaction_dv_test.rs
@@ -1,0 +1,101 @@
+//! TD-DELVEC-1 WI-6 test: compaction's `build_deleted_oids` collects the oids
+//! deleted (DV bit set) across the input segments — the core of compaction
+//! DV-awareness (a DV-deleted row is physically dropped at the merge, else it
+//! resurrects in the compacted output).
+//!
+//! Writes a coalesced RaBitQ `.pax` (OID resolver embedded) → marks one position
+//! deleted in a `.dv` → asserts a fresh `build_deleted_oids` pass (as compaction
+//! runs it, with a fresh `DeletionVectorStore` loading the `.dv` from disk)
+//! collects exactly that oid, not the live ones. In-crate so it can call the
+//! `pub(crate)` feature-gated associated fn + the segment helpers.
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    use crate::storage::engines::sst::compaction::Compaction;
+    use crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore;
+    use crate::storage::engines::sst::segment_format::{read_segment_records, write_pax_segment};
+    use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
+    use proximadb_block_format::VectorQuant;
+    use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord};
+
+    /// RaBitQ needs a non-trivial dimension; 64 mirrors the coalesced-cascade tests.
+    const DIM: usize = 64;
+
+    fn rec(oid: &str, i: usize) -> ProximaRecord {
+        let ts = 1_700_000_000_000_000_000 + i as i64;
+        let mut r = ProximaRecord {
+            oid: oid.into(),
+            tenant_id: "t".into(),
+            created_at_ns: ts,
+            updated_at_ns: ts,
+            ..Default::default()
+        };
+        let vec: Vec<f32> = (0..DIM).map(|d| (i as f32 + d as f32) * 0.1).collect();
+        r.embeddings.push(EmbeddingCell {
+            modality: "dense".into(),
+            dim: DIM as u32,
+            values: EmbeddingValues::Fp32(vec),
+            ..Default::default()
+        });
+        r
+    }
+
+    #[tokio::test]
+    async fn build_deleted_oids_collects_dv_deleted_oids_only() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let base = temp_dir.path().to_str().unwrap().to_string();
+        let pax_local = format!("{base}/seg.pax");
+        let seg = format!("file://{pax_local}");
+
+        // Write a coalesced RaBitQ segment (OID resolver embedded in the footer).
+        let records: Vec<ProximaRecord> = (0..3).map(|i| rec(&format!("r{i}"), i)).collect();
+        write_pax_segment(
+            Path::new(&pax_local),
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            None,
+        )?;
+
+        // Find r1's on-disk row position (the space the DV keys on).
+        let bytes = std::fs::read(&pax_local)?;
+        let on_disk = read_segment_records(&bytes, &[], &[], None)?;
+        let r1_pos = on_disk
+            .iter()
+            .position(|r| r.oid == "r1")
+            .expect("r1 in segment") as u32;
+
+        // Filesystem rooted at the temp dir.
+        let mut fs_config = FilesystemConfig::default();
+        fs_config.default_fs = Some(format!("file://{base}"));
+        let fs = Arc::new(FilesystemFactory::create(fs_config).await?);
+
+        // Mark r1 deleted (writes `{seg}.dv` — disk-authoritative).
+        let dv_marker = DeletionVectorStore::new(fs.clone());
+        assert!(
+            dv_marker.mark_deleted(&seg, r1_pos, 100).await?,
+            "r1 mark should be newly-set"
+        );
+
+        // A FRESH DV store (as compaction uses it) loads `{seg}.dv` from disk.
+        let dv_store = DeletionVectorStore::new(fs.clone());
+        let deleted = Compaction::build_deleted_oids(&fs, &dv_store, &[PathBuf::from(&seg)]).await;
+
+        assert!(
+            deleted.contains("r1"),
+            "the DV-deleted oid r1 must be collected: {deleted:?}"
+        );
+        assert!(
+            !deleted.contains("r0") && !deleted.contains("r2"),
+            "live oids r0/r2 must not be collected: {deleted:?}"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

TD-DELVEC-1 **WI-6** — compaction becomes DV-aware: a DV-deleted row is physically dropped at the merge (it used to resurrect in the compacted output), and the input segment's `.dv` is retired (it used to be orphaned on disk). Compaction previously ignored deletion vectors entirely.

## Change (feature-gated `cold-deletion-vectors`; default path unchanged)

**Enablers:**
- `VersionedDeletionVector::deleted_positions() -> Vec<u32>` — the versioned DV had no position iterator (only `delete_gen`/`is_deleted`).
- `read_segment_resolver(filesystem, path)` — extracted from `SstEngine::read_resolver` so callers without an `SstEngine` (compaction) can read a segment's OID resolver.

**Compaction wiring** (`perform_unified_vectorrecord_compaction`):
- Pre-merge, build a `deleted_oids: HashSet` from `task.input_files`: for each input, load its `{input}.dv` via a fresh `DeletionVectorStore` (disk-authoritative — reads the same file the engine wrote), take `deleted_positions()`, and map each to its oid via the segment's resolver (`read_segment_resolver` + `oid_at`). The merge dedup loses each record's source segment/position, so this is computed up front.
- In the merge loop, drop records whose oid is in `deleted_oids` (checked before tombstone/expiry). The output has no deleted rows → empty DV — no carry needed (matches TD §7.2-5: long-lived snapshots not pinned = today's tombstone reclaim).
- In the retire loop, `DeletionVectorStore::remove` each input's `.dv` (best-effort), alongside the existing segment retire.

`build_deleted_oids` is an associated fn (takes `&FilesystemFactory`, no `&self`) so it's testable without a `Compaction` instance.

## Verification

- `cargo fmt --all --check` (1.95.0) ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default — CI-gated) ✅
- `cargo build`/`test --features cold-deletion-vectors cold_compaction_dv` → `1 passed` ✅ (collects the DV-deleted oid, not the live ones)
- `cargo clippy -p proximadb --lib --features cold-deletion-vectors -- -D warnings` ✅

## Remaining arc

- A full end-to-end compaction test (flush → mark → compact → verify the output + `.dv` retire) is a follow-up; this PR's test drives `build_deleted_oids` directly.
- WI-5 retire-side + WI-7 (publish-before-retire ordering + conservative purge), plus the two non-blocking cleanups (WAL `CatalogResolver`; WI-3b fs-walk bypass).