### PR TITLE
fix(storage): bound compaction memory and enforce AXIS gates

### DIFF
--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -847,6 +847,31 @@ pub struct CompactionConfig {
 
     /// Target output file size in MB for size-based compaction.
     pub target_file_size_mb: usize,
+
+    /// Conservative peak-memory estimate per byte of input segment data.
+    ///
+    /// The initial `12.0` default includes headroom over the 9.85x incremental
+    /// RSS measured by the 3.3M-vector PAX compaction benchmark. This is an
+    /// admission estimate, not an allocation limit; operators can tighten it
+    /// as the streaming writer reduces measured amplification.
+    #[serde(default = "default_compaction_memory_amplification")]
+    pub memory_amplification_factor: f64,
+
+    /// Maximum share of process-visible capacity reserved for compactions.
+    /// Process-visible capacity is cgroup-constrained in containers.
+    #[serde(default = "default_compaction_memory_budget_fraction")]
+    pub memory_budget_fraction: f64,
+
+    /// Maximum share of currently available memory that compactions may
+    /// reserve. This live-pressure guard is applied in addition to the stable
+    /// capacity fraction.
+    #[serde(default = "default_compaction_available_memory_fraction")]
+    pub available_memory_fraction: f64,
+
+    /// Optional absolute ceiling for all in-flight compaction reservations.
+    /// Zero means automatic sizing from capacity and live availability.
+    #[serde(default)]
+    pub max_memory_mb: u64,
 }
 
 impl Default for CompactionConfig {
@@ -859,12 +884,28 @@ impl Default for CompactionConfig {
             max_levels: 7,
             strategy: "hybrid".to_string(),
             target_file_size_mb: 128,
+            memory_amplification_factor: default_compaction_memory_amplification(),
+            memory_budget_fraction: default_compaction_memory_budget_fraction(),
+            available_memory_fraction: default_compaction_available_memory_fraction(),
+            max_memory_mb: 0,
         }
     }
 }
 
 fn default_higher_level_file_threshold() -> usize {
     2
+}
+
+fn default_compaction_memory_amplification() -> f64 {
+    12.0
+}
+
+fn default_compaction_memory_budget_fraction() -> f64 {
+    0.25
+}
+
+fn default_compaction_available_memory_fraction() -> f64 {
+    0.5
 }
 
 /// Performance optimization configuration.

--- a/crates/foundation/proximadb-config/src/lib.rs
+++ b/crates/foundation/proximadb-config/src/lib.rs
@@ -921,15 +921,13 @@ pub struct OptimizationConfig {
 
     /// Enable AXIS indexes for approximate nearest neighbor search.
     ///
-    /// Default is `false` per ADR-070: the co-design PAX scan + survivor cache
-    /// is the default ANN path (recall@10=0.999, ~0.5ms hot for ~600 MB RAM
-    /// per collection, vs AXIS at ~1ms for ~8.6 GB RAM). AXIS remains
-    /// available per collection via `index_configs` (the #1145 gate:
-    /// `pax_off || !index_configs.is_empty()`), independent of this flag.
-    /// NOTE (TD-AXIS-2): this flag is not yet wired to boot-time AxisManager
-    /// initialization — the manager still constructs at startup either way;
-    /// the per-collection gate is what keeps AXIS cost off co-design
-    /// collections today.
+    /// Runtime master switch; the Cargo `axis` feature must also be compiled
+    /// and the collection must explicitly declare `index_configs`. Default is
+    /// `false` per ADR-070: the co-design PAX scan + survivor cache is the
+    /// default ANN path. The lightweight manager value may still be
+    /// constructed to keep the compile-time type graph stable, but it is not
+    /// registered with serving and no AXIS maintenance loops start while this
+    /// flag is false.
     #[serde(default = "default_enable_axis_indexes")]
     pub enable_axis_indexes: bool,
 

--- a/crates/foundation/proximadb-hardware/src/lib.rs
+++ b/crates/foundation/proximadb-hardware/src/lib.rs
@@ -20,6 +20,18 @@
 
 use std::sync::OnceLock;
 
+/// Dynamic memory capacity visible to this process.
+///
+/// Unlike [`HardwareCapabilities`], this value is refreshed for each call and
+/// is constrained by the active cgroup when one exists. That distinction is
+/// important for admission control: `sysinfo` may report the host's RAM to a
+/// container whose actual memory limit is much smaller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemorySnapshot {
+    pub total_bytes: u64,
+    pub available_bytes: u64,
+}
+
 /// Detected hardware capabilities (SIMD, CPU count, memory).
 ///
 /// Memory is stored in bytes (not MB) because every real consumer does size
@@ -107,9 +119,8 @@ impl HardwareCapabilities {
     }
 
     fn detect_memory_bytes() -> (u64, u64) {
-        let mut sys = sysinfo::System::new_all();
-        sys.refresh_memory();
-        (sys.total_memory(), sys.available_memory())
+        let snapshot = memory_snapshot();
+        (snapshot.total_bytes, snapshot.available_bytes)
     }
 
     /// Return the best available SIMD instruction set.
@@ -126,6 +137,83 @@ impl HardwareCapabilities {
             SimdLevel::Scalar
         }
     }
