### PR TITLE
refactor(abac): consolidate port-seam identity into PortIdentity — retire the _abac twins (TD-ABAC-7)

### DIFF
--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -77,7 +77,7 @@ pub(crate) mod test_support {
     };
     use proximadb_runtime::{
         ApiHandlersPort, CollectionPort, CollectionSchemaMetadata, CollectionSchemaUpdate,
-        QueryAdapterPort, UnifiedHandlers, VectorOpsPort,
+        PortIdentity, QueryAdapterPort, UnifiedHandlers, VectorOpsPort,
     };
     use serde_json::Value as JsonValue;
 
@@ -201,10 +201,9 @@ pub(crate) mod test_support {
         async fn handle_vector_search_v1_for_tenant(
             &self,
             request: VectorSearchRequest,
-            tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            identity: PortIdentity<'_>,
         ) -> Result<VectorOperationResponse> {
+            let tenant_id = identity.tenant_id;
             self.calls.lock().unwrap().push(ApiCall::VectorSearch {
                 tenant_id: tenant_id.map(ToOwned::to_owned),
                 collection_id: request.collection_id,
@@ -338,9 +337,7 @@ pub(crate) mod test_support {
         async fn search(
             &self,
             _request: VectorSearchRequest,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            _identity: PortIdentity<'_>,
         ) -> Result<VectorOperationResponse> {
             Ok(VectorOperationResponse::default())
         }
@@ -417,7 +414,7 @@ mod tests {
         CollectionConfig, CollectionOperation, CollectionRequest, HybridSearchRequest,
         VectorBatchRequest, VectorRecord, VectorSearchRequest,
     };
-    use proximadb_runtime::ApiHandlersPort;
+    use proximadb_runtime::{ApiHandlersPort, PortIdentity};
 
     use super::test_support::{ApiCall, RecordingApiPort, noop_unified_handlers};
 
@@ -452,9 +449,7 @@ mod tests {
                 collection_id: "tenant_docs".to_string(),
                 ..VectorSearchRequest::default()
             },
-            Some("tenant-a"),
-            None,
-            None,
+            PortIdentity::for_tenant("tenant-a"),
         )
         .await
         .unwrap();
@@ -598,7 +593,7 @@ mod tests {
         assert!(
             handlers
                 .vector_ops
-                .search(VectorSearchRequest::default(), None, None, None)
+                .search(VectorSearchRequest::default(), PortIdentity::anonymous())
                 .await
                 .unwrap()
                 .results

--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -425,6 +425,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Deliberately exercises the deprecated v1 ExecuteHybridQuery dispatch (TD-143).
+    #[allow(deprecated)]
     async fn recording_api_port_captures_all_protocol_dispatch_shapes() {
         let port = RecordingApiPort::new();
 

--- a/crates/platform/proximadb-runtime/src/bootstrap_config.rs
+++ b/crates/platform/proximadb-runtime/src/bootstrap_config.rs
@@ -805,8 +805,10 @@ mod tests {
 
     #[test]
     fn test_server_config_multi_port() {
-        let mut config = MultiServerConfig::default();
-        config.unified_mode = false;
+        let mut config = MultiServerConfig {
+            unified_mode: false,
+            ..Default::default()
+        };
 
         // Verify each protocol gets its own port
         let http_addr = config.http_bind_address();
@@ -848,8 +850,10 @@ mod tests {
     fn test_protocol_detection() {
         // Test the unified mode protocol detection configuration
         // (actual TCP-level detection happens at runtime, but we verify the config wiring)
-        let mut config = MultiServerConfig::default();
-        config.unified_mode = true;
+        let config = MultiServerConfig {
+            unified_mode: true,
+            ..Default::default()
+        };
 
         // In unified mode, all protocols share one address
         let unified = config.unified_bind_address();

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -1024,6 +1024,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Deliberately exercises the deprecated v1 ExecuteHybridQuery dispatch (TD-143).
+    #[allow(deprecated)]
     async fn unified_handlers_route_vector_hybrid_and_sql_operations() {
         let collection = Arc::new(MockCollectionPort::default());
         let vector_ops = Arc::new(MockVectorOpsPort::default());
@@ -1122,6 +1124,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // Deliberately exercises the deprecated v1 ExecuteHybridQuery dispatch (TD-143).
+    #[allow(deprecated)]
     async fn unified_handlers_report_missing_query_adapter_explicitly_and_sql_arrays_lower() {
         let handlers = make_handlers(
             Arc::new(MockCollectionPort::default()),

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -33,7 +33,7 @@ use crate::port::{
     ApiHandlersPort, CollectionSchemaColumn, CollectionSchemaEnforcement, CollectionSchemaMetadata,
     CollectionSchemaUpdate, CollectionTextStorage,
 };
-use crate::service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};
+use crate::service_ports::{CollectionPort, PortIdentity, QueryAdapterPort, VectorOpsPort};
 
 /// Global request counter for generating unique request IDs.
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -569,20 +569,18 @@ impl ApiHandlersPort for UnifiedHandlers {
     async fn handle_vector_search_v1_for_tenant(
         &self,
         request: VectorSearchRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: PortIdentity<'_>,
     ) -> Result<VectorOperationResponse> {
-        self.vector_ops
-            .search(request, tenant_id, subject, tenant_stable_id)
-            .await
+        self.vector_ops.search(request, identity).await
     }
 
     async fn handle_vector_search_v1(
         &self,
         request: VectorSearchRequest,
     ) -> Result<VectorOperationResponse> {
-        self.vector_ops.search(request, None, None, None).await
+        self.vector_ops
+            .search(request, PortIdentity::anonymous())
+            .await
     }
 
     async fn handle_vector_batch_v1_for_tenant(
@@ -831,10 +829,9 @@ mod tests {
         async fn search(
             &self,
             request: VectorSearchRequest,
-            tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            identity: PortIdentity<'_>,
         ) -> Result<VectorOperationResponse> {
+            let tenant_id = identity.tenant_id;
             self.calls
                 .lock()
                 .unwrap()
@@ -1049,9 +1046,7 @@ mod tests {
                     collection_id: "tenant".to_string(),
                     ..VectorSearchRequest::default()
                 },
-                Some("tenant-a"),
-                None,
-                None,
+                PortIdentity::for_tenant("tenant-a"),
             )
             .await
             .unwrap();

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -56,6 +56,6 @@ pub use rich_search::{
     RichSearchResult,
 };
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
-pub use service_ports::{CollectionPort, QueryAdapterPort, VectorOpsPort};
+pub use service_ports::{CollectionPort, PortIdentity, QueryAdapterPort, VectorOpsPort};
 pub use streaming_port::StreamingPort;
 pub use unified_query_port::UnifiedQueryPort;

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -9,6 +9,7 @@
 //! `ProximaValue` model. Protocol adapters are responsible for converting
 //! legacy wire values at the edge.
 
+use crate::service_ports::PortIdentity;
 use anyhow::Result;
 use async_trait::async_trait;
 use proximadb_data_model::{ProximaType, ProximaValue};
@@ -105,14 +106,13 @@ pub trait ApiHandlersPort: Send + Sync {
 
     // ── Vector ────────────────────────────────────────────────────────────────
 
-    /// `subject` + `tenant_stable_id` identify the authenticated principal for
-    /// ABAC enforcement at the shared search seam; `None` = no policy evaluation.
+    /// `identity` carries the tenant scope + authenticated principal for ABAC
+    /// enforcement at the shared search seam (TD-ABAC-7);
+    /// [`PortIdentity::anonymous`] = no policy evaluation.
     async fn handle_vector_search_v1_for_tenant(
         &self,
         request: VectorSearchRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: PortIdentity<'_>,
     ) -> Result<VectorOperationResponse>;
 
     async fn handle_vector_search_v1(

--- a/crates/platform/proximadb-runtime/src/record_search_port.rs
+++ b/crates/platform/proximadb-runtime/src/record_search_port.rs
@@ -17,13 +17,16 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::rich_search::{RichSearchRequest, RichSearchResponse};
+use crate::service_ports::PortIdentity;
 
 #[async_trait]
 pub trait RecordSearchPort: Send + Sync {
-    /// Run a canonical v2 search for `request.collection_id` under `tenant_id`.
+    /// Run a canonical v2 search for `request.collection_id` under
+    /// `identity.tenant_id`; `identity.subject` drives ABAC at the shared seam
+    /// (TD-ABAC-7) — `None` subject = passthrough.
     async fn search_record(
         &self,
         request: RichSearchRequest,
-        tenant_id: Option<&str>,
+        identity: PortIdentity<'_>,
     ) -> Result<RichSearchResponse>;
 }

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -90,22 +90,59 @@ pub trait CollectionPort: Send + Sync {
 
 // ── Vector operations ─────────────────────────────────────────────────────────
 
+/// The pre-resolution caller identity carried across port seams (TD-ABAC-7).
+///
+/// This is the RAW identity captured at the network boundary — not an
+/// authorization result (`AuthorizedReadContext` in `proximadb-abac` is what
+/// the enforcement seam *resolves from* it). Fields:
+///
+/// * `tenant_id` — the authoritative ADR-0083 string identity, used for
+///   tenant-scoped catalog/name resolution and `DrPathBuilder` paths.
+/// * `subject` — the authenticated principal (ABAC); `None` = unauthenticated
+///   / internal caller, which the seam treats as passthrough (no policy
+///   evaluation).
+/// * `tenant_stable_id` — the derived numeric projection of `tenant_id`
+///   (widened `account_u32`), the ABAC policy-lookup key. Never a second
+///   source of truth: the string stays authoritative.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PortIdentity<'a> {
+    pub tenant_id: Option<&'a str>,
+    pub subject: Option<&'a str>,
+    pub tenant_stable_id: Option<u64>,
+}
+
+impl<'a> PortIdentity<'a> {
+    /// No identity at all — internal/system callers; enforcement passthrough.
+    pub const fn anonymous() -> Self {
+        Self {
+            tenant_id: None,
+            subject: None,
+            tenant_stable_id: None,
+        }
+    }
+
+    /// Tenant-scoped but with no authenticated ABAC principal.
+    pub const fn for_tenant(tenant_id: &'a str) -> Self {
+        Self {
+            tenant_id: Some(tenant_id),
+            subject: None,
+            tenant_stable_id: None,
+        }
+    }
+}
+
 /// Port for vector CRUD and search operations.
 ///
 /// Implemented by root-crate `VectorOperationsService`.
 #[async_trait]
 pub trait VectorOpsPort: Send + Sync {
-    /// Execute a vector search, tenant-scoped when `tenant_id` is provided.
-    ///
-    /// `subject` + `tenant_stable_id` identify the authenticated principal for
-    /// ABAC enforcement at the shared search seam (`unified_search_v1_inner`);
-    /// `None` means no policy evaluation (internal/unauthenticated callers).
+    /// Execute a vector search, tenant-scoped when `identity.tenant_id` is
+    /// provided; `identity.subject` + `identity.tenant_stable_id` drive ABAC
+    /// enforcement at the shared search seam (`unified_search_v1_inner`).
     async fn search(
         &self,
         request: VectorSearchRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: PortIdentity<'_>,
     ) -> Result<VectorOperationResponse>;
 
     /// TD-XMODAL-4 S2: the **single canonical native vector-search kernel** — the

--- a/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
+++ b/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
@@ -1,5 +1,5 @@
 = TD-ABAC-7: Consolidate per-call identity params into one identity struct at the port seams
-:status: Open
+:status: Resolved
 :dim: D5
 :pillar: SEC
 

--- a/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
+++ b/docs/10-quality/td/TD-ABAC-7-port-identity-struct-consolidation.adoc
@@ -48,7 +48,9 @@ pub struct PortIdentity<'a> {
 
 * Replace the loose triple on `VectorOpsPort::search`,
   `ApiHandlersPort::handle_vector_search_v1_for_tenant`,
-  `search_v1`, `search_records_with_tenant_context` (+ the get-by-id twin)
+  `search_v1`, `search_records_with_tenant_context`, and the get-by-id pair
+  (`handle_record_get_for_tenant` / `get_record_with_tenant_context` — the
+  `_abac` twins collapse into the base methods, identity decides)
   with a single `identity: PortIdentity<'_>` param; provide
   `PortIdentity::anonymous()` for internal/test callers and a
   `From<&MiddlewareTenantContext>` bridge at the REST boundary (same pattern as

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -780,33 +780,20 @@ impl RecordOpsService {
     }
 
     /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
-    /// Canonical rich-record get handler used by v2 REST/gRPC/internal callers.
     ///
-    /// Delegates to [`Self::handle_record_get_for_tenant_abac`] with no subject
-    /// (the gRPC/internal callers preserve today's behavior — no ABAC). The REST
-    /// v2 surface calls `_abac` directly with the request subject.
+    /// Threads `identity.subject` + `identity.tenant_stable_id` so a
+    /// provisioned policy admit-checks the fetched record (fail-closed on
+    /// deny); a subject-less identity (gRPC/internal callers) is a
+    /// pass-through. Enforcement is `abac-policy`-gated inside the vector
+    /// service (TD-ABAC-7: one method, identity decides — no `_abac` twin).
     pub async fn handle_record_get_for_tenant(
         &self,
         request: RichRecordGetRequest,
-        tenant_id: Option<&str>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<RichRecordGetResponse> {
-        self.handle_record_get_for_tenant_abac(request, tenant_id, None, None)
-            .await
-    }
-
-    /// ABAC-aware rich-record get: same as
-    /// [`Self::handle_record_get_for_tenant`] but threads the request subject
-    /// and tenant stable id so a provisioned policy admit-checks the fetched
-    /// record (fail-closed on deny). Enforcement is `abac-policy`-gated inside
-    /// the vector service; default builds are a pass-through.
-    pub async fn handle_record_get_for_tenant_abac(
-        &self,
-        request: RichRecordGetRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
-    ) -> Result<RichRecordGetResponse> {
-        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
+        let tenant_context = self
+            .collection_service
+            .load_tenant_context(identity.tenant_id)?;
         let request = RichRecordGetRequest {
             collection_id: match self
                 .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
@@ -821,12 +808,7 @@ impl RecordOpsService {
         };
 
         self.vector_operations_service
-            .get_record_with_tenant_context_abac(
-                request,
-                tenant_context.as_ref(),
-                subject,
-                tenant_stable_id,
-            )
+            .get_record_with_tenant_context(request, tenant_context.as_ref(), identity)
             .await
     }
 

--- a/src/api_handlers/record_ops_service.rs
+++ b/src/api_handlers/record_ops_service.rs
@@ -756,11 +756,11 @@ impl RecordOpsService {
     pub async fn handle_record_search_for_tenant(
         &self,
         request: RichSearchRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<RichSearchResponse> {
-        let tenant_context = self.collection_service.load_tenant_context(tenant_id)?;
+        let tenant_context = self
+            .collection_service
+            .load_tenant_context(identity.tenant_id)?;
         let request = RichSearchRequest {
             collection_id: match self
                 .resolve_collection_id_internal(&request.collection_id, tenant_context.as_ref())
@@ -775,12 +775,7 @@ impl RecordOpsService {
         };
 
         self.vector_operations_service
-            .search_records_with_tenant_context(
-                request,
-                tenant_context.as_ref(),
-                subject,
-                tenant_stable_id,
-            )
+            .search_records_with_tenant_context(request, tenant_context.as_ref(), identity)
             .await
     }
 
@@ -974,9 +969,9 @@ impl proximadb_runtime::RecordSearchPort for RecordOpsService {
     async fn search_record(
         &self,
         request: RichSearchRequest,
-        tenant_id: Option<&str>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<RichSearchResponse> {
-        self.handle_record_search_for_tenant(request, tenant_id, None, None)
+        self.handle_record_search_for_tenant(request, identity)
             .await
     }
 }

--- a/src/datafusion/cross_modal.rs
+++ b/src/datafusion/cross_modal.rs
@@ -1140,9 +1140,7 @@ mod tests {
         async fn search(
             &self,
             _request: VectorSearchRequest,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            _identity: proximadb_runtime::PortIdentity<'_>,
         ) -> anyhow::Result<VectorOperationResponse> {
             let results = self
                 .matches
@@ -1747,14 +1745,12 @@ mod tests {
         async fn search(
             &self,
             _request: VectorSearchRequest,
-            tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            identity: proximadb_runtime::PortIdentity<'_>,
         ) -> anyhow::Result<VectorOperationResponse> {
             self.seen
                 .lock()
                 .unwrap()
-                .push(tenant_id.map(str::to_string));
+                .push(identity.tenant_id.map(str::to_string));
             Ok(VectorOperationResponse {
                 results: Some(SearchResult {
                     results: vec![],

--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -1223,7 +1223,14 @@ impl ProximaFlightService {
             "arrow_flight.v2.records.search",
             crate::observability::predicate_diagnostics::scope(async {
                 self.record_search_port
-                    .search_record(request, Some(tenant_id))
+                    .search_record(
+                        request,
+                        proximadb_runtime::PortIdentity {
+                            tenant_id: Some(tenant_id),
+                            subject: None,
+                            tenant_stable_id,
+                        },
+                    )
                     .await
             }),
         )

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1478,9 +1478,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     .record_ops
                     .handle_record_search_for_tenant(
                         search_request,
-                        Some(tenant_id.as_str()),
-                        None,
-                        None,
+                        proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
                     )
                     .await;
                 let tq = crate::observability::predicate_diagnostics::take_turboquant_hints();
@@ -1564,7 +1562,10 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // Execute search
         let response = self
             .record_ops
-            .handle_record_search_for_tenant(search_request, Some(tenant_id.as_str()), None, None)
+            .handle_record_search_for_tenant(
+                search_request,
+                proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
+            )
             .await
             .map_err(|e| Status::internal(format!("Search stream failed: {}", e)))?;
 

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -2355,7 +2355,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     include_vector: req.include_vector,
                     include_props: true,
                 },
-                Some(tenant_id.as_str()),
+                proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
             )
             .await
             .map_err(|e| Status::internal(format!("GetRecord failed: {e}")))?;

--- a/src/network/hybrid_search.rs
+++ b/src/network/hybrid_search.rs
@@ -128,7 +128,7 @@ impl HybridPort for RestHybridPortImpl {
             };
             let resp = self
                 .vector_ops
-                .search(search_request, None, None, None)
+                .search(search_request, proximadb_runtime::PortIdentity::anonymous())
                 .await
                 .map_err(|e| anyhow!("Vector search failed: {}", e))?;
             resp.results
@@ -529,9 +529,7 @@ mod tests {
         async fn search(
             &self,
             request: proximadb_v1::VectorSearchRequest,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            _identity: proximadb_runtime::PortIdentity<'_>,
         ) -> Result<proximadb_v1::VectorOperationResponse> {
             *self.last_request.lock().unwrap() = Some(request);
             Ok(proximadb_v1::VectorOperationResponse {

--- a/src/network/middleware/tenant.rs
+++ b/src/network/middleware/tenant.rs
@@ -202,6 +202,20 @@ impl From<&MiddlewareTenantContext> for crate::storage::tenant::context::Storage
     }
 }
 
+/// TD-ABAC-7: the one bridge from the middleware identity to the port-seam
+/// caller identity ([`proximadb_runtime::PortIdentity`]). REST handlers build
+/// it with `PortIdentity::from(&tenant)` instead of hand-threading the
+/// `{tenant_id, subject, tenant_stable_id}` triple per call site.
+impl<'a> From<&'a MiddlewareTenantContext> for proximadb_runtime::PortIdentity<'a> {
+    fn from(ctx: &'a MiddlewareTenantContext) -> Self {
+        Self {
+            tenant_id: Some(&ctx.tenant_id),
+            subject: ctx.subject.as_deref(),
+            tenant_stable_id: ctx.tenant_stable_id,
+        }
+    }
+}
+
 /// Source of the tenant ID (for audit and debugging)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TenantIdSource {

--- a/src/network/rest/canonical/rank_backend.rs
+++ b/src/network/rest/canonical/rank_backend.rs
@@ -124,7 +124,7 @@ impl HybridSearchBackend for ProductionHybridBackend {
 
         let response = self
             .vector_ops
-            .search(request, None, None, None)
+            .search(request, proximadb_runtime::PortIdentity::anonymous())
             .await
             .map_err(|err| RankError::ModelInference {
                 model_id: "production_hybrid_backend.vector".to_string(),
@@ -188,9 +188,7 @@ mod tests {
         async fn search(
             &self,
             request: VectorSearchRequest,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            _identity: proximadb_runtime::PortIdentity<'_>,
         ) -> anyhow::Result<VectorOperationResponse> {
             *self.last_request.lock().unwrap() = Some(request.clone());
             if let Some(reason) = self.fail_with.lock().unwrap().clone() {

--- a/src/network/rest/progressive_search_handler.rs
+++ b/src/network/rest/progressive_search_handler.rs
@@ -42,12 +42,7 @@ pub async fn progressive_search_handler(
     // Delegate directly to unified v1 handler
     let resp = state
         .api_handlers
-        .handle_vector_search_v1_for_tenant(
-            request,
-            Some(&tenant.tenant_id),
-            tenant.subject.as_deref(),
-            tenant.tenant_stable_id,
-        )
+        .handle_vector_search_v1_for_tenant(request, proximadb_runtime::PortIdentity::from(&tenant))
         .await
         .map_err(|e| {
             error!(

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -1688,9 +1688,7 @@ pub async fn search_with_typed_filters(
                 .record_ops
                 .handle_record_search_for_tenant(
                     search_request,
-                    Some(&tenant.tenant_id),
-                    tenant.subject.as_deref(),
-                    tenant.tenant_stable_id,
+                    proximadb_runtime::PortIdentity::from(&tenant),
                 )
                 .await;
             let downgraded =

--- a/src/network/rest/v2/records.rs
+++ b/src/network/rest/v2/records.rs
@@ -2097,16 +2097,14 @@ pub async fn get_record_v2(
 
     match state
         .record_ops
-        .handle_record_get_for_tenant_abac(
+        .handle_record_get_for_tenant(
             RichRecordGetRequest {
                 collection_id: collection_id.clone(),
                 record_id: record_id.clone(),
                 include_vector,
                 include_props: true,
             },
-            Some(&tenant.tenant_id),
-            tenant.subject.as_deref(),
-            tenant.tenant_stable_id,
+            proximadb_runtime::PortIdentity::from(&tenant),
         )
         .await
     {

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -3413,9 +3413,7 @@ mod rank_services_wiring_tests {
         async fn search(
             &self,
             _request: crate::proto::proximadb_v1::VectorSearchRequest,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
-            _tenant_stable_id: Option<u64>,
+            _identity: proximadb_runtime::PortIdentity<'_>,
         ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
             Ok(crate::proto::proximadb_v1::VectorOperationResponse {
                 success: true,

--- a/src/query/facade/strategies/vector.rs
+++ b/src/query/facade/strategies/vector.rs
@@ -243,7 +243,10 @@ impl QueryStrategy for VectorSearchStrategy {
         );
 
         // Execute search through VectorOps
-        let response = self.vector_ops.search_v1(proto_request, None, None).await?;
+        let response = self
+            .vector_ops
+            .search_v1(proto_request, proximadb_runtime::PortIdentity::anonymous())
+            .await?;
 
         let execution_time_ms = start.elapsed().as_millis() as u64;
 

--- a/src/query/federated/execution/mod.rs
+++ b/src/query/federated/execution/mod.rs
@@ -628,7 +628,9 @@ impl FederatedExecutor {
                 search_optimization: None,
             };
 
-            let response = vector_ops.search_v1(request, None, None).await?;
+            let response = vector_ops
+                .search_v1(request, proximadb_runtime::PortIdentity::anonymous())
+                .await?;
             let records = response
                 .results
                 .map(|result| result.results)

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -827,7 +827,8 @@ impl VectorOperationsService {
             .validate_tenant_collection_access(&req.collection_id, tenant_context)
             .await?
             .to_string();
-        self.search_v1(req, None, None).await
+        self.search_v1(req, proximadb_runtime::PortIdentity::anonymous())
+            .await
     }
 
     /// Execute canonical rich-record vector search.
@@ -839,8 +840,7 @@ impl VectorOperationsService {
         &self,
         request: RichSearchRequest,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<RichSearchResponse> {
         // TD-METRICS-1: this — not the query-facade adapter — is the entry the
         // canonical REST v2 record search actually traverses (verified live:
@@ -853,8 +853,8 @@ impl VectorOperationsService {
             .search_records_with_tenant_context_inner(
                 request,
                 tenant_context,
-                subject,
-                tenant_stable_id,
+                identity.subject,
+                identity.tenant_stable_id,
             )
             .await;
         if result.is_err() {
@@ -1397,8 +1397,7 @@ impl VectorOperationsService {
     pub async fn search_v1(
         &self,
         req: crate::proto::proximadb_v1::VectorSearchRequest,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         let collection_id = req.collection_id.clone();
         let top_k = req.top_k as usize;
@@ -1418,8 +1417,8 @@ impl VectorOperationsService {
             include_vectors,
             include_metadata,
             filter,
-            subject,
-            tenant_stable_id,
+            identity.subject,
+            identity.tenant_stable_id,
         )
         .await
     }
@@ -6371,10 +6370,9 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
     async fn search(
         &self,
         mut request: crate::proto::proximadb_v1::VectorSearchRequest,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
+        let tenant_id = identity.tenant_id;
         // TD-XMODAL-8: the cross-modal `vector_search` UDTF reaches this port carrying the pgwire
         // connection tenant. Resolve the collection UNDER that tenant — the same tenant-scoped
         // name→canonical-id resolution the REST record path does via
@@ -6391,7 +6389,7 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
         {
             request.collection_id = collection.id;
         }
-        self.search_v1(request, subject, tenant_stable_id).await
+        self.search_v1(request, identity).await
     }
 
     /// TD-XMODAL-4 S2: the single canonical native kernel for both the pgvector

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -934,27 +934,17 @@ impl VectorOperationsService {
         Ok(resp)
     }
 
-    /// Execute canonical rich-record get.
+    /// Execute canonical rich-record get: fetches the record, then admit-checks
+    /// the single result against `identity.subject`'s security predicate
+    /// (fail-closed on deny); a subject-less identity is a pass-through
+    /// (gRPC/internal callers). Enforcement is `abac-policy`-gated; default
+    /// builds pass the identity through ignored. (TD-ABAC-7: one method,
+    /// identity decides — no `_abac` twin.)
     pub async fn get_record_with_tenant_context(
         &self,
         request: RichRecordGetRequest,
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
-    ) -> Result<RichRecordGetResponse> {
-        self.get_record_with_tenant_context_abac(request, tenant_context, None, None)
-            .await
-    }
-
-    /// ABAC-aware rich-record get: fetches the record, then admit-checks the
-    /// single result against the subject's security predicate (fail-closed on
-    /// deny). The gRPC/internal callers keep the no-subject delegate (no
-    /// enforcement); the REST v2 surface passes the request subject. Enforcement
-    /// is `abac-policy`-gated; default builds pass the subject through ignored.
-    pub async fn get_record_with_tenant_context_abac(
-        &self,
-        request: RichRecordGetRequest,
-        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
-        subject: Option<&str>,
-        tenant_stable_id: Option<u64>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> Result<RichRecordGetResponse> {
         let collection_id = self
             .validate_tenant_collection_access(&request.collection_id, tenant_context)
@@ -983,10 +973,15 @@ impl VectorOperationsService {
 
         #[cfg(feature = "abac-policy")]
         let record = self
-            .admit_record_abac(record, subject, tenant_stable_id, &collection_id)
+            .admit_record_abac(
+                record,
+                identity.subject,
+                identity.tenant_stable_id,
+                &collection_id,
+            )
             .await;
         #[cfg(not(feature = "abac-policy"))]
-        let _ = (subject, tenant_stable_id);
+        let _ = identity;
 
         Ok(record)
     }

--- a/src/services/record_store.rs
+++ b/src/services/record_store.rs
@@ -1238,6 +1238,7 @@ impl TableRecordStore for VectorOpsTableRecordStore {
                     include_props: request.include_props,
                 },
                 tenant_context,
+                proximadb_runtime::PortIdentity::anonymous(),
             )
             .await
     }

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -235,7 +235,7 @@ async fn none_subject_is_passthrough_on_rest_records_path() {
     );
 }
 
-// ── get-by-id path (`get_record_with_tenant_context_abac`) ──
+// ── get-by-id path (`get_record_with_tenant_context`) ──
 //
 // A point lookup has no filter slot to push into, so enforcement is a post-check
 // on the single fetched record: denied subject ⇒ None (fail-closed); admitted
@@ -257,18 +257,13 @@ async fn admitted_subject_gets_only_accessible_record_on_getbyid_path() {
     let (svc, _collections) = fixture().await;
 
     let eng = svc
-        .get_record_with_tenant_context_abac(
-            get_request(OID_ENG),
-            None,
-            Some("alice"),
-            Some(TENANT),
-        )
+        .get_record_with_tenant_context(get_request(OID_ENG), None, subject_identity("alice"))
         .await
         .expect("abac get");
     assert!(eng.is_some(), "alice (dept=eng) may GET the eng record");
 
     let hr = svc
-        .get_record_with_tenant_context_abac(get_request(OID_HR), None, Some("alice"), Some(TENANT))
+        .get_record_with_tenant_context(get_request(OID_HR), None, subject_identity("alice"))
         .await
         .expect("abac get");
     assert!(
@@ -283,12 +278,7 @@ async fn denied_subject_gets_no_record_on_getbyid_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .get_record_with_tenant_context_abac(
-            get_request(OID_ENG),
-            None,
-            Some("mallory"),
-            Some(TENANT),
-        )
+        .get_record_with_tenant_context(get_request(OID_ENG), None, subject_identity("mallory"))
         .await
         .expect("abac get");
     assert!(
@@ -303,7 +293,7 @@ async fn none_subject_is_passthrough_on_getbyid_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .get_record_with_tenant_context_abac(get_request(OID_ENG), None, None, None)
+        .get_record_with_tenant_context(get_request(OID_ENG), None, PortIdentity::anonymous())
         .await
         .expect("abac get");
     assert!(

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -43,7 +43,7 @@ use proximadb_abac::{
 use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope};
 use proximadb_data_model::ProximaValue;
 use proximadb_records::{EmbeddingCell, EmbeddingValues, ProximaRecord, ProximaTreeNode};
-use proximadb_runtime::{RichRecordGetRequest, RichSearchRequest};
+use proximadb_runtime::{PortIdentity, RichRecordGetRequest, RichSearchRequest};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -52,6 +52,15 @@ const DIM: u32 = 4;
 const TENANT: u64 = 7;
 const OID_ENG: &str = "abac/record/eng";
 const OID_HR: &str = "abac/record/hr";
+
+/// The port-seam identity for a named ABAC subject under [`TENANT`].
+fn subject_identity(subject: &str) -> PortIdentity<'_> {
+    PortIdentity {
+        tenant_id: None,
+        subject: Some(subject),
+        tenant_stable_id: Some(TENANT),
+    }
+}
 
 /// Admit `alice` (dept=eng) under a `dept=eng` row predicate, scoped to
 /// `Namespace(0)` so it matches `resolve_vector_read_context`'s
@@ -175,7 +184,7 @@ async fn admitted_subject_sees_only_accessible_records_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context(request(), None, Some("alice"), Some(TENANT))
+        .search_records_with_tenant_context(request(), None, subject_identity("alice"))
         .await
         .expect("abac search");
 
@@ -196,7 +205,7 @@ async fn denied_subject_gets_empty_results_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context(request(), None, Some("mallory"), Some(TENANT))
+        .search_records_with_tenant_context(request(), None, subject_identity("mallory"))
         .await
         .expect("abac search");
 
@@ -215,7 +224,7 @@ async fn none_subject_is_passthrough_on_rest_records_path() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_records_with_tenant_context(request(), None, None, None)
+        .search_records_with_tenant_context(request(), None, PortIdentity::anonymous())
         .await
         .expect("abac search");
 
@@ -309,7 +318,7 @@ async fn v1_admitted_subject_sees_only_accessible_records() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_v1(v1_request(), Some("alice"), Some(TENANT))
+        .search_v1(v1_request(), subject_identity("alice"))
         .await
         .expect("v1 abac search");
 
@@ -330,7 +339,7 @@ async fn v1_denied_subject_gets_empty_results() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_v1(v1_request(), Some("mallory"), Some(TENANT))
+        .search_v1(v1_request(), subject_identity("mallory"))
         .await
         .expect("v1 abac search");
 
@@ -347,7 +356,7 @@ async fn v1_none_subject_is_passthrough() {
     let (svc, _collections) = fixture().await;
 
     let resp = svc
-        .search_v1(v1_request(), None, None)
+        .search_v1(v1_request(), PortIdentity::anonymous())
         .await
         .expect("v1 search");
 


### PR DESCRIPTION
## Summary

Implements **TD-ABAC-7** (filed in #1381): replace the loose `{tenant_id, subject, tenant_stable_id}` identity triple with one `PortIdentity<'a>` struct at every port seam, so future enforcement slices extend a struct instead of rippling every port signature.

- **New type**: `proximadb_runtime::PortIdentity<'a>` — the pre-resolution caller identity (`tenant_id` = authoritative ADR-0083 string scope, `subject` = ABAC principal, `tenant_stable_id` = derived policy key), with `anonymous()` / `for_tenant()` constructors. Distinct from `AuthorizedReadContext` (the post-resolution authorization result the seam resolves from it).
- **Adopted across**: `VectorOpsPort::search`, `ApiHandlersPort::handle_vector_search_v1_for_tenant`, `RecordSearchPort::search_record` (the Flight twin — folded in now so the Flight enforcement slice becomes "build the struct from its auth context", not another 9-impl ripple), and the root entry points `search_v1`, `search_records_with_tenant_context`, `handle_record_search_for_tenant`.
- **`_abac` twins retired**: `handle_record_get_for_tenant_abac` / `get_record_with_tenant_context_abac` (from #1376) collapse into the base methods — one method, identity decides, same philosophy as the #1379 seam.
- **One bridge**: `impl From<&MiddlewareTenantContext> for PortIdentity` — REST handlers write `PortIdentity::from(&tenant)` instead of hand-threading three params per call site.
- **Behavior-preserving**: subject/stable-id flow exactly as before; subject-less identity = passthrough. The Flight records caller now carries its already-resolved `tenant_stable_id` (subject stays `None` ⇒ passthrough unchanged).
- Plus a small rider: clears the 7 pre-existing strict-mode clippy lints in runtime/api test targets, making `cargo clippy -p proximadb-runtime -p proximadb-api --all-targets -- -D warnings` green.

## Tests

`tests/abac_rest_record_search_integration_test.rs` — all 12 enforcement tests (records / get-by-id / v1-progressive × admit / deny fail-closed / passthrough) migrated to `PortIdentity` and green under nextest, re-verified on the final rebase against develop (post #1381/#1382/#1383).

## Verification

- `cargo check -p proximadb --tests --features abac-policy` ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅
- `cargo clippy -p proximadb-runtime -p proximadb-api --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅ · `make work-commit-check` ✅

## Follow-ons (not this PR)

gRPC/Flight enforcement slices now reduce to building `PortIdentity` from `GrpcAuthContext` / the Flight auth context; the SQL `None` TODO in `canonical/handlers.rs` remains.