### PR TITLE
docs(sst): TD-DELVEC-1 vestigial cleanup — status refresh + stale comments + WI-3b test bypass

### DIFF
--- a/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
+++ b/docs/10-quality/td/TD-DELVEC-1-cold-tier-deletion-vectors.adoc
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 = TD-DELVEC-1: Cold-tier deletion vectors (merge-on-read) — F3v
-:status: Draft — design gate (pre-implementation)
+:status: Implemented — WI-1..WI-6 merged; WI-7 descoped (§7.2-5)
 :date: 2026-07-27
 :authors: co-design session 2026-07-27
 :realizes: ADR-072 D14 (tier-split delete: MVCC visibility + deletion vectors in the immutable cold tier), refines D11/D13
@@ -10,7 +10,7 @@
 
 [cols="1,3"]
 |===
-| Status | **Rev 5 (2026-07-28) — WI-1, WI-2a, WI-2b merged; WI-2c next.** Hardened after a 3-agent red-team (2026-07-27; §7), a verification-first recon, a DeepSeek cross-model review (§9), and a rev-5 persistence correction (§9.4). The naïve §2 design is superseded by §7.2; §7.2 is folded into numbered WIs (§8). **Rev-5 correction:** the OID→position resolver is an **immutable write-time component → a region in the segment footer** (`opr_off/opr_len`, mirrors the RaBitQ/SQ8 region pattern), NOT a `.opr` sidecar — all write-time components land as regions in the one atomic segment file (crash/DR-safe); only the post-write-mutable DV is external (CAS'd manifest, §7.2-3). Earlier revs' §9 corrections stand. Additive, feature-gated `cold-deletion-vectors`, default path byte-for-byte unchanged. **~4–5w**; off the OLTP critical path.
+| Status | **Rev 6 (2026-08-01) — WI-1..WI-6 merged (#1274, #1275, #1282, #1322, #1327, #1352, #1362, #1363, #1365, #1372, #1377); WI-7 (conservative-purge watermark) intentionally descoped per §7.2-5 (long-lived snapshots not pinned — a DV-deleted row is physically dropped at compaction, matching today's tombstone reclaim); the WI-5 straddle/retry sub-piece (§9.2 T2) is moot on the PAX path (§9.1/§9.3 — the DV and OlapDeltaMerge are different cold paths that don't co-apply).** Hardened after a 3-agent red-team (2026-07-27; §7), a verification-first recon, a DeepSeek cross-model review (§9), and a rev-5 persistence correction (§9.4). The naïve §2 design is superseded by §7.2; §7.2 is folded into numbered WIs (§8). **Rev-5 correction:** the OID→position resolver is an **immutable write-time component → a region in the segment footer** (`opr_off/opr_len`, mirrors the RaBitQ/SQ8 region pattern), NOT a `.opr` sidecar — all write-time components land as regions in the one atomic segment file (crash/DR-safe); only the post-write-mutable DV is external (CAS'd manifest, §7.2-3). Additive, feature-gated `cold-deletion-vectors`, default path byte-for-byte unchanged. **Deferred (non-blocking):** compaction retire doesn't invalidate the engine's OID resolver cache (memory leak, correctness-safe); the WAL `path_resolver` ROOT-vs-PREFIX DI is unwired (latent — the SstEngine resolver gives write/read agreement).
 | Problem | The cold tier deletes via **LSM tombstones** (delete-marker records that cascade through levels and are physically removed only at compaction) — every cold delete implies an eventual **segment rewrite**. D14 wants **deletion vectors**: a position bitmap overlaying the *immutable* segment, applied **merge-on-read**, purged at compaction behind the reader watermark — no rewrite on delete.
 | Feature | `cold-deletion-vectors` (additive, feature-gated; default path = today's tombstone+compaction, byte-for-byte unchanged).
 |===

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1447,7 +1447,12 @@ impl Compaction {
 
         for vector_record in &resolved_records {
             // TD-DELVEC-1 WI-6: drop DV-deleted rows (checked before tombstone/
-            // expiry so a DV delete always wins).
+            // expiry so a DV delete always wins). WI-7 (conservative purge
+            // watermark) is intentionally descoped per TD §7.2-5: long-lived
+            // snapshots are NOT pinned — a DV-deleted row is physically dropped
+            // here regardless of any hypothetical older reader, matching today's
+            // tombstone-reclaim behavior. If a past-T (time-travel) reader is
+            // ever added, revisit this to carry recent deletes forward.
             #[cfg(feature = "cold-deletion-vectors")]
             if deleted_oids.contains(&vector_record.id) {
                 deleted_vector_ids.push(vector_record.id.clone());

--- a/src/storage/engines/sst/core.rs
+++ b/src/storage/engines/sst/core.rs
@@ -358,7 +358,8 @@ pub struct SstEngine {
     /// TD-DELVEC-1 WI-3a-remaining-A: durable, CAS'd per-segment deletion-vector
     /// store. Feature-gated `cold-deletion-vectors`. Per-engine (authoritative
     /// owned state, not a shared cache), keyed by segment path; lazy-filled on
-    /// first touch + reload. INERT until WI-3b wires the delete path.
+    /// first touch + reload. Wired end-to-end (WI-3b delete, WI-4 merge-on-read,
+    /// WI-5 recovery reconcile, WI-6 compaction).
     #[cfg(feature = "cold-deletion-vectors")]
     pub(crate) deletion_vector_store:
         Option<Arc<crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore>>,

--- a/src/storage/engines/sst/deletion_vector_store.rs
+++ b/src/storage/engines/sst/deletion_vector_store.rs
@@ -32,8 +32,11 @@
 //! `load`) and could evict+reload. No eviction/budget for the MVP — the store is
 //! bounded by segment count (unlike the byte-budgeted resolver cache).
 //!
-//! INERT: nothing calls this yet — the delete-path wiring is WI-3b (blocked on
-//! this store + the WAL-LSN plumbing). Feature-gated `cold-deletion-vectors`.
+//! Wired end-to-end (TD-DELVEC-1 WI-3b..WI-6): the delete path sets bits
+//! (`legacy.rs`), recovery re-marks them (`reconcile_deletion_vectors`),
+//! merge-on-read consults them (`search_pax_file_exact` + `try_pax_cascade`),
+//! and compaction reads + retires them (`build_deleted_oids` + retire loop).
+//! Feature-gated `cold-deletion-vectors`.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/storage/engines/sst/tests/cold_delete_dv_test.rs
+++ b/src/storage/engines/sst/tests/cold_delete_dv_test.rs
@@ -7,14 +7,9 @@
 //! → `is_deleted_as_of` is snapshot-correct → the bits survive a restart
 //! (disk-authoritative reload). In-crate so it can read the `pub(crate)` DV store.
 //!
-//! **Test-scope note:** the segment is located by a direct filesystem walk rather
-//! than `resolve_oid_positions`, because `list_collection_files` →
-//! `get_collection_storage_url` is currently a placeholder (`/data/collections/{id}`,
-//! ignoring the collection's `base_location`) — a follow-up (make
-//! `get_collection_storage_url` honor the collection's storage assignment) is the
-//! prerequisite for the full `legacy.rs → resolve → mark_deleted` delete path to be
-//! end-to-end testable + correct for non-default base locations. The legacy.rs glue
-//! itself is compilation/clippy-validated (see the WI-3b plan's test-gaps).
+//! The segment is located via the engine's own `discover_sstable_files` (the
+//! `get_collection_storage_url` placeholder was retired by #1352 — it now resolves
+//! the collection's real `base_location`).
 
 #[cfg(test)]
 mod tests {
@@ -24,12 +19,13 @@ mod tests {
     use anyhow::Result;
     use tempfile::TempDir;
 
+    use crate::core::search::SearchParams;
     use crate::proto::proximadb_v1::{
         Collection, CollectionConfig, StorageAssignment, StorageEngine, VectorRecord,
     };
     use crate::storage::engines::sst::{SstConfig, core::SstEngine};
     use crate::storage::persistence::filesystem::{FilesystemConfig, FilesystemFactory};
-    use crate::storage::traits::{FlushParameters, UnifiedStorageFormat};
+    use crate::storage::traits::{FlushParameters, StorageQueryContext, UnifiedStorageFormat};
     use proximadb_distance_kernel::engine::UnifiedDistanceCompute;
 
     fn collection(id: &str, temp_dir: &TempDir) -> Collection {
@@ -72,23 +68,6 @@ mod tests {
             .unwrap()
     }
 
-    /// Recursively find the first `.pax` segment under `dir` (the SST engine writes
-    /// segments under a `collection_data_path` subpath). Returns the LOCAL path.
-    fn find_pax_segment(dir: &std::path::Path) -> Option<String> {
-        let entries = std::fs::read_dir(dir).ok()?;
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                if let Some(p) = find_pax_segment(&path) {
-                    return Some(p);
-                }
-            } else if path.extension().and_then(|e| e.to_str()) == Some("pax") {
-                return path.to_str().map(String::from);
-            }
-        }
-        None
-    }
-
     #[tokio::test]
     async fn cold_delete_sets_versioned_dv_bit_on_a_flushed_segment() -> Result<()> {
         let temp_dir = TempDir::new()?;
@@ -119,11 +98,20 @@ mod tests {
         let res = engine.do_flush(&flush).await?;
         assert!(res.success, "flush should produce a cold segment");
 
-        // Locate the flushed segment directly (see the module doc — resolve_oid_positions
-        // is blocked by the get_collection_storage_url placeholder).
-        let pax_local =
-            find_pax_segment(temp_dir.path()).expect("flush should have produced a .pax segment");
-        let seg = format!("file://{pax_local}");
+        // Locate the flushed segment via the engine's own discovery (#1352 retired
+        // the get_collection_storage_url placeholder — it resolves base_location now).
+        let storage_url = StorageQueryContext::new(
+            Arc::new(SearchParams::default()),
+            Arc::new(collection.clone()),
+        )
+        .collection_storage_path()
+        .expect("ctx has a storage assignment");
+        let files = engine.discover_sstable_files(&storage_url).await?;
+        let seg = files
+            .iter()
+            .find(|f| f.ends_with(".pax"))
+            .cloned()
+            .expect("flush should have produced a .pax segment");
 
         let dv = engine
             .deletion_vector_store


### PR DESCRIPTION
## What

Audit-driven cleanup of the landed TD-DELVEC-1 (F3v) arc — **no behavioral change** (comments, docs, test-only). The comprehensive vestigial-items audit (in the comments) confirmed the arc is complete + correctly feature-gated; this PR clears the stale residue.

## Changes
- **TD-DELVEC-1 status refresh**: header `:status:` (Draft → Implemented) + the §status cell to Rev 6 — WI-1..WI-6 merged; **WI-7 (conservative-purge watermark) intentionally descoped per §7.2-5** (long-lived snapshots not pinned — a DV-deleted row is physically dropped at compaction, matching today's tombstone reclaim); the WI-5 straddle/retry sub-piece (§9.2 T2) is moot on the PAX path (§9.1/§9.3). Deferred items noted (resolver-cache invalidation on compaction retire; WAL `path_resolver` DI).
- **Stale "INERT" comments** dropped (`deletion_vector_store.rs` + `core.rs`) — the DV store is wired end-to-end (delete WI-3b, merge-on-read WI-4, recovery reconcile WI-5, compaction WI-6).
- **WI-7 descope rationale** documented at the compaction drop site (cites §7.2-5 + the "revisit if a past-T reader is added" note).
- **`cold_delete_dv_test`**: replaced the `find_pax_segment` fs-walk bypass with the engine's own `discover_sstable_files` (#1352 retired the `get_collection_storage_url` placeholder) + dropped the stale "blocked by placeholder" doc-note. The rewritten test passes.

## Verification
- `cargo fmt --all --check` (1.95.0) ✅
- `cargo check -p proximadb --lib` (default) ✅
- `cargo test -p proximadb --lib --features cold-deletion-vectors cold_delete_sets_versioned_dv_bit` → `1 passed` ✅

## Deferred (tracked in the TD's "Deferred" note, not this PR)
- **C2**: compaction retire doesn't invalidate the engine's OID resolver cache (memory leak, correctness-safe) — needs a `get_global_oid_resolver_cache` accessor (separate PR).
- **WAL `path_resolver` ROOT-vs-PREFIX**: latent (the SstEngine resolver gives write/read agreement); the WAL DI machinery is unused.