+}
+
+/// Refresh host memory and constrain it to the process cgroup, if present.
+pub fn memory_snapshot() -> MemorySnapshot {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    effective_memory_snapshot(
+        sys.total_memory(),
+        sys.available_memory(),
+        detect_cgroup_memory(),
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CgroupMemory {
+    limit_bytes: u64,
+    current_bytes: u64,
+}
+
+fn effective_memory_snapshot(
+    host_total_bytes: u64,
+    host_available_bytes: u64,
+    cgroup: Option<CgroupMemory>,
+) -> MemorySnapshot {
+    let Some(cgroup) = cgroup.filter(|value| value.limit_bytes > 0) else {
+        return MemorySnapshot {
+            total_bytes: host_total_bytes,
+            available_bytes: host_available_bytes.min(host_total_bytes),
+        };
+    };
+
+    let total_bytes = host_total_bytes.min(cgroup.limit_bytes);
+    let cgroup_available = cgroup.limit_bytes.saturating_sub(cgroup.current_bytes);
+    MemorySnapshot {
+        total_bytes,
+        available_bytes: host_available_bytes.min(cgroup_available).min(total_bytes),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn detect_cgroup_memory() -> Option<CgroupMemory> {
+    detect_cgroup_v2().or_else(detect_cgroup_v1)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn detect_cgroup_memory() -> Option<CgroupMemory> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn detect_cgroup_v2() -> Option<CgroupMemory> {
+    let limit = read_cgroup_number("/sys/fs/cgroup/memory.max")?;
+    let current = read_cgroup_number("/sys/fs/cgroup/memory.current").unwrap_or(0);
+    Some(CgroupMemory {
+        limit_bytes: limit,
+        current_bytes: current,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn detect_cgroup_v1() -> Option<CgroupMemory> {
+    let limit = read_cgroup_number("/sys/fs/cgroup/memory/memory.limit_in_bytes")?;
+    let current = read_cgroup_number("/sys/fs/cgroup/memory/memory.usage_in_bytes").unwrap_or(0);
+    Some(CgroupMemory {
+        limit_bytes: limit,
+        current_bytes: current,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_cgroup_number(path: &str) -> Option<u64> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value = text.trim();
+    if value == "max" {
+        return None;
+    }
+    value.parse::<u64>().ok()
 }
 
 /// SIMD instruction set levels ordered from weakest to strongest.
@@ -190,5 +278,37 @@ mod tests {
         let default = HardwareCapabilities::default();
         assert_eq!(detected.cpu_count, default.cpu_count);
         assert_eq!(detected.has_avx2, default.has_avx2);
+    }
+
+    #[test]
+    fn cgroup_limit_constrains_host_memory() {
+        let gib = 1024 * 1024 * 1024;
+        let snapshot = effective_memory_snapshot(
+            64 * gib,
+            40 * gib,
+            Some(CgroupMemory {
+                limit_bytes: 8 * gib,
+                current_bytes: 3 * gib,
+            }),
+        );
+
+        assert_eq!(snapshot.total_bytes, 8 * gib);
+        assert_eq!(snapshot.available_bytes, 5 * gib);
+    }
+
+    #[test]
+    fn host_availability_remains_the_tighter_constraint() {
+        let gib = 1024 * 1024 * 1024;
+        let snapshot = effective_memory_snapshot(
+            64 * gib,
+            2 * gib,
+            Some(CgroupMemory {
+                limit_bytes: 8 * gib,
+                current_bytes: gib,
+            }),
+        );
+
+        assert_eq!(snapshot.total_bytes, 8 * gib);
+        assert_eq!(snapshot.available_bytes, 2 * gib);
     }
 }

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/rabitq.rs
@@ -53,6 +53,29 @@ pub struct RaBitQCode {
     pub inv_factor: f32,
 }
 
+/// Reusable per-worker storage for RaBitQ encoding.
+///
+/// Segment encoders process millions of rows. Allocating residual, normalized,
+/// and rotated vectors for every row causes allocator fragmentation and a large
+/// retained-RSS tail even though only a handful of rows are active at once.
+/// One scratch value per worker bounds those allocations to `O(workers * dim)`.
+#[derive(Debug, Default)]
+pub struct RaBitQEncodeScratch {
+    residual: Vec<f32>,
+    unit: Vec<f32>,
+    rotated: Vec<f32>,
+}
+
+impl RaBitQEncodeScratch {
+    pub fn new(dim: usize) -> Self {
+        Self {
+            residual: Vec::with_capacity(dim),
+            unit: Vec::with_capacity(dim),
+            rotated: Vec::with_capacity(dim),
+        }
+    }
+}
+
 /// SplitMix64 — a tiny, dependency-free deterministic PRNG so the rotation is
 /// reproducible from `seed` on both encode and decode.
 struct SplitMix64(u64);
@@ -205,27 +228,86 @@ fn packed_len(dim: usize) -> usize {
 /// Encode one vector to a [`RaBitQCode`] using a prebuilt `rotation`
 /// (`build_rotation(params.dim, params.seed)`).
 pub fn encode(vector: &[f32], params: &RaBitQParams, rotation: &[f32]) -> RaBitQCode {
+    let mut scratch = RaBitQEncodeScratch::new(params.dim);
+    let mut bits = vec![0u8; packed_len(params.dim)];
+    let encoded = encode_into(vector, params, rotation, &mut bits, &mut scratch);
+    let (dist_to_centroid, inv_factor) = encoded.unwrap_or((0.0, 0.0));
+    RaBitQCode {
+        bits,
+        dist_to_centroid,
+        inv_factor,
+    }
+}
+
+/// Encode into caller-owned bits using reusable scratch storage.
+///
+/// The arithmetic order intentionally matches [`encode`] so the optimized
+/// segment writer remains byte-identical to the established on-disk format.
+/// Returns `(distance_to_centroid, inverse_factor)`.
+pub fn encode_into(
+    vector: &[f32],
+    params: &RaBitQParams,
+    rotation: &[f32],
+    bits: &mut [u8],
+    scratch: &mut RaBitQEncodeScratch,
+) -> Result<(f32, f32)> {
     let dim = params.dim;
+    if dim == 0 {
+        bail!("RaBitQ encode requires dim > 0");
+    }
+    if vector.len() != dim || params.centroid.len() != dim {
+        bail!(
+            "RaBitQ encode dimension mismatch: vector={}, centroid={}, dim={dim}",
+            vector.len(),
+            params.centroid.len()
+        );
+    }
+    if rotation.len() != dim.saturating_mul(dim) {
+        bail!(
+            "RaBitQ rotation length {} != dim squared {}",
+            rotation.len(),
+            dim.saturating_mul(dim)
+        );
+    }
+    if bits.len() != packed_len(dim) {
+        bail!(
+            "RaBitQ output length {} != packed length {}",
+            bits.len(),
+            packed_len(dim)
+        );
+    }
+
     // residual = v - centroid
-    let residual: Vec<f32> = vector
-        .iter()
-        .zip(params.centroid.iter())
-        .map(|(&v, &c)| v - c)
-        .collect();
-    let dist_to_centroid = residual.iter().map(|v| v * v).sum::<f32>().sqrt();
+    scratch.residual.clear();
+    scratch.residual.extend(
+        vector
+            .iter()
+            .zip(params.centroid.iter())
+            .map(|(&v, &c)| v - c),
+    );
+    let dist_to_centroid = scratch.residual.iter().map(|v| v * v).sum::<f32>().sqrt();
 
     // unit residual, then rotate.
-    let unit: Vec<f32> = if dist_to_centroid > 1e-12 {
-        residual.iter().map(|v| v / dist_to_centroid).collect()
+    scratch.unit.clear();
+    if dist_to_centroid > 1e-12 {
+        scratch
+            .unit
+            .extend(scratch.residual.iter().map(|v| v / dist_to_centroid));
     } else {
-        vec![0.0; dim]
-    };
-    let rotated = apply_rotation(rotation, &unit);
+        scratch.unit.resize(dim, 0.0);
+    }
+    scratch.rotated.clear();
+    scratch.rotated.extend(rotation.chunks(dim).map(|row| {
+        row.iter()
+            .zip(&scratch.unit)
+            .map(|(a, b)| a * b)
+            .sum::<f32>()
+    }));
 
     // sign bits + factor = <x̄, õ> = (1/√D) Σ|õ_i|
-    let mut bits = vec![0u8; packed_len(dim)];
+    bits.fill(0);
     let mut abs_sum = 0.0f32;
-    for (i, &val) in rotated.iter().enumerate() {
+    for (i, &val) in scratch.rotated.iter().enumerate() {
         if val >= 0.0 {
             bits[i / 8] |= 1u8 << (i % 8);
         }
@@ -235,11 +317,7 @@ pub fn encode(vector: &[f32], params: &RaBitQParams, rotation: &[f32]) -> RaBitQ
     let factor = inv_sqrt_d * abs_sum; // ⟨x̄, õ⟩ ∈ [0,1]
     let inv_factor = if factor > 1e-6 { 1.0 / factor } else { 0.0 };
 
-    RaBitQCode {
-        bits,
-        dist_to_centroid,
-        inv_factor,
-    }
+    Ok((dist_to_centroid, inv_factor))
 }
 
 /// Rotate a query's residual once per query: `q̃ = P · (query − centroid)`.
@@ -557,6 +635,80 @@ mod tests {
             let set = code.bits[i / 8] & (1u8 << (i % 8)) != 0;
             assert_eq!(set, val >= 0.0, "bit {i} sign mismatch");
         }
+    }
+
+    #[test]
+    fn reusable_encode_is_byte_identical_and_rejects_bad_shapes() {
+        let dim = 32;
+        let seed = 73;
+        let corpus = [
+            (0..dim).map(|i| i as f32 * 0.25).collect::<Vec<_>>(),
+            (0..dim).map(|i| (i as f32 * 0.3).sin()).collect::<Vec<_>>(),
+        ];
+        let refs = corpus.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let params = fit_params(&refs, dim, seed);
+        let rotation = build_rotation(dim, seed);
+        // Allocation-heavy reference retained in the test to pin the exact
+        // arithmetic order and therefore the persisted code bytes.
+        let residual = corpus[1]
+            .iter()
+            .zip(&params.centroid)
+            .map(|(&value, &centroid)| value - centroid)
+            .collect::<Vec<_>>();
+        let expected_distance = residual
+            .iter()
+            .map(|value| value * value)
+            .sum::<f32>()
+            .sqrt();
+        let unit = if expected_distance > 1e-12 {
+            residual
+                .iter()
+                .map(|value| value / expected_distance)
+                .collect::<Vec<_>>()
+        } else {
+            vec![0.0; dim]
+        };
+        let rotated = apply_rotation(&rotation, &unit);
+        let mut expected_bits = vec![0u8; dim.div_ceil(8)];
+        let mut abs_sum = 0.0f32;
+        for (index, &value) in rotated.iter().enumerate() {
+            if value >= 0.0 {
+                expected_bits[index / 8] |= 1u8 << (index % 8);
+            }
+            abs_sum += value.abs();
+        }
+        let factor = abs_sum / (dim as f32).sqrt();
+        let expected_inverse = if factor > 1e-6 { 1.0 / factor } else { 0.0 };
+        let mut bits = vec![0u8; dim.div_ceil(8)];
+        let mut scratch = RaBitQEncodeScratch::new(dim);
+        let (distance, inverse) =
+            encode_into(&corpus[1], &params, &rotation, &mut bits, &mut scratch)
+                .expect("valid shapes encode");
+        assert_eq!(bits, expected_bits);
+        assert_eq!(distance.to_bits(), expected_distance.to_bits());
+        assert_eq!(inverse.to_bits(), expected_inverse.to_bits());
+
+        assert!(
+            encode_into(
+                &corpus[1][..dim - 1],
+                &params,
+                &rotation,
+                &mut bits,
+                &mut scratch
+            )
+            .is_err()
+        );
+        let short_len = bits.len() - 1;
+        assert!(
+            encode_into(
+                &corpus[1],
+                &params,
+                &rotation,
+                &mut bits[..short_len],
+                &mut scratch
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/horizontal/proximadb-codec/src/baseline/functions/sq8.rs
+++ b/crates/horizontal/proximadb-codec/src/baseline/functions/sq8.rs
@@ -58,9 +58,19 @@ impl Sq8Params {
 /// be represented by SQ8 and are carried via the null bitmap at the stripe
 /// layer). An empty / all-non-finite input yields a degenerate `[0, 0]` range.
 pub fn fit_params(values: &[f32]) -> Sq8Params {
+    fit_params_iter(values.iter().copied())
+}
+
+/// Fit SQ8 parameters from a stream of values without first flattening a
+/// segmented column into a second full-size `Vec<f32>`.
+///
+/// This is the canonical fitting kernel for both contiguous and segmented
+/// inputs. Keeping the reduction here prevents storage writers from copying an
+/// entire vector corpus merely to discover its min/max bounds.
+pub fn fit_params_iter(values: impl IntoIterator<Item = f32>) -> Sq8Params {
     let mut vmin = f32::INFINITY;
     let mut vmax = f32::NEG_INFINITY;
-    for &v in values {
+    for v in values {
         if v.is_finite() {
             if v < vmin {
                 vmin = v;
@@ -317,6 +327,18 @@ mod tests {
         assert_eq!(params.vmin, 0.0);
         assert_eq!(params.vmax, 1.0);
         assert_eq!(quantize_one(f32::NAN, &params), 0);
+    }
+
+    #[test]
+    fn streamed_fit_is_identical_to_contiguous_fit() {
+        let rows = [vec![-3.0, f32::NAN, 0.25], vec![7.5, f32::INFINITY, -1.25]];
+        let contiguous = rows.iter().flatten().copied().collect::<Vec<_>>();
+        let expected = fit_params(&contiguous);
+        let actual = fit_params_iter(rows.iter().flatten().copied());
+        assert_eq!(actual.scale.to_bits(), expected.scale.to_bits());
+        assert_eq!(actual.offset.to_bits(), expected.offset.to_bits());
+        assert_eq!(actual.vmin.to_bits(), expected.vmin.to_bits());
+        assert_eq!(actual.vmax.to_bits(), expected.vmax.to_bits());
     }
 
     #[test]

--- a/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
@@ -32,9 +32,11 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{Result, bail};
+#[cfg(test)]
+use proximadb_codec::functions::rabitq::encode;
 use proximadb_codec::functions::rabitq::{
-    QueryLut, build_rotation, build_rotation_cached, encode, fit_params, rank_candidates,
-    rank_candidates_ip, rotate_query,
+    QueryLut, RaBitQEncodeScratch, build_rotation, build_rotation_cached, encode_into, fit_params,
+    rank_candidates, rank_candidates_ip, rotate_query,
 };
 use proximadb_codec::{RaBitQCode, RaBitQParams};
 
@@ -174,6 +176,12 @@ pub fn encode_region(
             buf[bitmap_off + (i >> 3)] |= 1u8 << (i & 7);
         }
     }
+    // Allocate the final payload once. Workers fill disjoint fixed-stride rows
+    // in place with one reusable scratch buffer per worker. The former
+    // `Vec<Vec<u8>>` retained one allocation per row before concatenation.
+    let codes_off = buf.len();
+    buf.resize(region_len(dim, n), 0u8);
+    let codes = &mut buf[codes_off..];
     // TD-FLUSH-5: pass 2 (per-row encode) is embarrassingly parallel — row
     // i's bytes depend only on vectors[i] + the shared immutable
     // params/rotation fit in pass 1 (which stays sequential so the float
@@ -191,35 +199,33 @@ pub fn encode_region(
             .num_threads(encode_pool_threads())
             .build()
             .map_err(|e| anyhow::anyhow!("encode pool: {e}"))?;
-        let rows: Vec<Vec<u8>> = pool.install(|| {
-            vectors
-                .par_iter()
-                .map(|v| match v {
-                    Some(vec) => {
-                        let code = encode(vec, &params, &rotation);
-                        let mut row = Vec::with_capacity(stride);
-                        row.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
-                        row.extend_from_slice(&code.inv_factor.to_le_bytes());
-                        row.extend_from_slice(&code.bits);
-                        row
-                    }
-                    None => vec![0u8; stride],
-                })
-                .collect()
-        });
-        for row in rows {
-            buf.extend_from_slice(&row);
-        }
+        pool.install(|| {
+            codes
+                .par_chunks_mut(stride)
+                .zip(vectors.par_iter())
+                .try_for_each_init(
+                    || RaBitQEncodeScratch::new(dim_us),
+                    |scratch, (row, vector)| -> Result<()> {
+                        if let Some(vector) = vector {
+                            let (scalars, bits) = row.split_at_mut(8);
+                            let (distance, inverse) =
+                                encode_into(vector, &params, &rotation, bits, scratch)?;
+                            scalars[..4].copy_from_slice(&distance.to_le_bytes());
+                            scalars[4..].copy_from_slice(&inverse.to_le_bytes());
+                        }
+                        Ok(())
+                    },
+                )
+        })?;
     } else {
-        for v in vectors {
-            match v {
-                Some(vec) => {
-                    let code = encode(vec, &params, &rotation);
-                    buf.extend_from_slice(&code.dist_to_centroid.to_le_bytes());
-                    buf.extend_from_slice(&code.inv_factor.to_le_bytes());
-                    buf.extend_from_slice(&code.bits);
-                }
-                None => buf.extend(std::iter::repeat_n(0u8, stride)),
+        let mut scratch = RaBitQEncodeScratch::new(dim_us);
+        for (row, vector) in codes.chunks_mut(stride).zip(vectors) {
+            if let Some(vector) = vector {
+                let (scalars, bits) = row.split_at_mut(8);
+                let (distance, inverse) =
+                    encode_into(vector, &params, &rotation, bits, &mut scratch)?;
+                scalars[..4].copy_from_slice(&distance.to_le_bytes());
+                scalars[4..].copy_from_slice(&inverse.to_le_bytes());
             }
         }
     }

--- a/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_sq8.rs
@@ -33,7 +33,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{Result, bail};
-use proximadb_codec::functions::sq8::{Sq8Params, decode, fit_params, quantize_one};
+use proximadb_codec::functions::sq8::{Sq8Params, decode, fit_params_iter, quantize_one};
 
 /// `[n_rows u32][dim u32]` — the fixed part of the region header, before the
 /// 16 B `Sq8Params`.
@@ -141,13 +141,9 @@ pub fn encode_region(vectors: &[Option<&[f32]>], dim: u32) -> Result<(Vec<u8>, S
             );
         }
     }
-    // Flatten every present value for ONE segment-level params fit.
-    let total_present: usize = vectors.iter().map(|o| o.map_or(0, |v| v.len())).sum();
-    let mut flat: Vec<f32> = Vec::with_capacity(total_present);
-    for v in vectors.iter().flatten() {
-        flat.extend_from_slice(v);
-    }
-    let params = fit_params(&flat);
+    // Fit directly across segmented rows. The former flattening copy retained a
+    // second full f32 corpus during compaction (737 MiB at 1.44M × 128d).
+    let params = fit_params_iter(vectors.iter().flatten().flat_map(|v| v.iter().copied()));
 
     let n = vectors.len();
     let mut buf = Vec::with_capacity(region_len(dim, n));
@@ -165,6 +161,12 @@ pub fn encode_region(vectors: &[Option<&[f32]>], dim: u32) -> Result<(Vec<u8>, S
             buf[bitmap_off + (i >> 3)] |= 1u8 << (i & 7);
         }
     }
+    // Allocate the final payload once, then let workers fill disjoint fixed-size
+    // rows in place. The former `Vec<Vec<u8>>` allocated and retained one heap
+    // object per row before concatenation (millions of allocations at scale).
+    let codes_off = buf.len();
+    buf.resize(region_len(dim, n), 0u8);
+    let codes = &mut buf[codes_off..];
     // TD-FLUSH-5: pass 2 is per-row independent (row bytes = quantize of
     // vectors[i] against the pass-1 global params, which stay sequential for
     // bit-stable min/max). Ordered par_iter + in-order concat = byte-identical
@@ -177,27 +179,24 @@ pub fn encode_region(vectors: &[Option<&[f32]>], dim: u32) -> Result<(Vec<u8>, S
             .num_threads(crate::coalesced_rabitq::encode_pool_threads())
             .build()
             .map_err(|e| anyhow::anyhow!("encode pool: {e}"))?;
-        let rows: Vec<Vec<u8>> = pool.install(|| {
-            vectors
-                .par_iter()
-                .map(|v| match v {
-                    Some(vec) => vec.iter().map(|&f| quantize_one(f, &params)).collect(),
-                    None => vec![0u8; dim_us],
-                })
-                .collect()
-        });
-        for row in rows {
-            buf.extend_from_slice(&row);
-        }
-    } else {
-        for v in vectors {
-            match v {
-                Some(vec) => {
-                    for &f in *vec {
-                        buf.push(quantize_one(f, &params));
+        pool.install(|| {
+            codes
+                .par_chunks_mut(dim_us)
+                .zip(vectors.par_iter())
+                .for_each(|(row, vector)| {
+                    if let Some(vector) = vector {
+                        for (dst, &value) in row.iter_mut().zip(*vector) {
+                            *dst = quantize_one(value, &params);
+                        }
                     }
+                });
+        });
+    } else {
+        for (row, vector) in codes.chunks_mut(dim_us).zip(vectors) {
+            if let Some(vector) = vector {
+                for (dst, &value) in row.iter_mut().zip(*vector) {
+                    *dst = quantize_one(value, &params);
                 }
-                None => buf.extend(std::iter::repeat_n(0u8, dim_us)),
             }
         }
     }

--- a/crates/storage/proximadb-storage-common/src/pax_block.rs
+++ b/crates/storage/proximadb-storage-common/src/pax_block.rs
@@ -64,7 +64,7 @@ use crate::segment_layout::{
     LosslessTransformTag, ParameterScope, SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN,
     SEG_LAYOUT_VERSION, SEG_LAYOUT_VERSION_TWO_LEVEL, SegmentFooterIndex, SegmentHeaderPrefix,
     SourceFidelity, SourceRole, StatsKind, StripeEncodingDescriptor, TierRole, VectorTransform,
-    compression_flags, is_coalesced_segment, segment_tail,
+    compression_flags, is_coalesced_segment,
 };
 
 /// File extension for PAX segment files.
@@ -539,6 +539,99 @@ struct TwoLevelState {
     cell_end_blocks: Vec<u32>,
 }
 
+/// Cluster-ordered embedding-0 vectors retained for the coalesced A/B regions.
+///
+/// One contiguous allocation replaces `Vec<Option<Vec<f32>>>`, which created
+/// one allocation per record and left a multi-gigabyte allocator RSS tail after
+/// million-row compactions. Missing rows occupy a zero-filled fixed-width slot;
+/// the compact validity bitmap determines whether encoders observe that slot.
+#[derive(Default)]
+struct CoalescedVectorBuffer {
+    dim: usize,
+    expected_rows: usize,
+    values: Vec<f32>,
+    valid: Vec<bool>,
+}
+
+impl CoalescedVectorBuffer {
+    fn push(&mut self, values: Option<&[f32]>) -> Result<usize> {
+        if self.valid.is_empty() && self.expected_rows > 0 {
+            self.valid
+                .try_reserve_exact(self.expected_rows)
+                .map_err(|error| anyhow::anyhow!("reserve coalesced validity bitmap: {error}"))?;
+        }
+        match values {
+            Some(values) if !values.is_empty() => {
+                if self.dim == 0 {
+                    self.dim = values.len();
+                    let prior_values = self.valid.len().checked_mul(self.dim).ok_or_else(|| {
+                        anyhow::anyhow!("coalesced vector buffer size exceeds usize")
+                    })?;
+                    let observed_rows = self.valid.len().checked_add(1).ok_or_else(|| {
+                        anyhow::anyhow!("coalesced vector row count exceeds usize")
+                    })?;
+                    let expected_values = self
+                        .expected_rows
+                        .max(observed_rows)
+                        .checked_mul(self.dim)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("coalesced vector reservation exceeds usize")
+                        })?;
+                    self.values
+                        .try_reserve_exact(expected_values)
+                        .map_err(|error| {
+                            anyhow::anyhow!("reserve coalesced vector buffer: {error}")
+                        })?;
+                    self.values.resize(prior_values, 0.0);
+                }
+                if values.len() != self.dim {
+                    bail!(
+                        "coalesced vector dim {} != established dim {}",
+                        values.len(),
+                        self.dim
+                    );
+                }
+                self.values.extend_from_slice(values);
+                self.valid.push(true);
+                values
+                    .len()
+                    .checked_mul(std::mem::size_of::<f32>())
+                    .ok_or_else(|| anyhow::anyhow!("coalesced vector byte size exceeds usize"))
+            }
+            _ => {
+                if self.dim > 0 {
+                    let next_len = self.values.len().checked_add(self.dim).ok_or_else(|| {
+                        anyhow::anyhow!("coalesced vector buffer size exceeds usize")
+                    })?;
+                    self.values.resize(next_len, 0.0);
+                }
+                self.valid.push(false);
+                Ok(0)
+            }
+        }
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn with_expected_rows(mut self, expected_rows: usize) -> Self {
+        self.expected_rows = expected_rows;
+        self
+    }
+
+    fn refs(&self) -> Vec<Option<&[f32]>> {
+        if self.dim == 0 {
+            return Vec::new();
+        }
+        self.values
+            .chunks_exact(self.dim)
+            .zip(&self.valid)
+            .map(|(values, valid)| valid.then_some(values))
+            .collect()
+    }
+}
+
 /// TD-COMPACT-1 S2: cumulative writer sub-phase timers, allocated only when
 /// `PROXIMADB_TRACE_PAX_WRITE` is set at writer construction. Buckets cover the
 /// per-record `add_record` work plus the finish-time coalesced region encodes;
@@ -630,9 +723,9 @@ pub struct PaxSegmentWriter {
     /// on, data blocks are written as `VectorQuant::Sq8` (the survivor-rerank
     /// data) — the unchanged SQ8 decode path reconstructs + reranks them.
     coalesced_rabitq: bool,
-    /// Embedding-0 f32 vectors in cluster (add) order, buffered for the
-    /// segment-level RaBitQ region. Populated only when `coalesced_rabitq` is on.
-    rabitq_vectors: Vec<Option<Vec<f32>>>,
+    /// Embedding-0 f32 vectors in cluster (add) order, buffered contiguously for
+    /// the segment-level RaBitQ/SQ8 regions. Populated only in coalesced mode.
+    rabitq_vectors: CoalescedVectorBuffer,
     /// TD-RDSTRAT-8: the two-level-IVF coarse model + boundary bookkeeping.
     /// Present ⇒ emit the v3 layout (`[prefix][A0][A][B][D][footer]`): the
     /// current block is force-flushed at every coarse-cell boundary (blocks
@@ -712,7 +805,7 @@ impl PaxSegmentWriter {
             block_radii: Vec::new(),
             block_transformed_sq8_columns: Vec::new(),
             coalesced_rabitq: false,
-            rabitq_vectors: Vec::new(),
+            rabitq_vectors: CoalescedVectorBuffer::default(),
             two_level: None,
             per_row_estimate: 0,
             compute_oid_resolver: false,
@@ -826,6 +919,15 @@ impl PaxSegmentWriter {
     pub fn with_coalesced_rabitq(mut self, enabled: bool) -> Self {
         self.coalesced_rabitq = enabled;
         self.current_writer = self.fresh_block_writer();
+        self
+    }
+
+    /// Pre-size corpus-wide coalesced bookkeeping from the already-admitted
+    /// record count. Reservation itself is fallible and occurs on first append,
+    /// so allocation failure is returned through [`Self::add_record`].
+    pub fn with_expected_rows(mut self, expected_rows: usize) -> Self {
+        self.rabitq_vectors =
+            std::mem::take(&mut self.rabitq_vectors).with_expected_rows(expected_rows);
         self
     }
 
@@ -963,12 +1065,11 @@ impl PaxSegmentWriter {
             // extraction silently dropped non-Fp32 embeddings (e.g. after ingest-time
             // canonical-precision coercion) → garbage SQ8 params → 0.35% recall.
             let t = trace_on.then(Instant::now);
-            let v = record.embeddings.first().map(|e| e.values.to_fp32_owned());
+            let values = record.embeddings.first().map(|cell| cell.as_fp32_cow());
+            rabitq_bytes = self.rabitq_vectors.push(values.as_deref())?;
             if let Some(t) = t {
                 d_rabitq = t.elapsed();
-                rabitq_bytes = v.as_ref().map_or(0, |v| v.len() * 4);
             }
-            self.rabitq_vectors.push(v);
         }
 
         // Encoding-aware size estimate: compute the per-row byte cost from the
@@ -1193,13 +1294,7 @@ impl PaxSegmentWriter {
         // Coalesced-RaBitQ requires embedding-0 f32 vectors to build the region.
         // If there are none (a non-vector or malformed batch), fall through to the
         // legacy layout rather than failing the flush — mixed-read-safe.
-        let coalesced_dim = self
-            .rabitq_vectors
-            .iter()
-            .flatten()
-            .next()
-            .map(|v| v.len())
-            .unwrap_or(0) as u32;
+        let coalesced_dim = self.rabitq_vectors.dim() as u32;
 
         let result = if self.coalesced_rabitq && coalesced_dim > 0 {
             self.finish_coalesced(coalesced_dim, capture_sq8)
@@ -1436,7 +1531,7 @@ impl PaxSegmentWriter {
         // 1. Build the coalesced RaBitQ region (single segment centroid) over the
         //    cluster-ordered embedding-0 vectors. `self.file_buf` already holds the
         //    blocks at 0-based offsets (relative to the blocks region).
-        let refs: Vec<Option<&[f32]>> = self.rabitq_vectors.iter().map(|o| o.as_deref()).collect();
+        let refs = self.rabitq_vectors.refs();
         let seed = RABITQ_SEED_BASE ^ (col_id::EMBED_BASE as u64);
         // TD-COMPACT-1 S2: the finish-time Region A encode (fit + rotation +
         // per-vector RaBitQ) accumulates into the `rabitq` bucket, Region B
@@ -1453,6 +1548,24 @@ impl PaxSegmentWriter {
         if let (Some(t), Some(tr)) = (t, self.write_trace.as_deref_mut()) {
             tr.rerank_encode += t.elapsed();
         }
+        if let Some(tr) = self.write_trace.as_deref_mut() {
+            let live_buffers = self
+                .file_buf
+                .capacity()
+                .saturating_add(
+                    self.rabitq_vectors
+                        .values
+                        .capacity()
+                        .saturating_mul(std::mem::size_of::<f32>()),
+                )
+                .saturating_add(region_bytes.capacity())
+                .saturating_add(sq8_region_bytes.capacity());
+            tr.peak_buffered_bytes = tr.peak_buffered_bytes.max(live_buffers);
+        }
+        // Both coalesced tiers are now encoded. Release the full f32 corpus
+        // before footer assembly, file publication, and optional cache seeding.
+        drop(refs);
+        self.rabitq_vectors = CoalescedVectorBuffer::default();
 
         // TD-RDSTRAT-8: geometry first — A0's byte length is deterministic from
         // (k_c, dim, n_comp), so every downstream offset is known BEFORE A0's
@@ -1618,32 +1731,27 @@ impl PaxSegmentWriter {
             a0_len,
         };
 
-        // 4. Assemble: header [+ A0] + Region A + Region B + blocks +
-        //    [footer][footer_len][magic].
-        let mut out = Vec::with_capacity(
-            header_len as usize
-                + a0_len as usize
-                + region_bytes.len()
-                + sq8_region_bytes.len()
-                + opr_len as usize
-                + self.file_buf.len()
-                + footer_body.len()
-                + 16,
-        );
+        // 4. Stream the already-ordered regions into the local staging file.
+        // The former assembly allocated a second whole-segment `Vec` and copied
+        // Region D into it while `file_buf` remained live. Sequential writes are
+        // byte-identical and remove that output-size peak from compaction RSS.
         let header_bytes = header.to_bytes();
-        out.extend_from_slice(&header_bytes);
-        if let Some(a0) = &a0_bytes {
-            out.extend_from_slice(a0);
-        }
-        out.extend_from_slice(&region_bytes);
-        out.extend_from_slice(&sq8_region_bytes);
-        if let Some(opr) = &opr_bytes {
-            out.extend_from_slice(opr);
-        }
-        out.extend_from_slice(&self.file_buf);
-        out.extend(segment_tail(&footer_body));
-
-        let total_bytes = self.write_file(&out)?;
+        let mut trailer = Vec::with_capacity(16);
+        trailer.extend_from_slice(&(footer_body.len() as u64).to_le_bytes());
+        trailer.extend_from_slice(SEGMENT_MAGIC);
+        let total_bytes = self.write_coalesced_file(
+            &header_bytes,
+            a0_bytes.as_deref(),
+            &region_bytes,
+            &sq8_region_bytes,
+            opr_bytes.as_deref(),
+            &footer_body,
+            &trailer,
+        )?;
+        // Region D has reached the local staging file and is no longer needed.
+        // Releasing it here keeps cache-on-write Arc construction from
+        // overlapping a segment-sized compressed block buffer.
+        self.file_buf = Vec::new();
         let cache_seed = capture_sq8.map(|include_sq8| {
             let rabitq_header_len = rabitq_region_header_len(dim).min(region_bytes.len());
             PaxCacheSeed {
@@ -1680,6 +1788,43 @@ impl PaxSegmentWriter {
         let mut f = std::fs::File::create(&self.path)?;
         f.write_all(buf)?;
         Ok(buf.len() as u64)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write_coalesced_file(
+        &self,
+        header: &[u8],
+        a0: Option<&[u8]>,
+        rabitq: &[u8],
+        sq8: &[u8],
+        oid_resolver: Option<&[u8]>,
+        footer: &[u8],
+        tail: &[u8],
+    ) -> Result<u64> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::File::create(&self.path)?;
+        let mut total = 0u64;
+        for part in [
+            Some(header),
+            a0,
+            Some(rabitq),
+            Some(sq8),
+            oid_resolver,
+            Some(&self.file_buf),
+            Some(footer),
+            Some(tail),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            file.write_all(part)?;
+            total = total
+                .checked_add(part.len() as u64)
+                .ok_or_else(|| anyhow::anyhow!("PAX segment length exceeds u64"))?;
+        }
+        Ok(total)
     }
 
     /// Test-only: finish writing a **legacy v1** segment (segment index without
@@ -2060,6 +2205,29 @@ mod tests {
     use super::*;
     use proximadb_records::ProximaRecord;
 
+    #[test]
+    fn coalesced_vector_buffer_is_contiguous_and_preserves_null_rows() -> Result<()> {
+        let mut buffer = CoalescedVectorBuffer::default();
+        buffer.push(None)?;
+        buffer.push(Some(&[1.0, 2.0, 3.0]))?;
+        buffer.push(None)?;
+        buffer.push(Some(&[4.0, 5.0, 6.0]))?;
+
+        assert_eq!(buffer.dim(), 3);
+        assert_eq!(buffer.values.len(), 12);
+        assert_eq!(
+            buffer.refs(),
+            vec![
+                None,
+                Some(&[1.0, 2.0, 3.0][..]),
+                None,
+                Some(&[4.0, 5.0, 6.0][..])
+            ]
+        );
+        assert!(buffer.push(Some(&[7.0, 8.0])).is_err());
+        Ok(())
+    }
+
     fn make_record(oid: &str, tenant: &str, ts: i64) -> ProximaRecord {
         ProximaRecord {
             oid: oid.into(),
@@ -2148,7 +2316,7 @@ mod tests {
     }
 
     #[test]
-    fn coalesced_footer_assigns_actual_clustered_sq8_encoding() -> Result<()> {
+    fn coalesced_footer_does_not_advertise_hoisted_sq8_as_block_transform() -> Result<()> {
         use proximadb_records::{EmbeddingCell, EmbeddingValues};
 
         const ROWS_PER_CLUSTER: usize = 256;
@@ -2190,17 +2358,20 @@ mod tests {
         let segment = std::fs::read(&path)?;
         let footer = SegmentFooterIndex::locate_in_segment(&segment)?
             .ok_or_else(|| anyhow::anyhow!("coalesced footer missing"))?;
-        let transformed = footer.encoding_map.iter().find(|descriptor| {
-            descriptor.physical_column_id == col_id::EMBED_BASE
-                && descriptor.transform_tag == LosslessTransformTag::ClusteredForBitpackU8
-        });
-        let transformed =
-            transformed.ok_or_else(|| anyhow::anyhow!("clustered SQ8 descriptor missing"))?;
-        assert!(footer.block_tier_assignments.iter().any(|assignment| {
-            assignment.physical_column_id == col_id::EMBED_BASE
-                && assignment.descriptor_id == transformed.descriptor_id
-        }));
-        assert_eq!(transformed.rebuild_source_id, EXTERNAL_CANONICAL_SOURCE_ID);
+        assert!(
+            footer.encoding_map.iter().all(|descriptor| {
+                descriptor.physical_column_id != col_id::EMBED_BASE
+                    || descriptor.transform_tag != LosslessTransformTag::ClusteredForBitpackU8
+            }),
+            "coalesced SQ8 lives in Region B, so Region D must not advertise a block transform"
+        );
+        assert!(
+            footer
+                .block_tier_assignments
+                .iter()
+                .all(|assignment| assignment.physical_column_id != col_id::EMBED_BASE),
+            "hoisted Region B has no per-block SQ8 assignment"
+        );
         Ok(())
     }
 
@@ -2285,8 +2456,8 @@ mod tests {
 
     /// TD-RDSTRAT-5 S1: with `with_block_centroids(true)`, the segment writer
     /// returns one centroid per block = the exact mean of that block's embedding-0
-    /// f32 vectors. Block-cutting is by current-block row count (`row_count*1024 >=
-    /// threshold`), so `threshold = 2*1024` puts exactly 2 rows per block.
+    /// f32 vectors. This fixture cuts an explicit block boundary so its
+    /// two-block shape is independent of the encoding-aware byte estimator.
     #[test]
     fn block_centroids_are_exact_per_block_means() {
         use proximadb_records::{EmbeddingCell, EmbeddingValues};
@@ -2320,12 +2491,18 @@ mod tests {
         )
         .with_quant(VectorQuant::RawF32)
         .with_block_centroids(true);
-        for r in [
+        for (row, r) in [
             rec("a", vec![0.0, 0.0]),
             rec("b", vec![2.0, 2.0]),
             rec("c", vec![10.0, 10.0]),
             rec("d", vec![12.0, 12.0]),
-        ] {
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if row == 2 {
+                w.flush_current_block().unwrap();
+            }
             w.add_record(&r).unwrap();
         }
         let meta = w.finish().unwrap();
@@ -2463,12 +2640,18 @@ mod tests {
         )
         .with_quant(VectorQuant::RawF32)
         .with_block_centroids(true);
-        for r in [
+        for (row, r) in [
             rec("a", vec![0.0, 0.0]),
             rec("b", vec![2.0, 2.0]),
             rec("c", vec![7.0, 7.0]), // identical pair: zero spread
             rec("d", vec![7.0, 7.0]),
-        ] {
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if row == 2 {
+                w.flush_current_block().unwrap();
+            }
             w.add_record(&r).unwrap();
         }
         let meta = w.finish().unwrap();
@@ -2547,7 +2730,13 @@ mod tests {
         .with_quant(VectorQuant::RawF32)
         .with_block_centroids(true);
         // block 0: fills 0 & 4 → mean 2; block 1: fills 10 & 20 → mean 15.
-        for r in [rec("a", 0.0), rec("b", 4.0), rec("c", 10.0), rec("d", 20.0)] {
+        for (row, r) in [rec("a", 0.0), rec("b", 4.0), rec("c", 10.0), rec("d", 20.0)]
+            .into_iter()
+            .enumerate()
+        {
+            if row == 2 {
+                w.flush_current_block().unwrap();
+            }
             w.add_record(&r).unwrap();
         }
         let meta = w.finish().unwrap();

--- a/crates/storage/proximadb-storage-traits/src/lib.rs
+++ b/crates/storage/proximadb-storage-traits/src/lib.rs
@@ -66,7 +66,7 @@ mod types;
 // Re-exports from decomposed submodules for backward compatibility
 pub use query::{
     ParsedQuantizationConfig, QuantizationLevel, QuantizationType, RlsRecordPredicate,
-    StorageQueryContext, StorageQueryMetadata,
+    StorageQueryContext, StorageQueryMetadata, collection_declares_axis_index,
 };
 pub use results::{CompactionResult, EngineHealth, EngineStatistics, FlushResult};
 pub use types::{

--- a/crates/storage/proximadb-storage-traits/src/query.rs
+++ b/crates/storage/proximadb-storage-traits/src/query.rs
@@ -3,7 +3,7 @@
 //! This module provides types used by storage engines during query execution,
 //! including row-level security predicates, search parameters, and metadata.
 
-use proximadb_proto::proximadb_v1::Collection;
+use proximadb_proto::proximadb_v1::{Collection, CollectionConfig};
 pub use proximadb_quantization_types::QuantizationType;
 use proximadb_search_types::block_prune::BlockPruneMode;
 use proximadb_storage_ports::{collection_data_path_typed, typed_identity_from_storage_assignment};
@@ -12,6 +12,15 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use super::{PerformanceTier, StorageFormatStrategy};
+
+/// Whether a collection explicitly declares an AXIS index.
+///
+/// This is the single collection-level serving predicate shared by query,
+/// insert, and flush paths. Storage-format and quantization tags affect the
+/// representation written to PAX; they are not index declarations.
+pub fn collection_declares_axis_index(config: Option<&CollectionConfig>) -> bool {
+    config.is_some_and(|config| !config.index_configs.is_empty())
+}
 
 /// Predicate evaluated by the storage engine at scan time for row-level security.
 ///
@@ -298,20 +307,9 @@ impl StorageQueryContext {
 
         let metadata = StorageQueryMetadata {
             collection_id: collection.id.clone(),
-            use_axis_indexes: config
-                .map(|c| {
-                    // AXIS when the collection has index_configs OR has opted out of
-                    // the co-designed PAX scan (`pax_vector_format:off`). index_configs
-                    // alone is too narrow a proxy: a collection that disables PAX falls
-                    // back to the legacy .sst + AXIS path, so the gate must not skip
-                    // AXIS for it (otherwise its AXIS store is never rebuilt from SST).
-                    let pax_off = c
-                        .tags
-                        .iter()
-                        .any(|t| t.trim().eq_ignore_ascii_case("pax_vector_format:off"));
-                    pax_off || !c.index_configs.is_empty()
-                })
-                .unwrap_or(false),
+            // Index declarations are authoritative. A storage-format or
+            // quantization tag changes representation, not serving policy.
+            use_axis_indexes: collection_declares_axis_index(config),
             has_quantization: config.and_then(|c| c.quantization.as_ref()).is_some(),
             dimension: config.map_or(0, |c| c.dimension as usize),
             distance_metric: config
@@ -614,5 +612,48 @@ mod tests {
         assert_eq!(metadata.collection_id, "");
         assert!(!metadata.use_axis_indexes);
         assert!(!metadata.has_quantization);
+    }
+
+    #[test]
+    fn query_context_requires_an_explicit_index_config_for_axis() {
+        use proximadb_proto::proximadb_v1::{CollectionConfig, IndexConfig};
+
+        let format_only = Arc::new(Collection {
+            config: Some(CollectionConfig {
+                tags: vec!["pax_vector_format:off".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let format_only_ctx = StorageQueryContext::new(
+            Arc::new(proximadb_search_types::search_params::SearchParams::default()),
+            format_only,
+        );
+        assert!(!format_only_ctx.metadata.use_axis_indexes);
+
+        let indexed = Arc::new(Collection {
+            config: Some(CollectionConfig {
+                index_configs: vec![IndexConfig::default()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let indexed_ctx = StorageQueryContext::new(
+            Arc::new(proximadb_search_types::search_params::SearchParams::default()),
+            indexed,
+        );
+        assert!(indexed_ctx.metadata.use_axis_indexes);
+    }
+
+    #[test]
+    fn collection_axis_declaration_fails_closed() {
+        assert!(!collection_declares_axis_index(None));
+        assert!(!collection_declares_axis_index(Some(
+            &CollectionConfig::default()
+        )));
+        assert!(collection_declares_axis_index(Some(&CollectionConfig {
+            index_configs: vec![proximadb_proto::proximadb_v1::IndexConfig::default()],
+            ..Default::default()
+        })));
     }
 }

--- a/docs/10-quality/td/TD-AXIS-2-enable-axis-indexes-flag-not-wired-to-boot.adoc
+++ b/docs/10-quality/td/TD-AXIS-2-enable-axis-indexes-flag-not-wired-to-boot.adoc
@@ -6,8 +6,8 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open** — flag default flipped to `false` (ADR-070 posture) in the same PR that filed this TD; the boot wiring remains.
-| Severity | Medium — no correctness impact (the #1145 per-collection gate governs AXIS usage on the hot path), but the documented server-level knob is a silent no-op, and boot-time AxisManager construction cost is unavoidable even for pure co-design deployments.
+| Status | **Resolved (2026-08-01)** — the runtime flag now gates every serving registration, feed, flush hook, and background maintenance loop. The lazy `AxisManager` value remains constructed when the feature is compiled, but construction performs no training, corpus read, or worker spawn.
+| Severity | Resolved P0 prevention — an ungated discovery recluster previously cloned and trained over a 3.3M-vector PAX-only collection while compaction was running.
 | Component | `crates/foundation/proximadb-config/src/lib.rs` (`OptimizationConfig.enable_axis_indexes`); `src/network/shared_services.rs` (`SharedServices::new` AxisManager construction); `src/storage/engine.rs` (`StorageEngine::new_internal` AxisManager construction)
 | Tracked-by | link:../../12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc[ADR-070] (AXIS not the default for co-design collections)
 | Pillar | PERF (idle footprint), DX (config honesty)
@@ -17,9 +17,10 @@ toc::[]
 
 == Symptom
 
-`[storage.optimization] enable_axis_indexes = false` in the server TOML parses and
-deserializes, but **nothing reads the field**. Both boot paths construct the
-AxisManager unconditionally:
+Historically, `[storage.optimization] enable_axis_indexes = false` parsed but
+did not control the live AXIS registrations or maintenance loops. Both boot
+paths constructed and exposed an `AxisManager`, and the discovery drift watcher
+could enqueue reclustering for a PAX-only collection.
 
 * `SharedServices::new` (the live server path) — builds the manager, wires the
   recall-probe gate / filesystem factory / persist dir / catalog resolver,
@@ -29,37 +30,67 @@ AxisManager unconditionally:
   + WAL-inline-flush globals; the field is a non-optional struct member used on
   the delete / create-collection / drop-collection / auto-flush paths.
 
-An operator who sets the flag to `false` (e.g. the AnvaiOps AKS ConfigMap does)
-reasonably expects boot-time AXIS initialization to be skipped; today it is not.
+The 3.3M compaction experiment exposed the consequence: at the 60-second drift
+interval, reclustering materialized the full collection and trained k-means even
+though `enable_axis_indexes=false`, `index_configs=[]`, and no served AXIS index
+existed. The resulting process-RSS peak was incorrectly attributable to
+compaction until the per-component trace separated the concurrent workload.
 
-== What already protects the hot path
+== Resolution: three fail-closed gates
 
-This TD is about the *boot* footprint only. The per-collection gate (#1145,
-`use_axis_indexes = pax_off || !index_configs.is_empty()` in
-`proximadb-storage-traits/src/query.rs`) plus the flush-side skip (#1155)
-already keep AXIS build + search cost off co-design collections — the measured
-~8.6 GB / busy-core AXIS cost is per collection *with indexes built*, not from
-the bare manager construction.
+The gates are evaluated cheapest-first:
 
-== Fix shape (when picked up)
+[cols="1,2,3", options="header"]
+|===
+| Gate | Fail-closed condition | Result
 
-Gate both construction sites on `config.optimization.enable_axis_indexes`. That
-requires threading `Option<Arc<AxisManager>>` through:
+| Compile capability
+| Cargo feature `axis` absent
+| AXIS-only drift/recluster modules and call sites are not compiled. The normal
+  PAX server still builds.
 
-* `StorageEngine.axis_index_manager` (+ its delete / ensure-strategy / drop /
-  `AutoFlushDriver::spawn` uses — the flush materializer already takes
-  `Option<&AxisManager>`),
-* `VectorOperationsService` (constructor + `axis_index_manager()` accessor),
-* the global registration seams (all `get_*_axis_manager()` readers already
-  return `Option` and degrade to the PAX/direct-scan path).
+| Process runtime policy
+| `storage.optimization.enable_axis_indexes=false` (the default)
+| No SST/Orion/flush global registration; no EventLog consumer, recall observer,
+  drift watcher, or recall sweeper; auto-flush receives no AXIS handle; vector
+  operations, the multimodal vector store, and external-vector index build/search
+  do not query or feed AXIS.
 
-Semantics to preserve: with the flag `false`, a collection that declares
-`index_configs` should either fail loudly at create time or degrade to the PAX
-scan path with a WARN — never silently build a partial index through the
-still-referenced direct `Arc`s while the search-side globals are absent.
+| Collection declaration
+| collection config absent, or `index_configs` absent/empty
+| Search, direct insert, and flush share the single
+  `collection_declares_axis_index` predicate and use PAX. A format tag such as
+  `pax_vector_format:off` changes representation only and cannot opt into AXIS.
 
-== Interim posture
+| Served-index maintenance
+| no published IVF/HNSW index exists
+| Discovery recluster exits before `list_all_records_with_tenant_context`, so it
+  cannot materialize or clone the corpus merely to discover that there is no
+  index to swap.
+|===
 
-The flag's default is `false` (matches ADR-070 and the co-design deployment
-posture); its doc comment states explicitly that it is not yet load-bearing at
-boot. Deployments relying on the per-collection gate lose nothing.
+Configured collections may still build or restore their declared index through
+the normal ingest/search lifecycle. Continuous reclustering is stricter: it is
+maintenance of an already-served index, never an implicit bootstrap route.
+
+== Why the manager value is still constructed
+
+`AxisManager::new` is lazy: it performs no collection read, training, or worker
+spawn. Retaining the value preserves the compile-time type graph without
+threading `Option<Arc<AxisManager>>` through unrelated APIs. The load-bearing
+contract is that the value is not registered or touched while the runtime gate
+is false. Direct/internal `VectorOperationsService` construction also defaults
+the runtime gate to false; production boot must explicitly apply the resolved
+configuration.
+
+== Verification
+
+* AXIS build: collection eligibility, flush dispatch, and served-index presence
+  unit tests pass.
+* No-AXIS build: the CI-equivalent
+  `proximadb-server --no-default-features --features
+  sql_frontend,graph-first-sks,unified-facade-routing,canonical-document-store,datafusion-integration,otlp-metering`
+  check passes.
+* The 3.3M memory/compaction run must be repeated on a release binary to confirm
+  the absence of the concurrent `Training clustering model ... 3300000 vectors`
+  trace before updating the benchmark evidence ledger.

--- a/docs/10-quality/td/TD-AXIS-3-converge-flush-to-axis-and-retire-the-queue.adoc
+++ b/docs/10-quality/td/TD-AXIS-3-converge-flush-to-axis-and-retire-the-queue.adoc
@@ -95,8 +95,8 @@ Compile is not evidence here — this changes the indexing path.
   it). Code-verified; the hook reads the same source the old queue re-read from
   disk.
 * Unit tests on the shared guard: absent config ⇒ no AXIS (ADR-070), empty
-  `index_configs` without the `pax_vector_format:off` tag ⇒ no AXIS, tag match
-  trimmed + case-insensitive, missing manager ⇒ quiet no-op.
+  `index_configs` ⇒ no AXIS, a `pax_vector_format:off` representation tag alone
+  ⇒ no AXIS, explicit index config ⇒ dispatch, missing manager ⇒ quiet no-op.
 * A recording-`IndexEngine` spy pins the dispatch: the guard, once passed,
   delivers the exact records + files to `handle_flushed_vectors` (explicit handle)
   *and* via the boot-registered global fallback (the path VIPER/HELIX/NOVA take,

--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed.** Measured 2026-07-23 on SIFT 1M (develop @ 02725d81a, post #1161/#1163) during the restart/recovery pressure tests.
+| Status | **Open; bounded writer measured.** The 2026-08-02 release/Azurite revalidation reduced a comparable large-task writer-tail delta by 75.6%, while the O(write-buffer) spill/streaming objective remains open.
 | Priority | **P0** — the OOM takes down the whole server (all tenants, all collections), not just the compaction. On memory-constrained nodes (Spot instances, small pods) any 1M-scale compaction is a self-inflicted outage; jetsam/OOM-killer takes the process mid-compaction, which then also triggers the unclean-restart WAL-replay cost (TD-IVF-1).
 | Component | `src/storage/engines/sst/compaction.rs` (`perform_unified_vectorrecord_compaction`, lines ~890–1138); `src/core/search/mvcc_resolution.rs`; `compactor_impl.rs` (`k_way_merge`, `compact_level_tiered`, `retrain_pca_model_for_compaction`).
 | Evidence | macOS jetsam: `memorystatus: killing largest compressed process proximadb-server [15323] 125835 MB`. Input: 6 L0 `.pax` files, 763 MB on disk, 1M × 128-dim f32 (512 MB raw vectors). Server RSS was ~11 GB before the compaction; footprint ballooned to ~126 GB (compressed accounting) within ~2–4 min and the process was killed. Peak-RSS sweep below.
@@ -78,10 +78,24 @@ The bounded-writer remediation is format-neutral:
 . stream header/A0/A/B/D/footer to the local staging file instead of building a
   second whole-segment output vector.
 
-The 5 GiB ceiling remains unchanged until the same release/Azurite 3.3M bed is
-rerun. A lower observed factor may justify a lower amplification reservation;
-a larger merge ceiling is justified only if measured peak RSS, retained RSS,
-recall, and final segment geometry all remain inside the node headroom.
+=== Bounded-writer release verdict (2026-08-02)
+
+The same release/Azurite 3.3M workload now passes with the bounded writer. A
+comparable large task moved from 385,695,616 input bytes / 11,353 MiB
+incremental RSS (30.86x) to 344,444,987 bytes / 2,773 MiB (8.44x): **75.6%
+less incremental RSS** and **72.7% lower amplification**. Across all five new
+morsels the largest observed ratio was 10.75x, so the 12.0x admission factor
+remains warranted. The complete trace, hashes, three-segment layout, recall,
+and GET controls are recorded in
+link:../../_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc[the
+post-fix evidence artifact].
+
+The 5 GiB serving-process ceiling remains unchanged. It produced three
+segments and held recall@10 at 0.981 object-cold, but total process RSS still
+reached 14,105 MiB because WAL/cache/allocator baseline is outside the
+compaction reservation. Larger consolidation should use explicit local spill
+with an independent scratch-byte reservation; OS swap is not an admission
+mechanism. The streaming/spill design remains the open S2 work.
 
 == The finding
 

--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -11,6 +11,37 @@
 | Evidence | macOS jetsam: `memorystatus: killing largest compressed process proximadb-server [15323] 125835 MB`. Input: 6 L0 `.pax` files, 763 MB on disk, 1M × 128-dim f32 (512 MB raw vectors). Server RSS was ~11 GB before the compaction; footprint ballooned to ~126 GB (compressed accounting) within ~2–4 min and the process was killed. Peak-RSS sweep below.
 |===
 
+== 2026-08-01 current result and remediation
+
+The historical investigation below found and removed two dominant unrelated
+amplifiers (AXIS training concurrency and the incorrect PAX
+`embedding_count`). A new serialized release/Azurite run now provides the
+admission-controller baseline after those fixes and after the canonical-record
+/ in-place-MVCC rewrite:
+
+* 3.3M vectors, five L0 PAX segments, 882,773,394 input bytes;
+* RSS approximately 8,655 MiB → 16,951 MiB, **+8,296 MiB**;
+* current incremental amplification **9.85x input segment bytes**; and
+* one 882,842,998-byte L1 output in 38.991 seconds, recall@10 0.993-0.998.
+
+The complete evidence is
+link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[recorded
+here]. The implemented hardening is:
+
+. remove legacy `VectorRecord` round trips and background-only merged-vector
+  retention;
+. resolve sorted canonical records in place;
+. select deterministic whole-file morsels from a byte budget before decoding;
+. reserve `input_bytes × 12` process-wide before sorting/training/encoding; and
+. constrain that reservation by cgroup-visible capacity, live availability,
+  and an optional absolute ceiling (ADR-086 / TD-COMPACT-4).
+
+This closes the unbounded-start correctness gap. It does **not** close the
+longer-term O(write-buffer) streaming objective: current compaction still
+materializes its admitted morsel. Status remains open until the post-change
+3.3M bound is measured and the streaming design removes the measured 9.85x
+factor rather than merely budgeting it.
+
 == The finding
 
 Explicitly exercising the L0→L1 compaction path on a 1M-vector SIFT collection

--- a/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
+++ b/docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc
@@ -42,6 +42,47 @@ materializes its admitted morsel. Status remains open until the post-change
 3.3M bound is measured and the streaming design removes the measured 9.85x
 factor rather than merely budgeting it.
 
+=== Post-admission writer-tail localization (2026-08-01)
+
+The serialized follow-up run (`ef5cc387e`, release/Azurite, 3.3M vectors,
+5 GiB absolute compaction ceiling) proves that admission and allocation shape
+are separate controls. No compaction reservations overlapped, yet the largest
+task admitted 385,695,616 input bytes at a 4,628,347,392-byte projection and
+grew process RSS by approximately 11,353 MiB (**30.86x input bytes**). The
+writer reported only 903,758,542 logical buffered bytes. The next task began
+from the elevated RSS baseline, demonstrating allocator retention rather than
+a second active reservation.
+
+The code trace accounts for the missing logical-to-RSS gap:
+
+* the PAX writer retained `Vec<Option<Vec<f32>>>`, one independent allocation
+  per row, while the canonical records remained live;
+* SQ8 fitting flattened the same complete f32 corpus into another vector;
+* both parallel Region A and Region B encoders collected `Vec<Vec<u8>>`, one
+  retained output allocation per row, before concatenating into their final
+  region;
+* final PAX publication allocated a second whole-segment vector and copied the
+  compressed Region D buffer into it; and
+* the clustering order/model stayed live through region finalization.
+
+The bounded-writer remediation is format-neutral:
+
+. retain coalesced vectors in one fixed-width contiguous buffer plus a compact
+  validity bitmap;
+. fit SQ8 min/max directly over segmented rows;
+. pre-size the final A/B payloads and let bounded Rayon workers fill disjoint
+  row slices in place;
+. reuse one RaBitQ residual/unit/rotation scratch arena per worker;
+. release f32 vectors and the clustering plan before footer/cache finalization;
+  and
+. stream header/A0/A/B/D/footer to the local staging file instead of building a
+  second whole-segment output vector.
+
+The 5 GiB ceiling remains unchanged until the same release/Azurite 3.3M bed is
+rerun. A lower observed factor may justify a lower amplification reservation;
+a larger merge ceiling is justified only if measured peak RSS, retained RSS,
+recall, and final segment geometry all remain inside the node headroom.
+
 == The finding
 
 Explicitly exercising the L0→L1 compaction path on a 1M-vector SIFT collection

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -34,7 +34,10 @@ S2 — **Implemented: hybrid byte policy + file morsels.** The projection is
 The effective process-wide budget is the minimum of cgroup/host-visible total
 RAM × 0.25, currently available RAM × 0.50, and the optional `max_memory_mb`
 ceiling. Discovery packs oldest-first whole-file morsels within the remaining
-input-byte budget and requires at least two files. An oversized file stays
+input-byte budget and requires at least two files for ordinary fanout
+compaction. The threshold-one L0 training signal may promote one admitted PAX
+file to the trained layout; this preserves the existing write/search contract
+without letting training run before admission. An oversized file stays
 horizontal; streaming repartition remains TD-COMPACT-2 follow-up work.
 
 S3 — **Partially implemented: pressure priority + observability.** Live

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -5,43 +5,45 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed** (2026-07-23, restart/recovery pressure tests). Ops-side complement to TD-COMPACT-2 (per-job memory) and TD-COMPACT-3 (trigger honesty).
-| Priority | **P1** — multi-collection servers can start several compactions concurrently (per-engine workers, `background_thread_count = 4`) with NO global admission control; measured single-job cost today is ~40 GB at 120k input, so even two concurrent mid-size compactions exceed a 64 GB node. Queries co-resident with a swapping compaction degrade ~6× (cold mean 148 ms → 880 s wall for the compaction window).
-| Component | `src/storage/engines/sst/compaction.rs` (`start_workers`/`schedule_compaction`), flush-path inline compaction (`services/operations/vectors/flush.rs`), a new global admission gate shared across collections/engines.
-| Evidence | Pressure tests 2026-07-23: one 120k-input compaction = ~40 GB peak / 17-20 min (rebased, trainer gated); 1M-input = jetsam kill at ~126 GB. Flush path runs compaction inline (awaited), so "compaction is async/internal" does not hold on that path today.
+| Status | **Implemented; release revalidation in progress** (2026-08-01). ADR-086 accepted; deterministic unit and config tests green. The post-change bounded 3.3M run is the remaining promotion evidence.
+| Priority | **P1** — independent collection workers formerly had only a count limit and could double-spend process memory. The corrected 3.3M release/Azurite control measured 841.9 MiB input and +8,296 MiB RSS (**9.85x**) for one job.
+| Component | `src/storage/common/compaction_memory.rs`; `src/storage/common/compaction_utils.rs`; `src/storage/engines/sst/compaction.rs`; `proximadb-hardware` dynamic/cgroup-aware memory snapshot.
+| Evidence | link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[3.3M release/Azurite baseline]. Historical 2026-07-23 attribution is retained in TD-COMPACT-2; its 40-126 GiB observations included now-fixed AXIS and PAX writer defects and are not the admission factor.
 |===
 
 == The finding
 
-Compaction scheduling is per-collection/per-engine with a thread-count cap
-only. There is no global controller that (a) bounds how many compactions run
-concurrently across ALL collections, (b) accounts for projected per-job
-memory, or (c) subordinates background work to query traffic. Under default
-config a busy multi-tenant node can therefore self-inflict memory exhaustion
-even after the per-job fixes land, and today a single unbounded job already
-does (TD-COMPACT-2).
+Compaction scheduling was per-collection/per-engine with a thread-count cap
+only. A worker count cannot distinguish a small maintenance merge from a
+corpus-sized merge, and independent collections could reserve the same free
+memory. The implementation now accounts projected bytes process-wide before
+any record-proportional work. Explicit OS scheduling priority remains future
+work; the live-availability term yields admission capacity as foreground/cache
+work consumes memory.
 
 == Direction
 
-S1 — **Global admission gate**: one server-wide async semaphore for compaction
-jobs across all collections/engines. Default concurrency: min(2,
-cores/4). All entry points (threshold scheduler, flush-path inline call, the
-repaired operator trigger from TD-COMPACT-3) must acquire it — the inline
-flush-path call becomes "enqueue and return" (flush durability does not depend
-on compaction).
+S1 — **Implemented: process-wide weighted admission.** One atomic projected-byte
+reservation domain is shared by every SST collection and worker. It replaces a
+count semaphore because job sizes differ by orders of magnitude. ADR-076 has
+already made flush enqueue-and-return; workers acquire memory before the
+canonical compaction path.
 
-S2 — **Memory-aware admission**: gate on projected job cost, not just count:
-`projected = input_bytes × amplification` (amplification from the measured
-sweep table in TD-COMPACT-2 until the streaming fix lands, then
-O(write-buffer)). Admit while `sum(projected of running jobs) + headroom <
-available_ram × fraction`; oversized single jobs are split per TD-COMPACT-2 S1
-(sub-batch by files) instead of admitted whole.
+S2 — **Implemented: hybrid byte policy + file morsels.** The projection is
+`input_bytes × 12.0`, where 12.0 includes headroom over the measured 9.85x.
+The effective process-wide budget is the minimum of cgroup/host-visible total
+RAM × 0.25, currently available RAM × 0.50, and the optional `max_memory_mb`
+ceiling. Discovery packs oldest-first whole-file morsels within the remaining
+input-byte budget and requires at least two files. An oversized file stays
+horizontal; streaming repartition remains TD-COMPACT-2 follow-up work.
 
-S3 — **Priority + observability**: background jobs run at lower scheduling
-priority than query serving; expose `compaction_queue_depth`,
-`compaction_running`, `compaction_projected_bytes` as Prometheus gauges
-(TD-METRICS family) so operators can see the queue instead of inferring it
-from CPU/RSS.
+S3 — **Partially implemented: pressure priority + observability.** Live
+available-memory refresh makes compaction admission yield to query/cache
+pressure. Prometheus exposes `proximadb_compaction_queue_depth`,
+`proximadb_compaction_running`,
+`proximadb_compaction_memory_reserved_bytes`, and
+`proximadb_compaction_memory_admission_waits_total`. Explicit CPU/I/O scheduler
+priority is not yet implemented and must not be inferred from these gauges.
 
 S4 — **Interim mitigation available today — uniform fan-3 leveled geometry**:
 `3× Lₙ₋₁ → 1× Lₙ` up to the existing `max_levels = 7`
@@ -60,8 +62,10 @@ TD-COMPACT-2 write-phase fix land.
 
 == Notes
 
-* Queue depth alone is NOT sufficient: with today's per-job cost a depth-1
-  queue still OOMs at 1M input — S2's budget (and TD-COMPACT-2's per-job fix)
-  carry the correctness burden; the queue carries stability under fan-out.
+* Queue depth alone is NOT sufficient: a depth-1 queue can still admit a job
+  too large for its pod. The byte budget and whole-file morsel bound carry the
+  correctness burden; the queue reports fan-out.
 * Interacts with #1164's cores-ratio compaction threads (CPU-side cap); this
   TD adds the memory-side and cross-collection dimensions.
+* A low budget can increase steady-state segments and GETs/query. That is the
+  explicit memory-stability/read-cost trade-off, not a silent acceptance miss.

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -37,7 +37,10 @@ ceiling. Discovery packs oldest-first whole-file morsels within the remaining
 input-byte budget and requires at least two files for ordinary fanout
 compaction. The threshold-one L0 training signal may promote one admitted PAX
 file to the trained layout; this preserves the existing write/search contract
-without letting training run before admission. An oversized file stays
+without letting training run before admission. Its reason remains attached to
+bounded L0 follow-up morsels—derived from the immutable L0-to-PAX task shape,
+not timing-sensitive collection state—until the untrained tail is drained,
+then clears before higher-level fanout work. An oversized file stays
 horizontal; streaming repartition remains TD-COMPACT-2 follow-up work.
 
 S3 — **Partially implemented: pressure priority + observability.** Live

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -5,10 +5,10 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Implemented; release revalidation in progress** (2026-08-01). ADR-086 accepted; deterministic unit and config tests green. The post-change bounded 3.3M run is the remaining promotion evidence.
+| Status | **Implemented; release revalidated** (2026-08-02). ADR-086 accepted; deterministic unit/config tests and the bounded 3.3M release/Azurite run are green.
 | Priority | **P1** — independent collection workers formerly had only a count limit and could double-spend process memory. The corrected 3.3M release/Azurite control measured 841.9 MiB input and +8,296 MiB RSS (**9.85x**) for one job.
 | Component | `src/storage/common/compaction_memory.rs`; `src/storage/common/compaction_utils.rs`; `src/storage/engines/sst/compaction.rs`; `proximadb-hardware` dynamic/cgroup-aware memory snapshot.
-| Evidence | link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[3.3M release/Azurite baseline]. Historical 2026-07-23 attribution is retained in TD-COMPACT-2; its 40-126 GiB observations included now-fixed AXIS and PAX writer defects and are not the admission factor.
+| Evidence | link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[3.3M release/Azurite baseline] and link:../../_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc[post-fix bounded-writer verification]. Historical 2026-07-23 attribution is retained in TD-COMPACT-2; its 40-126 GiB observations included now-fixed AXIS and PAX writer defects and are not the admission factor.
 |===
 
 == The finding
@@ -68,6 +68,16 @@ amplification rises (~log₃ vs log₅ passes/record — more PUT/GET churn on
 object storage); (c) slower convergence to the few-large-files state
 TD-FLUSH-3 wants for the read path. Treat as a stopgap until S1/S2 and the
 TD-COMPACT-2 write-phase fix land.
+
+S5 — **Next mechanism: explicit spill, not OS swap.** A spill execution mode
+keeps the RAM admission limit and adds an independent local scratch-byte
+reservation. Bounded sorted runs, incremental MVCC/deletion-vector resolution,
+deterministic sampled training, cell-partition streams, and region staging can
+then consolidate inputs larger than the in-memory morsel without increasing
+serving-process RAM. Scratch is disposable and no output becomes visible until
+one completed final object is uploaded and the manifest generation is
+atomically replaced. Remote/Spot placement is optional policy; the spill and
+publication correctness mechanisms belong in the engine.
 
 == Notes
 

--- a/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
+++ b/docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc
@@ -42,6 +42,9 @@ bounded L0 follow-up morsels—derived from the immutable L0-to-PAX task shape,
 not timing-sensitive collection state—until the untrained tail is drained,
 then clears before higher-level fanout work. An oversized file stays
 horizontal; streaming repartition remains TD-COMPACT-2 follow-up work.
+Object-store discovery also rejects staging components from the full URL (not
+only `DirEntry.name`), preventing a bounded follow-up from consuming an
+unpublished `__flush` object while its final-key promotion is in flight.
 
 S3 — **Partially implemented: pressure priority + observability.** Live
 available-memory refresh makes compaction admission yield to query/cache

--- a/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
+++ b/docs/10-quality/td/TD-IVF-2-insert-path-axis-training-ignores-empty-index-specs.adoc
@@ -5,7 +5,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Proposed.** Measured 2026-07-23 during the restart/recovery pressure tests (develop @ 02725d81a, post #1163).
+| Status | **S1 resolved; S1b remains.** Search, direct insert, and flush now share one fail-closed `index_configs` predicate, additionally dominated by the process runtime gate. The superlinear trainer allocation for collections that explicitly opt into AXIS remains open.
 | Priority | **P0 — this path is the primary memory-kill driver, not just a CPU tax.** Controlled measurement (single-collection server, NO compaction): ingesting 120k × 128-dim (61 MB raw) then letting the insert-path training fire took RSS from 4.35 GB to a **55.6 GB peak (+51.2 GB)** and the training **did not complete within 15.5 min** (64 GB machine, deep in swap). At 1M after an unclean restart it ran **>43 min at ~90–300% CPU, RSS 10→39.5 GB and climbing** until manually killed. The 126 GB jetsam kill originally attributed to compaction (TD-COMPACT-2) is predominantly THIS path — the compaction-window peak (55.6 GB) is indistinguishable from the AXIS-only control (55.59 GB). All of it on a collection that never asked for AXIS.
 | Component | `src/index/axis/management/manager.rs` (`insert_into_ivf` :2069, incremental train :2217); `src/index/axis/clustering.rs` (`train_model` :255); config `enable_axis_indexes` (`proximadb-config/src/lib.rs:939–963`, default **true**; also `config/config.toml:60`).
 | Evidence | Collection `sift1m` created via REST v2 with `index_specs: []` (verified by GET). Live ingest run: `🎯 Training clustering model for collection 1 with 634000 vectors` (14:20:59). Post-unclean-kill restart: recovery flushes correctly skip AXIS (zero training lines at boot — #1163 works), but ~2.5 min later the WAL-replayed inserts hit the AXIS incremental path: `Training PCA model: 916000 vectors` (1 s) then `🎯 Training clustering model for collection 1 with 1000000 vectors` — still ~90% CPU 13+ min later. Handoff Test 1's "idle CPU < 5%" assertion fails on unclean restarts because of this path.
@@ -40,6 +40,25 @@ REMAINING scope (why this TD stays open at reduced priority):
    pinned to the commit that closed it, so a regression test can guard it —
    the death-spiral evidence below documents the failure mode to protect
    against.
+
+== Status update — three-gate enforcement (2026-08-01)
+
+S1 is now closed across all serving feeds:
+
+* compile without `axis` removes the AXIS-only discovery modules;
+* `storage.optimization.enable_axis_indexes=false` prevents manager
+  registration, insert/search feed, flush hooks, and AXIS background loops;
+* absent/empty `index_configs` fails the shared collection predicate used by
+  query context, direct insert, and flush;
+* `pax_vector_format:off` remains a PAX representation/quantization choice and
+  no longer masquerades as an index declaration;
+* reclustering additionally requires an already-published IVF/HNSW index before
+  it performs the storage-inclusive corpus read.
+
+The last bullet closes a later manifestation of the same failure class: a
+3.3M-vector PAX-only collection was materialized and trained by the 60-second
+discovery watcher concurrently with compaction. That run is not valid
+compaction-memory evidence and must be repeated after this fix.
 
 == The finding
 

--- a/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
+++ b/docs/12-design/adr/ADR-070-axis-not-needed-for-codesign-collections.adoc
@@ -24,7 +24,7 @@ Measured on SIFT 1M via REST (post-fix): recall@10 = 0.999, mean latency 476ms c
 
 AXIS (HNSW/IVF in-memory index) is **not the default** for collections without `index_configs`. The co-design PAX scan path (Stage 1 + Stage 3) is the default, and is sufficient for codegraph and similar read-heavy, upsert-prone workloads.
 
-AXIS remains available as an **opt-in** via `index_configs` for workloads that need sub-5ms latency (e.g., real-time code completion, interactive autocomplete). The per-collection AXIS gate (#1145) already routes correctly: `use_axis_indexes = pax_off || !index_configs.is_empty()`.
+AXIS remains available as an **opt-in** via non-empty `index_configs` for workloads that need sub-5ms latency (e.g., real-time code completion, interactive autocomplete). Runtime serving additionally requires `storage.optimization.enable_axis_indexes=true`; compile-time capability additionally requires the Cargo `axis` feature. A format tag such as `pax_vector_format:off` controls PAX representation and is not an index declaration.
 
 == Economics (1M code entities, 768d embeddings)
 
@@ -46,6 +46,7 @@ The ~27ms latency difference (1ms AXIS vs 28ms warm PAX) does not justify 8.6GB 
 * **Positive**: $31/month RAM savings per collection; O(1) upserts (no re-index); immediate restart (no async rebuild); simpler operations (no index persistence/recovery).
 * **Negative**: cold-query latency is ~476ms (object-store GETs) — mitigated by the survivor cache (warms to ~28ms) and parallel morsel search (TD-SEARCH-2, ~7× speedup → ~70ms cold).
 * **AXIS is not removed** — it stays as an opt-in for latency-sensitive use cases. The #1145 gate + #1155 flush-skip already prevent AXIS from being built/queried for co-design collections.
+* **Continuous maintenance is stricter than declared intent** — reclustering requires a published IVF/HNSW index before reading the collection corpus. It cannot bootstrap an absent index as a side effect of drift observation.
 
 == Related
 

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -1,0 +1,132 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-086: Byte-weighted, process-wide compaction memory admission
+:status: Accepted
+:date: 2026-08-01
+
+[cols="1,3"]
+|===
+|Status |**Accepted** — implementation tracked by TD-COMPACT-2 and TD-COMPACT-4
+|Date |2026-08-01
+|Decider |Vijaykumar Singh
+|Amends |ADR-076 background compaction admission
+|Evidence
+|link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[3.3M-vector release/Azurite memory profile]
+|===
+
+== Context
+
+ADR-076 removed compaction from the flush latency path and bounded L0 file
+count, but its worker-count limit is not a memory limit. Four workers can still
+start four large, independent collection merges. Before this decision, task
+discovery selected every eligible file at a level and workers materialized the
+records before any process-wide resource reservation.
+
+The release/Azurite 3.3M-vector control run measured five PAX inputs totalling
+882,773,394 bytes and an incremental compaction RSS of approximately 8,296 MiB:
+**9.85 bytes of peak resident memory per byte of immutable input**. The run
+completed, but the same geometry is unsafe on an 8 GiB pod and unsafe when two
+collections compact concurrently on a larger node.
+
+Neither a fixed byte limit nor a percentage alone is sufficient:
+
+* a fixed limit ignores the pod or server size;
+* a capacity percentage ignores current query/cache pressure;
+* live available memory alone is volatile and lets a quiet instant consume an
+  excessive share of a large host; and
+* a worker-count semaphore gives a 20 MiB merge the same weight as an 850 MiB
+  merge.
+
+== Decision
+
+=== D1 — Input bytes are the admission currency
+
+Every compaction task carries the sum of its immutable input segment sizes as
+an unsigned 64-bit byte count. Projected peak memory is:
+
+`projected_bytes = ceil(input_bytes * memory_amplification_factor)`
+
+The initial factor is `12.0`, providing 22% headroom over the measured 9.85x
+incremental RSS. It is an auditable conservative estimate, not a claim that
+all allocations scale perfectly linearly. The factor remains TOML-configurable
+so later streaming work can lower it only after new release evidence.
+
+=== D2 — The tightest independent guard wins
+
+For each scheduling and admission decision:
+
+`effective_budget = min(process_visible_total * 0.25,
+                         currently_available * 0.50,
+                         optional_absolute_ceiling)`
+
+`process_visible_total` and `currently_available` are refreshed from the OS;
+on Linux they are constrained by cgroup memory limit and current usage. The
+absolute ceiling is disabled when `max_memory_mb = 0` and is intended for an
+operator who must reserve a known amount for query/cache/sidecar workloads.
+
+The capacity fraction prevents background maintenance from owning the node.
+The live fraction yields to foreground and cache pressure. The absolute value
+is a final operator safety rail. No one of the three replaces the other two.
+
+=== D3 — Admission is process-wide and byte-weighted
+
+All SST compaction workers and collections share one atomic projected-byte
+reservation counter. A task begins record materialization, MVCC resolution,
+sorting, clustering, training, encoding, and writing only after its complete
+projection fits the effective budget after existing reservations.
+
+The reservation is RAII-owned by the worker and is released on success, error,
+cancellation, or shutdown. Admission periodically refreshes live memory so
+memory returned by query/cache work can unblock the queue.
+
+=== D4 — Discovery creates byte-bounded file morsels
+
+Task discovery deterministically orders candidates oldest first and packs only
+whole, mutually exclusive files that fit the current input-byte budget. A
+one-file rewrite is rejected because it cannot reduce query fanout. If no pair
+fits, the level remains horizontal and the scheduler reports the decision.
+
+The controller never divides a PAX segment in memory merely to satisfy a
+budget. Repacking one oversized segment is future streaming/repartition work.
+
+=== D5 — Remove avoidable copies before budgeting them
+
+The compaction read/MVCC/write path uses canonical `ProximaRecord` values
+end-to-end, resolves sorted MVCC batches in place, and does not retain the
+background-only merged-vector copy. Admission is defense in depth around the
+remaining real materialization, not permission to preserve known duplicate
+representations.
+
+=== D6 — Expose the decision
+
+Prometheus exports process-wide queue depth, running count, projected reserved
+bytes, and admission waits. Logs include input bytes, projected bytes, wait
+duration, and horizontal/no-pair decisions.
+
+== Consequences
+
+* Concurrent collections cannot independently reserve the same free memory.
+* Sorting, clustering, training, and encoding happen only after admission.
+* Small jobs can progress around a single oversized file without exceeding the
+  budget.
+* A constrained node can retain more query-visible segments, increasing
+  GETs/query. This is a deliberate stability/read-cost Pareto point: provision
+  more memory, raise the explicit ceiling, or land streaming compaction to
+  consolidate further without restoring OOM risk.
+* The initial 12x factor is intentionally conservative. It must be revised from
+  a release-profile, object-store-path benchmark rather than intuition.
+* This decision bounds aggregate projected memory but does not make the writer
+  streaming. TD-COMPACT-2's O(write-buffer) merge/write target remains open.
+
+== Verification
+
+The implementation must prove:
+
+* deterministic byte-bounded morsel selection, including oversized-file skip,
+  at-least-two-files, and zero-budget fail-closed cases;
+* weighted cross-collection reservation and RAII release;
+* cgroup capacity/current-usage constraint arithmetic;
+* config validation for finite amplification and fractions in `(0, 1]`;
+* unchanged behavior when the automatic absolute ceiling (`0`) is used; and
+* a release/Azurite 3.3M-vector run showing that the configured bound changes
+  merge geometry without recall loss or process-memory oversubscription.

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -92,6 +92,12 @@ derives the threshold-one continuation from the immutable L0-to-PAX task shape
 across residual L0 follow-up morsels and clears it before any higher-level
 fanout merge. Admission still precedes every training morsel.
 
+Discovery evaluates the authoritative object URL, not only its basename, and
+excludes any `__flush`, `__compact`, `.tmp`, or `.staging` path component. Flat
+object-store LIST responses can expose a normal `L0_….pax` basename for an
+unpublished `/__flush/L0_….pax` object; admitting it races atomic promotion and
+can materialize the same records twice.
+
 The controller never divides a PAX segment in memory merely to satisfy a
 budget. Repacking one oversized segment is future streaming/repartition work.
 
@@ -115,6 +121,9 @@ duration, and horizontal/no-pair decisions.
 * Sorting, clustering, training, and encoding happen only after admission.
 * Small jobs can progress around a single oversized file without exceeding the
   budget.
+* Remote staging objects are never compaction inputs. Replacing the current
+  remote staging-copy promotion with one final-key upload plus an atomic
+  manifest publication is a separate object-store publish-protocol decision.
 * A constrained node can retain more query-visible segments, increasing
   GETs/query. This is a deliberate stability/read-cost Pareto point: provision
   more memory, raise the explicit ceiling, or land streaming compaction to

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -12,6 +12,7 @@
 |Amends |ADR-076 background compaction admission
 |Evidence
 |link:../../_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc[3.3M-vector release/Azurite memory profile]
+and link:../../_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc[post-fix bounded-writer verification]
 |===
 
 == Context
@@ -141,6 +142,13 @@ duration, and horizontal/no-pair decisions.
   a release-profile, object-store-path benchmark rather than intuition.
 * This decision bounds aggregate projected memory but does not make the writer
   streaming. TD-COMPACT-2's O(write-buffer) merge/write target remains open.
+* OS swap is not a compaction execution mode. The preferred follow-up is
+  deterministic application-managed spill with separate RAM and scratch-byte
+  reservations. Spill may enlarge the input morsel without relaxing the RAM
+  safety rail.
+* Neutral task telemetry, spill correctness, and atomic publication remain OSS
+  mechanisms. Provider-price, tenant-tier, Spot/on-demand, and fleet-placement
+  decisions are external control-plane policy.
 
 == Verification
 
@@ -155,3 +163,8 @@ The implementation must prove:
 * unchanged behavior when the automatic absolute ceiling (`0`) is used; and
 * a release/Azurite 3.3M-vector run showing that the configured bound changes
   merge geometry without recall loss or process-memory oversubscription.
+
+The 2026-08-02 verification satisfied the final release gate: five admitted
+morsels remained inside the 12x factor (maximum observed 10.75x), the collection
+settled at three segments under the 5 GiB ceiling, and object-cold recall@10 was
+0.981.

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -109,6 +109,15 @@ background-only merged-vector copy. Admission is defense in depth around the
 remaining real materialization, not permission to preserve known duplicate
 representations.
 
+The PAX write boundary follows the same rule. Coalesced f32 inputs use one
+fixed-width contiguous arena, Region A/B encoders fill their pre-sized final
+payloads directly with one reusable scratch arena per worker, SQ8 fitting
+reduces over segmented rows, and final regions stream to the local staging
+file. Corpus-wide f32 buffers are released as soon as A/B encoding completes;
+the compressed block buffer is released after staging-file publication. The
+admission factor budgets irreducible live state, not millions of avoidable
+per-row allocations or a second whole-segment assembly buffer.
+
 === D6 — Expose the decision
 
 Prometheus exports process-wide queue depth, running count, projected reserved

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -87,7 +87,10 @@ Ordinary fanout compaction requires at least two files; if no pair fits, the
 level remains horizontal and the scheduler reports the decision. The existing
 threshold-one L0 training signal is the narrow exception: it may admit one
 untrained PAX file because the rewrite promotes the query layout even though it
-does not reduce file count. Admission still precedes that training work.
+does not reduce file count. When the byte budget splits that work, the worker
+derives the threshold-one continuation from the immutable L0-to-PAX task shape
+across residual L0 follow-up morsels and clears it before any higher-level
+fanout merge. Admission still precedes every training morsel.
 
 The controller never divides a PAX segment in memory merely to satisfy a
 budget. Repacking one oversized segment is future streaming/repartition work.

--- a/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
+++ b/docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc
@@ -82,9 +82,12 @@ memory returned by query/cache work can unblock the queue.
 === D4 — Discovery creates byte-bounded file morsels
 
 Task discovery deterministically orders candidates oldest first and packs only
-whole, mutually exclusive files that fit the current input-byte budget. A
-one-file rewrite is rejected because it cannot reduce query fanout. If no pair
-fits, the level remains horizontal and the scheduler reports the decision.
+whole, mutually exclusive files that fit the current input-byte budget.
+Ordinary fanout compaction requires at least two files; if no pair fits, the
+level remains horizontal and the scheduler reports the decision. The existing
+threshold-one L0 training signal is the narrow exception: it may admit one
+untrained PAX file because the rewrite promotes the query layout even though it
+does not reduce file count. Admission still precedes that training work.
 
 The controller never divides a PAX segment in memory merely to satisfy a
 budget. Repacking one oversized segment is future streaming/repartition work.
@@ -123,7 +126,8 @@ duration, and horizontal/no-pair decisions.
 The implementation must prove:
 
 * deterministic byte-bounded morsel selection, including oversized-file skip,
-  at-least-two-files, and zero-budget fail-closed cases;
+  ordinary at-least-two-files, threshold-one layout promotion, and zero-budget
+  fail-closed cases;
 * weighted cross-collection reservation and RAII release;
 * cgroup capacity/current-usage constraint arithmetic;
 * config validation for finite amplification and fractions in `(0, 1]`;

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -411,6 +411,10 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Persistent PAX warm tier and post-publication cache population
 | Accepted (2026-07-29)
 | Adds a real restart-persistent, checksum-verified local-disk tier behind both PAX warm caches; promotes local hits to DRAM, writes through authoritative misses, and seeds writer-owned invariant/SQ8 bytes only after atomic publication. Corrects the legacy `NvmeBackend` assumption (it is memory-only), makes coarse-probe metadata population default-on, purges DRAM/local/replay entries after compaction input deletion, and adds bounded prefix coalescing. Tracked: TD-CACHE-9 and TD-SEARCH-3.
+| link:ADR-086-byte-weighted-compaction-memory-admission.adoc[ADR-086]
+| Byte-weighted, process-wide compaction memory admission
+| Accepted (2026-08-01)
+| Converts immutable input-segment bytes to a conservative peak-RSS reservation (initially 12x from a measured 9.85x 3.3M-vector run), admits against the tightest of cgroup-visible capacity, live available memory, and an optional absolute ceiling, and shares one weighted reservation counter across collections. Discovery packs deterministic whole-file morsels before materialization; if no pair fits, the level remains horizontal instead of risking an OOM. Tracked: TD-COMPACT-2/4.
 | link:ADR-0083-consolidated-catalog-identity-model.adoc[ADR-0083]
 | Consolidated catalog identity model — the composite is the SOLE canonical identity; retire the global u64
 | Accepted — Revision 2 (2026-07-30)

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -790,3 +790,22 @@ hardware = "Local macOS arm64 (Apple Silicon, 64GB), serialized release run; Azu
 date = "2026-08-01"
 version = "e60fc85c9500f4e08e5cf3ff9946f04921d97b1a"
 notes = "Five L0 inputs totalled 882,773,394 B (841.9 MiB); compaction boundary RSS ~8,655 MiB and write-done RSS 16,951 MiB, delta 8,296 MiB = 9.85x. 5->1 in 38.991s; output 882,842,998 B. Recall@10 post-write/local-warm/object-cold = 0.998/0.995/0.993. This is the PRE-ADMISSION baseline but already includes the canonical/in-place copy reduction; it supports the 12.0 projection default and does not validate the post-change cap."
+
+[[claims]]
+id = "compaction_bounded_writer_3m3"
+claim = "The bounded PAX writer reduces the comparable 3.3M large-morsel writer-tail RSS delta from 11,353 MiB / 30.86x input to 2,773 MiB / 8.44x; all five post-fix morsels remain within the 12.0x admission factor (maximum observed 10.75x). Under a 5 GiB ceiling the collection settles at three segments and retains object-cold recall@10 0.981."
+metric = "task-relative incremental peak RSS/input bytes + absolute RSS + settled segment geometry + recall@10 + GET/query"
+status = "measured"
+asserted_in = [
+  "docs/_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc",
+  "docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc",
+  "docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc",
+  "docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc",
+]
+bench_source = "scripts/bench/sift1m_get_reduction.py"
+bench_command = "PROXIMADB_COUNT_FS_IO=1 PROXIMADB_TRACE_COMPACTION_MEM=1 <repo-python> scripts/bench/sift1m_get_reduction.py --binary target/release/proximadb-server --binary-source-revision 82c29d4eb66e706a8c65c37ea1fc84c240d4581f --root <fresh-root> --base-path <bigann10m.u8bin> --base-format u8bin --query-path <bigann-query.u8bin> --query-format u8bin --groundtruth-path <3.3m-top20.ivecs> --groundtruth-format ivecs --groundtruth-scope-rows 3300000 --rows 3300000 --batch-size 30000 --ingest-transport flight --write-buffer-mb 8192 --compaction-max-memory-mb 5120 --flush-vector-threshold 660000 --flush-floor-predicted-mb 96 --queries 100 --top-k 10 --nprobe 9 --azurite --storage-url az://<container>/<prefix>"
+artifact = "docs/_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc"
+hardware = "Local macOS arm64 (Apple Silicon, 64 GiB), serialized release run; Azurite HTTP object path"
+date = "2026-08-02"
+version = "82c29d4eb66e706a8c65c37ea1fc84c240d4581f"
+notes = "Release binary SHA-256 8a0c584e8327ea6caf018d494f2a8796f828afc715391c274ac08fbc403792c8; result SHA-256 ae004366bae2bd053ac131449bdccacbde4d26686c28848e52bfa7eccbb36b16. Five task ratios: 5.97x, 10.75x, 8.44x, 0.59x, 5.23x. Absolute process peak 14,105 MiB; retained baseline is reported separately from task delta. Three PAX v3 segments total 882,860,995 B / 99 cells. nprobe=9 is per segment: 27 cells/query, object-cold 58.63 GET/query and 489.98 ms p50. A neighboring nprobe=8 control failed recall at 0.977 and is not the recommendation. Azurite is operation-count and relative-latency evidence, not Azure WAN latency."

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -772,3 +772,21 @@ hardware = "Local macOS arm64 Apple Silicon, 64 GiB RAM, serialized release-serv
 date = "2026-07-31"
 version = "3.3M develop-derived PR #1345 @ 06c9e5678fa7de6a782563bdeb2625e74ba6b37e; lower calibration matrices @ b160d2107d67f712ea78a3d0779d62763f3dfba4 / 504e849a4d2ea84791310540403808a89f3e3fea"
 notes = "3.3M matrix: 20 points, 1000 queries/point, status pass, no failures, SHA-256 5d32b83cf4987956d1bfb71ae93a77e67d76682c6b7b9464f167cea0066e8cc6. Exact binary SHA-256 d6b660cf425f4251f841d882d64420a137060668d6cdde150be215849598e431. Azurite is operation-count and relative-latency evidence, not Azure WAN latency. Cluster radii are persisted shape metadata but do not participate in current centroid-distance probe selection. The four-scale fit is cross-revision calibration evidence; rerun all scales on one binary before a canonical five-point publication."
+
+[[claims]]
+id = "compaction_memory_amplification_3m3"
+claim = "After canonical-record and in-place-MVCC copy removal, a release-profile 3.3M-vector PAX compaction over the production Azure backend/Azurite path still consumes 9.85x incremental RSS per input-segment byte; input bytes are therefore a usable conservative admission currency, with 12x initial headroom"
+metric = "incremental_peak_rss_bytes / input_segment_bytes + compaction wall time + settled segment count + recall@10"
+status = "measured"
+asserted_in = [
+  "docs/12-design/adr/ADR-086-byte-weighted-compaction-memory-admission.adoc",
+  "docs/10-quality/td/TD-COMPACT-2-compaction-memory-amplification-oom.adoc",
+  "docs/10-quality/td/TD-COMPACT-4-memory-aware-compaction-admission-control.adoc",
+]
+bench_source = "scripts/bench/sift1m_get_reduction.py"
+bench_command = "PROXIMADB_TRACE_COMPACTION_MEM=1 PROXIMADB_TRACE_PAX_WRITE=1 PROXIMADB_SKIP_AXIS_INDEXING=1 PROXIMADB_FLUSH_PREDICTED_BYTES_FLOOR_MB=96 PROXIMADB_PAX_IVF_K=100 python3 scripts/bench/sift1m_get_reduction.py --binary target/release/proximadb-server --root <root> --sift-dir <bigann10m-view> --groundtruth-path <3.3m-top20.ivecs> --groundtruth-scope-rows 3300000 --rows 3300000 --batch-size 30000 --flush-vector-threshold 660000 --queries 100 --top-k 10 --nprobe 20 --azurite --storage-url az://<container>/<prefix>"
+artifact = "docs/_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc"
+hardware = "Local macOS arm64 (Apple Silicon, 64GB), serialized release run; Azurite HTTP object path"
+date = "2026-08-01"
+version = "e60fc85c9500f4e08e5cf3ff9946f04921d97b1a"
+notes = "Five L0 inputs totalled 882,773,394 B (841.9 MiB); compaction boundary RSS ~8,655 MiB and write-done RSS 16,951 MiB, delta 8,296 MiB = 9.85x. 5->1 in 38.991s; output 882,842,998 B. Recall@10 post-write/local-warm/object-cold = 0.998/0.995/0.993. This is the PRE-ADMISSION baseline but already includes the canonical/in-place copy reduction; it supports the 12.0 projection default and does not validate the post-change cap."

--- a/docs/_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc
+++ b/docs/_internal/status/COMPACTION_MEMORY_3M3_BASELINE_2026_08_01.adoc
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Compaction memory baseline — BIGANN/SIFT-family 3.3M, release + Azurite (2026-08-01)
+
+== Purpose
+
+Measure the real PAX L0-to-L1 compaction memory curve before adding the
+byte-weighted admission controller. This run already includes the canonical
+`ProximaRecord` path and in-place sorted MVCC resolution, so it measures the
+remaining pipeline rather than the removed legacy DTO copies.
+
+== Provenance
+
+[cols="1,3"]
+|===
+|Source revision |`e60fc85c9500f4e08e5cf3ff9946f04921d97b1a`
+|Binary |release profile, arm64; SHA-256 `e1a0a9788998fa7d5685daa07a5e8552612f1e42b4264e981f3a21830425fcff`
+|Hardware |Apple Silicon, 64 GiB RAM
+|Object path |production Azure backend over Azurite HTTP (`az://`), not `file://`
+|Dataset |3,300,000 vectors, 128 dimensions, BIGANN u8 source; exact 3.3M top-20 ground truth
+|Ingest |Arrow Flight, 30,000 rows/batch, 660,000 vector flush threshold, 96 MiB predicted flush floor
+|Search |100 distinct queries/phase, top-10, `k_c=100`, `nprobe=20`, NEON SQ8 rerank
+|Trace |`PROXIMADB_TRACE_COMPACTION_MEM=1`, `PROXIMADB_TRACE_PAX_WRITE=1`; AXIS/drift work disabled
+|===
+
+The original machine-local result and log were captured at
+`/private/tmp/proximadb-bigann33m-mem-7d6cd-a8/`. That temporary path is not a
+repository artifact; all decision-bearing values are transcribed below.
+
+== Compaction memory result
+
+[cols="1,1,1", options="header"]
+|===
+|L0 records |Input segment bytes |PAX writer peak buffered bytes
+|690,000 |184,010,354 |432,236,138
+|720,000 |192,537,789 |451,556,010
+|690,000 |184,812,723 |433,038,486
+|600,000 |160,706,264 |376,554,674
+|600,000 |160,706,264 |376,554,674
+|===
+
+Five L0 segments (882,773,394 bytes, 841.9 MiB) merged into one 882,842,998-byte
+L1 segment in 38.991 seconds. RSS moved from approximately 8,655 MiB at the
+compaction boundary to 16,951 MiB at write completion:
+
+* incremental RSS: **8,296 MiB**;
+* incremental-RSS/input-byte amplification: **9.85x**;
+* decoded input reads: approximately +4,245 MiB;
+* in-place MVCC resolution: +1,504 MiB; and
+* writer stage: +2,213 MiB, with 2,069,994,048 tracked peak buffered bytes.
+
+The measurement supports an initial admission factor of **12.0x**, which adds
+approximately 22% headroom. It does not prove that 12x is universally tight;
+mixed dimensions, metadata shapes, compression, and deletion density require
+future stratified evidence.
+
+== Read-path control
+
+The completed one-segment layout retained quality:
+
+[cols="1,1,1,1", options="header"]
+|===
+|Phase |Recall@10 |GETs/query |p50
+|First query after write |0.998 |4.04 |95.54 ms
+|Local-disk warm |0.995 |0.90 |71.36 ms
+|Object cold (Azurite HTTP) |0.993 |40.28 |543.47 ms
+|===
+
+Azurite latency is local-emulator evidence, not an Azure WAN claim. GET counters
+come from the measured ProximaDB process. The cold phase fetched 105.2 MB/query
+because `nprobe=20` visits 20% of the 100 cells; this benchmark isolates
+compaction memory and does not claim that the probe geometry is the economic
+knee.
+
+== Interpretation
+
+The input-byte sum is known before record decoding and predicts the dominant
+memory scale well enough for conservative admission. Worker count alone is not
+a safe bound. Conversely, a small absolute limit can prevent one-segment
+convergence and raise GET fanout; the post-change benchmark must report both
+peak memory and settled segment geometry rather than declaring either metric in
+isolation.

--- a/docs/_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc
+++ b/docs/_internal/status/COMPACTION_MEMORY_3M3_BOUNDED_WRITER_2026_08_02.adoc
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Compaction bounded-writer verification — BIGANN 3.3M, release + Azurite (2026-08-02)
+
+== Purpose
+
+Verify the post-admission PAX writer remediation on the same 3.3M-vector
+release/Azurite workload that exposed a 30.86x writer-tail RSS amplification.
+The run measures memory and read geometry together so a safe memory result
+cannot silently claim success by retaining an uneconomic segment layout.
+
+== Provenance
+
+[cols="1,3"]
+|===
+|Source revision |`82c29d4eb66e706a8c65c37ea1fc84c240d4581f`
+|Binary |release profile with Azure support, arm64, 191,892,048 bytes; SHA-256 `8a0c584e8327ea6caf018d494f2a8796f828afc715391c274ac08fbc403792c8`
+|Hardware |Apple Silicon, 64 GiB RAM; serialized run
+|Object path |production Azure HTTP backend over Azurite (`az://`), not `file://`
+|Dataset |3,300,000 BIGANN uint8 vectors, 128 dimensions; independently generated exact 3.3M top-20 ground truth
+|Ingest |Arrow Flight, 30,000 rows/batch, 660,000-vector flush threshold, 96 MiB predicted flush floor
+|Compaction policy |12.0x memory projection, 25% capacity fraction, 50% live-availability fraction, 5 GiB absolute ceiling
+|Search |100 distinct queries/phase, top-10, global `nprobe=9`; the override is per segment
+|Trace |`PROXIMADB_TRACE_COMPACTION_MEM=1`, `PROXIMADB_COUNT_FS_IO=1`
+|===
+
+Machine-local artifacts are retained at
+`/private/tmp/proximadb-bigann33m-mem-admit-a18/`:
+
+* `result.json`: SHA-256
+  `ae004366bae2bd053ac131449bdccacbde4d26686c28848e52bfa7eccbb36b16`;
+* `benchmark.toml`: SHA-256
+  `582628311f3f6512668b2f358ca673ac9029f7c1ef9fb45c3d0a8880e8290ea9`;
+  and
+* `server-ingest.log`: SHA-256
+  `ed4a0bcbceb279053906d78e73b50188391ae6bbe70887426f6fa9eb0a5827b8`.
+
+These temporary files are not repository artifacts; all decision-bearing
+values are transcribed below.
+
+== Memory result
+
+Each row is one admitted task. `Baseline` is reconstructed from the trace's
+first `rss_mb - delta_mb` checkpoint. `Peak delta` is the largest stage RSS
+minus that task baseline, so allocator state inherited from earlier tasks is
+not charged twice.
+
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+|Task |Input bytes |Projected bytes |Baseline |Peak |Peak delta |Delta/input
+|1 |184,010,354 |2,208,124,248 |8,083 MiB |9,130 MiB |1,047 MiB |5.97x
+|2 |160,396,216 |1,924,754,592 |9,131 MiB |10,775 MiB |1,644 MiB |10.75x
+|3 |344,444,987 |4,133,339,844 |10,775 MiB |13,548 MiB |2,773 MiB |8.44x
+|4 |337,483,901 |4,049,806,812 |13,914 MiB |14,105 MiB |191 MiB |0.59x
+|5 |200,884,783 |2,410,617,396 |10,288 MiB |11,290 MiB |1,002 MiB |5.23x
+|===
+
+The largest observed ratio is **10.75x**, inside the configured 12.0x
+projection. The most comparable pre-fix task admitted 385,695,616 bytes and
+grew 11,353 MiB (30.86x) at `write_done`. Post-fix task 3 admitted 344,444,987
+bytes and grew 2,773 MiB (8.44x), reducing the similarly sized writer-tail
+delta by **75.6%** and amplification by **72.7%**. The absolute process peak
+also fell from 24,264 MiB to 14,105 MiB, but task-relative delta is the
+decision currency because process baselines contain allocator, WAL, and cache
+state.
+
+The result validates retaining the 12.0x factor. It does not justify lowering
+the safety factor: task 2 reached 10.75x, leaving only 11.6% factor headroom.
+It also does not justify raising the 5 GiB ceiling on a serving process: total
+RSS includes a large non-compaction baseline that the reservation does not
+cap.
+
+== Settled layout and read-path control
+
+Ingest completed in 46.152 seconds (71,502 vectors/second). The 5 GiB ceiling
+settled the collection into three PAX v3 segments:
+
+[cols="1,1,1,1", options="header"]
+|===
+|Level |Rows |Bytes |Coarse cells
+|L1 |1,260,000 |337,514,824 |38
+|L1 |750,000 |200,903,021 |22
+|L2 |1,290,000 |344,443,150 |39
+|===
+
+Total: 3,300,000 rows, 882,860,995 bytes, 99 coarse cells. A global
+`nprobe=9` therefore probes 27 cells/query (nine per segment), not nine cells
+per collection.
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+|Phase |Recall@10 |GET/query |Bytes/query |p50 |Cells/query
+|First query after write |0.982 |4.63 |11.10 MB |80.68 ms |27
+|Local-disk warm |0.982 |0.92 |1.77 MB |67.38 ms |27
+|Object cold (Azurite HTTP) |0.981 |58.63 |162.62 MB |489.98 ms |27
+|===
+
+A neighboring three-segment control at global `nprobe=8` probed 24 cells and
+reduced object-cold GET/query to 54.26, but its cold recall was 0.977. It is a
+failed quality point, not a deployable recommendation. The result SHA-256 is
+`e1c75b438958e20f62bfe9c3a770e7da54a82e1c3a98bac5e5244934246de5c4`.
+
+The previous global `nprobe=20` control probed 53/99 cells because the override
+was independently capped per segment. Relative to that over-probed control,
+`nprobe=9` reduced cold GET/query 87.80 -> 58.63 and p50 728.46 -> 489.98 ms
+while preserving the 0.98 recall contract. This is a multi-segment validation
+point, not a replacement for the checked-in single-segment four-scale power
+law.
+
+== Decision
+
+* Keep the 12.0x in-memory admission factor and 5 GiB serving-process ceiling.
+* The bounded writer closes the measured per-row/whole-segment allocation
+  regression, but TD-COMPACT-2 remains open until compaction is O(write-buffer).
+* Do not use OS swap to enlarge a serving task. The next mechanism is explicit,
+  application-managed spill with separate RAM and scratch-byte admission.
+* Spill should permit one larger output without exposing partial objects:
+  scratch locally, upload the completed final object once, then CAS the
+  manifest. A separate Spot worker is an optional commercial placement policy,
+  not a correctness dependency.
+* The three-segment result retains roughly twice the logical probe work of the
+  one-segment 3.3M quality floor. Segment consolidation remains a direct GET
+  lever, provided it is achieved without restoring memory oversubscription.
+
+Azurite is faithful operation-count evidence and a relative local-HTTP latency
+comparison. It is not an Azure WAN latency claim.

--- a/scripts/bench/sift1m_get_reduction.py
+++ b/scripts/bench/sift1m_get_reduction.py
@@ -1139,6 +1139,7 @@ def write_config(
     storage_url: str,
     flush_interval_secs: int = 12,
     flush_floor_predicted_mb: int = 128,
+    compaction_max_memory_mb: int = 0,
 ) -> None:
     data = root / "data"
     config = f"""[server]
@@ -1157,6 +1158,12 @@ mmap_enabled = false
 
 [storage.optimization]
 enable_mmap = false
+
+[storage.compaction_config]
+memory_amplification_factor = 12.0
+memory_budget_fraction = 0.25
+available_memory_fraction = 0.5
+max_memory_mb = {compaction_max_memory_mb}
 
 [[storage.storage_locations]]
 url = "{storage_url}"
@@ -1796,6 +1803,15 @@ def main() -> int:
     )
     parser.add_argument("--write-buffer-mb", type=int, default=4096)
     parser.add_argument(
+        "--compaction-max-memory-mb",
+        type=int,
+        default=0,
+        help=(
+            "optional absolute ceiling for process-wide projected compaction "
+            "memory; zero keeps cgroup/live-memory auto-sizing"
+        ),
+    )
+    parser.add_argument(
         "--flush-vector-threshold",
         type=int,
         default=100_000,
@@ -1896,6 +1912,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.write_buffer_mb <= 0:
         raise RuntimeError("--write-buffer-mb must be positive")
+    if args.compaction_max_memory_mb < 0:
+        raise RuntimeError("--compaction-max-memory-mb must be non-negative")
     if args.flush_vector_threshold <= 0:
         raise RuntimeError("--flush-vector-threshold must be positive")
     if args.flush_floor_predicted_mb < 0:
@@ -2091,6 +2109,7 @@ def main() -> int:
         storage_url,
         flush_interval_secs,
         args.flush_floor_predicted_mb,
+        args.compaction_max_memory_mb,
     )
     server_url = f"http://127.0.0.1:{args.port}"
     local_disk = root / "local-disk-cache"
@@ -2206,6 +2225,12 @@ def main() -> int:
             ),
         },
         "compute_profile": compute_profile(),
+        "compaction_memory_policy": {
+            "memory_amplification_factor": 12.0,
+            "memory_budget_fraction": 0.25,
+            "available_memory_fraction": 0.5,
+            "max_memory_mb": args.compaction_max_memory_mb,
+        },
         "thresholds": {
             "post_write_max_gets_per_query": args.post_write_max_gets,
             "local_disk_warm_max_gets_per_query": args.local_warm_max_gets,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1695,6 +1695,32 @@ impl SstConfig {
                      recommendation [1.0, 1.5]; segment accumulation or rewrite churn may result"
                 );
             }
+            if !compaction.memory_amplification_factor.is_finite()
+                || compaction.memory_amplification_factor < 1.0
+            {
+                return Err(
+                    "compaction memory_amplification_factor must be finite and at least 1.0"
+                        .to_string(),
+                );
+            }
+            if !compaction.memory_budget_fraction.is_finite()
+                || !(0.0..=1.0).contains(&compaction.memory_budget_fraction)
+                || compaction.memory_budget_fraction == 0.0
+            {
+                return Err(
+                    "compaction memory_budget_fraction must be finite and in (0.0, 1.0]"
+                        .to_string(),
+                );
+            }
+            if !compaction.available_memory_fraction.is_finite()
+                || !(0.0..=1.0).contains(&compaction.available_memory_fraction)
+                || compaction.available_memory_fraction == 0.0
+            {
+                return Err(
+                    "compaction available_memory_fraction must be finite and in (0.0, 1.0]"
+                        .to_string(),
+                );
+            }
         }
         if let Some(path) = &self.cache_local_disk_path {
             if path.trim().is_empty() {
@@ -1819,6 +1845,30 @@ mod sst_config_validation_tests {
             compaction.level_multiplier = 1.0;
             compaction.higher_level_file_threshold = 1;
         }
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn compaction_memory_policy_fails_closed_on_invalid_ratios() {
+        let mut config = SstConfig::default();
+        let compaction = config
+            .compaction_config
+            .get_or_insert_with(CompactionConfig::default);
+        compaction.memory_amplification_factor = 0.99;
+        assert!(config.validate().is_err());
+
+        let compaction = config
+            .compaction_config
+            .get_or_insert_with(CompactionConfig::default);
+        compaction.memory_amplification_factor = 12.0;
+        compaction.memory_budget_fraction = 0.0;
+        assert!(config.validate().is_err());
+
+        let compaction = config
+            .compaction_config
+            .get_or_insert_with(CompactionConfig::default);
+        compaction.memory_budget_fraction = 0.25;
+        compaction.available_memory_fraction = 1.01;
         assert!(config.validate().is_err());
     }
 

--- a/src/core/search/mvcc_resolution.rs
+++ b/src/core/search/mvcc_resolution.rs
@@ -53,7 +53,7 @@ impl MvccResolver {
 
         for record in records {
             let oid = &record.oid;
-            if oid.is_empty() || oid == "null" || oid == "none" || oid.trim().is_empty() {
+            if is_append_only_oid(oid) {
                 append_only.push(record);
             } else {
                 id_groups.entry(oid.clone()).or_default().push(record);
@@ -127,6 +127,95 @@ impl MvccResolver {
         resolved
     }
 
+    /// Resolve an owned compaction batch with bounded auxiliary memory.
+    ///
+    /// The general query-path resolver above intentionally accepts arbitrary
+    /// input order, but its `HashMap<String, Vec<...>>` shape is pathological
+    /// for compaction: a 10M-row segment with unique OIDs allocates 10M map
+    /// entries and 10M one-element vectors while the full input remains live.
+    /// Compaction already owns the entire batch, so it can sort by OID and scan
+    /// contiguous version groups instead.
+    ///
+    /// This implementation:
+    ///
+    /// * sorts records in place with the allocation-free unstable sorter;
+    /// * marks at most one winner per versioned OID in a one-byte-per-row mask;
+    /// * compacts winners in the original allocation with `Vec::retain`;
+    /// * never clones an embedding, OID, property tree, or record.
+    ///
+    /// Output is deterministic by OID. Within an OID, effective version then
+    /// creation/update time provide the tie-break order; append-only rows use
+    /// the same deterministic temporal order. The MVCC rules match
+    /// [`Self::resolve_batch`].
+    pub fn resolve_sorted_batch(&self, mut records: Vec<ProximaRecord>) -> Vec<ProximaRecord> {
+        records.sort_unstable_by(|left, right| {
+            left.oid
+                .cmp(&right.oid)
+                .then_with(|| effective_version(left).cmp(&effective_version(right)))
+                .then_with(|| left.created_at_ns.cmp(&right.created_at_ns))
+                .then_with(|| left.updated_at_ns.cmp(&right.updated_at_ns))
+        });
+
+        let mut keep = vec![false; records.len()];
+        let mut group_start = 0usize;
+        while group_start < records.len() {
+            let group_oid = records[group_start].oid.as_str();
+            let mut group_end = group_start + 1;
+            while group_end < records.len() && records[group_end].oid == group_oid {
+                group_end += 1;
+            }
+
+            if is_append_only_oid(group_oid) {
+                for index in group_start..group_end {
+                    keep[index] = !self.is_expired(&records[index]);
+                }
+                group_start = group_end;
+                continue;
+            }
+
+            // Any expired version is a deletion marker for the entire OID.
+            if records[group_start..group_end]
+                .iter()
+                .any(|record| self.is_expired(record))
+            {
+                group_start = group_end;
+                continue;
+            }
+
+            let start_version = effective_version(&records[group_start]);
+            if start_version > 1 {
+                group_start = group_end;
+                continue;
+            }
+
+            let mut expected = start_version;
+            let mut winner = None;
+            for (offset, record) in records[group_start..group_end].iter().enumerate() {
+                let version = effective_version(record);
+                if version == expected {
+                    winner = Some(group_start + offset);
+                    expected += 1;
+                } else if version > expected {
+                    break;
+                }
+                // version < expected is an older duplicate of a version that
+                // already won through the deterministic timestamp ordering.
+            }
+            if let Some(index) = winner {
+                keep[index] = true;
+            }
+            group_start = group_end;
+        }
+
+        let mut index = 0usize;
+        records.retain(|_| {
+            let retain = keep[index];
+            index += 1;
+            retain
+        });
+        records
+    }
+
     /// Return `true` if the record's TTL has elapsed.
     pub fn is_expired(&self, record: &ProximaRecord) -> bool {
         record
@@ -167,6 +256,11 @@ fn effective_version(r: &ProximaRecord) -> u64 {
     } else {
         r.record_version
     }
+}
+
+#[inline]
+fn is_append_only_oid(oid: &str) -> bool {
+    oid.is_empty() || oid == "null" || oid == "none" || oid.trim().is_empty()
 }
 
 impl Default for MvccResolver {
@@ -369,5 +463,76 @@ mod tests {
 
         assert!(resolver.compare_records(&valid, &expired));
         assert!(!resolver.compare_records(&expired, &valid));
+    }
+
+    /// TD-COMPACT-2: the compaction resolver must not allocate one HashMap
+    /// entry plus one Vec allocation per OID. The sort-and-scan path is
+    /// behavior-equivalent to the general query-path resolver for mixed MVCC
+    /// inputs, including append-only rows and expiry.
+    #[test]
+    fn sorted_batch_matches_general_resolver() {
+        let resolver = MvccResolver::with_timestamp(1000);
+        let records = vec![
+            create_record(Some("id2"), 3, 350, None),
+            create_record(None, 0, 130, None),
+            create_record(Some("id1"), 2, 200, None),
+            create_record(Some("id3"), 1, 100, Some(500)),
+            create_record(Some("id2"), 1, 150, None),
+            create_record(Some("id1"), 1, 100, None),
+            create_record(Some("id2"), 1, 140, None),
+            create_record(Some("id2"), 2, 250, None),
+            create_record(Some("null"), 0, 300, None),
+        ];
+
+        let mut general: Vec<(String, u64, i64)> = resolver
+            .resolve_batch(records.clone())
+            .into_iter()
+            .map(|record| (record.oid, record.record_version, record.created_at_ns))
+            .collect();
+        general.sort();
+
+        let mut sorted: Vec<(String, u64, i64)> = resolver
+            .resolve_sorted_batch(records)
+            .into_iter()
+            .map(|record| (record.oid, record.record_version, record.created_at_ns))
+            .collect();
+        sorted.sort();
+
+        assert_eq!(sorted, general);
+    }
+
+    /// Moving through low-memory MVCC must preserve the embedding allocation.
+    /// A pointer change here exposes a hidden full-vector clone even when the
+    /// logical record is unchanged.
+    #[test]
+    fn sorted_batch_moves_embedding_without_cloning() {
+        let resolver = MvccResolver::with_timestamp(1000);
+        let record = create_record(Some("owned"), 1, 100, None);
+        let original_ptr = record.embeddings[0]
+            .values
+            .as_fp32_slice()
+            .map(<[f32]>::as_ptr);
+
+        let resolved = resolver.resolve_sorted_batch(vec![record]);
+        let resolved_ptr = resolved[0].embeddings[0]
+            .values
+            .as_fp32_slice()
+            .map(<[f32]>::as_ptr);
+
+        assert_eq!(resolved_ptr, original_ptr);
+    }
+
+    #[test]
+    fn sorted_batch_output_is_deterministic_by_oid() {
+        let resolver = MvccResolver::with_timestamp(1000);
+        let records = vec![
+            create_record(Some("z"), 1, 100, None),
+            create_record(Some("a"), 1, 100, None),
+            create_record(Some("m"), 1, 100, None),
+        ];
+
+        let resolved = resolver.resolve_sorted_batch(records);
+        let ids: Vec<&str> = resolved.iter().map(|record| record.oid.as_str()).collect();
+        assert_eq!(ids, vec!["a", "m", "z"]);
     }
 }

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -3478,6 +3478,14 @@ impl AxisManager {
         self.hnsw_indexes.read().await.contains_key(collection_id)
     }
 
+    /// Whether a published ANN index currently serves this collection.
+    ///
+    /// Continuous reclustering is maintenance for an existing served index;
+    /// it must not bootstrap one by first materializing the entire collection.
+    pub async fn has_served_index(&self, collection_id: &str) -> bool {
+        self.has_ivf_index(collection_id).await || self.has_hnsw_index(collection_id).await
+    }
+
     /// Phase 8 F1 recluster apply-step for HNSW-served collections: rebuild the
     /// collection's HNSW graph from a complete record set and **atomically swap**
     /// it in as the served index. Same atomic-swap pattern as the IVF path — a
@@ -5539,6 +5547,22 @@ mod recluster_apply_tests {
             !results.is_empty(),
             "ColdBinaryOnly index must serve Stage-1 despite a closed recall gate"
         );
+    }
+
+    #[tokio::test]
+    async fn served_index_presence_is_false_until_an_index_is_published() {
+        let manager = AxisManager::new(AxisConfig::default()).await.unwrap();
+
+        assert!(!manager.has_served_index("pax-only").await);
+
+        let records = batch("served", 40, 8, 1);
+        assert!(
+            manager
+                .rebuild_and_swap_ivf_index("indexed", &records)
+                .await
+                .unwrap()
+        );
+        assert!(manager.has_served_index("indexed").await);
     }
 
     #[tokio::test]

--- a/src/metrics/operational_metrics.rs
+++ b/src/metrics/operational_metrics.rs
@@ -184,6 +184,22 @@ lazy_static! {
         "Wall-clock duration of completed LSM compactions",
         vec![0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0],
     );
+    pub static ref COMPACTION_MEMORY_RESERVED_BYTES: IntGauge = gauge(
+        "proximadb_compaction_memory_reserved_bytes",
+        "Projected peak resident bytes reserved by all in-flight compactions",
+    );
+    pub static ref COMPACTION_MEMORY_ADMISSION_WAITS_TOTAL: IntCounter = counter(
+        "proximadb_compaction_memory_admission_waits_total",
+        "Compaction tasks that waited for process-wide weighted memory admission",
+    );
+    pub static ref COMPACTION_QUEUE_DEPTH: IntGauge = gauge(
+        "proximadb_compaction_queue_depth",
+        "Compaction tasks queued across all collections",
+    );
+    pub static ref COMPACTION_RUNNING: IntGauge = gauge(
+        "proximadb_compaction_running",
+        "Compaction tasks currently executing across all collections",
+    );
 }
 
 /// Mirror monotonic cache-internal local-disk counters into Prometheus counters and
@@ -239,6 +255,10 @@ pub fn touch() {
     COMPACTIONS_TOTAL.get();
     COMPACTION_BYTES_READ_TOTAL.get();
     COMPACTION_BYTES_WRITTEN_TOTAL.get();
+    COMPACTION_MEMORY_RESERVED_BYTES.get();
+    COMPACTION_MEMORY_ADMISSION_WAITS_TOTAL.get();
+    COMPACTION_QUEUE_DEPTH.get();
+    COMPACTION_RUNNING.get();
     let _ = COMPACTION_SECONDS.get_sample_count();
 }
 

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -1413,6 +1413,12 @@ impl SharedServices {
         // SharedServices field that AppState/route-health read.
         let recall_probe_gate = Arc::new(crate::catalog::RecallProbeGate::new());
 
+        // The Cargo feature is compile-time capability only. This runtime
+        // master switch must also be on before AXIS is registered with serving
+        // or any AXIS background maintenance loop is started.
+        #[cfg(feature = "axis")]
+        let axis_runtime_enabled = storage_config.optimization.enable_axis_indexes;
+
         // Create AxisManager for index operations (AXIS-gated: the whole index
         // engine + its registrations vanish from a PAX-exact-scan build).
         #[cfg(feature = "axis")]
@@ -1458,15 +1464,19 @@ impl SharedServices {
 
             let m = Arc::new(axis_manager_inner);
             debug!("✅ SharedServices::new - AxisManager created successfully");
-            // Make AXIS manager available to graph-first entity store by default
-            crate::storage::entity_store::orion_backend::set_global_axis_manager(m.clone());
-            // Make AXIS manager available to SST engine for HNSW/IVF search
-            crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
-            debug!(
-                "✅ SharedServices::new - AXIS manager registered with SST engine for HNSW/IVF search"
-            );
-            // ADR-078: register the same manager for the shared flush→AXIS hook.
-            crate::storage::common::axis_flush_hook::set_flush_axis_manager(m.clone());
+            if axis_runtime_enabled {
+                // Make AXIS available only when both its compile capability and
+                // process-level policy are enabled. Collection-level intent is
+                // checked at the ingest/search boundaries.
+                crate::storage::entity_store::orion_backend::set_global_axis_manager(m.clone());
+                crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
+                crate::storage::common::axis_flush_hook::set_flush_axis_manager(m.clone());
+                debug!("✅ SharedServices::new - AXIS runtime enabled and registered with serving");
+            } else {
+                info!(
+                    "AXIS capability compiled but runtime-disabled by storage.optimization.enable_axis_indexes=false"
+                );
+            }
             m
         };
 
@@ -1529,33 +1539,31 @@ impl SharedServices {
             // Start the AXIS EventLog consumer as a background task (AXIS-gated).
             // This polls the EventLog and builds AXIS indexes when flush events occur.
             #[cfg(feature = "axis")]
-            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            if axis_runtime_enabled {
+                let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+                // TD-LIFECYCLE-1: registered (not leaked) so a clean shutdown
+                // can stop the loop; see services::shutdown_registry.
+                crate::services::shutdown_registry::register("axis-eventlog-consumer", shutdown_tx);
+                if let Some(event_log_service) = crate::services::events::log::event_log_service() {
+                    let _consumer_handle =
+                        crate::index::axis::integration::eventlog_consumer::start_axis_consumer(
+                            event_log_service.inner(),
+                            axis_manager.clone(),
+                            filesystem_factory.clone(),
+                            collection_cache.clone(),
+                            orchestrator.clone(),
+                            shutdown_rx,
+                        )
+                        .await;
 
-            // TD-LIFECYCLE-1: registered (not leaked) so a clean shutdown
-            // can stop the loop; see services::shutdown_registry.
-            #[cfg(feature = "axis")]
-            crate::services::shutdown_registry::register("axis-eventlog-consumer", shutdown_tx);
-
-            #[cfg(feature = "axis")]
-            if let Some(event_log_service) = crate::services::events::log::event_log_service() {
-                let _consumer_handle =
-                    crate::index::axis::integration::eventlog_consumer::start_axis_consumer(
-                        event_log_service.inner(),
-                        axis_manager.clone(),
-                        filesystem_factory.clone(),
-                        collection_cache.clone(),
-                        orchestrator.clone(),
-                        shutdown_rx,
-                    )
-                    .await;
-
-                info!(
-                    "✅ SharedServices: AXIS EventLog consumer started - background index processing is available for collections that explicitly configure indexes"
-                );
-            } else {
-                warn!(
-                    "⚠️ SharedServices: EventLog service unavailable after initialization; AXIS consumer not started."
-                );
+                    info!(
+                        "✅ SharedServices: AXIS EventLog consumer started for explicitly indexed collections"
+                    );
+                } else {
+                    warn!(
+                        "⚠️ SharedServices: EventLog service unavailable after initialization; AXIS consumer not started."
+                    );
+                }
             }
         }
 
@@ -1595,6 +1603,8 @@ impl SharedServices {
             // the SharedServices field so search-path recordings and
             // operator inspection share state.
             .with_affinity_registry(affinity_registry.clone());
+            #[cfg(feature = "axis")]
+            let svc = svc.with_axis_runtime_enabled(axis_runtime_enabled);
             // FA-2 (abac-policy): wire the durable ABAC enforcer into the vector
             // service so `unified_search_native` enforces the subject's accessibility
             // predicate on every search (push-down for conjunctive policies, post-filter
@@ -2299,7 +2309,11 @@ impl SharedServices {
                 vector_operations_service.unified_engine(),
             );
             #[cfg(feature = "axis")]
-            let vs = vs.with_index_manager(axis_manager.clone());
+            let vs = if axis_runtime_enabled {
+                vs.with_index_manager(axis_manager.clone())
+            } else {
+                vs
+            };
             vs
         });
         let graph_store = Arc::new(
@@ -2698,6 +2712,7 @@ impl SharedServices {
                     catalog_manager.clone(),
                     axis_manager.clone(),
                 )
+                .with_axis_runtime_enabled(axis_runtime_enabled)
             }
             #[cfg(not(feature = "axis"))]
             {
@@ -2733,7 +2748,7 @@ impl SharedServices {
         // Phase-5 recall observer (AXIS-gated): the whole job probes AXIS-managed
         // IVF/HNSW recall, so it is not spawned in a PAX-exact-scan build.
         #[cfg(feature = "axis")]
-        {
+        if axis_runtime_enabled {
             // Phase-5 recall observer (TD-075 / F2): periodically probes
             // quantized-vs-exact recall per collection and feeds the shared
             // RecallProbeGate, so the quantized IVF route opens once recall is
@@ -2762,7 +2777,8 @@ impl SharedServices {
                 "✅ SharedServices: RecallObserver spawned (Phase 5 recall gate + F1 recall-degradation trigger)"
             );
         }
-        {
+        #[cfg(feature = "axis")]
+        if axis_runtime_enabled {
             // Trigger arm (T1.9): the write-volume drift watcher is the first
             // live producer — it counts each collection's own write batches since
             // its last completed recluster (per-collection, not a global-LSN
@@ -2798,7 +2814,7 @@ impl SharedServices {
         // Recall-drift sweeper (AXIS-gated): walks `recall_target:`-tagged
         // collections and emits axis_recall_drift_* metrics — no AXIS, no drift.
         #[cfg(feature = "axis")]
-        {
+        if axis_runtime_enabled {
             // Recall-drift sweeper: every 5 min, walk every
             // collection with a `recall_target:` tag and emit a
             // Prometheus drift observation

--- a/src/services/discovery/mod.rs
+++ b/src/services/discovery/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! See `docs/12-design/PHASE8_CONTINUOUS_LOOP_HLD_LLD_2026_05_28.adoc` (F1).
 
+#[cfg(feature = "axis")]
 mod drift;
 mod executor;
 mod job;
@@ -21,6 +22,7 @@ mod registry;
 mod service;
 mod trigger;
 
+#[cfg(feature = "axis")]
 pub use drift::{
     DEFAULT_DRIFT_INTERVAL, DEFAULT_DRIFT_THRESHOLD_WRITES, DriftWatcher, drift_exceeds,
     interval_from_env, spawn_drift_watcher, threshold_writes_from_env,

--- a/src/services/discovery/passes/recluster.rs
+++ b/src/services/discovery/passes/recluster.rs
@@ -44,6 +44,21 @@ pub async fn run(ctx: &PassContext) -> Result<DiscoveryJobResult> {
         .await?;
     let collection_id = collection_object_id.to_string();
 
+    // Fail before the storage-inclusive corpus read. AXIS being compiled is
+    // only a capability; runtime policy, collection index intent, and an
+    // already-published served index must all be present. Recluster is
+    // maintenance, not an implicit full-corpus bootstrap path.
+    if !vector_ops
+        .has_reclusterable_axis_index(&collection_id)
+        .await?
+    {
+        let mut result = DiscoveryJobResult::default();
+        result
+            .quality_metrics
+            .insert("recluster_skipped_no_served_index".to_string(), 1.0);
+        return Ok(result);
+    }
+
     // Storage-inclusive read of the snapshot (WAL/memtable + flushed storage),
     // merged by oid (freshest wins) — same read path the dedup pass uses.
     let records = vector_ops

--- a/src/services/external_collection/service.rs
+++ b/src/services/external_collection/service.rs
@@ -80,6 +80,8 @@ pub struct ExternalCollectionService {
     catalog_manager: Arc<CatalogManager>,
     #[cfg(feature = "axis")]
     axis_manager: Arc<AxisManager>,
+    #[cfg(feature = "axis")]
+    axis_runtime_enabled: bool,
     /// F5 Slice 3: per-collection BM25 inverted index over the source text
     /// column (keyed by collection name). In-memory; built on `build`/`refresh`.
     fulltext_indexes: Arc<RwLock<HashMap<String, FullTextIndex>>>,
@@ -96,7 +98,27 @@ impl ExternalCollectionService {
             catalog_manager,
             #[cfg(feature = "axis")]
             axis_manager,
+            #[cfg(feature = "axis")]
+            axis_runtime_enabled: false,
             fulltext_indexes: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Apply the process-level AXIS policy resolved during server boot.
+    #[cfg(feature = "axis")]
+    pub fn with_axis_runtime_enabled(mut self, enabled: bool) -> Self {
+        self.axis_runtime_enabled = enabled;
+        self
+    }
+
+    #[cfg(feature = "axis")]
+    fn require_axis_runtime_enabled(&self) -> Result<()> {
+        if self.axis_runtime_enabled {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "external vector indexes require storage.optimization.enable_axis_indexes=true"
+            )
         }
     }
 
@@ -176,6 +198,8 @@ impl ExternalCollectionService {
     /// publish it (`Fresh`). Reads the source but copies nothing into ProximaDB
     /// storage. Returns the number of records indexed.
     pub async fn build(&self, id: &str) -> Result<usize> {
+        #[cfg(feature = "axis")]
+        self.require_axis_runtime_enabled()?;
         let mut ec = self
             .registry
             .get(id)
@@ -230,6 +254,8 @@ impl ExternalCollectionService {
     /// source is unchanged. This is the remediation for the advisory
     /// `RebuildRequired` state; a future background sweep can call it.
     pub async fn refresh(&self, id: &str) -> Result<RefreshOutcome> {
+        #[cfg(feature = "axis")]
+        self.require_axis_runtime_enabled()?;
         let mut ec = self
             .registry
             .get(id)
@@ -287,6 +313,7 @@ impl ExternalCollectionService {
     /// status/projection transitions around it.
     #[cfg(feature = "axis")]
     async fn build_inner(&self, ec: &ExternalCollection) -> Result<usize> {
+        self.require_axis_runtime_enabled()?;
         let records = read_external_records(&ec.spec)?;
         let count = records.len();
         let built = self
@@ -540,6 +567,7 @@ impl ExternalCollectionService {
         query: Vec<f32>,
         k: usize,
     ) -> Result<Vec<ExternalHit>> {
+        self.require_axis_runtime_enabled()?;
         let q = AxisHybridQuery {
             collection_id: ec.spec.name.clone(),
             vector_query: Some(VectorQuery::Dense {
@@ -789,7 +817,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat.clone(),
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
 
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20);
@@ -823,6 +852,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_disabled_rejects_build_before_reading_the_source() {
+        let path = fixture_path();
+        write_parquet_fixture(&path, 20, 20);
+        let cat = catalog_manager_with_default().await;
+        let axis = axis_manager().await;
+        let svc = ExternalCollectionService::new(
+            Arc::new(ExternalCollectionRegistry::new()),
+            cat,
+            axis.clone(),
+        );
+        let spec = ExternalCollectionSpec::parquet(
+            "disabled_ext",
+            path.to_str().unwrap(),
+            "id",
+            "vector",
+            20,
+        );
+        let ec = svc.register(spec).await.unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        let error = svc.build(&ec.id).await.unwrap_err();
+        assert!(
+            error.to_string().contains("enable_axis_indexes=true"),
+            "runtime policy must fail before the missing source is read: {error:#}"
+        );
+        assert!(!axis.has_served_index("disabled_ext").await);
+    }
+
+    #[tokio::test]
     async fn build_in_place_makes_index_queryable_and_fresh() {
         let path = fixture_path();
         let expect = write_parquet_fixture(&path, 32, 32);
@@ -832,7 +890,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat.clone(),
             axis.clone(),
-        );
+        )
+        .with_axis_runtime_enabled(true);
 
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 32);
@@ -867,7 +926,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20);
         let ec = svc.register(spec).await.unwrap();
@@ -884,7 +944,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20);
         let ec = svc.register(spec).await.unwrap();
@@ -920,7 +981,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 24);
         let ec = svc.register(spec).await.unwrap();
@@ -966,7 +1028,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat.clone(),
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20)
                 .with_text_column("text");
@@ -979,7 +1042,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             catalog_manager_with_default().await,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec2 = ExternalCollectionSpec::parquet(
             "ext_plain",
             path.to_str().unwrap(),
@@ -1004,7 +1068,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20)
                 .with_text_column("text");
@@ -1052,7 +1117,8 @@ mod tests {
         let axis = axis_manager().await;
 
         // Build with the first service (BM25 populated in its in-memory map).
-        let svc1 = ExternalCollectionService::new(registry.clone(), cat.clone(), axis.clone());
+        let svc1 = ExternalCollectionService::new(registry.clone(), cat.clone(), axis.clone())
+            .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20)
                 .with_text_column("text");
@@ -1061,7 +1127,8 @@ mod tests {
 
         // Simulate a restart: a fresh service shares the durable registry + the
         // (still-resident) IVF index, but starts with an EMPTY BM25 map.
-        let svc2 = ExternalCollectionService::new(registry, cat, axis);
+        let svc2 =
+            ExternalCollectionService::new(registry, cat, axis).with_axis_runtime_enabled(true);
         assert!(
             !svc2.has_fulltext_index("ext_docs"),
             "fresh service starts without BM25"
@@ -1100,7 +1167,8 @@ mod tests {
             Arc::new(ExternalCollectionRegistry::new()),
             cat,
             axis_manager().await,
-        );
+        )
+        .with_axis_runtime_enabled(true);
         let spec =
             ExternalCollectionSpec::parquet("ext_docs", path.to_str().unwrap(), "id", "vector", 20)
                 .with_text_column("text");

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -81,17 +81,13 @@ use super::write::{
 };
 
 /// ADR-070 / ADR-081: AXIS is a configured projection, not an automatic cost
-/// paid by every vector collection. PAX-only collections carry no index config;
-/// the explicit RawF32 compatibility tag retains the established AXIS path.
+/// paid by every vector collection. PAX-only collections carry no index config.
+/// Encoding/layout tags are not index declarations and therefore cannot enable
+/// AXIS by themselves.
 #[cfg_attr(not(feature = "axis"), allow(dead_code))]
-fn collection_uses_axis_indexes(collection: &Collection) -> bool {
-    collection.config.as_ref().is_some_and(|config| {
-        !config.index_configs.is_empty()
-            || config
-                .tags
-                .iter()
-                .any(|tag| tag.trim().eq_ignore_ascii_case("pax_vector_format:off"))
-    })
+fn collection_uses_axis_indexes(axis_runtime_enabled: bool, collection: &Collection) -> bool {
+    axis_runtime_enabled
+        && crate::storage::traits::collection_declares_axis_index(collection.config.as_ref())
 }
 
 // Import vector query service contract (Phase 2.1)
@@ -519,6 +515,12 @@ pub struct VectorOperationsService {
     /// AXIS index manager for index lookups
     #[cfg(feature = "axis")]
     axis_index_manager: Arc<crate::index::AxisManager>,
+
+    /// Runtime AXIS master switch. The compile feature only makes the
+    /// capability available; no collection may feed, query, or maintain AXIS
+    /// while this process-level policy is false.
+    #[cfg(feature = "axis")]
+    axis_runtime_enabled: bool,
 
     /// Collection port for metadata and configuration (Phase 9 / Task #76)
     collection_port: Arc<dyn proximadb_runtime::CollectionPort>,
@@ -1777,6 +1779,10 @@ impl VectorOperationsService {
             query_cache,
             #[cfg(feature = "axis")]
             axis_index_manager,
+            #[cfg(feature = "axis")]
+            // Fail closed for direct/internal construction. Production boot
+            // applies the configured runtime policy through the builder below.
+            axis_runtime_enabled: false,
             collection_port,
             orchestrator: None,
 
@@ -1796,6 +1802,35 @@ impl VectorOperationsService {
             directory_cache: None,
             affinity_registry: None,
         }
+    }
+
+    /// Apply the process-level AXIS policy resolved from
+    /// `storage.optimization.enable_axis_indexes`.
+    #[cfg(feature = "axis")]
+    pub fn with_axis_runtime_enabled(mut self, enabled: bool) -> Self {
+        self.axis_runtime_enabled = enabled;
+        self
+    }
+
+    /// Whether continuous reclustering may touch this collection.
+    ///
+    /// This intentionally checks all runtime gates before the discovery pass
+    /// reads any records: process policy, collection index intent, and an
+    /// already-published served index. Recluster maintains an index; it does
+    /// not bootstrap one by cloning the whole corpus.
+    #[cfg(feature = "axis")]
+    pub async fn has_reclusterable_axis_index(&self, collection_id: &str) -> Result<bool> {
+        if !self.axis_runtime_enabled {
+            return Ok(false);
+        }
+        let collection = self.get_or_load_collection(collection_id).await?;
+        if !collection_uses_axis_indexes(true, &collection) {
+            return Ok(false);
+        }
+        Ok(self
+            .axis_index_manager
+            .has_served_index(&collection.id)
+            .await)
     }
 
     /// Set tenant manager for multi-tenant support (builder-style)
@@ -4073,7 +4108,8 @@ impl VectorOperationsService {
         // the index. This avoids the 8.6GB RSS + minutes of IVF training for
         // cost-optimized, object-storage-backed collections.
         #[cfg(feature = "axis")]
-        let collection_has_axis_indexes = collection_uses_axis_indexes(&collection);
+        let collection_has_axis_indexes =
+            collection_uses_axis_indexes(self.axis_runtime_enabled, &collection);
         #[cfg(not(feature = "axis"))]
         let collection_has_axis_indexes = false;
 
@@ -4629,7 +4665,8 @@ impl VectorOperationsService {
         #[cfg(feature = "axis")]
         let collection = self.get_or_load_collection(&collection_id).await?;
         #[cfg(feature = "axis")]
-        let axis_duration = if collection_uses_axis_indexes(&collection) {
+        let axis_duration = if collection_uses_axis_indexes(self.axis_runtime_enabled, &collection)
+        {
             let axis_start = std::time::Instant::now();
             for record in vectors.iter() {
                 if let Err(e) = self
@@ -6740,7 +6777,7 @@ mod axis_insert_gate_tests {
             }),
             ..Default::default()
         };
-        assert!(!collection_uses_axis_indexes(&collection));
+        assert!(!collection_uses_axis_indexes(true, &collection));
     }
 
     #[test]
@@ -6752,11 +6789,16 @@ mod axis_insert_gate_tests {
             }),
             ..Default::default()
         };
-        assert!(collection_uses_axis_indexes(&collection));
+        assert!(collection_uses_axis_indexes(true, &collection));
+
+        assert!(
+            !collection_uses_axis_indexes(false, &collection),
+            "the runtime master switch must win over collection index intent"
+        );
     }
 
     #[test]
-    fn raw_f32_compatibility_tag_feeds_axis() {
+    fn format_tag_without_index_config_does_not_feed_axis() {
         let collection = Collection {
             config: Some(CollectionConfig {
                 tags: vec!["pax_vector_format:off".to_string()],
@@ -6764,7 +6806,12 @@ mod axis_insert_gate_tests {
             }),
             ..Default::default()
         };
-        assert!(collection_uses_axis_indexes(&collection));
+        assert!(!collection_uses_axis_indexes(true, &collection));
+    }
+
+    #[test]
+    fn absent_collection_config_does_not_feed_axis() {
+        assert!(!collection_uses_axis_indexes(true, &Collection::default()));
     }
 }
 

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -46,7 +46,7 @@ use crate::storage::write_fence::StorageWriteFence;
 pub struct AutoFlushDriver {
     policy: FlushPolicy,
     #[cfg(feature = "axis")]
-    axis_index_manager: Arc<AxisManager>,
+    axis_index_manager: Option<Arc<AxisManager>>,
     /// A6 storage-write fence (default-OFF). Captured at spawn time; on the live
     /// server it is injected into the storage engine post-construction, so this
     /// may be `None` here — acceptable at MVP (single-pod, fence default-OFF).
@@ -64,7 +64,7 @@ impl AutoFlushDriver {
     /// `flush_interval_secs = 0` and `wal_max_bytes = 0` makes this a no-op.
     pub fn spawn(
         policy: FlushPolicy,
-        #[cfg(feature = "axis")] axis_index_manager: Arc<AxisManager>,
+        #[cfg(feature = "axis")] axis_index_manager: Option<Arc<AxisManager>>,
         storage_write_fence: Option<Arc<dyn StorageWriteFence>>,
     ) {
         if !policy.needs_scheduler() {
@@ -184,7 +184,7 @@ impl AutoFlushDriver {
             pending.spawn(async move {
                 let start = Instant::now();
                 #[cfg(feature = "axis")]
-                let axis_arg: Option<&AxisManager> = Some(&task_axis);
+                let axis_arg: Option<&AxisManager> = task_axis.as_deref();
                 #[cfg(not(feature = "axis"))]
                 let axis_arg: Option<&()> = None;
                 let result = materialize_collection(

--- a/src/storage/common/axis_flush_hook.rs
+++ b/src/storage/common/axis_flush_hook.rs
@@ -56,27 +56,18 @@ pub fn flush_axis_manager() -> Option<Arc<dyn IndexEngine>> {
 /// Co-design: the AXIS build (HNSW/IVF training + RAM) is expensive and was the
 /// flush-latency bottleneck (~101s per 21k vectors of pure HNSW build), so
 /// collections that never query AXIS must not pay for it. Mirrors the gate the
-/// search route applies (`use_axis_indexes`: `index_configs` non-empty, or the
-/// `pax_vector_format:off` tag).
+/// search route applies (`use_axis_indexes`: `index_configs` non-empty).
 ///
 /// Absent config ⇒ **false**. Co-design is the default per ADR-070, so an
 /// unknown collection means "no AXIS", not "train AXIS". Recovery flushes land
 /// here.
 pub fn axis_needed(params: &FlushParameters) -> bool {
-    match params
-        .collection_config
-        .as_ref()
-        .and_then(|c| c.config.as_ref())
-    {
-        Some(c) => {
-            let pax_off = c
-                .tags
-                .iter()
-                .any(|t| t.trim().eq_ignore_ascii_case("pax_vector_format:off"));
-            pax_off || !c.index_configs.is_empty()
-        }
-        None => false,
-    }
+    crate::storage::traits::collection_declares_axis_index(
+        params
+            .collection_config
+            .as_ref()
+            .and_then(|collection| collection.config.as_ref()),
+    )
 }
 
 /// Index just-flushed vectors into AXIS (TD-112, ADR-078).
@@ -272,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_index_configs_without_pax_off_does_not_request_axis() {
+    fn empty_index_configs_do_not_request_axis() {
         let cfg = CollectionConfig {
             index_configs: vec![],
             tags: vec![],
@@ -282,16 +273,13 @@ mod tests {
     }
 
     #[test]
-    fn pax_vector_format_off_tag_requests_axis() {
+    fn format_tag_without_index_config_does_not_request_axis() {
         let cfg = CollectionConfig {
             index_configs: vec![],
             tags: vec!["  PAX_Vector_Format:OFF ".to_string()],
             ..Default::default()
         };
-        assert!(
-            axis_needed(&params_with(Some(cfg), 10)),
-            "tag match must be trimmed and case-insensitive"
-        );
+        assert!(!axis_needed(&params_with(Some(cfg), 10)));
     }
 
     /// No manager registered and none passed ⇒ returns quietly rather than
@@ -299,8 +287,7 @@ mod tests {
     #[tokio::test]
     async fn missing_axis_manager_is_a_no_op() {
         let cfg = CollectionConfig {
-            index_configs: vec![],
-            tags: vec!["pax_vector_format:off".to_string()],
+            index_configs: vec![proximadb_proto::proximadb_v1::IndexConfig::default()],
             ..Default::default()
         };
         index_flushed_into_axis(None, &params_with(Some(cfg), 5), vec!["f.pax".into()]).await;
@@ -313,8 +300,7 @@ mod tests {
     #[tokio::test]
     async fn convergence_dispatches_records_to_handle_flushed_vectors() {
         let cfg = CollectionConfig {
-            index_configs: vec![],
-            tags: vec!["pax_vector_format:off".to_string()],
+            index_configs: vec![proximadb_proto::proximadb_v1::IndexConfig::default()],
             ..Default::default()
         };
         let spy = Arc::new(RecordingIndexEngine::default());
@@ -347,8 +333,7 @@ mod tests {
     #[tokio::test]
     async fn boot_registered_global_is_used_when_engine_passes_none() {
         let cfg = CollectionConfig {
-            index_configs: vec![],
-            tags: vec!["pax_vector_format:off".to_string()],
+            index_configs: vec![proximadb_proto::proximadb_v1::IndexConfig::default()],
             ..Default::default()
         };
         let concrete = Arc::new(RecordingIndexEngine::default());

--- a/src/storage/common/compaction_memory.rs
+++ b/src/storage/common/compaction_memory.rs
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 ProximaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+//! Process-wide, byte-weighted compaction memory admission.
+//!
+//! Input segment bytes are the stable workload signal. They are converted to
+//! projected peak resident bytes with a measured amplification factor, then
+//! admitted against the tightest of process-visible capacity, live available
+//! memory, and an optional operator ceiling. All collections share one
+//! reservation counter so independent workers cannot double-spend the budget.
+
+use crate::core::config::CompactionConfig;
+use proximadb_hardware::{MemorySnapshot, memory_snapshot};
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tokio::sync::Notify;
+
+const MIB: u64 = 1024 * 1024;
+const ADMISSION_RECHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Auditable result of applying the configured policy to one memory snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompactionMemoryBudget {
+    pub capacity_budget_bytes: u64,
+    pub available_budget_bytes: u64,
+    pub absolute_ceiling_bytes: Option<u64>,
+    pub effective_budget_bytes: u64,
+    pub reserved_bytes: u64,
+    pub remaining_bytes: u64,
+    pub max_input_bytes: u64,
+}
+
+/// Convert immutable input bytes into a conservative peak-RSS reservation.
+pub fn projected_compaction_memory_bytes(input_bytes: u64, config: &CompactionConfig) -> u64 {
+    let amplification = config.memory_amplification_factor.max(1.0);
+    ((input_bytes as f64) * amplification)
+        .ceil()
+        .min(u64::MAX as f64) as u64
+}
+
+/// Apply the hybrid capacity/live/absolute policy to an injected snapshot.
+/// Injection keeps the arithmetic deterministic and independently testable.
+pub fn compaction_memory_budget(
+    config: &CompactionConfig,
+    snapshot: MemorySnapshot,
+    reserved_bytes: u64,
+) -> CompactionMemoryBudget {
+    let capacity_budget_bytes = fraction_of(snapshot.total_bytes, config.memory_budget_fraction);
+    let available_budget_bytes =
+        fraction_of(snapshot.available_bytes, config.available_memory_fraction);
+    let absolute_ceiling_bytes =
+        (config.max_memory_mb > 0).then(|| config.max_memory_mb.saturating_mul(MIB));
+
+    let mut effective_budget_bytes = capacity_budget_bytes.min(available_budget_bytes);
+    if let Some(absolute) = absolute_ceiling_bytes {
+        effective_budget_bytes = effective_budget_bytes.min(absolute);
+    }
+    let remaining_bytes = effective_budget_bytes.saturating_sub(reserved_bytes);
+    let amplification = config.memory_amplification_factor.max(1.0);
+    let max_input_bytes = ((remaining_bytes as f64) / amplification).floor() as u64;
+
+    CompactionMemoryBudget {
+        capacity_budget_bytes,
+        available_budget_bytes,
+        absolute_ceiling_bytes,
+        effective_budget_bytes,
+        reserved_bytes,
+        remaining_bytes,
+        max_input_bytes,
+    }
+}
+
+fn fraction_of(bytes: u64, fraction: f64) -> u64 {
+    if !fraction.is_finite() || fraction <= 0.0 {
+        return 0;
+    }
+    ((bytes as f64) * fraction.min(1.0))
+        .floor()
+        .min(u64::MAX as f64) as u64
+}
+
+/// Current input-byte budget after accounting for every running collection.
+pub fn current_compaction_input_budget(config: &CompactionConfig) -> CompactionMemoryBudget {
+    compaction_memory_budget(
+        config,
+        memory_snapshot(),
+        global_admission().reserved_bytes(),
+    )
+}
+
+pub fn reserved_compaction_memory_bytes() -> u64 {
+    global_admission().reserved_bytes()
+}
+
+/// One process-wide weighted coordinator. A count semaphore cannot distinguish
+/// a 20 MiB maintenance merge from an 850 MiB corpus merge.
+#[derive(Debug, Default)]
+pub struct CompactionMemoryAdmission {
+    reserved_bytes: AtomicU64,
+    notify: Notify,
+}
+
+impl CompactionMemoryAdmission {
+    pub fn reserved_bytes(&self) -> u64 {
+        self.reserved_bytes.load(Ordering::Acquire)
+    }
+
+    fn try_reserve(
+        self: &Arc<Self>,
+        projected_bytes: u64,
+        budget_bytes: u64,
+    ) -> Option<CompactionMemoryReservation> {
+        let mut observed = self.reserved_bytes.load(Ordering::Acquire);
+        loop {
+            if projected_bytes > budget_bytes.saturating_sub(observed) {
+                return None;
+            }
+            match self.reserved_bytes.compare_exchange_weak(
+                observed,
+                observed.saturating_add(projected_bytes),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(CompactionMemoryReservation {
+                        admission: Arc::clone(self),
+                        reserved_bytes: projected_bytes,
+                    });
+                }
+                Err(current) => observed = current,
+            }
+        }
+    }
+}
+
+/// RAII reservation released on every worker exit path, including errors and
+/// cancellation.
+#[derive(Debug)]
+pub struct CompactionMemoryReservation {
+    admission: Arc<CompactionMemoryAdmission>,
+    reserved_bytes: u64,
+}
+
+impl CompactionMemoryReservation {
+    pub fn reserved_bytes(&self) -> u64 {
+        self.reserved_bytes
+    }
+}
+
+impl Drop for CompactionMemoryReservation {
+    fn drop(&mut self) {
+        self.admission
+            .reserved_bytes
+            .fetch_sub(self.reserved_bytes, Ordering::AcqRel);
+        self.admission.notify.notify_waiters();
+    }
+}
+
+fn global_admission() -> &'static Arc<CompactionMemoryAdmission> {
+    static ADMISSION: OnceLock<Arc<CompactionMemoryAdmission>> = OnceLock::new();
+    ADMISSION.get_or_init(|| Arc::new(CompactionMemoryAdmission::default()))
+}
+
+/// Wait until the candidate fits both current live memory and the reservations
+/// held by other collections. Periodic refresh notices memory released by
+/// non-compaction work; `shutdown` prevents manager shutdown from hanging.
+pub async fn acquire_compaction_memory(
+    input_bytes: u64,
+    config: &CompactionConfig,
+    shutdown: &AtomicBool,
+) -> Option<CompactionMemoryReservation> {
+    let projected_bytes = projected_compaction_memory_bytes(input_bytes, config);
+    let admission = global_admission();
+
+    loop {
+        if shutdown.load(Ordering::Acquire) {
+            return None;
+        }
+
+        let notified = admission.notify.notified();
+        let snapshot = memory_snapshot();
+        let budget = compaction_memory_budget(config, snapshot, 0);
+        if let Some(reservation) =
+            admission.try_reserve(projected_bytes, budget.effective_budget_bytes)
+        {
+            return Some(reservation);
+        }
+
+        tokio::select! {
+            _ = notified => {}
+            _ = tokio::time::sleep(ADMISSION_RECHECK_INTERVAL) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn hybrid_budget_uses_the_tightest_guard() {
+        let mut config = CompactionConfig::default();
+        config.memory_budget_fraction = 0.25;
+        config.available_memory_fraction = 0.5;
+        config.max_memory_mb = 8 * 1024;
+
+        let budget = compaction_memory_budget(
+            &config,
+            MemorySnapshot {
+                total_bytes: 64 * GIB,
+                available_bytes: 20 * GIB,
+            },
+            GIB,
+        );
+
+        assert_eq!(budget.capacity_budget_bytes, 16 * GIB);
+        assert_eq!(budget.available_budget_bytes, 10 * GIB);
+        assert_eq!(budget.absolute_ceiling_bytes, Some(8 * GIB));
+        assert_eq!(budget.effective_budget_bytes, 8 * GIB);
+        assert_eq!(budget.remaining_bytes, 7 * GIB);
+    }
+
+    #[test]
+    fn measured_amplification_converts_bytes_without_integer_truncation() {
+        let mut config = CompactionConfig::default();
+        config.memory_amplification_factor = 9.85;
+
+        assert_eq!(projected_compaction_memory_bytes(100, &config), 985);
+    }
+
+    #[test]
+    fn weighted_admission_prevents_parallel_oversubscription() {
+        let admission = Arc::new(CompactionMemoryAdmission::default());
+        let first = admission
+            .try_reserve(700, 1_000)
+            .expect("first weighted reservation should fit");
+        assert!(admission.try_reserve(400, 1_000).is_none());
+        assert_eq!(admission.reserved_bytes(), 700);
+
+        drop(first);
+        let second = admission
+            .try_reserve(400, 1_000)
+            .expect("released bytes should be reusable");
+        assert_eq!(second.reserved_bytes(), 400);
+    }
+}

--- a/src/storage/common/compaction_orchestrator.rs
+++ b/src/storage/common/compaction_orchestrator.rs
@@ -730,6 +730,14 @@ impl StagingDetector {
         name.starts_with("__") || name.contains(".tmp") || name.contains(".staging")
     }
 
+    /// Check every URL/path component. Flat object-store listings commonly
+    /// return a tiered filename as `DirEntry::name` while the authoritative
+    /// URL still contains `__flush` or `__compact`; basename-only filtering
+    /// can therefore compact an unpublished object and duplicate its rows.
+    pub fn is_staging_path(&self, path: &str) -> bool {
+        path.split('/').any(|component| self.is_staging(component))
+    }
+
     /// Get staging prefix for atomic operations
     pub fn staging_prefix() -> &'static str {
         "__staging_"
@@ -799,8 +807,8 @@ impl TieredFileRegistry {
 
         for entry in entries {
             // Skip staging files/directories
-            if self.staging_detector.is_staging(&entry.name) {
-                debug!("⏭️  Skipping staging: {}", entry.name);
+            if self.staging_detector.is_staging_path(&entry.url) {
+                debug!("⏭️  Skipping staging object: {}", entry.url);
                 continue;
             }
 
@@ -1171,17 +1179,31 @@ mod tests {
     #[tokio::test]
     async fn cloud_prefix_discovery_lists_without_exact_prefix_object() {
         let segment_name = "L0_20260730T120000_deadbeef.pax";
+        let staged_segment_name = "L0_20260730T120001_cafebabe.pax";
         let filesystem = PrefixOnlyFileSystem {
             exists_calls: AtomicUsize::new(0),
-            entries: vec![DirEntry {
-                name: segment_name.to_string(),
-                url: format!("az://segments/1/data/{segment_name}"),
-                metadata: FsFileMetadata {
-                    size: 4096,
-                    is_directory: false,
-                    ..Default::default()
+            entries: vec![
+                DirEntry {
+                    name: segment_name.to_string(),
+                    url: format!("az://segments/1/data/{segment_name}"),
+                    metadata: FsFileMetadata {
+                        size: 4096,
+                        is_directory: false,
+                        ..Default::default()
+                    },
                 },
-            }],
+                DirEntry {
+                    // Flat object-store listings expose the basename here;
+                    // only the URL retains the __flush path component.
+                    name: staged_segment_name.to_string(),
+                    url: format!("az://segments/1/data/__flush/{staged_segment_name}"),
+                    metadata: FsFileMetadata {
+                        size: 8192,
+                        is_directory: false,
+                        ..Default::default()
+                    },
+                },
+            ],
         };
 
         let files = TieredFileRegistry::new()

--- a/src/storage/common/compaction_orchestrator.rs
+++ b/src/storage/common/compaction_orchestrator.rs
@@ -730,12 +730,38 @@ impl StagingDetector {
         name.starts_with("__") || name.contains(".tmp") || name.contains(".staging")
     }
 
-    /// Check every URL/path component. Flat object-store listings commonly
-    /// return a tiered filename as `DirEntry::name` while the authoritative
-    /// URL still contains `__flush` or `__compact`; basename-only filtering
-    /// can therefore compact an unpublished object and duplicate its rows.
-    pub fn is_staging_path(&self, path: &str) -> bool {
-        path.split('/').any(|component| self.is_staging(component))
+    /// Check URL/path components *below* the listed data prefix.
+    ///
+    /// Flat object-store listings commonly return a tiered basename while the
+    /// authoritative URL retains a nested `__flush` or `__compact` component.
+    /// The prefix itself is deliberately excluded: Linux `tempfile` roots are
+    /// named `/tmp/.tmpXXXX`, and treating that ambient parent as staging makes
+    /// every file in a local test/embedded collection disappear from discovery.
+    pub fn is_staging_path_under(&self, data_prefix: &str, path: &str) -> bool {
+        fn without_local_scheme(value: &str) -> &str {
+            value.strip_prefix("file://").unwrap_or(value)
+        }
+
+        let prefix = without_local_scheme(data_prefix).trim_end_matches('/');
+        let candidate = without_local_scheme(path);
+        let relative = candidate.strip_prefix(prefix).and_then(|suffix| {
+            if suffix.is_empty() || suffix.starts_with('/') {
+                Some(suffix.trim_start_matches('/'))
+            } else {
+                None
+            }
+        });
+
+        match relative {
+            Some(relative) => relative
+                .split('/')
+                .filter(|component| !component.is_empty())
+                .any(|component| self.is_staging(component)),
+            None => path
+                .rsplit('/')
+                .next()
+                .is_some_and(|name| self.is_staging(name)),
+        }
     }
 
     /// Get staging prefix for atomic operations
@@ -807,7 +833,10 @@ impl TieredFileRegistry {
 
         for entry in entries {
             // Skip staging files/directories
-            if self.staging_detector.is_staging_path(&entry.url) {
+            if self
+                .staging_detector
+                .is_staging_path_under(data_directory, &entry.url)
+            {
                 debug!("⏭️  Skipping staging object: {}", entry.url);
                 continue;
             }
@@ -1326,5 +1355,18 @@ mod tests {
         assert!(detector.is_staging("file.tmp"));
         assert!(detector.is_staging("file.staging"));
         assert!(!detector.is_staging("normal_file.sstable"));
+
+        assert!(!detector.is_staging_path_under(
+            "/tmp/.tmp-parent/data",
+            "file:///tmp/.tmp-parent/data/L0_20260802T010203_deadbeef.pax"
+        ));
+        assert!(detector.is_staging_path_under(
+            "az://segments/1/data",
+            "az://segments/1/data/__flush/L0_20260802T010203_deadbeef.pax"
+        ));
+        assert!(!detector.is_staging_path_under(
+            "az://segments/1/data",
+            "az://segments/1/database/L0_20260802T010203_deadbeef.pax"
+        ));
     }
 }

--- a/src/storage/common/compaction_utils.rs
+++ b/src/storage/common/compaction_utils.rs
@@ -214,6 +214,21 @@ fn higher_level_file_threshold(config: &CompactionConfig, level: u32) -> usize {
         .ceil() as usize
 }
 
+fn l0_minimum_morsel_files(
+    config: &CompactionConfig,
+    engine_type: &StorageEngineType,
+    extension: &str,
+) -> usize {
+    if config.l0_file_threshold == 1
+        && *engine_type == StorageEngineType::SST
+        && extension.eq_ignore_ascii_case("pax")
+    {
+        1
+    } else {
+        2
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CompactionMorsel {
     input_files: Vec<String>,
@@ -224,12 +239,14 @@ struct CompactionMorsel {
 
 /// Pack the oldest files that fit the current input-byte budget. Oversized
 /// files remain horizontal; smaller, mutually exclusive peers may still make
-/// progress around them. A one-file rewrite never reduces query fanout.
-fn select_compaction_morsel(
+/// progress around them.
+fn select_compaction_morsel_with_minimum(
     files: &[GenericFileMetadata],
     max_input_bytes: u64,
+    minimum_files: usize,
 ) -> Option<CompactionMorsel> {
-    if max_input_bytes == 0 || files.len() < 2 {
+    let minimum_files = minimum_files.max(1);
+    if max_input_bytes == 0 || files.len() < minimum_files {
         return None;
     }
 
@@ -252,12 +269,22 @@ fn select_compaction_morsel(
         }
     }
 
-    (input_files.len() >= 2).then_some(CompactionMorsel {
+    (input_files.len() >= minimum_files).then_some(CompactionMorsel {
         input_files,
         input_bytes,
         total_candidate_bytes,
         total_candidate_files: files.len(),
     })
+}
+
+/// Ordinary compaction must reduce query-visible fanout, so it requires at
+/// least two input files. The L0 training path calls the configurable helper
+/// directly because its threshold-one rewrite changes the on-disk layout.
+fn select_compaction_morsel(
+    files: &[GenericFileMetadata],
+    max_input_bytes: u64,
+) -> Option<CompactionMorsel> {
+    select_compaction_morsel_with_minimum(files, max_input_bytes, 2)
 }
 
 impl CompactionTaskBuilder {
@@ -322,10 +349,18 @@ impl CompactionTaskBuilder {
         // Check if Level 0 compaction is needed
         if should_compact_l0 {
             let memory_budget = current_compaction_input_budget(config);
-            let morsel = filtered_files
-                .compactable_files
-                .get(&0)
-                .and_then(|files| select_compaction_morsel(files, memory_budget.max_input_bytes));
+            // The flush training arm deliberately overrides the L0 threshold
+            // to one so an untrained PAX segment can be promoted to the
+            // searchable v3 layout. It is useful work even though it does not
+            // reduce file count; admission still happens before training.
+            let minimum_files = l0_minimum_morsel_files(config, &engine_type, extension);
+            let morsel = filtered_files.compactable_files.get(&0).and_then(|files| {
+                select_compaction_morsel_with_minimum(
+                    files,
+                    memory_budget.max_input_bytes,
+                    minimum_files,
+                )
+            });
 
             if let Some(morsel) = morsel {
                 info!(
@@ -334,6 +369,7 @@ impl CompactionTaskBuilder {
                     candidate_files = morsel.total_candidate_files,
                     candidate_bytes = morsel.total_candidate_bytes,
                     projected_budget_bytes = memory_budget.remaining_bytes,
+                    layout_promotion = minimum_files == 1,
                     "✅ {} COMPACTION: Triggering bounded L0 morsel for collection {} (excluded {} pending files)",
                     engine_type,
                     collection_id,
@@ -641,6 +677,27 @@ mod tests {
 
         assert!(select_compaction_morsel(&files, 300 * MIB).is_none());
         assert!(select_compaction_morsel(&files[..1], 512 * MIB).is_none());
+    }
+
+    #[test]
+    fn threshold_one_training_morsel_can_promote_one_untrained_file() {
+        let files = vec![sized_file("untrained-L0.pax", 0, 180)];
+        let mut config = CompactionConfig::default();
+        config.l0_file_threshold = 1;
+
+        let minimum_files = l0_minimum_morsel_files(&config, &StorageEngineType::SST, "pax");
+        let morsel = select_compaction_morsel_with_minimum(&files, 512 * MIB, minimum_files)
+            .expect("the explicit threshold-one training arm must promote its one L0 file");
+
+        assert_eq!(minimum_files, 1);
+        assert_eq!(morsel.input_files, vec!["untrained-L0.pax"]);
+        assert_eq!(morsel.input_bytes, 180 * MIB);
+
+        assert_eq!(
+            l0_minimum_morsel_files(&config, &StorageEngineType::VIPER, "parquet"),
+            2,
+            "threshold one must not turn non-PAX compaction into one-file rewrites"
+        );
     }
 
     #[test]

--- a/src/storage/common/compaction_utils.rs
+++ b/src/storage/common/compaction_utils.rs
@@ -15,6 +15,7 @@ use tracing::{debug, info};
 
 use super::flush_handler_trait::FlushHandlerFactory;
 use crate::core::config::CompactionConfig;
+use crate::storage::common::compaction_memory::current_compaction_input_budget;
 use crate::storage::common::compaction_orchestrator::{GenericFileMetadata, TieredFileRegistry};
 use crate::storage::persistence::filesystem::FilesystemFactory;
 
@@ -213,6 +214,52 @@ fn higher_level_file_threshold(config: &CompactionConfig, level: u32) -> usize {
         .ceil() as usize
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactionMorsel {
+    input_files: Vec<String>,
+    input_bytes: u64,
+    total_candidate_bytes: u64,
+    total_candidate_files: usize,
+}
+
+/// Pack the oldest files that fit the current input-byte budget. Oversized
+/// files remain horizontal; smaller, mutually exclusive peers may still make
+/// progress around them. A one-file rewrite never reduces query fanout.
+fn select_compaction_morsel(
+    files: &[GenericFileMetadata],
+    max_input_bytes: u64,
+) -> Option<CompactionMorsel> {
+    if max_input_bytes == 0 || files.len() < 2 {
+        return None;
+    }
+
+    let mut ordered = files.iter().collect::<Vec<_>>();
+    ordered.sort_unstable_by(|left, right| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+
+    let total_candidate_bytes = ordered
+        .iter()
+        .fold(0u64, |total, file| total.saturating_add(file.size_bytes));
+    let mut input_files = Vec::new();
+    let mut input_bytes = 0u64;
+    for file in ordered {
+        if file.size_bytes <= max_input_bytes.saturating_sub(input_bytes) {
+            input_bytes = input_bytes.saturating_add(file.size_bytes);
+            input_files.push(file.path.clone());
+        }
+    }
+
+    (input_files.len() >= 2).then_some(CompactionMorsel {
+        input_files,
+        input_bytes,
+        total_candidate_bytes,
+        total_candidate_files: files.len(),
+    })
+}
+
 impl CompactionTaskBuilder {
     /// Check if compaction is needed and build task if necessary
     /// This unifies logic from SST's check_compaction_needed and VIPER's discover_compactable_files
@@ -274,25 +321,45 @@ impl CompactionTaskBuilder {
 
         // Check if Level 0 compaction is needed
         if should_compact_l0 {
-            let compactable_files = file_discovery.get_compaction_files(&filtered_files, 0);
+            let memory_budget = current_compaction_input_budget(config);
+            let morsel = filtered_files
+                .compactable_files
+                .get(&0)
+                .and_then(|files| select_compaction_morsel(files, memory_budget.max_input_bytes));
+
+            if let Some(morsel) = morsel {
+                info!(
+                    input_files = morsel.input_files.len(),
+                    input_bytes = morsel.input_bytes,
+                    candidate_files = morsel.total_candidate_files,
+                    candidate_bytes = morsel.total_candidate_bytes,
+                    projected_budget_bytes = memory_budget.remaining_bytes,
+                    "✅ {} COMPACTION: Triggering bounded L0 morsel for collection {} (excluded {} pending files)",
+                    engine_type,
+                    collection_id,
+                    filtered_files.pending_count
+                );
+
+                return Ok(Some(CompactionTaskInfo {
+                    collection_id: collection_id.to_string(),
+                    source_level: 0,
+                    target_level: 1,
+                    input_files: morsel.input_files,
+                    input_bytes: morsel.input_bytes,
+                    extension: extension.to_string(),
+                    pending_files_count: filtered_files.pending_count,
+                    total_files_count: filtered_files.total_files,
+                }));
+            }
 
             info!(
-                "✅ {} COMPACTION: Triggering with {} compactable files for collection {} (excluded {} pending files)",
+                max_input_bytes = memory_budget.max_input_bytes,
+                effective_budget_bytes = memory_budget.effective_budget_bytes,
+                reserved_bytes = memory_budget.reserved_bytes,
+                "⏸️ {} COMPACTION: L0 remains horizontal because no file pair fits the current memory budget for collection {}",
                 engine_type,
-                compactable_files.len(),
-                collection_id,
-                filtered_files.pending_count
+                collection_id
             );
-
-            return Ok(Some(CompactionTaskInfo {
-                collection_id: collection_id.to_string(),
-                source_level: 0,
-                target_level: 1,
-                input_files: compactable_files,
-                extension: extension.to_string(),
-                pending_files_count: filtered_files.pending_count,
-                total_files_count: filtered_files.total_files,
-            }));
         }
 
         // Check higher levels if needed (using configured max_levels)
@@ -354,25 +421,47 @@ impl CompactionTaskBuilder {
             // amplification. In particular, a size-only trigger must not
             // cascade one large file through every level.
             if higher_level_compaction_reduces_fanout(level_file_count, should_compact) {
-                let compactable_files = file_discovery.get_compaction_files(&filtered_files, level);
+                let memory_budget = current_compaction_input_budget(config);
+                let morsel = filtered_files
+                    .compactable_files
+                    .get(&level)
+                    .and_then(|files| {
+                        select_compaction_morsel(files, memory_budget.max_input_bytes)
+                    });
+
+                if let Some(morsel) = morsel {
+                    info!(
+                        input_files = morsel.input_files.len(),
+                        input_bytes = morsel.input_bytes,
+                        candidate_files = morsel.total_candidate_files,
+                        candidate_bytes = morsel.total_candidate_bytes,
+                        "✅ {} COMPACTION: Level {} triggering bounded morsel for collection {}",
+                        engine_type,
+                        level,
+                        collection_id
+                    );
+
+                    return Ok(Some(CompactionTaskInfo {
+                        collection_id: collection_id.to_string(),
+                        source_level: level,
+                        target_level: level + 1,
+                        input_files: morsel.input_files,
+                        input_bytes: morsel.input_bytes,
+                        extension: extension.to_string(),
+                        pending_files_count: filtered_files.pending_count,
+                        total_files_count: filtered_files.total_files,
+                    }));
+                }
 
                 info!(
-                    "✅ {} COMPACTION: Level {} triggering with {} files for collection {}",
-                    engine_type,
                     level,
-                    compactable_files.len(),
+                    max_input_bytes = memory_budget.max_input_bytes,
+                    effective_budget_bytes = memory_budget.effective_budget_bytes,
+                    reserved_bytes = memory_budget.reserved_bytes,
+                    "⏸️ {} COMPACTION: level remains horizontal because no file pair fits the current memory budget for collection {}",
+                    engine_type,
                     collection_id
                 );
-
-                return Ok(Some(CompactionTaskInfo {
-                    collection_id: collection_id.to_string(),
-                    source_level: level,
-                    target_level: level + 1,
-                    input_files: compactable_files,
-                    extension: extension.to_string(),
-                    pending_files_count: filtered_files.pending_count,
-                    total_files_count: filtered_files.total_files,
-                }));
             }
         }
 
@@ -433,6 +522,8 @@ pub struct CompactionTaskInfo {
     pub source_level: u32,
     pub target_level: u32,
     pub input_files: Vec<String>,
+    /// Immutable segment bytes used for weighted memory admission.
+    pub input_bytes: u64,
     pub extension: String,
     pub pending_files_count: usize,
     pub total_files_count: usize,
@@ -481,6 +572,8 @@ impl CompactionSelfHealing {
 mod tests {
     use super::*;
 
+    const MIB: u64 = 1024 * 1024;
+
     fn file(level: u32) -> GenericFileMetadata {
         GenericFileMetadata {
             path: format!("L{level}.pax"),
@@ -489,6 +582,76 @@ mod tests {
             timestamp: 0,
             extension: "pax".to_string(),
         }
+    }
+
+    fn sized_file(path: &str, timestamp: u64, size_mb: u64) -> GenericFileMetadata {
+        GenericFileMetadata {
+            path: path.to_string(),
+            size_bytes: size_mb * MIB,
+            level: 0,
+            timestamp,
+            extension: "pax".to_string(),
+        }
+    }
+
+    #[test]
+    fn compaction_morsel_bounds_input_bytes_oldest_first() {
+        let files = (0..5)
+            .map(|index| sized_file(&format!("L0_{index}.pax"), index, 180))
+            .collect::<Vec<_>>();
+
+        let morsel = select_compaction_morsel(&files, 512 * MIB)
+            .expect("two oldest files fit the compaction budget");
+
+        assert_eq!(morsel.input_files, vec!["L0_0.pax", "L0_1.pax"]);
+        assert_eq!(morsel.input_bytes, 360 * MIB);
+        assert_eq!(morsel.total_candidate_bytes, 900 * MIB);
+        assert_eq!(morsel.total_candidate_files, 5);
+    }
+
+    #[test]
+    fn compaction_morsel_skips_unpairable_oversized_oldest_file() {
+        let files = vec![
+            sized_file("oversized.pax", 0, 600),
+            sized_file("oldest-fitting.pax", 1, 200),
+            sized_file("second-fitting.pax", 2, 200),
+            sized_file("third-fitting.pax", 3, 100),
+        ];
+
+        let morsel = select_compaction_morsel(&files, 512 * MIB)
+            .expect("smaller peers should compact around an oversized file");
+
+        assert_eq!(
+            morsel.input_files,
+            vec![
+                "oldest-fitting.pax",
+                "second-fitting.pax",
+                "third-fitting.pax"
+            ]
+        );
+        assert_eq!(morsel.input_bytes, 500 * MIB);
+    }
+
+    #[test]
+    fn compaction_morsel_requires_two_files_within_budget() {
+        let files = vec![
+            sized_file("first.pax", 0, 180),
+            sized_file("second.pax", 1, 180),
+        ];
+
+        assert!(select_compaction_morsel(&files, 300 * MIB).is_none());
+        assert!(select_compaction_morsel(&files[..1], 512 * MIB).is_none());
+    }
+
+    #[test]
+    fn zero_compaction_input_budget_fails_closed() {
+        let files = vec![
+            sized_file("first.pax", 0, 600),
+            sized_file("second.pax", 1, 600),
+            sized_file("third.pax", 2, 600),
+        ];
+
+        assert!(select_compaction_morsel(&files, 0).is_none());
     }
 
     #[tokio::test]

--- a/src/storage/common/mod.rs
+++ b/src/storage/common/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod axis_flush_hook;
 pub mod bitmap;
+pub mod compaction_memory;
 pub mod compaction_orchestrator;
 pub mod compaction_utils;
 pub mod flush_handler_trait;
@@ -15,6 +16,7 @@ pub mod mmap_vectors;
 pub mod compaction_test_utils;
 
 pub use bitmap::*;
+pub use compaction_memory::*;
 pub use compaction_orchestrator::*;
 pub use compaction_utils::*;
 pub use flush_handler_trait::*;

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -29,6 +29,8 @@ pub struct StorageEngine {
     write_ahead_log_manager: Arc<WriteAheadLogManager>,
     #[cfg(feature = "axis")]
     axis_index_manager: Arc<AxisManager>,
+    #[cfg(feature = "axis")]
+    axis_runtime_enabled: bool,
     compaction_manager: Arc<Compaction>,
     filesystem: Arc<crate::storage::persistence::filesystem::FilesystemFactory>,
 
@@ -134,18 +136,20 @@ impl StorageEngine {
             .first()
             .cloned()
             .unwrap_or_else(|| PathBuf::from("./data"));
+        #[cfg(feature = "axis")]
+        let axis_runtime_enabled = config.optimization.enable_axis_indexes;
         // Initialize AXIS index manager with default configuration
         #[cfg(feature = "axis")]
         let axis_index_manager = {
             let axis_config = AxisConfig::default();
             let m = Arc::new(AxisManager::new(axis_config).await?);
-            // Make AXIS manager available to SST engine for HNSW/IVF search
-            crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
-            // Also expose the concrete AxisManager for the WAL-layer inline flush trigger
-            // (resolved via `crate::index::get_global_axis_manager`), so an inline flush
-            // clears the AXIS projection exactly like the periodic/shutdown paths.
-            crate::index::set_global_axis_manager(m.clone());
-            info!("✅ AXIS manager registered with SST engine for HNSW/IVF search");
+            if axis_runtime_enabled {
+                // Make AXIS available only after both the compile capability
+                // and process runtime policy are enabled.
+                crate::storage::engines::sst::core::set_sst_axis_manager(m.clone());
+                crate::index::set_global_axis_manager(m.clone());
+                info!("✅ AXIS runtime enabled and registered with storage serving");
+            }
             m
         };
 
@@ -183,6 +187,8 @@ impl StorageEngine {
             write_ahead_log_manager,
             #[cfg(feature = "axis")]
             axis_index_manager,
+            #[cfg(feature = "axis")]
+            axis_runtime_enabled,
             compaction_manager,
             filesystem,
             distance_compute,
@@ -256,7 +262,8 @@ impl StorageEngine {
         #[cfg(feature = "axis")]
         crate::storage::auto_flush_driver::AutoFlushDriver::spawn(
             flush_policy,
-            self.axis_index_manager.clone(),
+            self.axis_runtime_enabled
+                .then(|| self.axis_index_manager.clone()),
             self.storage_write_fence.clone(),
         );
         #[cfg(not(feature = "axis"))]
@@ -404,7 +411,9 @@ impl StorageEngine {
             // round-trip in runtime-evidence/TD163_SERVER_FLUSH_MATERIALIZATION_2026_06_26.md.
             // Shutdown is terminal, so the freed batches are never re-flushed.
             #[cfg(feature = "axis")]
-            let axis_arg: Option<&AxisManager> = Some(&self.axis_index_manager);
+            let axis_arg: Option<&AxisManager> = self
+                .axis_runtime_enabled
+                .then_some(self.axis_index_manager.as_ref());
             #[cfg(not(feature = "axis"))]
             let axis_arg: Option<&()> = None;
             match materialize_collection(
@@ -791,7 +800,7 @@ impl StorageEngine {
 
         // Remove from search index
         #[cfg(feature = "axis")]
-        if exists {
+        if exists && self.axis_runtime_enabled {
             self.axis_index_manager
                 .delete(collection_id, id.clone())
                 .await?;
@@ -901,13 +910,6 @@ impl StorageEngine {
         tracing::debug!(
             "📁 Collection directories created, SST tree will be initialized on first access"
         );
-
-        // Ensure search index strategy exists for the collection
-        #[cfg(feature = "axis")]
-        self.axis_index_manager
-            .ensure_collection_strategy(&collection_id)
-            .await
-            .map_err(|e| crate::core::StorageError::IndexError(e.to_string()))?;
 
         tracing::info!(
             "✅ Created collection: {} with directories at {}",
@@ -1124,9 +1126,11 @@ impl StorageEngine {
 
             // Remove AXIS indexes for collection
             #[cfg(feature = "axis")]
-            self.axis_index_manager
-                .drop_collection(collection_id)
-                .await?;
+            if self.axis_runtime_enabled {
+                self.axis_index_manager
+                    .drop_collection(collection_id)
+                    .await?;
+            }
 
             // Clean up SST files for the dropped collection
             if let Some(sst_storage) = self.sst_storages.get(collection_id) {
@@ -1196,6 +1200,9 @@ impl StorageEngine {
         &self,
         collection_id: &str,
     ) -> crate::storage::Result<Option<HashMap<String, serde_json::Value>>> {
+        if !self.axis_runtime_enabled {
+            return Ok(None);
+        }
         // Get AXIS index statistics
         match self
             .axis_index_manager
@@ -1230,6 +1237,9 @@ impl StorageEngine {
     /// Optimize search index
     #[cfg(feature = "axis")]
     pub async fn optimize_index(&self, collection_id: &str) -> crate::storage::Result<()> {
+        if !self.axis_runtime_enabled {
+            return Ok(());
+        }
         // Trigger AXIS analysis and optimization
         self.axis_index_manager
             .analyze_and_optimize(collection_id)

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -205,6 +205,22 @@ pub struct SstCompactionTask {
     pub precision_hint: Option<proximadb_records::EmbeddingScalarType>,
 }
 
+fn training_follow_up_threshold(source_level: u8, output_file: &Path) -> Option<usize> {
+    let writes_trained_pax = source_level == 0
+        && output_file
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("pax"));
+    writes_trained_pax.then_some(1)
+}
+
+fn retain_training_guard_for_follow_up(
+    training_chain_active: bool,
+    scheduled_follow_up_level: Option<u8>,
+) -> bool {
+    training_chain_active && scheduled_follow_up_level == Some(0)
+}
+
 /// Priority levels for compaction tasks
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CompactionPriority {
@@ -1061,6 +1077,12 @@ impl Compaction {
                 // (schedule_compaction) — no insert here. We only remove below
                 // once the task is processed.
                 let compaction_key = task.output_file.to_string_lossy().to_string();
+                let training_guard_active = task.output_file.parent().is_some_and(|dir| {
+                    let key = dir.to_string_lossy();
+                    training_in_flight
+                        .lock()
+                        .is_ok_and(|guard| guard.contains(key.as_ref()))
+                });
 
                 let start_time = std::time::Instant::now();
 
@@ -1083,6 +1105,7 @@ impl Compaction {
                         &training_in_flight,
                         &compaction_key,
                         task.output_file.parent(),
+                        true,
                     )
                     .await;
                     break;
@@ -1157,6 +1180,9 @@ impl Compaction {
                 // a future flush that may never arrive after ingest settles.
                 // Schedule before releasing the current active marker, keeping
                 // the quiescence barrier closed across the hand-off.
+                let mut scheduled_follow_up_level = None;
+                let follow_up_threshold =
+                    training_follow_up_threshold(task.level, &task.output_file);
                 if succeeded
                     && !shutdown_signal.load(Ordering::SeqCst)
                     && let Some(collection_dir) = task.output_file.parent()
@@ -1165,22 +1191,33 @@ impl Compaction {
                         .check_compaction_needed(
                             task.collection_object_id,
                             collection_dir,
-                            None,
+                            follow_up_threshold,
                             task.precision_hint,
                         )
                         .await
                     {
                         Ok(Some(follow_up)) => {
+                            let follow_up_level = follow_up.level;
                             match compaction.schedule_compaction(follow_up).await {
-                                Ok(true) => info!(
-                                    collection_object_id = task.collection_object_id,
-                                    "Compaction follow-up morsel enqueued after level {}",
-                                    task.level
-                                ),
-                                Ok(false) => debug!(
-                                    collection_object_id = task.collection_object_id,
-                                    "Compaction follow-up already owned by another morsel"
-                                ),
+                                Ok(true) => {
+                                    scheduled_follow_up_level = Some(follow_up_level);
+                                    info!(
+                                        collection_object_id = task.collection_object_id,
+                                        layout_promotion_chain = follow_up_threshold.is_some(),
+                                        "Compaction follow-up morsel enqueued after level {}",
+                                        task.level
+                                    );
+                                }
+                                Ok(false) => {
+                                    // Another active task owns this work. Keep
+                                    // the training guard when that owner is an
+                                    // L0 morsel so it inherits threshold one.
+                                    scheduled_follow_up_level = Some(follow_up_level);
+                                    debug!(
+                                        collection_object_id = task.collection_object_id,
+                                        "Compaction follow-up already owned by another morsel"
+                                    );
+                                }
                                 Err(error) => warn!(
                                     collection_object_id = task.collection_object_id,
                                     "Compaction follow-up enqueue failed: {error}"
@@ -1197,11 +1234,18 @@ impl Compaction {
 
                 // TD-COMPACT-6 D1: release the enqueue-time active marker and the
                 // per-collection training guard so the flush path can re-arm.
+                // A bounded L0 training follow-up retains the guard and the
+                // threshold-one reason until the untrained tail is drained.
+                let retain_training_guard = retain_training_guard_for_follow_up(
+                    training_guard_active,
+                    scheduled_follow_up_level,
+                );
                 Self::release_task_state(
                     &active_compactions,
                     &training_in_flight,
                     &compaction_key,
                     task.output_file.parent(),
+                    !retain_training_guard,
                 )
                 .await;
             } else {
@@ -1215,21 +1259,22 @@ impl Compaction {
     /// TD-COMPACT-6 (ADR-076 D1): drop the per-task bookkeeping once a worker
     /// finishes a task (Ok, Err, or manager-construction failure). Removes the
     /// output-file key from `active_compactions` (re-allowing compaction to the
-    /// same output) and, if the task carried a `collection_dir`, clears the
-    /// shared `training_in_flight` guard (re-arming the flush path's
-    /// `should_trigger_compaction` training arm for that collection). Shared by
-    /// every worker exit path so the guard can never leak.
+    /// same output). It normally clears the shared `training_in_flight` guard;
+    /// a successfully handed-off L0 training morsel retains it so the bounded
+    /// chain cannot lose its threshold-one reason. Shared by every worker exit
+    /// path so the guard can never leak.
     async fn release_task_state(
         active_compactions: &Arc<RwLock<HashMap<String, SstCompactionTask>>>,
         training_in_flight: &Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
         compaction_key: &str,
         collection_dir: Option<&Path>,
+        clear_training_guard: bool,
     ) {
         {
             let mut active = active_compactions.write().await;
             active.remove(compaction_key);
         }
-        if let Some(dir) = collection_dir {
+        if clear_training_guard && let Some(dir) = collection_dir {
             let key = dir.to_string_lossy();
             if let Ok(mut guard) = training_in_flight.lock() {
                 guard.remove(key.as_ref());

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -46,6 +46,7 @@ use crate::storage::common::*;
 pub struct LevelBasedSstCompactionTask {
     pub level: u32,
     pub input_files: Vec<String>,
+    pub input_bytes: u64,
     pub target_level: u32,
     pub extension: String,
 }
@@ -185,6 +186,8 @@ pub struct SstCompactionTask {
     pub collection_identity: crate::core::stable_id::CollectionIdentity,
     pub level: u8,
     pub input_files: Vec<PathBuf>,
+    /// Immutable input bytes used by process-wide weighted memory admission.
+    pub input_bytes: u64,
     pub output_file: PathBuf,
     pub priority: CompactionPriority,
     /// Block size in KB for compacted output (uses server default if None)
@@ -250,6 +253,21 @@ pub struct EnhancedSstCompactionStats {
 enum MergedVectorTracking {
     Disabled,
     Enabled,
+}
+
+struct CompactionRunningMetricGuard;
+
+impl CompactionRunningMetricGuard {
+    fn begin() -> Self {
+        crate::metrics::operational_metrics::COMPACTION_RUNNING.inc();
+        Self
+    }
+}
+
+impl Drop for CompactionRunningMetricGuard {
+    fn drop(&mut self) {
+        crate::metrics::operational_metrics::COMPACTION_RUNNING.dec();
+    }
 }
 
 struct PreparedCompactionRecords {
@@ -780,6 +798,7 @@ impl Compaction {
             .unwrap_or(queue.len()); // Insert at end if no lower priority task found
 
         queue.insert(insert_pos, task);
+        crate::metrics::operational_metrics::COMPACTION_QUEUE_DEPTH.inc();
         drop(queue);
         self.task_notify.notify_one();
 
@@ -901,6 +920,7 @@ impl Compaction {
         let unified_task = task_info.map(|info| LevelBasedSstCompactionTask {
             level: info.source_level,
             input_files: info.input_files,
+            input_bytes: info.input_bytes,
             target_level: info.target_level,
             extension: info.extension,
         });
@@ -938,6 +958,7 @@ impl Compaction {
                 collection_identity: crate::core::stable_id::CollectionIdentity::default(),
                 level: task.level as u8,
                 input_files,
+                input_bytes: task.input_bytes,
                 output_file,
                 priority,
                 block_size_kb: None,      // Use server default
@@ -1027,6 +1048,7 @@ impl Compaction {
             };
 
             if let Some(task) = task {
+                crate::metrics::operational_metrics::COMPACTION_QUEUE_DEPTH.dec();
                 debug!(
                     "Worker {} processing compaction for level {} with {} files -> {}",
                     worker_id,
@@ -1041,6 +1063,44 @@ impl Compaction {
                 let compaction_key = task.output_file.to_string_lossy().to_string();
 
                 let start_time = std::time::Instant::now();
+
+                let memory_config = compaction
+                    .config
+                    .compaction_config
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_default();
+                let admission_started = std::time::Instant::now();
+                let Some(memory_reservation) = acquire_compaction_memory(
+                    task.input_bytes,
+                    &memory_config,
+                    shutdown_signal.as_ref(),
+                )
+                .await
+                else {
+                    Self::release_task_state(
+                        &active_compactions,
+                        &training_in_flight,
+                        &compaction_key,
+                        task.output_file.parent(),
+                    )
+                    .await;
+                    break;
+                };
+                let admission_wait = admission_started.elapsed();
+                if admission_wait >= std::time::Duration::from_millis(1) {
+                    crate::metrics::operational_metrics::COMPACTION_MEMORY_ADMISSION_WAITS_TOTAL
+                        .inc();
+                }
+                crate::metrics::operational_metrics::COMPACTION_MEMORY_RESERVED_BYTES
+                    .set(i64::try_from(reserved_compaction_memory_bytes()).unwrap_or(i64::MAX));
+                info!(
+                    input_bytes = task.input_bytes,
+                    projected_memory_bytes = memory_reservation.reserved_bytes(),
+                    admission_wait_ms = admission_wait.as_millis(),
+                    "Compaction memory reservation admitted"
+                );
+                let _running_metric = CompactionRunningMetricGuard::begin();
 
                 // Reuse the persistent Compaction instance (shared Arc). The
                 // former code built a fresh `Compaction` per task via
@@ -1088,6 +1148,9 @@ impl Compaction {
                         false
                     }
                 };
+                drop(memory_reservation);
+                crate::metrics::operational_metrics::COMPACTION_MEMORY_RESERVED_BYTES
+                    .set(i64::try_from(reserved_compaction_memory_bytes()).unwrap_or(i64::MAX));
 
                 // A completed morsel changes the level geometry. Re-evaluate
                 // it immediately so higher-level compaction does not depend on

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -28,7 +28,6 @@ use crate::storage::Result;
 // Removed ZeroCopyIOSystem - using UnifiedCachingFilesystem instead
 use crate::storage::engines::core::formats::arrow_block::{ArrowBlockConfig, ArrowBlockWriter};
 use crate::storage::engines::sst::readers::sst_query_engine::UnifiedSstableReader;
-use crate::storage::optimization::{MetadataSorter, SortingStats};
 use crate::storage::persistence::filesystem::caching_filesystem::UnifiedCachingFilesystem;
 use crate::storage::persistence::filesystem::{FilesystemError, FilesystemFactory, FsResult};
 use crate::storage::transaction_coordinator::{
@@ -102,10 +101,9 @@ pub fn get_global_precision_resolver()
 ///
 /// `[COMPACT mem] stage=<name> records=<n> rss_mb=<resident MB> delta_mb=<since previous stage>`
 ///
-/// plus a one-time per-record deep-size sample at the canonical-conversion
-/// boundary:
+/// plus a one-time canonical-record deep-size sample after input collection:
 ///
-/// `[COMPACT mem] sample vr_bytes=<..> pr_bytes=<..> emb_count=<..>`
+/// `[COMPACT mem] sample pr_bytes=<..> emb_count=<..>`
 struct CompactionMemTrace {
     /// `Some` only when tracing is enabled (holds the sysinfo handle so the
     /// disabled path allocates nothing and refreshes nothing).
@@ -160,19 +158,15 @@ impl CompactionMemTrace {
         eprintln!("{line}");
     }
 
-    /// One-time per-record deep-size sample at the canonical-conversion stage:
-    /// serialized (bincode) sizes of the same record in both forms, so the
-    /// per-record weight is measured rather than assumed. No-op when disabled.
-    fn sample_record(&self, vr: &VectorRecord, pr: &ProximaRecord) {
+    /// One-time serialized deep-size sample of the canonical record. The
+    /// compaction pipeline intentionally has no legacy `VectorRecord` copy.
+    fn sample_record(&self, pr: &ProximaRecord) {
         if self.sys.is_none() {
             return;
         }
-        let vr_bytes = bincode::serialize(vr).map(|b| b.len()).unwrap_or(0);
         let pr_bytes = bincode::serialize(pr).map(|b| b.len()).unwrap_or(0);
         let emb_count = pr.embeddings.len();
-        let line = format!(
-            "[COMPACT mem] sample vr_bytes={vr_bytes} pr_bytes={pr_bytes} emb_count={emb_count}"
-        );
+        let line = format!("[COMPACT mem] sample pr_bytes={pr_bytes} emb_count={emb_count}");
         tracing::info!("{line}");
         eprintln!("{line}");
     }
@@ -197,14 +191,10 @@ pub struct SstCompactionTask {
     pub block_size_kb: Option<u32>,
     /// Compression configuration (uses server default if None)
     pub compression_config: Option<crate::proto::proximadb_v1::CompressionConfig>,
-    /// Target embedding precision the writer should reconstitute records
-    /// to before flushing the rewritten block. When `None`, records keep
-    /// the precision they carried into the compaction (today: always fp32
-    /// because the `VectorRecord` intermediate flattens to fp32). When
-    /// `Some(target)`, `EmbeddingCell::coerce_to_precision(target)` is
-    /// called on every record at the writer reconstitution site —
-    /// recovers fp16 / bf16 / int8 collections from the fp32 pivot
-    /// bit-exact for fp16 (fp32 strictly dominates fp16).
+    /// Target embedding precision to enforce before flushing the rewritten
+    /// block. When `None`, canonical records keep the precision they carried
+    /// into compaction. When `Some(target)`, every embedding is coerced before
+    /// either PAX or Arrow writes it.
     ///
     /// The compaction scheduler populates this from
     /// `CanonicalPrecisionResolver::resolve` for the output collection;
@@ -251,6 +241,23 @@ pub struct EnhancedSstCompactionStats {
 
     /// Whether a full index rebuild is recommended
     pub recommend_full_rebuild: bool,
+}
+
+/// Whether a caller needs the legacy AXIS update payload in enhanced stats.
+/// Background compaction consumes only `base_stats`, so enabling tracking
+/// there would retain a second full corpus until the write completes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergedVectorTracking {
+    Disabled,
+    Enabled,
+}
+
+struct PreparedCompactionRecords {
+    records: Vec<ProximaRecord>,
+    deleted_vector_ids: Vec<String>,
+    merged_vectors: Vec<VectorRecord>,
+    expired_records_count: u64,
+    tombstones_removed_count: u64,
 }
 
 /// Manages background compaction of SST files
@@ -1172,13 +1179,18 @@ impl Compaction {
     /// background workers (which hold an `Arc<Compaction>` clone).
     async fn perform_compaction(&self, task: &SstCompactionTask) -> Result<SstCompactionStats> {
         let enhanced_stats = self
-            .perform_compaction_enhanced(task, &self.config, self.atomic_coordinator.clone(), None)
+            .perform_unified_canonical_compaction(
+                task,
+                &self.config,
+                self.atomic_coordinator.clone(),
+                None,
+                MergedVectorTracking::Disabled,
+            )
             .await?;
         Ok(enhanced_stats.base_stats)
     }
 
-    /// UNIFIED compaction using VectorRecord natively (eliminates dual paths)
-    /// OPTIMIZATION: Single path for all compaction, reuses existing reader/writer infrastructure
+    /// Unified canonical-record compaction path.
     pub async fn perform_compaction_enhanced(
         &self,
         task: &SstCompactionTask,
@@ -1195,12 +1207,14 @@ impl Compaction {
             task.level
         );
 
-        // SINGLE PATH: Use unified VectorRecord path (fastest, no SstRecord conversions)
-        self.perform_unified_vectorrecord_compaction(
+        // Single canonical path: no legacy DTO conversion between reader,
+        // MVCC resolution, and writer.
+        self.perform_unified_canonical_compaction(
             task,
             _config,
             atomic_coordinator,
             compression_config,
+            MergedVectorTracking::Enabled,
         )
         .await
     }
@@ -1234,14 +1248,12 @@ impl Compaction {
         }
     }
 
-    /// Original enhanced compaction implementation (now used as fallback)
-    /// UNIFIED VectorRecord compaction (eliminates SstRecord conversions completely)
-    /// OPTIMIZATION: Single streaming path, no dual conversions, fastest performance
     /// TD-DELVEC-1 WI-6: collect the oids deleted (DV bit set) across the input
     /// segments, so the compaction merge can physically drop them. Reads each
     /// input's DV (`{input}.dv`, disk-authoritative) + the segment's OID resolver
-    /// footer region (position → oid). The merge dedup loses each record's source
-    /// segment/position, so this is computed up front from the inputs. Feature-gated.
+    /// footer region (position → oid). The canonical merge loses each record's
+    /// source segment/position, so this is computed up front from the inputs.
+    /// Feature-gated.
     #[cfg(feature = "cold-deletion-vectors")]
     pub(crate) async fn build_deleted_oids(
         filesystem: &crate::storage::persistence::filesystem::FilesystemFactory,
@@ -1273,15 +1285,18 @@ impl Compaction {
         deleted
     }
 
-    async fn perform_unified_vectorrecord_compaction(
+    /// Canonical compaction path: `ProximaRecord` ownership flows from the
+    /// mixed-format reader through MVCC into the PAX/Arrow writer.
+    async fn perform_unified_canonical_compaction(
         &self,
         task: &SstCompactionTask,
         config: &SstConfig,
         atomic_coordinator: Option<Arc<TransactionCoordinator>>,
         compression_config: Option<crate::proto::proximadb_v1::CompressionConfig>,
+        merged_vector_tracking: MergedVectorTracking,
     ) -> Result<EnhancedSstCompactionStats> {
         debug!(
-            "🚀 UNIFIED COMPACTION: VectorRecord-only path with compression: {:?}",
+            "🚀 UNIFIED COMPACTION: canonical record path with compression: {:?}",
             compression_config
                 .as_ref()
                 .map(|c| format!("algorithm={}, level={:?}", c.algorithm, c.level))
@@ -1291,12 +1306,14 @@ impl Compaction {
         // Stage-boundary RSS checkpoints (env-gated, PROXIMADB_TRACE_COMPACTION_MEM).
         let mut memtrace = CompactionMemTrace::new();
 
-        // OPTIMIZATION: Direct VectorRecord collection, no SstRecord conversions
-        let mut all_vector_records: Vec<VectorRecord> = Vec::new();
+        // Canonical ownership from reader through writer. The former legacy
+        // VectorRecord pivot cloned vectors/properties, dropped record-envelope
+        // fields, and then re-expanded the same corpus for MVCC and writing.
+        let mut all_records: Vec<ProximaRecord> = Vec::new();
         let mut bytes_read = 0u64;
 
         debug!(
-            "🚀 UNIFIED: Merging {} input files for level {} (VectorRecord-only path)",
+            "🚀 UNIFIED: Merging {} input files for level {} (canonical record path)",
             task.input_files.len(),
             task.level
         );
@@ -1304,14 +1321,13 @@ impl Compaction {
         for input_file in &task.input_files {
             let input_path = input_file.to_string_lossy();
 
-            // OPTIMIZED: Direct VectorRecord extraction (no SstRecord conversions)
             match self.read_all_records_from_file_unified(&input_path).await {
                 Ok(records) => {
                     // Per-file checkpoint: catches reader-side residue (decoded
                     // blocks, whole-file byte copies) accumulating across files.
                     memtrace.stage("input_file_read", records.len());
                     info!(
-                        "✅ Extracted {} VectorRecords from {} (no conversions)",
+                        "✅ Extracted {} canonical records from {}",
                         records.len(),
                         input_path
                     );
@@ -1331,8 +1347,7 @@ impl Compaction {
                         warn!("No records extracted from SST file: {}", input_path);
                     }
 
-                    // FASTEST: Direct VectorRecord append (no conversions!)
-                    all_vector_records.extend(records);
+                    all_records.extend(records);
                 }
                 Err(e) => {
                     warn!(
@@ -1344,98 +1359,23 @@ impl Compaction {
             }
         }
 
-        memtrace.stage("all_records_extended", all_vector_records.len());
+        memtrace.stage("all_records_extended", all_records.len());
         info!(
-            "✅ Collected {} total VectorRecords from {} input files (no conversions)",
-            all_vector_records.len(),
+            "✅ Collected {} canonical records from {} input files",
+            all_records.len(),
             task.input_files.len()
         );
 
-        // OPTIMIZED: Sort VectorRecords directly by (id, version, timestamp) for merge deduplication
-        all_vector_records.sort_by(|a, b| {
-            let id_a = &a.id;
-            let id_b = &b.id;
-
-            // First sort by ID
-            match id_a.cmp(id_b) {
-                std::cmp::Ordering::Equal => {
-                    // For same ID, sort by version (newer versions first)
-                    match b.version.unwrap_or(0).cmp(&a.version.unwrap_or(0)) {
-                        std::cmp::Ordering::Equal => {
-                            // For same version, sort by timestamp (newer timestamp first)
-                            b.timestamp.cmp(&a.timestamp)
-                        }
-                        other => other,
-                    }
-                }
-                other => other,
-            }
-        });
-        memtrace.stage("input_sorted", all_vector_records.len());
-
-        // OPTIMIZED: Merge-deduplicate legacy SST records directly, then lower
-        // through canonical ProximaRecord for MVCC resolution.
-        let mut merged_vector_records: Vec<VectorRecord> = Vec::new();
-        let mut last_id = String::new();
-
-        for record in all_vector_records {
-            let record_id = &record.id;
-
-            // For append-only vectors (empty IDs), keep all records
-            if record_id.is_empty() || record_id.starts_with("__append_only_") {
-                merged_vector_records.push(record);
-            } else if record_id != &last_id {
-                // New ID, add it
-                last_id = record_id.clone();
-                merged_vector_records.push(record);
-            } else {
-                // Same ID, skip (we already have the latest version due to sorting)
-            }
+        if let Some(record) = all_records.first() {
+            memtrace.sample_record(record);
         }
 
-        memtrace.stage("dedup", merged_vector_records.len());
-        info!(
-            "🔍 UNIFIED COMPACTION: Merged to {} unique VectorRecords after deduplication",
-            merged_vector_records.len()
-        );
-
-        let resolver = MvccResolver::new();
-        let canonical_records: Vec<ProximaRecord> = merged_vector_records
-            .iter()
-            .map(ProximaRecord::from)
-            .collect();
-        // One-time per-record deep-size sample: same record in both forms.
-        if let (Some(vr), Some(pr)) = (merged_vector_records.first(), canonical_records.first()) {
-            memtrace.sample_record(vr, pr);
-        }
-        memtrace.stage("canonical_convert", canonical_records.len());
-        let resolved_records: Vec<VectorRecord> = resolver
-            .resolve_batch(canonical_records)
-            .into_iter()
-            .map(VectorRecord::from)
-            .collect();
-        memtrace.stage("mvcc_resolved", resolved_records.len());
-        info!(
-            "🔍 UNIFIED COMPACTION: MVCC resolution: {} records after resolution",
-            resolved_records.len()
-        );
-
-        // Convert merged data to vectors for sorting
-        let mut vector_records = Vec::new();
-        let current_time = chrono::Utc::now().timestamp_millis();
-        let mut expired_records_count = 0;
-        let mut tombstones_removed_count = 0;
-
-        // Track deleted vectors for AXIS
-        let mut deleted_vector_ids = Vec::new();
-        let mut merged_vectors = Vec::new();
-
-        // TD-DELVEC-1 WI-6: build the set of oids whose deletion-vector bit is
-        // set in any input segment, so the merge physically drops them (a DV-
-        // deleted row must not resurrect in the compacted output). The merge
-        // dedup loses each record's source segment/position, so this is computed
-        // up front from the input segments' DVs + OID resolvers. The `dv_store`
-        // is reused below to retire the inputs' `.dv` files.
+        // TD-DELVEC-1 WI-6: materialize deletion-vector OIDs before source
+        // identity is lost by MVCC resolution. Remove every version of a
+        // deleted OID from the owned canonical corpus so neither the writer nor
+        // optional AXIS merged-vector tracking can observe a deleted row. Keep
+        // this store alive through input retirement below so the corresponding
+        // `.dv` objects are removed only after the replacement is published.
         #[cfg(feature = "cold-deletion-vectors")]
         let dv_store =
             crate::storage::engines::sst::deletion_vector_store::DeletionVectorStore::new(
@@ -1444,72 +1384,33 @@ impl Compaction {
         #[cfg(feature = "cold-deletion-vectors")]
         let deleted_oids =
             Self::build_deleted_oids(&self.filesystem_factory, &dv_store, &task.input_files).await;
+        #[cfg(feature = "cold-deletion-vectors")]
+        all_records.retain(|record| !deleted_oids.contains(&record.oid));
 
-        for vector_record in &resolved_records {
-            // TD-DELVEC-1 WI-6: drop DV-deleted rows (checked before tombstone/
-            // expiry so a DV delete always wins). WI-7 (conservative purge
-            // watermark) is intentionally descoped per TD §7.2-5: long-lived
-            // snapshots are NOT pinned — a DV-deleted row is physically dropped
-            // here regardless of any hypothetical older reader, matching today's
-            // tombstone-reclaim behavior. If a past-T (time-travel) reader is
-            // ever added, revisit this to carry recent deletes forward.
-            #[cfg(feature = "cold-deletion-vectors")]
-            if deleted_oids.contains(&vector_record.id) {
-                deleted_vector_ids.push(vector_record.id.clone());
-                continue;
-            }
-            // Tombstone detection: empty vector + expires_at in past (including 0)
-            // expires_at = 0 means "epoch time" which is always in the past = tombstone marker
-            let is_tombstone = vector_record.vector.is_empty()
-                && vector_record
-                    .expires_at
-                    .is_some_and(|e| Self::epoch_millis(e) <= current_time);
+        let mut prepared = Self::prepare_canonical_records(
+            all_records,
+            Self::current_time_ns(),
+            merged_vector_tracking,
+        );
+        memtrace.stage("mvcc_resolved_in_place", prepared.records.len());
+        info!(
+            "🔍 UNIFIED COMPACTION: MVCC resolution retained {} canonical records",
+            prepared.records.len()
+        );
 
-            // Check if record is expired (TTL-based expiry for non-tombstones)
-            // This is different from tombstones - these are regular records that have expired
-            let is_expired = !is_tombstone
-                && vector_record.expires_at.is_some_and(|expires_at| {
-                    let expires_at_ms = Self::epoch_millis(expires_at);
-                    expires_at_ms > 0 && expires_at_ms < current_time
-                });
-
-            // Skip expired records completely - they are physically deleted
-            if is_expired {
-                expired_records_count += 1;
-                // Track deleted vector for AXIS
-                deleted_vector_ids.push(vector_record.id.clone());
-                continue;
-            }
-            let should_keep = if is_tombstone {
-                // Keep tombstones that are less than 1 hour old
-                let age = current_time - Self::epoch_millis(vector_record.timestamp.unwrap_or(0));
-                let keep_tombstone = age < (60 * 60 * 1000); // 1 hour in milliseconds
-
-                if !keep_tombstone {
-                    tombstones_removed_count += 1;
-                    // Track deleted vector for AXIS
-                    deleted_vector_ids.push(vector_record.id.clone());
-                }
-
-                keep_tombstone
-            } else {
-                true // Keep all active, non-expired records
-            };
-
-            if should_keep {
-                // OPTIMIZED: Direct VectorRecord usage (already a VectorRecord)
-
-                // Track merged vectors for AXIS (non-tombstone records)
-                if !is_tombstone {
-                    merged_vectors.push(vector_record.clone());
-                }
-
-                vector_records.push(vector_record.clone());
-            }
-        }
-        // After the :1081/:1084 merge clones (merged_vectors + vector_records are
-        // BOTH full clones while resolved_records is still alive = 3 copies).
-        memtrace.stage("merge_clones", vector_records.len());
+        let expired_records_count = prepared.expired_records_count;
+        let tombstones_removed_count = prepared.tombstones_removed_count;
+        let deleted_vector_ids = std::mem::take(&mut prepared.deleted_vector_ids);
+        #[cfg(feature = "cold-deletion-vectors")]
+        let deleted_vector_ids = {
+            let mut deleted_vector_ids = deleted_vector_ids;
+            deleted_vector_ids.extend(deleted_oids);
+            deleted_vector_ids.sort_unstable();
+            deleted_vector_ids.dedup();
+            deleted_vector_ids
+        };
+        let merged_vectors = std::mem::take(&mut prepared.merged_vectors);
+        let mut records = prepared.records;
 
         // Log cleanup statistics
         if expired_records_count > 0 || tombstones_removed_count > 0 {
@@ -1519,53 +1420,21 @@ impl Compaction {
             );
         }
 
-        // OPTIMIZED: Sort VectorRecords by metadata for optimal encoding (no conversions)
-        let vector_records_len = vector_records.len();
-        info!(
-            "🔄 UNIFIED COMPACTION: Sorting {} VectorRecords by metadata for optimal encoding",
-            vector_records_len
-        );
-        let (sorted_vectors, sort_stats) =
-            Self::sort_vectors_for_compaction(vector_records).await?;
-        memtrace.stage("sort_return", sorted_vectors.len());
-        info!(
-            "✅ UNIFIED COMPACTION: Sorted records (estimated compression improvement: {:.1}%)",
-            sort_stats.compression_estimate * 100.0
-        );
-
-        // FASTEST: Direct VectorRecord to writer (no SstRecord conversions!)
-        let mut sorted_vector_records: Vec<(String, VectorRecord)> = Vec::new();
-        for (seq, vector) in sorted_vectors.into_iter().enumerate() {
-            let vector_id = if vector.id.is_empty() {
-                String::new()
-            } else {
-                vector.id.clone()
-            };
-
-            // Handle append-only vectors (empty/null IDs) specially
-            let key = if vector_id.is_empty() {
-                // For append-only vectors, use sequence number as unique key
-                let append_only_key = format!("__append_only_seq_{}", seq);
-                info!(
-                    "🔍 UNIFIED: Append-only vector at sequence {}, using key='{}'",
-                    seq, append_only_key
-                );
-                append_only_key
-            } else {
-                vector_id
-            };
-
-            // NO CONVERSIONS: Direct VectorRecord use
-            sorted_vector_records.push((key, vector));
+        // Precision is a writer-boundary policy and applies uniformly to PAX
+        // and Arrow. Canonical input already preserves non-fp32 payloads; the
+        // hint only coerces when the collection policy explicitly requests it.
+        if let Some(target) = task.precision_hint {
+            for record in &mut records {
+                for cell in &mut record.embeddings {
+                    cell.coerce_to_precision(target);
+                }
+            }
         }
 
-        info!(
-            "🔍 UNIFIED COMPACTION: Prepared {} sorted VectorRecords (zero conversions)",
-            sorted_vector_records.len()
-        );
+        let records_len = records.len();
 
         // Handle empty records case - return early without writing SSTable
-        if sorted_vector_records.is_empty() {
+        if records.is_empty() {
             info!(
                 "📋 SST COMPACTION: No records to compact after merging. Returning without writing SSTable."
             );
@@ -1577,21 +1446,16 @@ impl Compaction {
                     files_merged: task.input_files.len() as u64,
                     avg_compaction_time_ms: start_time.elapsed().as_millis() as u64,
                     last_compaction_time: Some(chrono::Utc::now()),
-                    expired_records_deleted: 0,
-                    tombstones_removed: 0,
+                    expired_records_deleted: expired_records_count,
+                    tombstones_removed: tombstones_removed_count,
                 },
-                merged_vectors: Vec::new(),
-                deleted_vector_ids: Vec::new(),
+                merged_vectors,
+                deleted_vector_ids,
                 recommend_full_rebuild: false,
             });
         }
 
-        // Convert to BTreeMap for SSTable writer (temporary, until we update writer)
-        let mut btree_records = BTreeMap::new();
-        for (key, record) in sorted_vector_records {
-            btree_records.insert(key, record);
-        }
-        memtrace.stage("pre_write", btree_records.len());
+        memtrace.stage("pre_write", records.len());
 
         // M1-3 (ADR-049): the legacy ProximaBlocks write arms (which needed a
         // block size + a writer-local filesystem factory + compression config)
@@ -1684,16 +1548,13 @@ impl Compaction {
                 BlockFormat::PaxBlock | BlockFormat::ProximaBlocks => {
                     // P3 Phase E: compact to a `.pax` segment, re-encoding the merged
                     // records with RaBitQ. Mixed-read-safe — source segments may be
-                    // legacy `.sst` or `.pax` (btree_records already merged them); the
+                    // legacy `.sst` or `.pax` (canonical records already merged them); the
                     // rewrite emits the configured PAX format. The output filename is
                     // format-aware (`.pax`) via `generate_output_file_path`, so
                     // discovery + the cascade dispatch route it correctly.
                     let collection_id = self
                         .extract_collection_id_from_paths(&task.input_files)
                         .unwrap_or_else(|_| "default".to_string());
-                    let records: Vec<ProximaRecord> =
-                        btree_records.values().map(ProximaRecord::from).collect();
-                    memtrace.stage("write_input_converted", records.len());
                     if let Some(parent) = staging_file_path.parent() {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
@@ -1767,10 +1628,10 @@ impl Compaction {
                     debug!("🔍 COMPACTION: Using ArrowBlockWriter for Arrow format");
 
                     // Infer dimension from first record
-                    let dimension = btree_records
-                        .values()
-                        .next()
-                        .map_or(128, |r| r.vector.len() as u32);
+                    let dimension = records
+                        .first()
+                        .and_then(|record| record.embeddings.first())
+                        .map_or(128, |embedding| embedding.dim);
 
                     // Ensure parent directory exists
                     if let Some(parent) = staging_file_path.parent() {
@@ -1781,19 +1642,6 @@ impl Compaction {
                     let config = ArrowBlockConfig::new(dimension);
                     let mut writer = ArrowBlockWriter::new(&staging_file_path, config)
                         .map_err(|e| crate::core::StorageError::SstEngine(e.to_string()))?;
-
-                    // ArrowBlock writes canonical records; this branch is the
-                    // boundary from legacy SST compaction records.
-                    let mut records: Vec<ProximaRecord> =
-                        btree_records.values().map(ProximaRecord::from).collect();
-                    memtrace.stage("write_input_converted", records.len());
-                    if let Some(target) = task.precision_hint {
-                        for record in &mut records {
-                            for cell in &mut record.embeddings {
-                                cell.coerce_to_precision(target);
-                            }
-                        }
-                    }
 
                     writer
                         .write_block(&records)
@@ -1861,9 +1709,6 @@ impl Compaction {
                     let collection_id = self
                         .extract_collection_id_from_paths(&task.input_files)
                         .unwrap_or_else(|_| "default".to_string());
-                    let records: Vec<ProximaRecord> =
-                        btree_records.values().map(ProximaRecord::from).collect();
-                    memtrace.stage("write_input_converted", records.len());
                     if let Some(parent) = task.output_file.parent() {
                         std::fs::create_dir_all(parent)
                             .map_err(crate::core::StorageError::DiskIO)?;
@@ -1932,10 +1777,10 @@ impl Compaction {
                     debug!("🔍 COMPACTION (non-atomic): Using ArrowBlockWriter for Arrow format");
 
                     // Infer dimension from first record
-                    let dimension = btree_records
-                        .values()
-                        .next()
-                        .map_or(128, |r| r.vector.len() as u32);
+                    let dimension = records
+                        .first()
+                        .and_then(|record| record.embeddings.first())
+                        .map_or(128, |embedding| embedding.dim);
 
                     // Ensure parent directory exists
                     if let Some(parent) = task.output_file.parent() {
@@ -1946,19 +1791,6 @@ impl Compaction {
                     let config = ArrowBlockConfig::new(dimension);
                     let mut writer = ArrowBlockWriter::new(&task.output_file, config)
                         .map_err(|e| crate::core::StorageError::SstEngine(e.to_string()))?;
-
-                    // ArrowBlock writes canonical records; this branch is the
-                    // boundary from legacy SST compaction records.
-                    let mut records: Vec<ProximaRecord> =
-                        btree_records.values().map(ProximaRecord::from).collect();
-                    memtrace.stage("write_input_converted", records.len());
-                    if let Some(target) = task.precision_hint {
-                        for record in &mut records {
-                            for cell in &mut record.embeddings {
-                                cell.coerce_to_precision(target);
-                            }
-                        }
-                    }
 
                     writer
                         .write_block(&records)
@@ -1989,7 +1821,7 @@ impl Compaction {
                 }
             }
         };
-        memtrace.stage("write_done", vector_records_len);
+        memtrace.stage("write_done", records_len);
 
         debug!(
             "Wrote {} bytes to output file {}",
@@ -2147,7 +1979,7 @@ impl Compaction {
             bytes_read / 1024 / 1024,
             bytes_written / 1024 / 1024,
             compression_ratio,
-            vector_records_len,
+            records_len,
             expired_records_count,
             tombstones_removed_count
         );
@@ -2491,7 +2323,7 @@ impl Compaction {
     async fn read_all_records_from_file_unified(
         &self,
         file_path: &str,
-    ) -> Result<Vec<VectorRecord>> {
+    ) -> Result<Vec<ProximaRecord>> {
         info!(
             "🔥 COMPACTION UNIFIED: Reading {} with optimized strategy",
             file_path
@@ -2537,7 +2369,7 @@ impl Compaction {
                 records.len(),
                 file_path
             );
-            return Ok(records.into_iter().map(VectorRecord::from).collect());
+            return Ok(records);
         }
 
         // Use compaction-optimized reading strategy
@@ -2567,7 +2399,7 @@ impl Compaction {
                     );
                 }
 
-                Ok(records.into_iter().map(VectorRecord::from).collect())
+                Ok(records)
             }
             Err(e) => {
                 warn!("❌ COMPACTION UNIFIED: Failed to read {}: {}", file_path, e);
@@ -2579,39 +2411,63 @@ impl Compaction {
         }
     }
 
-    /// Sort vector records by metadata for optimal compaction encoding
-    /// Uses same sorting strategy as flush operations to maintain consistency
-    async fn sort_vectors_for_compaction(
-        vector_records: Vec<VectorRecord>,
-    ) -> Result<(Vec<VectorRecord>, SortingStats)> {
-        debug!(
-            "🔄 Sorting {} vectors for optimal SSTable compaction encoding",
-            vector_records.len()
-        );
+    fn prepare_canonical_records(
+        records: Vec<ProximaRecord>,
+        current_time_ns: i64,
+        merged_vector_tracking: MergedVectorTracking,
+    ) -> PreparedCompactionRecords {
+        const TOMBSTONE_RETENTION_NS: i64 = 60 * 60 * 1_000_000_000;
 
-        if vector_records.is_empty() {
-            return Ok((vector_records, SortingStats::default()));
+        let mut expired_records_count = 0u64;
+        let mut tombstones_removed_count = 0u64;
+        let mut deleted_vector_ids = Vec::new();
+        for record in &records {
+            let is_expired = record
+                .valid_to_ns
+                .is_some_and(|valid_to_ns| valid_to_ns < current_time_ns);
+            if !is_expired {
+                continue;
+            }
+
+            deleted_vector_ids.push(record.oid.clone());
+            if record.embeddings.is_empty() {
+                let age_ns = current_time_ns.saturating_sub(record.created_at_ns);
+                if age_ns >= TOMBSTONE_RETENTION_NS {
+                    tombstones_removed_count += 1;
+                }
+            } else {
+                expired_records_count += 1;
+            }
         }
+        deleted_vector_ids.sort_unstable();
+        deleted_vector_ids.dedup();
 
-        // Create metadata sorter for optimal SSTable encoding
-        let sorter = MetadataSorter::new(Default::default());
+        let resolver = MvccResolver::with_timestamp_ns(current_time_ns);
+        let records = resolver.resolve_sorted_batch(records);
+        let merged_vectors = match merged_vector_tracking {
+            MergedVectorTracking::Disabled => Vec::new(),
+            MergedVectorTracking::Enabled => records
+                .iter()
+                .filter(|record| !record.embeddings.is_empty())
+                .map(VectorRecord::from)
+                .collect(),
+        };
 
-        // Sort records to optimize for:
-        // 1. Sequential access patterns in SSTable blocks
-        // 2. Better compression ratios in block-based storage
-        // 3. Improved bloom filter effectiveness
-        let canonical_records: Vec<ProximaRecord> =
-            vector_records.iter().map(ProximaRecord::from).collect();
-        let (sorted_records, sort_stats) = sorter.sort_for_encoding(canonical_records)?;
-        let sorted_records: Vec<VectorRecord> =
-            sorted_records.into_iter().map(VectorRecord::from).collect();
+        PreparedCompactionRecords {
+            records,
+            deleted_vector_ids,
+            merged_vectors,
+            expired_records_count,
+            tombstones_removed_count,
+        }
+    }
 
-        debug!(
-            "✅ LSM compaction sorting complete: {} records sorted for optimal SSTable encoding",
-            sorted_records.len()
-        );
-
-        Ok((sorted_records, sort_stats))
+    fn current_time_ns() -> i64 {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        nanos.min(i64::MAX as u128) as i64
     }
 
     fn epoch_millis(timestamp: i64) -> i64 {

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -32,6 +32,7 @@ async fn test_compaction_task_scheduling() {
         collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![],
+        input_bytes: 0,
         output_file: PathBuf::from("/tmp/output.db"),
         priority: CompactionPriority::Medium,
         block_size_kb: None,
@@ -56,6 +57,7 @@ async fn td_compact6_schedule_dedups_same_output_at_enqueue() {
         collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![PathBuf::from("/nonexistent/proxima_d1_test/input.pax")],
+        input_bytes: 0,
         output_file: PathBuf::from("/nonexistent/proxima_d1_test/compacted_L1.pax"),
         priority: CompactionPriority::Medium,
         block_size_kb: None,
@@ -92,6 +94,7 @@ async fn compaction_morsel_admission_rejects_overlapping_inputs() {
         collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 1,
         input_files: vec![input.clone()],
+        input_bytes: 0,
         output_file: PathBuf::from(format!(
             "/nonexistent/morsel/{}.pax",
             segment_id.to_path_segment()
@@ -145,6 +148,7 @@ async fn td_compact6_worker_clears_training_in_flight_after_completion() {
         // STILL runs release_task_state (the post-match cleanup), which is the
         // path under test. No real files needed.
         input_files: vec![coll_dir.join("input.pax")],
+        input_bytes: 0,
         output_file: coll_dir.join("compacted_L1.pax"),
         priority: CompactionPriority::Medium,
         block_size_kb: None,
@@ -252,6 +256,7 @@ async fn test_sst_compaction_expired_deletion_unit() -> anyhow::Result<()> {
         collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![input_file],
+        input_bytes: 0,
         output_file: output_file.clone(),
         priority: CompactionPriority::Medium,
         block_size_kb: None,
@@ -620,8 +625,10 @@ async fn canonical_compaction_round_trips_real_pax_inputs() -> anyhow::Result<()
     let compaction = Compaction::new(config.clone()).await?;
     let task = CompactionTask {
         collection_object_id: 7,
+        collection_identity: crate::core::stable_id::CollectionIdentity::default(),
         level: 0,
         input_files: vec![input_a.clone(), input_b.clone()],
+        input_bytes: 0,
         output_file: output.clone(),
         priority: CompactionPriority::High,
         block_size_kb: None,

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -1,3 +1,4 @@
+use super::MergedVectorTracking;
 use crate::storage::engines::sst::blocks::SstRecord;
 use crate::storage::engines::sst::{
     Compaction, CompactionPriority, CompactionStats, CompactionTask, SstConfig,
@@ -437,6 +438,221 @@ fn epoch_millis_accepts_seconds_millis_micros_and_nanos() {
         1_782_912_345_678
     );
     assert_eq!(Compaction::epoch_millis(0), 0);
+}
+
+/// TD-COMPACT-2: compaction must keep the canonical record envelope intact.
+/// The former ProximaRecord -> VectorRecord -> ProximaRecord pivot discarded
+/// tenancy/labels and cloned the dense vector. Pointer equality locks the
+/// ownership contract in addition to the logical fields.
+#[test]
+fn canonical_compaction_prepare_preserves_record_and_embedding_ownership() {
+    use proximadb_records::{EmbeddingCell, EmbeddingValues, LabelSet, ProximaRecord};
+
+    let now_ns = 1_800_000_000_000_000_000i64;
+    let mut labels = LabelSet::new();
+    labels.insert("retained-label");
+    let record = ProximaRecord {
+        oid: "owned-record".to_string(),
+        record_version: 1,
+        tenant_id: "tenant-stable-id".to_string(),
+        permitted_principals: vec!["reader-7".to_string()],
+        created_at_ns: now_ns - 1_000,
+        updated_at_ns: now_ns - 500,
+        embeddings: vec![EmbeddingCell::new_fp32(
+            "sift",
+            "dense_vector",
+            4,
+            vec![1.0, 2.0, 3.0, 4.0],
+        )],
+        labels,
+        ..ProximaRecord::default()
+    };
+    let original_ptr = record.embeddings[0]
+        .values
+        .as_fp32_slice()
+        .map(<[f32]>::as_ptr);
+
+    let prepared =
+        Compaction::prepare_canonical_records(vec![record], now_ns, MergedVectorTracking::Disabled);
+
+    assert_eq!(prepared.records.len(), 1);
+    let retained = &prepared.records[0];
+    assert_eq!(retained.tenant_id, "tenant-stable-id");
+    assert_eq!(retained.permitted_principals, vec!["reader-7"]);
+    assert!(retained.labels.contains("retained-label"));
+    assert!(matches!(
+        retained.embeddings[0].values,
+        EmbeddingValues::Fp32(_)
+    ));
+    let retained_ptr = retained.embeddings[0]
+        .values
+        .as_fp32_slice()
+        .map(<[f32]>::as_ptr);
+    assert_eq!(retained_ptr, original_ptr);
+    assert!(prepared.merged_vectors.is_empty());
+}
+
+#[test]
+fn background_compaction_skips_dead_merged_vector_stats_copy() {
+    use proximadb_records::{EmbeddingCell, ProximaRecord};
+
+    let now_ns = 1_800_000_000_000_000_000i64;
+    let make_record = || ProximaRecord {
+        oid: "tracked-record".to_string(),
+        record_version: 1,
+        created_at_ns: now_ns - 1_000,
+        updated_at_ns: now_ns - 500,
+        embeddings: vec![EmbeddingCell::new_fp32(
+            "sift",
+            "dense_vector",
+            2,
+            vec![1.0, 2.0],
+        )],
+        ..ProximaRecord::default()
+    };
+
+    let background = Compaction::prepare_canonical_records(
+        vec![make_record()],
+        now_ns,
+        MergedVectorTracking::Disabled,
+    );
+    assert_eq!(background.records.len(), 1);
+    assert!(background.merged_vectors.is_empty());
+
+    let enhanced = Compaction::prepare_canonical_records(
+        vec![make_record()],
+        now_ns,
+        MergedVectorTracking::Enabled,
+    );
+    assert_eq!(enhanced.records.len(), 1);
+    assert_eq!(enhanced.merged_vectors.len(), 1);
+    assert_eq!(enhanced.merged_vectors[0].id, "tracked-record");
+}
+
+#[test]
+fn canonical_compaction_prepare_accounts_expiry_and_old_tombstones() {
+    use proximadb_records::{EmbeddingCell, ProximaRecord};
+
+    let now_ns = 1_800_000_000_000_000_000i64;
+    let active = ProximaRecord {
+        oid: "active".to_string(),
+        record_version: 1,
+        created_at_ns: now_ns - 1_000,
+        updated_at_ns: now_ns - 500,
+        embeddings: vec![EmbeddingCell::new_fp32(
+            "sift",
+            "dense_vector",
+            2,
+            vec![1.0, 2.0],
+        )],
+        ..ProximaRecord::default()
+    };
+    let expired = ProximaRecord {
+        oid: "expired".to_string(),
+        valid_to_ns: Some(now_ns - 1),
+        ..active.clone()
+    };
+    let old_tombstone = ProximaRecord {
+        oid: "deleted".to_string(),
+        created_at_ns: now_ns - 2 * 60 * 60 * 1_000_000_000,
+        updated_at_ns: now_ns - 2 * 60 * 60 * 1_000_000_000,
+        valid_to_ns: Some(now_ns - 1),
+        embeddings: Vec::new(),
+        ..ProximaRecord::default()
+    };
+
+    let prepared = Compaction::prepare_canonical_records(
+        vec![active, expired, old_tombstone],
+        now_ns,
+        MergedVectorTracking::Disabled,
+    );
+
+    assert_eq!(prepared.records.len(), 1);
+    assert_eq!(prepared.records[0].oid, "active");
+    assert_eq!(prepared.expired_records_count, 1);
+    assert_eq!(prepared.tombstones_removed_count, 1);
+    assert_eq!(prepared.deleted_vector_ids, vec!["deleted", "expired"]);
+}
+
+#[tokio::test]
+async fn canonical_compaction_round_trips_real_pax_inputs() -> anyhow::Result<()> {
+    use crate::storage::engines::sst::segment_format::{read_segment_records, write_pax_segment};
+    use proximadb_block_format::VectorQuant;
+    use proximadb_records::{EmbeddingCell, ProximaRecord};
+    use tempfile::tempdir;
+
+    let dir = tempdir()?;
+    let input_a = dir.path().join("segment_L0_a.pax");
+    let input_b = dir.path().join("segment_L0_b.pax");
+    let output = dir.path().join("segment_L1_compacted.pax");
+    let make_record = |oid: &str, value: f32| ProximaRecord {
+        oid: oid.to_string(),
+        record_version: 1,
+        tenant_id: "tenant-42".to_string(),
+        created_at_ns: 1_700_000_000_000_000_000,
+        updated_at_ns: 1_700_000_000_000_000_000,
+        embeddings: vec![EmbeddingCell::new_fp32(
+            "sift",
+            "dense_vector",
+            4,
+            vec![value; 4],
+        )],
+        ..ProximaRecord::default()
+    };
+    write_pax_segment(
+        &input_a,
+        &[make_record("a", 1.0), make_record("b", 2.0)],
+        "collection-7",
+        1,
+        VectorQuant::Sq8,
+        None,
+    )?;
+    write_pax_segment(
+        &input_b,
+        &[make_record("c", 3.0), make_record("d", 4.0)],
+        "collection-7",
+        1,
+        VectorQuant::Sq8,
+        None,
+    )?;
+
+    let config = SstConfig::default();
+    let compaction = Compaction::new(config.clone()).await?;
+    let task = CompactionTask {
+        collection_object_id: 7,
+        level: 0,
+        input_files: vec![input_a.clone(), input_b.clone()],
+        output_file: output.clone(),
+        priority: CompactionPriority::High,
+        block_size_kb: None,
+        compression_config: None,
+        precision_hint: None,
+    };
+    let stats = compaction
+        .perform_compaction_enhanced(&task, &config, None, None)
+        .await?;
+
+    assert_eq!(stats.base_stats.files_merged, 2);
+    assert_eq!(stats.merged_vectors.len(), 4);
+    assert!(output.exists());
+    assert!(!input_a.exists());
+    assert!(!input_b.exists());
+
+    let output_bytes = std::fs::read(&output)?;
+    let output_records = read_segment_records(&output_bytes, &[], &[], None)?;
+    assert_eq!(output_records.len(), 4);
+    assert!(
+        output_records
+            .iter()
+            .all(|record| record.tenant_id == "tenant-42")
+    );
+    let mut oids: Vec<&str> = output_records
+        .iter()
+        .map(|record| record.oid.as_str())
+        .collect();
+    oids.sort_unstable();
+    assert_eq!(oids, vec!["a", "b", "c", "d"]);
+    Ok(())
 }
 
 /// With a CanonicalPrecisionResolver wired in and a fp16 collection

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -1,4 +1,6 @@
-use super::MergedVectorTracking;
+use super::{
+    MergedVectorTracking, retain_training_guard_for_follow_up, training_follow_up_threshold,
+};
 use crate::storage::engines::sst::blocks::SstRecord;
 use crate::storage::engines::sst::{
     Compaction, CompactionPriority, CompactionStats, CompactionTask, SstConfig,
@@ -175,6 +177,33 @@ async fn td_compact6_worker_clears_training_in_flight_after_completion() {
     );
 
     let _ = manager.stop().await;
+}
+
+#[test]
+fn bounded_training_chain_keeps_threshold_one_until_l0_is_drained() {
+    assert_eq!(
+        training_follow_up_threshold(0, &PathBuf::from("L1_output.pax")),
+        Some(1)
+    );
+    assert_eq!(
+        training_follow_up_threshold(1, &PathBuf::from("L2_output.pax")),
+        None
+    );
+    assert_eq!(
+        training_follow_up_threshold(0, &PathBuf::from("L1_output.arrow")),
+        None
+    );
+
+    assert!(retain_training_guard_for_follow_up(true, Some(0)));
+    assert!(
+        !retain_training_guard_for_follow_up(true, Some(1)),
+        "a higher-level follow-up means the untrained L0 tail is drained"
+    );
+    assert!(
+        !retain_training_guard_for_follow_up(true, None),
+        "the guard must clear when no follow-up was admitted"
+    );
+    assert!(!retain_training_guard_for_follow_up(false, Some(0)));
 }
 
 // Unit tests for expired record deletion during compaction

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -1744,10 +1744,9 @@ mod tests {
                 dimension: 4,
                 distance_metric: Some(DistanceMetric::Cosine as i32),
                 storage_engine: Some(StorageEngine::Sst as i32),
-                // This test asserts flush indexes into AXIS, so opt into the legacy
-                // .sst + AXIS path: index_flushed_into_axis builds AXIS only when
-                // index_configs is set OR pax_vector_format:off (the per-collection gate).
-                tags: vec!["pax_vector_format:off".to_string()],
+                // This test asserts flush indexes into AXIS, so declare an
+                // explicit collection index. Format tags are not index intent.
+                index_configs: vec![crate::proto::proximadb_v1::IndexConfig::default()],
                 ..Default::default()
             }),
             storage_assignment: Some(StorageAssignment {

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -422,7 +422,8 @@ fn write_pax_segment_ordered(
     // file-level header region for RaBitQ-quantized writes (default ON per the
     // ADR-061 pre-GA in-place amendment; `PROXIMADB_PAX_COALESCED_RABITQ=0` opts
     // out to the legacy in-block RaBitQ layout for mixed-read / measurement).
-    .with_coalesced_rabitq(quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled());
+    .with_coalesced_rabitq(quant == VectorQuant::RaBitQ && coalesced_rabitq_enabled())
+    .with_expected_rows(records.len());
     // TD-DELVEC-1 WI-3a: capture the OID→position resolver (footer region, WI-2c)
     // so a cold-resident delete (WI-3b) can set a deletion-vector bit without
     // rewriting the segment. Feature-gated; default builds are byte-for-byte
@@ -439,10 +440,12 @@ fn write_pax_segment_ordered(
     }
     let trace = pax_write_trace();
     let t_encode = std::time::Instant::now();
-    match &plan {
+    // Consume the ordering plan here so its row-order/runs/model allocations are
+    // released before the writer's Region A/B finalization peak.
+    match plan {
         Some(plan) => {
             let mut next_run = 1usize;
-            for (ordered_row, &i) in plan.order.iter().enumerate() {
+            for (ordered_row, i) in plan.order.into_iter().enumerate() {
                 if plan
                     .runs
                     .get(next_run)

--- a/tests/external_collection_index_in_place_test.rs
+++ b/tests/external_collection_index_in_place_test.rs
@@ -107,7 +107,8 @@ async fn external_parquet_indexed_in_place_and_searchable_without_copy() {
         Arc::new(ExternalCollectionRegistry::new()),
         cat.clone(),
         axis.clone(),
-    );
+    )
+    .with_axis_runtime_enabled(true);
 
     // Register un-copied.
     let spec = ExternalCollectionSpec::parquet(
@@ -212,7 +213,8 @@ async fn external_hybrid_search_fuses_text_and_vector() {
     let cat = catalog_manager().await;
     let axis = Arc::new(AxisManager::new(AxisConfig::default()).await.unwrap());
     let svc =
-        ExternalCollectionService::new(Arc::new(ExternalCollectionRegistry::new()), cat, axis);
+        ExternalCollectionService::new(Arc::new(ExternalCollectionRegistry::new()), cat, axis)
+            .with_axis_runtime_enabled(true);
 
     let spec = ExternalCollectionSpec::parquet(
         "ext_hybrid",

--- a/tests/python/test_sift_get_reduction_harness.py
+++ b/tests/python/test_sift_get_reduction_harness.py
@@ -312,13 +312,25 @@ def test_config_preserves_object_store_url(tmp_path: Path) -> None:
     config_path = tmp_path / "benchmark.toml"
     storage_url = "adls://benchmarks/run-1"
 
-    HARNESS.write_config(config_path, tmp_path, 5690, 128, 20_000, storage_url)
+    HARNESS.write_config(
+        config_path,
+        tmp_path,
+        5690,
+        128,
+        20_000,
+        storage_url,
+        compaction_max_memory_mb=4096,
+    )
 
     config = config_path.read_text()
     assert f'url = "{storage_url}"' in config
     assert "[storage.optimization]\nenable_mmap = false" in config
     assert "vector_count_threshold = 20000" in config
     assert "flush_floor_predicted_mb = 128" in config
+    assert "memory_amplification_factor = 12.0" in config
+    assert "memory_budget_fraction = 0.25" in config
+    assert "available_memory_fraction = 0.5" in config
+    assert "max_memory_mb = 4096" in config
 
 
 def test_config_records_controlled_geometry_flush_floor(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- remove the legacy VectorRecord copy pivot from SST compaction and admit compactions by projected bytes against live/cgroup-aware memory
- preserve admitted L0 training/layout promotion, drain bounded training tails, and exclude unpublished staging objects from discovery
- enforce AXIS as layered capability: compile feature, runtime enable_axis_indexes, explicit non-empty collection index_configs; reclustering additionally requires a published IVF/HNSW index
- keep format tags representation-only and fail closed before corpus/source reads when runtime or collection gates are absent
- preserve develop deletion-vector filtering and retirement in the canonical compaction path after rebase

## Verification

- cargo check -p proximadb-server --no-default-features --features sql_frontend,graph-first-sks,unified-facade-routing,canonical-document-store,datafusion-integration,otlp-metering -j 1
- cargo clippy --lib --bins -- -D warnings
- cargo test -p proximadb-storage-traits axis -j 1
- six AXIS flush-hook tests; fail-closed/positive insert gates; served-index prerequisite; runtime-disabled external-source guard
- cargo test -p proximadb --lib --features cold-deletion-vectors build_deleted_oids_collects_dv_deleted_oids_only -j 1
- 25 Python SIFT harness tests
- make work-commit-check
- benchmark evidence ledger validation: 48 claims

## Operational behavior

With AXIS not compiled, no AXIS code is present. With AXIS compiled but runtime-disabled, no manager registration, watchers, sweepers, indexing, reclustering, or external index reads run. With runtime enabled but no explicit collection index config, vector ingest/search/flush remain on the PAX path without AXIS work.