### PR TITLE
refactor(abac): move REST records-search enforcement to the shared search seam (TD-ABAC-5/6)

### DIFF
--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -748,25 +748,12 @@ impl RecordOpsService {
 
     /// Canonical rich-record search handler used by v2 REST/gRPC/internal callers.
     ///
-    /// Delegates to [`Self::handle_record_search_for_tenant_abac`] with no
-    /// subject — the gRPC/Flight/internal callers preserve today's behavior (no
-    /// ABAC enforcement). The REST v2 surface calls `_abac` directly with the
-    /// request subject so a provisioned policy admits/denies/filters the results.
+    /// Threads the request subject + tenant stable id into the vector service so
+    /// ABAC enforces at the shared `unified_search_v1_inner` seam (fail-closed on
+    /// deny). Callers without a subject (gRPC/Flight/internal today) pass `None` ⇒
+    /// `System` passthrough (today's behavior). Enforcement is `abac-policy`-gated
+    /// inside the vector service; default builds are a pass-through.
     pub async fn handle_record_search_for_tenant(
-        &self,
-        request: RichSearchRequest,
-        tenant_id: Option<&str>,
-    ) -> Result<RichSearchResponse> {
-        self.handle_record_search_for_tenant_abac(request, tenant_id, None, None)
-            .await
-    }
-
-    /// ABAC-aware rich-record search: same as
-    /// [`Self::handle_record_search_for_tenant`] but threads the request subject
-    /// and tenant stable id into the vector service so ABAC enforces (fail-closed
-    /// on deny). The enforcement itself is `abac-policy`-gated inside the vector
-    /// service, so default builds are a pass-through.
-    pub async fn handle_record_search_for_tenant_abac(
         &self,
         request: RichSearchRequest,
         tenant_id: Option<&str>,
@@ -788,7 +775,7 @@ impl RecordOpsService {
         };
 
         self.vector_operations_service
-            .search_records_with_tenant_context_abac(
+            .search_records_with_tenant_context(
                 request,
                 tenant_context.as_ref(),
                 subject,
@@ -963,7 +950,7 @@ impl proximadb_runtime::RecordSearchPort for RecordOpsService {
         request: RichSearchRequest,
         tenant_id: Option<&str>,
     ) -> Result<RichSearchResponse> {
-        self.handle_record_search_for_tenant(request, tenant_id)
+        self.handle_record_search_for_tenant(request, tenant_id, None, None)
             .await
     }
 }

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1476,7 +1476,12 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             crate::observability::predicate_diagnostics::scope(async {
                 let outcome = self
                     .record_ops
-                    .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()))
+                    .handle_record_search_for_tenant(
+                        search_request,
+                        Some(tenant_id.as_str()),
+                        None,
+                        None,
+                    )
                     .await;
                 let tq = crate::observability::predicate_diagnostics::take_turboquant_hints();
                 (outcome, tq)
@@ -1559,7 +1564,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // Execute search
         let response = self
             .record_ops
-            .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()))
+            .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()), None, None)
             .await
             .map_err(|e| Status::internal(format!("Search stream failed: {}", e)))?;
 

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1686,7 +1686,7 @@ pub async fn search_with_typed_filters(
         crate::observability::predicate_diagnostics::scope(async {
             let outcome = state
                 .record_ops
-                .handle_record_search_for_tenant_abac(
+                .handle_record_search_for_tenant(
                     search_request,
                     Some(&tenant.tenant_id),
                     tenant.subject.as_deref(),

--- a/src/query/aql/sources/memory.rs
+++ b/src/query/aql/sources/memory.rs
@@ -271,6 +271,8 @@ impl AqlSource for MemoryAqlSource {
                 recall_k,
                 scope_filter,
                 None,
+                None,
+                None,
             )
             .await
             .map_err(|e| ProximaDBError::Query(QueryError::VectorSearch(e.to_string())))?;

--- a/src/query/aql/sources/vector.rs
+++ b/src/query/aql/sources/vector.rs
@@ -124,6 +124,8 @@ impl AqlSource for VectorAqlSource {
                 top_k as usize,
                 None, // No filter pushdown implemented in this skeleton
                 None, // No specific search config
+                None,
+                None,
             )
             .await
             .map_err(|e| {

--- a/src/query/execution/executor.rs
+++ b/src/query/execution/executor.rs
@@ -779,6 +779,8 @@ impl MultiModalQueryExecutor {
                     top_k,
                     filters.cloned(),
                     Some(search_config),
+                    None,
+                    None,
                 )
                 .await?
             } else {

--- a/src/query/facade/strategies/vector.rs
+++ b/src/query/facade/strategies/vector.rs
@@ -243,7 +243,7 @@ impl QueryStrategy for VectorSearchStrategy {
         );
 
         // Execute search through VectorOps
-        let response = self.vector_ops.search_v1(proto_request).await?;
+        let response = self.vector_ops.search_v1(proto_request, None, None).await?;
 
         let execution_time_ms = start.elapsed().as_millis() as u64;
 

--- a/src/query/federated/execution/mod.rs
+++ b/src/query/federated/execution/mod.rs
@@ -628,7 +628,7 @@ impl FederatedExecutor {
                 search_optimization: None,
             };
 
-            let response = vector_ops.search_v1(request).await?;
+            let response = vector_ops.search_v1(request, None, None).await?;
             let records = response
                 .results
                 .map(|result| result.results)

--- a/src/services/agent_memory.rs
+++ b/src/services/agent_memory.rs
@@ -557,7 +557,15 @@ impl MemoryStore for VectorMemoryStore {
         let vector = self.embedder.embed(&fact.text, &scope.tenant_id).await?;
         let results = self
             .vector_ops
-            .unified_search_v1(&scope.collection, vector, k, scope_filter(scope), None)
+            .unified_search_v1(
+                &scope.collection,
+                vector,
+                k,
+                scope_filter(scope),
+                None,
+                None,
+                None,
+            )
             .await
             .map_err(|e| anyhow!("memory retrieve failed: {e}"))?;
 

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -827,7 +827,7 @@ impl VectorOperationsService {
             .validate_tenant_collection_access(&req.collection_id, tenant_context)
             .await?
             .to_string();
-        self.search_v1(req).await
+        self.search_v1(req, None, None).await
     }
 
     /// Execute canonical rich-record vector search.
@@ -839,39 +839,14 @@ impl VectorOperationsService {
         &self,
         request: RichSearchRequest,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<RichSearchResponse> {
         // TD-METRICS-1: this — not the query-facade adapter — is the entry the
         // canonical REST v2 record search actually traverses (verified live:
         // the adapter-side counters never moved during the SIFT ratchet run).
         // Count + time here; the adapter keeps its own increments for the
         // facade surfaces, which do not route through this method.
-        let om_start = std::time::Instant::now();
-        crate::metrics::operational_metrics::QUERIES_TOTAL.inc();
-        let result = self
-            .search_records_with_tenant_context_inner(request, tenant_context, None, None)
-            .await;
-        if result.is_err() {
-            crate::metrics::operational_metrics::QUERIES_FAILED_TOTAL.inc();
-        }
-        crate::metrics::operational_metrics::SEARCH_LATENCY_SECONDS
-            .observe(om_start.elapsed().as_secs_f64());
-        result
-    }
-
-    /// ABAC-aware variant of [`search_records_with_tenant_context`] for the REST
-    /// records surface: threads the request subject + tenant stable id so a
-    /// provisioned policy admits/denies/filters the results (fail-closed on
-    /// deny). The gRPC/Flight twins still call the original (`None` subject ⇒ no
-    /// enforcement, unchanged) until their own slice adopts this variant. The
-    /// enforcement logic itself is `abac-policy`-gated inside `_inner`, so under
-    /// default builds this is a pass-through (subject ignored).
-    pub async fn search_records_with_tenant_context_abac(
-        &self,
-        request: RichSearchRequest,
-        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
-    ) -> Result<RichSearchResponse> {
         let om_start = std::time::Instant::now();
         crate::metrics::operational_metrics::QUERIES_TOTAL.inc();
         let result = self
@@ -908,32 +883,11 @@ impl VectorOperationsService {
         // survive to the search engine intact.
         let filter = rich_filters_to_filter_expression(&request.filters);
 
-        // TD-ABAC-5/6 (REST records): push the subject's accessibility predicate
-        // into the search — conjunctive ⇒ AND into `filter` (pushdown); non-
-        // conjunctive ⇒ `post_filter` applied to the results below. Fail-closed:
-        // a denied subject gets an empty response. `None` subject (the gRPC/Flight
-        // callers that still delegate with `None`) ⇒ System passthrough, i.e. the
-        // pre-feature behavior — no enforcement until those surfaces adopt `_abac`.
-        #[cfg(feature = "abac-policy")]
-        let (filter, post_filter) = match self
-            .records_read_context(subject, tenant_stable_id, &collection_id)
-            .await
-        {
-            Some(read_ctx) => self.apply_abac_vector_filter(filter, &read_ctx),
-            None => {
-                return Ok(RichSearchResponse {
-                    results: Vec::new(),
-                    total_found: 0,
-                    collection_id: Some(collection_id),
-                    predicate_shortfall: None,
-                });
-            }
-        };
-        #[cfg(not(feature = "abac-policy"))]
-        let _ = (subject, tenant_stable_id);
-
         // The rich path mirrors the previous `include_fields: None` defaults:
-        // metadata included, vectors excluded.
+        // metadata included, vectors excluded. ABAC enforcement is applied at the
+        // shared `unified_search_v1_inner` seam (TD-ABAC-5/6) via the threaded
+        // subject + tenant_stable_id — no per-endpoint ABAC here (the previous
+        // block was retired once the seam covered the records path).
         let response = self
             .run_unified_search_v1(
                 collection_id.clone(),
@@ -942,6 +896,8 @@ impl VectorOperationsService {
                 false,
                 true,
                 filter,
+                subject,
+                tenant_stable_id,
             )
             .await?;
         let Some(search_result) = response.results else {
@@ -954,22 +910,6 @@ impl VectorOperationsService {
         };
 
         let mut resp = v1_search_result_to_rich(search_result);
-
-        // ABAC post-filter: non-conjunctive security expressions (e.g. those that
-        // can't be AND'd into the ANN pushdown) are evaluated against each row's
-        // props here. Mirrors `post_filter_search_results` on the native path.
-        #[cfg(feature = "abac-policy")]
-        if let Some(security) = &post_filter {
-            use crate::core::search::sql_value_filter::proxima_value_to_json;
-            use crate::security::rls::filter_lattice::admits_with_security;
-            resp.results.retain(|r| {
-                admits_with_security(None, Some(security), &|field: &str| {
-                    r.props.get(field).map(proxima_value_to_json)
-                })
-            });
-            // A post-filtered result is a real "<top_k match the policy" outcome;
-            // recompute shortfall below accounts for the new length.
-        }
 
         // TD-064(a): authoritative shortfall recompute at the response
         // boundary — the TRUE final merged counts vs the user's `top_k`.
@@ -1398,6 +1338,8 @@ impl VectorOperationsService {
     pub async fn search_v1(
         &self,
         req: crate::proto::proximadb_v1::VectorSearchRequest,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         let collection_id = req.collection_id.clone();
         let top_k = req.top_k as usize;
@@ -1417,6 +1359,8 @@ impl VectorOperationsService {
             include_vectors,
             include_metadata,
             filter,
+            subject,
+            tenant_stable_id,
         )
         .await
     }
@@ -1438,6 +1382,8 @@ impl VectorOperationsService {
         include_vectors: bool,
         include_metadata: bool,
         filter: Option<FilterExpression>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         // P4 advisor observability: capture per-search latency so
         // the post-search hook can populate the recall-residual /
@@ -1459,7 +1405,15 @@ impl VectorOperationsService {
         });
 
         let results = self
-            .unified_search_v1(&collection_id, query_vector, top_k, filter, cfg)
+            .unified_search_v1(
+                &collection_id,
+                query_vector,
+                top_k,
+                filter,
+                cfg,
+                subject,
+                tenant_stable_id,
+            )
             .await?;
 
         let (results, total_count) = if let Some(r) = results.into_iter().next() {
@@ -2756,9 +2710,19 @@ impl VectorOperationsService {
         k: usize,
         filter: Option<FilterExpression>,
         config: Option<UnifiedSearchConfig>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<Vec<crate::proto::proximadb_v1::SearchResult>> {
         let (results, _explain) = self
-            .unified_search_v1_inner(collection_id, query_vector, k, filter, config)
+            .unified_search_v1_inner(
+                collection_id,
+                query_vector,
+                k,
+                filter,
+                config,
+                subject,
+                tenant_stable_id,
+            )
             .await?;
         Ok(results)
     }
@@ -2775,10 +2739,32 @@ impl VectorOperationsService {
         k: usize,
         filter: Option<FilterExpression>,
         config: Option<UnifiedSearchConfig>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<(
         Vec<crate::proto::proximadb_v1::SearchResult>,
         Option<crate::query::explain::VectorObjectEconomyExplain>,
     )> {
+        // ABAC seam (cache-safe — TD-ABAC-5/6): fold the subject's security
+        // predicate into `filter` BEFORE the cache key is derived below. The
+        // augmented filter becomes part of the cache key, so two subjects with
+        // different (conjunctive) policies never share an entry. The rare
+        // non-conjunctive case returns a `post_filter` AND makes us bypass the
+        // cache (re-bind `cache_hit` to None + skip the cache write), since its
+        // key can't distinguish subjects — see below. Denied ⇒ fail-closed empty.
+        #[cfg(feature = "abac-policy")]
+        let (filter, post_filter) = match self
+            .records_read_context(subject, tenant_stable_id, collection_id)
+            .await
+        {
+            None => return Ok((Vec::new(), None)),
+            Some(read_ctx) => self.apply_abac_vector_filter(filter, &read_ctx),
+        };
+        #[cfg(not(feature = "abac-policy"))]
+        let _ = (subject, tenant_stable_id);
+        #[cfg(not(feature = "abac-policy"))]
+        let post_filter: Option<FilterExpression> = None;
+
         // ADR-0083 D5: resolve the mutable name/alias once at the catalog
         // boundary. Every cache, WAL, AXIS, and storage lookup below is keyed
         // by the immutable numeric L1 identity.
@@ -2841,6 +2827,16 @@ impl VectorOperationsService {
                 .await
         } else {
             self.query_cache.get_if_fresh_v1(&cache_key, 300).await
+        };
+        // ABAC: a non-conjunctive post-filter can't be cached safely (its key
+        // can't distinguish subjects), so bypass the cache and recompute each
+        // time. Conjunctive security is already baked into the augmented cache
+        // key above, so a hit there is subject-specific and safe.
+        #[cfg(feature = "abac-policy")]
+        let cache_hit = if post_filter.is_some() {
+            None
+        } else {
+            cache_hit
         };
         if let Some(cached_v1) = cache_hit {
             // Phase 7.2: a process-local cache hit is the strongest
@@ -2921,6 +2917,18 @@ impl VectorOperationsService {
             )
             .await?;
 
+        // ABAC post-filter (non-conjunctive security predicates that couldn't be
+        // pushed into the ANN search): drop inadmissible rows from the merged
+        // result before conversion. Conjunctive security was already AND'd into
+        // the search filter above.
+        #[cfg(feature = "abac-policy")]
+        let merged_results = match &post_filter {
+            Some(security) => {
+                crate::security::rls::post_filter_search_results(merged_results, security)
+            }
+            None => merged_results,
+        };
+
         // Build v1 results from the merged records
         let v1_results = vec![self.optimized_results_to_proto_v1(
             merged_results,
@@ -2933,9 +2941,21 @@ impl VectorOperationsService {
         // write raced in during the search, the LSN has advanced past query_lsn,
         // so this entry simply won't be served to a later Strong read (it will
         // recompute) — conservative, never a stale hit.
-        self.query_cache
-            .cache_with_dependencies_v1_at_lsn(cache_key, v1_results.clone(), Vec::new(), query_lsn)
-            .await;
+        //
+        // ABAC: skip caching when a non-conjunctive post-filter applied — that
+        // entry's key (user filter only) can't distinguish subjects, so caching
+        // it would leak across subjects. Conjunctive security is already in the
+        // augmented cache key, so caching there is subject-specific and safe.
+        if post_filter.is_none() {
+            self.query_cache
+                .cache_with_dependencies_v1_at_lsn(
+                    cache_key,
+                    v1_results.clone(),
+                    Vec::new(),
+                    query_lsn,
+                )
+                .await;
+        }
 
         // Phase 7.2: record affinity on a successful v1 search.
         self.record_search_affinity(collection_id);
@@ -3622,7 +3642,7 @@ impl VectorOperationsService {
         // For StaleOk requests and cache hits the explain is None,
         // matching the helper's documented contract.
         let (results, explain) = self
-            .unified_search_v1_inner(collection_id, query_vector, k, filter, config)
+            .unified_search_v1_inner(collection_id, query_vector, k, filter, config, None, None)
             .await?;
         hints.vector_object_economy = explain;
         Ok((results, hints))
@@ -6240,6 +6260,8 @@ impl VectorQueryService for VectorOperationsService {
                 request.top_k,
                 filter,
                 None, // Use default config
+                None,
+                None,
             )
             .await
             .map_err(|e| proximadb_kernel::error::QueryError::VectorSearch(e.to_string()))?;
@@ -6308,7 +6330,7 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
         {
             request.collection_id = collection.id;
         }
-        self.search_v1(request).await
+        self.search_v1(request, None, None).await
     }
 
     /// TD-XMODAL-4 S2: the single canonical native kernel for both the pgvector

--- a/src/storage/entity_store_legacy.rs
+++ b/src/storage/entity_store_legacy.rs
@@ -658,6 +658,8 @@ impl EntityStore for ProximaEntityStore {
                         top_k,
                         core_filter.clone(),
                         Some(search_config),
+                        None,
+                        None,
                     )
                     .await?;
 

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! TD-ABAC-5/6 (REST records slice): proves ABAC enforcement FIRES on the REST
-//! record-search path (`search_records_with_tenant_context_abac`), not just the
+//! record-search path (`search_records_with_tenant_context`), not just the
 //! fusion/service seam.
 //!
 //! A `VectorOperationsService` is built with a durable ABAC enforcer; the REST
@@ -145,7 +145,7 @@ async fn admitted_subject_sees_only_accessible_records_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context_abac(request(), None, Some("alice"), Some(TENANT))
+        .search_records_with_tenant_context(request(), None, Some("alice"), Some(TENANT))
         .await
         .expect("abac search");
 
@@ -166,7 +166,7 @@ async fn denied_subject_gets_empty_results_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context_abac(request(), None, Some("mallory"), Some(TENANT))
+        .search_records_with_tenant_context(request(), None, Some("mallory"), Some(TENANT))
         .await
         .expect("abac search");
 
@@ -185,7 +185,7 @@ async fn none_subject_is_passthrough_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context_abac(request(), None, None, None)
+        .search_records_with_tenant_context(request(), None, None, None)
         .await
         .expect("abac search");
 


### PR DESCRIPTION
Retires the per-endpoint records-search `_abac` variant (#1373): ABAC now applies **once at the shared `unified_search_v1_inner` seam** that every search route funnels through — *"enforce where the search happens, not at each door."* This is the architectural fix discussed: `progressive_search`/v1-search are just doors to the same engine, so enforcement belongs at the engine seam, not per-endpoint.

## Change
- **`unified_search_v1_inner`** resolves the subject's `ReadContext` and folds the security predicate into `filter` **above the result cache** — cache-safe (the augmented filter is part of the cache key for conjunctive policies; the rare non-conjunctive case bypasses the cache + post-filters via `post_filter_search_results`). Denied ⇒ fail-closed empty. Mirrors the existing `unified_search_native` block.
- **Thread** `subject` + `tenant_stable_id` (non-cfg `Option`) through `search_v1` → `run_unified_search_v1` → `unified_search_v1` → `_inner`. Internal callers (federated/facade/aql/executor/agent-memory/embedded/postgres) pass `None` ⇒ `System` passthrough (today's behavior).
- **Records**: the #1373 `_abac` variants are removed; `search_records_with_tenant_context` + `handle_record_search_for_tenant` take + thread the subject. REST v2 records handler passes `tenant.subject`/`tenant_stable_id`; gRPC/Flight/internal pass `None`.

## Verification
- `cargo clippy -p proximadb --lib -- -D warnings` (default) ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- `cargo nextest run --test abac_rest_record_search_integration_test --features abac-policy` → **6/6 pass** — the records enforcement tests now exercise the **seam** (admit/deny/passthrough), proving the #1373 retirement is correct ✅
- `cargo fmt --check` ✅; `make work-commit-check` ✅

`abac-policy`-gated; default builds pass the subject through ignored (identical behavior).

## Follow-on (the v1/progressive bypass — NOT in this PR)
The v1/`progressive` REST surface currently delegates with `None` (passthrough). Closing that bypass requires threading the subject through two **cross-crate port traits** (`VectorOpsPort::search`, `ApiHandlersPort::handle_vector_search_v1_for_tenant` in runtime/api) — a layering-sensitive change isolated to its own focused PR.