### PR TITLE
ci(qa-gate): OOM-proof the cloud-emulator job (debuginfo off + swap headroom)

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -272,6 +272,14 @@ jobs:
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
+      # #941-class OOM mitigations, applied here after the 2026-08-01 promotion
+      # (#1378) had this job runner-shutdown-killed TWICE mid-compile: the
+      # workspace outgrew the jobs=2 middle ground (#882) on the 16GB runner.
+      # Dropping debuginfo halves rustc peak memory and target size; the swap
+      # step below turns any residual spike into a slowdown, not a dead runner.
+      # Scoped to this job only — the other qa-gate jobs pass within budget.
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.95.0
@@ -290,6 +298,13 @@ jobs:
           path: /home/runner/.cache/sccache
           key: sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: sccache-${{ runner.os }}-
+      - name: Add swap headroom
+        run: |
+          sudo fallocate -l 12G /mnt/swapfile-ci
+          sudo chmod 600 /mnt/swapfile-ci
+          sudo mkswap /mnt/swapfile-ci
+          sudo swapon /mnt/swapfile-ci
+          free -h
       - name: Validate Cool tier against Azure/S3/GCS emulators
         # docker + aws/az CLIs are preinstalled on ubuntu-latest runners.
         run: bash scripts/run_cloud_emulator_tests.sh


### PR DESCRIPTION
## Summary
Unblocks promotion PR #1378: its Cloud object-store emulators gate was runner-shutdown-killed **twice** mid-compile (01:44 and 03:07 UTC) — the classic 16GB-runner OOM presentation (#941 class), not a test failure (every test that ran passed; all four other heavy gates are green). The workspace has outgrown the job's `CARGO_BUILD_JOBS=2` middle ground (#882) after 235 commits of develop growth.

Applies the same mitigations that already protect ci.yml's unit-test job, **scoped to this one job** (the others pass within budget):
- `CARGO_PROFILE_TEST_DEBUG=0` + `CARGO_PROFILE_DEV_DEBUG=0` — halves rustc peak memory and target size
- 12G swap headroom on `/mnt` — a residual spike becomes a slowdown instead of a dead runner

debug=0 changes the rustc invocations, so the first run compiles cold under sccache — inside the job's 90m cap (set for exactly this cold case on #980).

After this lands on develop I'll refresh the #1378 release branch (freshness merge), which re-runs the gates with the fixed workflow.

## Test plan
- [x] YAML parses; change is env + one step copied verbatim from ci.yml's proven swap block
- [x] Attribution guard clean