### PR TITLE
feat(abac): enforce provisioned policy on the REST v1/progressive search path (TD-ABAC-5/6)

### DIFF
--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -202,6 +202,8 @@ pub(crate) mod test_support {
             &self,
             request: VectorSearchRequest,
             tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> Result<VectorOperationResponse> {
             self.calls.lock().unwrap().push(ApiCall::VectorSearch {
                 tenant_id: tenant_id.map(ToOwned::to_owned),
@@ -337,6 +339,8 @@ pub(crate) mod test_support {
             &self,
             _request: VectorSearchRequest,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> Result<VectorOperationResponse> {
             Ok(VectorOperationResponse::default())
         }
@@ -449,6 +453,8 @@ mod tests {
                 ..VectorSearchRequest::default()
             },
             Some("tenant-a"),
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -592,7 +598,7 @@ mod tests {
         assert!(
             handlers
                 .vector_ops
-                .search(VectorSearchRequest::default(), None)
+                .search(VectorSearchRequest::default(), None, None, None)
                 .await
                 .unwrap()
                 .results

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -570,15 +570,19 @@ impl ApiHandlersPort for UnifiedHandlers {
         &self,
         request: VectorSearchRequest,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<VectorOperationResponse> {
-        self.vector_ops.search(request, tenant_id).await
+        self.vector_ops
+            .search(request, tenant_id, subject, tenant_stable_id)
+            .await
     }
 
     async fn handle_vector_search_v1(
         &self,
         request: VectorSearchRequest,
     ) -> Result<VectorOperationResponse> {
-        self.vector_ops.search(request, None).await
+        self.vector_ops.search(request, None, None, None).await
     }
 
     async fn handle_vector_batch_v1_for_tenant(
@@ -828,6 +832,8 @@ mod tests {
             &self,
             request: VectorSearchRequest,
             tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> Result<VectorOperationResponse> {
             self.calls
                 .lock()
@@ -1044,6 +1050,8 @@ mod tests {
                     ..VectorSearchRequest::default()
                 },
                 Some("tenant-a"),
+                None,
+                None,
             )
             .await
             .unwrap();

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -105,10 +105,14 @@ pub trait ApiHandlersPort: Send + Sync {
 
     // ── Vector ────────────────────────────────────────────────────────────────
 
+    /// `subject` + `tenant_stable_id` identify the authenticated principal for
+    /// ABAC enforcement at the shared search seam; `None` = no policy evaluation.
     async fn handle_vector_search_v1_for_tenant(
         &self,
         request: VectorSearchRequest,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<VectorOperationResponse>;
 
     async fn handle_vector_search_v1(

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -96,10 +96,16 @@ pub trait CollectionPort: Send + Sync {
 #[async_trait]
 pub trait VectorOpsPort: Send + Sync {
     /// Execute a vector search, tenant-scoped when `tenant_id` is provided.
+    ///
+    /// `subject` + `tenant_stable_id` identify the authenticated principal for
+    /// ABAC enforcement at the shared search seam (`unified_search_v1_inner`);
+    /// `None` means no policy evaluation (internal/unauthenticated callers).
     async fn search(
         &self,
         request: VectorSearchRequest,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> Result<VectorOperationResponse>;
 
     /// TD-XMODAL-4 S2: the **single canonical native vector-search kernel** — the

--- a/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
+++ b/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
@@ -1,0 +1,74 @@
+= TD-ABAC-7: Consolidate per-call identity params into one identity struct at the port seams
+:status: Open
+:dim: D5
+:pillar: SEC
+
+== Problem
+
+The cross-crate port traits now carry the caller identity as **three loose
+parameters** per method: `tenant_id: Option<&str>` (the authoritative
+string-scoping identity — catalog resolution, `DrPathBuilder` paths),
+`subject: Option<&str>` (the authenticated principal for ABAC), and
+`tenant_stable_id: Option<u64>` (the derived ADR-0083 account projection used
+as the policy-lookup key). The v1/progressive enforcement slice widened
+`VectorOpsPort::search` and `ApiHandlersPort::handle_vector_search_v1_for_tenant`
+to this 3-param shape (mirroring the `search_v1` seam signature from the
+records slice), and the records/get-by-id entry points
+(`search_records_with_tenant_context`, `search_v1`) carry the same triple.
+
+Three loose params per method is the smell:
+
+* every new enforcement surface re-ripples all port impls (the v1 slice touched
+  2 trait defs + 9 impls + ~6 callers, all mechanically);
+* the triple can drift apart (a caller passing `subject` without
+  `tenant_stable_id` silently disables policy resolution);
+* future identity fields (namespace scoping per ADR-074, request purpose /
+  billing class) would widen every signature again.
+
+Dropping `tenant_id` in favour of `tenant_stable_id` alone is NOT the fix: the
+string is the sole authoritative identity component (ADR-0083 composite;
+catalog + `DrPathBuilder` are string-keyed) and `tenant_stable_id` is optional
+until the default-tenant mint lands — collapsing to the u64 would add a
+reverse-lookup drift seam of exactly the class ADR-0083 retired.
+
+== Next action
+
+Introduce one small `Copy`-cheap identity struct (working name
+`PortIdentity<'a>` or reuse/extend the existing `#[cfg(abac-policy)]`
+`ReadContext` shape from the FA-enforcement track, made non-cfg):
+
+[source,rust]
+----
+pub struct PortIdentity<'a> {
+    pub tenant_id: Option<&'a str>,        // scoping/resolution (authoritative)
+    pub subject: Option<&'a str>,          // ABAC principal
+    pub tenant_stable_id: Option<u64>,     // ABAC policy key (derived)
+}
+----
+
+* Replace the loose triple on `VectorOpsPort::search`,
+  `ApiHandlersPort::handle_vector_search_v1_for_tenant`,
+  `search_v1`, `search_records_with_tenant_context` (+ the get-by-id twin)
+  with a single `identity: PortIdentity<'_>` param; provide
+  `PortIdentity::anonymous()` for internal/test callers and a
+  `From<&MiddlewareTenantContext>` bridge at the REST boundary (same pattern as
+  the namespace-isolation C seam).
+* One struct, one seam: gRPC/Flight adoption (their records twins currently
+  delegate `None`) then becomes "build the struct from `GrpcAuthContext`",
+  not another signature ripple.
+
+== Key locations
+
+* `crates/platform/proximadb-runtime/src/service_ports.rs` (`VectorOpsPort::search`)
+* `crates/platform/proximadb-runtime/src/port.rs` (`ApiHandlersPort`)
+* `src/services/operations/vectors/legacy.rs` (`search_v1`,
+  `search_records_with_tenant_context`, port impls)
+* `src/network/middleware/tenant.rs` (`MiddlewareTenantContext` — the source
+  of all three fields)
+
+== Dependencies / sequencing
+
+* After the v1/progressive enforcement PR (this TD's trigger) merges.
+* Coordinate with the gRPC/Flight ABAC follow-ons — doing the struct first
+  makes those slices smaller; doing it after makes it a 3-surface refactor.
+* Behavior-preserving; no wire/SDK impact (internal ports only).

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -1141,6 +1141,8 @@ mod tests {
             &self,
             _request: VectorSearchRequest,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> anyhow::Result<VectorOperationResponse> {
             let results = self
                 .matches
@@ -1746,6 +1748,8 @@ mod tests {
             &self,
             _request: VectorSearchRequest,
             tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> anyhow::Result<VectorOperationResponse> {
             self.seen
                 .lock()

--- a/src/network/hybrid_search.rs
+++ b/src/network/hybrid_search.rs
@@ -128,7 +128,7 @@ impl HybridPort for RestHybridPortImpl {
             };
             let resp = self
                 .vector_ops
-                .search(search_request, None)
+                .search(search_request, None, None, None)
                 .await
                 .map_err(|e| anyhow!("Vector search failed: {}", e))?;
             resp.results
@@ -530,6 +530,8 @@ mod tests {
             &self,
             request: proximadb_v1::VectorSearchRequest,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> Result<proximadb_v1::VectorOperationResponse> {
             *self.last_request.lock().unwrap() = Some(request);
             Ok(proximadb_v1::VectorOperationResponse {

--- a/src/network/rest/canonical/rank_backend.rs
+++ b/src/network/rest/canonical/rank_backend.rs
@@ -122,12 +122,14 @@ impl HybridSearchBackend for ProductionHybridBackend {
             search_optimization: None,
         };
 
-        let response = self.vector_ops.search(request, None).await.map_err(|err| {
-            RankError::ModelInference {
+        let response = self
+            .vector_ops
+            .search(request, None, None, None)
+            .await
+            .map_err(|err| RankError::ModelInference {
                 model_id: "production_hybrid_backend.vector".to_string(),
                 reason: format!("vector search failed for '{collection}': {err}"),
-            }
-        })?;
+            })?;
 
         let results = response
             .results
@@ -187,6 +189,8 @@ mod tests {
             &self,
             request: VectorSearchRequest,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> anyhow::Result<VectorOperationResponse> {
             *self.last_request.lock().unwrap() = Some(request.clone());
             if let Some(reason) = self.fail_with.lock().unwrap().clone() {

--- a/src/network/rest/progressive_search_handler.rs
+++ b/src/network/rest/progressive_search_handler.rs
@@ -42,7 +42,12 @@ pub async fn progressive_search_handler(
     // Delegate directly to unified v1 handler
     let resp = state
         .api_handlers
-        .handle_vector_search_v1_for_tenant(request, Some(&tenant.tenant_id))
+        .handle_vector_search_v1_for_tenant(
+            request,
+            Some(&tenant.tenant_id),
+            tenant.subject.as_deref(),
+            tenant.tenant_stable_id,
+        )
         .await
         .map_err(|e| {
             error!(

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -3414,6 +3414,8 @@ mod rank_services_wiring_tests {
             &self,
             _request: crate::proto::proximadb_v1::VectorSearchRequest,
             _tenant_id: Option<&str>,
+            _subject: Option<&str>,
+            _tenant_stable_id: Option<u64>,
         ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
             Ok(crate::proto::proximadb_v1::VectorOperationResponse {
                 success: true,

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -6372,6 +6372,8 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
         &self,
         mut request: crate::proto::proximadb_v1::VectorSearchRequest,
         tenant_id: Option<&str>,
+        subject: Option<&str>,
+        tenant_stable_id: Option<u64>,
     ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         // TD-XMODAL-8: the cross-modal `vector_search` UDTF reaches this port carrying the pgwire
         // connection tenant. Resolve the collection UNDER that tenant — the same tenant-scoped
@@ -6389,7 +6391,7 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
         {
             request.collection_id = collection.id;
         }
-        self.search_v1(request, None, None).await
+        self.search_v1(request, subject, tenant_stable_id).await
     }
 
     /// TD-XMODAL-4 S2: the single canonical native kernel for both the pgvector

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -21,6 +21,12 @@
 //! regardless of the collection's catalog object id (the test harness mints
 //! name-shaped ids that don't parse as the numeric object id).
 //!
+//! The `v1_*` tests prove the same enforcement on the **v1 search path**
+//! (`search_v1` — the entry the REST v1 + `/progressive/search` routes reach via
+//! `ApiHandlersPort::handle_vector_search_v1_for_tenant` → `VectorOpsPort::search`;
+//! progressive is a thin delegate to the same v1 handler, so one v1 test covers
+//! both routes).
+//!
 //! Default-OFF: this file compiles only under `--features abac-policy`.
 
 #![cfg(all(test, feature = "abac-policy"))]
@@ -110,6 +116,30 @@ fn request() -> RichSearchRequest {
         top_k: 10,
         filters: vec![],
     }
+}
+
+/// The proto-typed request the v1 REST + progressive routes carry.
+fn v1_request() -> proximadb::proto::proximadb_v1::VectorSearchRequest {
+    proximadb::proto::proximadb_v1::VectorSearchRequest {
+        collection_id: COLLECTION.to_string(),
+        queries: vec![proximadb::proto::proximadb_v1::SearchQuery {
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+            filters: Default::default(),
+            advanced_filter: None,
+        }],
+        top_k: 10,
+        include_fields: None,
+        search_params: None,
+        distance_metric_override: None,
+        search_optimization: None,
+    }
+}
+
+fn v1_result_ids(resp: &proximadb::proto::proximadb_v1::VectorOperationResponse) -> Vec<String> {
+    resp.results
+        .as_ref()
+        .map(|r| r.results.iter().map(|rec| rec.id.clone()).collect())
+        .unwrap_or_default()
 }
 
 /// Build the service + collection + records once; the per-subject assertions
@@ -270,5 +300,60 @@ async fn none_subject_is_passthrough_on_getbyid_path() {
     assert!(
         resp.is_some(),
         "a None subject (gRPC/internal path) may GET the record (passthrough)"
+    );
+}
+
+/// v1/progressive path: an admitted subject sees only `dept=eng` records.
+#[tokio::test]
+async fn v1_admitted_subject_sees_only_accessible_records() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_v1(v1_request(), Some("alice"), Some(TENANT))
+        .await
+        .expect("v1 abac search");
+
+    let ids = v1_result_ids(&resp);
+    assert!(
+        ids.iter().any(|id| id == OID_ENG),
+        "alice (dept=eng) must see the eng record on the v1 path; got {ids:?}"
+    );
+    assert!(
+        !ids.iter().any(|id| id == OID_HR),
+        "the hr record must be filtered out on the v1 path; got {ids:?}"
+    );
+}
+
+/// v1/progressive path: a denied subject gets an EMPTY result — fail-closed.
+#[tokio::test]
+async fn v1_denied_subject_gets_empty_results() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_v1(v1_request(), Some("mallory"), Some(TENANT))
+        .await
+        .expect("v1 abac search");
+
+    let ids = v1_result_ids(&resp);
+    assert!(
+        ids.is_empty(),
+        "mallory (unbound) must be denied on the v1 path — empty results (fail-closed); got {ids:?}"
+    );
+}
+
+/// v1/progressive path: a `None` subject (internal callers) is passthrough.
+#[tokio::test]
+async fn v1_none_subject_is_passthrough() {
+    let (svc, _collections) = fixture().await;
+
+    let resp = svc
+        .search_v1(v1_request(), None, None)
+        .await
+        .expect("v1 search");
+
+    let ids = v1_result_ids(&resp);
+    assert!(
+        ids.iter().any(|id| id == OID_ENG) && ids.iter().any(|id| id == OID_HR),
+        "a None subject must see both records on the v1 path (passthrough); got {ids:?}"
     );
 }


### PR DESCRIPTION
## Summary

Closes the **last REST scalar-read ABAC bypass**: the v1 search and `/api/v2/progressive/search` routes delegated `subject=None` through two cross-crate port traits, so the authenticated principal never reached the shared enforcement seam (`unified_search_v1_inner`, #1379). With this PR, the full REST scalar-read surface (records search #1373/#1379, get-by-id #1376, v1/progressive) enforces a provisioned policy at the single seam.

- `ApiHandlersPort::handle_vector_search_v1_for_tenant` and `VectorOpsPort::search` now carry `subject: Option<&str>` + `tenant_stable_id: Option<u64>` (non-cfg Options; `None` = no policy evaluation, so internal callers are behavior-unchanged).
- `progressive_search_handler` passes the real `tenant.subject` / `tenant.tenant_stable_id` from the tenant middleware (progressive is a thin delegate to the v1 handler — the cascade is engine-level — so enforcement lands at the seam, not per-endpoint).
- The real `VectorOpsPort::search` impl threads the identity to `search_v1` (the seam entry) instead of hardcoding `None, None`; the 7 test/mock port impls ignore the new params.
- Files **TD-ABAC-7**: consolidate the `{tenant_id, subject, tenant_stable_id}` triple into one identity struct at the port seams (this PR keeps the mechanical 3-param shape to mirror the #1379 seam signature; the struct is the right follow-on before the gRPC/Flight slices).

## Tests

`tests/abac_rest_record_search_integration_test.rs` (+3, mirroring the records tests; `--features abac-policy`):
- `v1_admitted_subject_sees_only_accessible_records` — alice (dept=eng) sees only the eng record.
- `v1_denied_subject_gets_empty_results` — mallory (unbound) gets empty, fail-closed.
- `v1_none_subject_is_passthrough` — internal callers unchanged.

9/9 pass under nextest (3 records regression + 3 v1 + 3 harness), re-verified post-rebase onto develop.

## Verification

- `cargo clippy --workspace --all-targets --features abac-policy -- -D warnings` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` (default config) ✅
- `cargo fmt --check` ✅ · `make work-commit-check` ✅ · `check_td_adr_unique.py` ✅

## Follow-ons (not this PR)

- TD-ABAC-7 (filed here): port-seam identity struct.
- SQL TODO (`canonical/handlers.rs` passes None) + gRPC/Flight records twins thread their own subject source (`GrpcAuthContext`).
- Any retirement/canonicalization of the proto-v1-shaped REST search routes is an API-surface/spec decision (SDK regen per mandate 15) — orthogonal to closing this enforcement gap.