### PR TITLE
feat(abac): thread the real subject on gRPC + Arrow Flight records paths (TD-ABAC-5/6)

### DIFF
--- a/src/network/arrow_ipc/service.rs
+++ b/src/network/arrow_ipc/service.rs
@@ -1198,6 +1198,7 @@ impl ProximaFlightService {
         &self,
         ticket: FlightSearchTicket,
         tenant_id: &str,
+        subject: Option<&str>,
     ) -> Result<Vec<arrow_array::RecordBatch>> {
         let include_vector = ticket.include_vector;
         let request = ticket.to_rich_request()?;
@@ -1227,7 +1228,7 @@ impl ProximaFlightService {
                         request,
                         proximadb_runtime::PortIdentity {
                             tenant_id: Some(tenant_id),
-                            subject: None,
+                            subject,
                             tenant_stable_id,
                         },
                     )
@@ -1556,7 +1557,11 @@ impl FlightService for ProximaFlightService {
             )?;
 
             let batches = self
-                .handle_v2_search(search_ticket, &auth_context.tenant_id)
+                .handle_v2_search(
+                    search_ticket,
+                    &auth_context.tenant_id,
+                    auth_context.user_id.as_deref(),
+                )
                 .await
                 .map_err(|e| TonicStatus::internal(format!("Search failed: {}", e)))?;
 
@@ -2708,6 +2713,7 @@ impl FlightService for ProximaFlightService {
                 self.handle_bulk_search_exchange(
                     collection_id,
                     auth_context.tenant_id,
+                    auth_context.user_id,
                     first_msg,
                     stream,
                 )
@@ -3154,6 +3160,7 @@ impl ProximaFlightService {
         &self,
         collection_id: String,
         tenant_id: String,
+        subject: Option<String>,
         first_msg: FlightData,
         mut stream: TonicStreaming<FlightData>,
     ) -> TonicResult<<Self as FlightService>::DoExchangeStream> {
@@ -3235,7 +3242,10 @@ impl ProximaFlightService {
                     include_vector,
                 };
 
-                let search_batches = match self.handle_v2_search(ticket, &tenant_id).await {
+                let search_batches = match self
+                    .handle_v2_search(ticket, &tenant_id, subject.as_deref())
+                    .await
+                {
                     Ok(batches) => batches,
                     Err(e) => {
                         let meta = serde_json::to_vec(&serde_json::json!({

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1448,6 +1448,8 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<TypedSearchResponse>, Status> {
         let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
+        let subject = grpc_auth::user_id(&request);
+        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1478,7 +1480,11 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     .record_ops
                     .handle_record_search_for_tenant(
                         search_request,
-                        proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
+                        proximadb_runtime::PortIdentity {
+                            tenant_id: Some(tenant_id.as_str()),
+                            subject: subject.as_deref(),
+                            tenant_stable_id,
+                        },
                     )
                     .await;
                 let tq = crate::observability::predicate_diagnostics::take_turboquant_hints();
@@ -1537,6 +1543,8 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<Self::SearchStreamStream>, Status> {
         let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
+        let subject = grpc_auth::user_id(&request);
+        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1564,7 +1572,11 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             .record_ops
             .handle_record_search_for_tenant(
                 search_request,
-                proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
+                proximadb_runtime::PortIdentity {
+                    tenant_id: Some(tenant_id.as_str()),
+                    subject: subject.as_deref(),
+                    tenant_stable_id,
+                },
             )
             .await
             .map_err(|e| Status::internal(format!("Search stream failed: {}", e)))?;
@@ -2345,6 +2357,8 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         request: Request<proximadb_v2::GetRecordRequest>,
     ) -> Result<Response<proximadb_v2::GetRecordResponse>, Status> {
         let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
+        let subject = grpc_auth::user_id(&request);
+        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
         let req = request.into_inner();
         let result = self
             .record_ops
@@ -2355,7 +2369,11 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     include_vector: req.include_vector,
                     include_props: true,
                 },
-                proximadb_runtime::PortIdentity::for_tenant(tenant_id.as_str()),
+                proximadb_runtime::PortIdentity {
+                    tenant_id: Some(tenant_id.as_str()),
+                    subject: subject.as_deref(),
+                    tenant_stable_id,
+                },
             )
             .await
             .map_err(|e| Status::internal(format!("GetRecord failed: {e}")))?;


### PR DESCRIPTION
## Summary

Completes the ABAC enforcement chain across the records read surfaces: after the seam (#1379), the REST slices (#1373/#1376/#1381), and the `PortIdentity` consolidation (#1390), this activates enforcement for **authenticated gRPC and Arrow Flight callers** by building `PortIdentity` from each surface's auth context instead of delegating a subject-less identity.

- **gRPC** `record_service` (search, search_stream, get): `PortIdentity` from `grpc_auth::{resolved_tenant_id, user_id, tenant_stable_id}` — the same accessors TD-134 row-level RBAC already trusts; `tenant_stable_id` was wired by the TD-TENANT-1 resolver (#1359).
- **Arrow Flight** `handle_v2_search` (canonical DoGet route + `bulk_search` DoExchange): takes the authenticated subject from `AuthenticatedFlightContext.user_id` (surfaced by `resolve_request_identity`, TD-ABAC-6 PR-C) alongside the already-resolved stable id.
- **Semantics unchanged at the seam**: enforcement fires only under `abac-policy` AND a provisioned policy for the tenant — admit/deny-fail-closed/passthrough exactly as the 12 seam ratchet tests prove (`tests/abac_rest_record_search_integration_test.rs`). Unauthenticated callers keep `subject = None` ⇒ passthrough (no behavior change for today's deployments).
- **Deliberately not wired**: the REST `execute_sql` handler in `canonical/handlers.rs` — it is unrouted (dead code); the live SQL surfaces (pgwire / gRPC SQL) get their own subject-threading slice.

## Testing

The caller-side threading is type-forced (every site must supply the identity) and sources the one accessor per surface that existing RBAC already uses; the enforcement semantics those identities trigger are covered by the 12-test seam ratchet suite, re-verified green on this branch's base. A surface-level e2e (Flight/gRPC request with a provisioned policy end-to-end) is the follow-on gate once the admin provisioning e2e fixture exists.

## Verification

- `cargo check -p proximadb --lib/--tests --features abac-policy` ✅
- `cargo clippy -p proximadb --lib -- -D warnings` ✅ · `cargo fmt --check` ✅ · `make work-commit-check` ✅