### PR TITLE
refactor(decomp): extract cdc sinks → proximadb-cdc (TD-DECOMP-9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7074,10 +7074,13 @@ dependencies = [
 name = "proximadb-cdc"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "rand 0.8.6",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/integrations/proximadb-cdc/Cargo.toml
+++ b/crates/integrations/proximadb-cdc/Cargo.toml
@@ -13,6 +13,10 @@ description = "Change-Data-Capture event types + runtime — extracted from the 
 name = "proximadb_cdc"
 path = "src/lib.rs"
 
+[features]
+# Kafka sink uses rdkafka when enabled; stubs otherwise (mirrors root's cdc-kafka feature).
+cdc-kafka = []
+
 [dependencies]
 # `event` uses serde (derive) + serde_json (Value/ser) + rand (event-id gen).
 # Connector/sink/transform slices (later) add tokio/async-trait/prost/etc.
@@ -21,3 +25,7 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+# sinks: async-trait (CdcSink trait), tracing (logging), reqwest (webhook HTTP).
+async-trait.workspace = true
+tracing.workspace = true
+reqwest = { version = "0.11", features = ["json"] }

--- a/crates/integrations/proximadb-cdc/src/lib.rs
+++ b/crates/integrations/proximadb-cdc/src/lib.rs
@@ -15,4 +15,5 @@
 pub mod error;
 pub mod event;
 pub mod metrics;
+pub mod sinks;
 pub mod transform;

--- a/crates/integrations/proximadb-cdc/src/sinks/kafka.rs
+++ b/crates/integrations/proximadb-cdc/src/sinks/kafka.rs
@@ -21,7 +21,7 @@ use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
-use crate::cdc::event::ChangeEvent;
+use crate::event::ChangeEvent;
 
 #[cfg(feature = "cdc-kafka")]
 use super::traits::SinkError;
@@ -535,7 +535,7 @@ impl CdcSink for KafkaSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cdc::event::{Operation, SourceInfo};
+    use crate::event::{Operation, SourceInfo};
 
     /// Throwaway credential for auth-wiring tests, sourced at runtime so no
     /// string literal is used as a cryptographic value

--- a/crates/integrations/proximadb-cdc/src/sinks/mod.rs
+++ b/crates/integrations/proximadb-cdc/src/sinks/mod.rs
@@ -44,8 +44,8 @@ pub use traits::RetryConfig;
 pub use traits::{CdcSink, MessageFormat, SinkConfig, SinkError, SinkResult, SinkStats};
 pub use webhook::{HttpMethod, WebhookConfig, WebhookSink};
 
-use crate::cdc::error::{CdcError, CdcResult};
-use crate::cdc::event::ChangeEvent;
+use crate::error::{CdcError, CdcResult};
+use crate::event::ChangeEvent;
 
 /// Sink factory for creating sinks from configuration
 pub struct SinkFactory;
@@ -309,7 +309,7 @@ mod tests {
     }
 
     fn create_test_event() -> ChangeEvent {
-        use crate::cdc::event::{Operation, SourceInfo};
+        use crate::event::{Operation, SourceInfo};
         ChangeEvent::new(
             SourceInfo::postgres("testdb", "public", "test_server"),
             Operation::Insert,

--- a/crates/integrations/proximadb-cdc/src/sinks/traits.rs
+++ b/crates/integrations/proximadb-cdc/src/sinks/traits.rs
@@ -20,7 +20,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::cdc::event::ChangeEvent;
+use crate::event::ChangeEvent;
 
 use super::{KafkaConfig, WebhookConfig};
 
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn test_message_format_json() {
-        use crate::cdc::event::{Operation, SourceInfo};
+        use crate::event::{Operation, SourceInfo};
 
         let event = ChangeEvent::new(
             SourceInfo::postgres("testdb", "public", "server"),

--- a/crates/integrations/proximadb-cdc/src/sinks/webhook.rs
+++ b/crates/integrations/proximadb-cdc/src/sinks/webhook.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::cdc::event::ChangeEvent;
+use crate::event::ChangeEvent;
 
 use super::traits::{CdcSink, MessageFormat, RetryConfig, SinkError, SinkResult, SinkStats};
 
@@ -523,7 +523,7 @@ impl CdcSink for WebhookSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cdc::event::{Operation, SourceInfo};
+    use crate::event::{Operation, SourceInfo};
 
     /// Throwaway credential for auth-wiring tests, sourced at runtime so no
     /// string literal is used as a cryptographic value

--- a/docs/10-quality/td/TD-DECOMP-9-extract-cdc-sinks.adoc
+++ b/docs/10-quality/td/TD-DECOMP-9-extract-cdc-sinks.adoc
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-9: Extract cdc sinks → proximadb-cdc (god-crate decomposition)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing (delivered by this slice)
+| Severity | Low — build/dev-loop only; zero runtime, API, or on-disk-format impact (behavior-neutral re-export)
+| Component | `crates/integrations/proximadb-cdc` (`sinks`); root `src/cdc/mod.rs` (re-export shim)
+| Relates to | `roadmap/techdebt/P2_GOD_CRATE_TEST_DECOMPOSITION.md`; [[TD-DECOMP-1]] (recipe); [[TD-DECOMP-7]]/[[TD-DECOMP-8]] (cdc crate seed + transform/error)
+|===
+
+== Why
+
+Continues the cdc vein. The sinks subgraph (`mod.rs` + `kafka` + `webhook` + `traits`, **44
+tests**) is the next cohesive unit — its only non-self deps are `event` + `error` (both now
+in the cdc crate via TD-DECOMP-7/8). Deps: `serde` + `tracing` + `async-trait` + `reqwest`
+(webhook HTTP). The cdc crate goes 83→127 tests.
+
+== What moved (behavior-neutral)
+
+* `src/cdc/sinks/` (`mod.rs` 6t + `kafka.rs` 14t + `webhook.rs` 16t + `traits.rs` 8t) →
+  `crates/integrations/proximadb-cdc/src/sinks/` (verbatim subdir move).
+* Rewrite: `crate::cdc::{event,error}` → `crate::{event,error}` (now siblings).
+* `proximadb-cdc/Cargo.toml`: + `async-trait`, `tracing` (workspace), `reqwest` (inline
+  `{ version = "0.11", features = ["json"] }` — not a workspace dep).
+* `proximadb-cdc/src/lib.rs`: `pub mod sinks;`.
+* Root `src/cdc/mod.rs`: `pub mod sinks;` → `pub use proximadb_cdc::sinks;`.
+
+== Verification
+
+* `cargo check -p proximadb-cdc` green; `nextest` — 127 tests pass.
+* `cargo check -p proximadb` green (root compiles through re-export).
+* `check_workspace_boundaries.py` + `check-layering.sh` green (integration-tier-legal).
+* `cargo build -p proximadb-server` + `clippy -D warnings` + `fmt` + `work-commit-check` green.
+
+== Follow-ups (cdc vein)
+
+* `outbound/{dedup,router,config,position,subscriber,exactly_once}` + `connectors/*` + `coordinator`.
+* **Running total once merged: ~252 tests out of root lib binary** (208 + 44).

--- a/src/cdc/mod.rs
+++ b/src/cdc/mod.rs
@@ -120,7 +120,8 @@ pub use proximadb_cdc::event;
 pub use proximadb_cdc::metrics;
 pub mod offset;
 pub mod outbound;
-pub mod sinks;
+// `sinks` now lives in `proximadb-cdc` (TD-DECOMP-9); re-exported.
+pub use proximadb_cdc::sinks;
 pub mod source;
 // `transform` (mod/filter/schema/embedding) now lives in `proximadb-cdc` (TD-DECOMP-8);
 // re-exported so `crate::cdc::transform::*` paths resolve unchanged.


### PR DESCRIPTION
## What
Continues the cdc vein (#1382 seed + #1386 transform/error/metrics). Extracts the **sinks** subgraph → `proximadb-cdc`: **44 tests** relocated (cdc crate 83→127). Behavior-neutral.

## Change
- `git mv src/cdc/sinks/` (mod + kafka 14t + webhook 16t + traits 8t) → `proximadb-cdc/src/sinks/`.
- Rewrite: `crate::cdc::{event,error}` → `crate::{event,error}`. Added deps: `async-trait`, `tracing`, `reqwest` (inline `0.11`/json — webhook HTTP). Added `cdc-kafka` feature (cfg gate mirrors root).

## Verification (quiet machine)
| check | result |
|---|---|
| `cargo check -p proximadb` | ✅ |
| `nextest -p proximadb-cdc` | ✅ **127 passed** (83→127: +44 sinks) |
| `check_workspace_boundaries` + `check-layering` | ✅ |
| `cargo build -p proximadb-server` | ✅ |
| `cargo clippy -p proximadb-cdc -D warnings` | ✅ |
| `cargo fmt --check` + `work-commit-check` + td-unique | ✅ |

**Running total once merged: ~252 tests out of root lib binary** (208 + 44).

## Follow-ups (TD-DECOMP-9)
`outbound/{dedup,router,config,position,subscriber,exactly_once}` + `connectors/*` + `coordinator` (the hub).
