### PR TITLE
docs(adr): ADR-087 caller-identity propagation — one foundation identity, fail-closed composition (TD-ABAC-8..11)

### DIFF
--- a/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
+++ b/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
@@ -1,0 +1,25 @@
+= TD-ABAC-10: pgwire constructs the foundation identity (subject to the relational read boundary)
+:status: Open
+:dim: D5
+:pillar: SEC
+
+Problem: pgwire is the one network surface not yet constructing
+`ResolvedRequestIdentity`. Session tenant resolution has its own
+`DEFAULT_TENANT` semantics (`src/network/postgres/protocol.rs` ~:615, ~:2032)
+and no subject reaches the relational read boundary from psql sessions —
+although the boundary itself already accepts one
+(`execute_sql_v1(..., subject)`, TD-ABAC-3/5).
+
+Next action (ADR-087 §Decision 5): at pgwire startup/session establishment,
+build `ResolvedRequestIdentity` — tenant via the existing session resolution
+(DEFAULT_TENANT semantics preserved), subject from the pg user through
+`resolve_subject_assertion` under the deployment `HeaderTrustPolicy`
+(`auth_class = TrustAsserted` for trust auth; `Authenticated` when a real
+credential authenticated the session), `tenant_stable_id` stamped by the
+shared resolver (TD-ABAC-8). Carry it in session state; the SELECT lowering
+threads it to `execute_sql_v1`/the seam.
+
+Note: pgwire trust-auth subjects are spoofable by design — that is what
+`AuthClass::TrustAsserted` records; deployments gate via `HeaderTrustPolicy`.
+
+Depends on [[TD-ABAC-8]]. Ref ADR-087, TD-ABAC-3, TD-ABAC-5.

--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -1,0 +1,31 @@
+= TD-ABAC-11: Default-tenant mint + flip the seam composition rule to fail-closed on absent stable id
+:status: Open
+:dim: D5
+:pillar: SEC
+
+Problem (the P1 of ADR-087): the seam's composition rule
+(`records_read_context`, `src/services/operations/vectors/legacy.rs`)
+enforces only on `(Some(subject), Some(tenant_stable_id))`. The cell
+`(Some(subject), None)` — authenticated subject, unminted tenant or no
+resolver wired — **passes through silently**. Enforcement strength therefore
+equals mint/resolver coverage, and the `GrpcAuthContext` doc-claim
+"unminted ⇒ fail-closed deny" is not what the seam implements. An attacker
+whose tenant is unminted is un-policed even where a policy intent exists.
+
+Next action (strict ordering — totality before strictness):
+1. **Default-tenant mint** (the long-pending PR3 of the TD-TENANT-1 track):
+   mint a stable id for the default/every tenant at catalog bootstrap +
+   binding-provisioning admin path keyed by tenant string, resolved at write.
+   Makes `tenant_stable_id` total for real deployments.
+2. **Flip the rule** in the same release train: enforcer wired ∧ subject
+   present ∧ stable id absent ⇒ DENY. Unit-test the full truth table
+   (enforcer × subject × stable id × auth_class) in isolation.
+3. **Cross-surface e2e ratchet**: provisioned policy exercised over
+   REST/gRPC/Flight/pgwire × admit/deny-fail-closed/passthrough (needs the
+   provisioning e2e fixture from step 1).
+
+Do NOT flip before the mint lands — it would fail-close every unminted
+dev/embedded deployment that wires an enforcer.
+
+Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
+[[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).

--- a/docs/10-quality/td/TD-ABAC-8-foundation-identity-carrier.adoc
+++ b/docs/10-quality/td/TD-ABAC-8-foundation-identity-carrier.adoc
@@ -1,0 +1,31 @@
+= TD-ABAC-8: Complete ResolvedRequestIdentity (stable id, stamp-once) and make it the request carrier
+:status: Open
+:dim: D5
+:pillar: SEC
+
+Problem: `tenant_stable_id` (the ABAC policy key) is stamped per-surface by
+optional resolvers (REST middleware, `GrpcAuthContext`, Flight inline
+`stable_id_of`) — N resolution points, N drift seams, and consumers below the
+network layer cannot see the foundation identity at all (the REST identity
+Extension is the root-crate `MiddlewareTenantContext`, invisible to
+`proximadb-api` handlers by layering).
+
+Next action (per ADR-087 §Decision 1–3):
+1. Add `tenant_stable_id: Option<u64>` to
+   `proximadb_tenant::ResolvedRequestIdentity`; stamp it in the single
+   resolution point per surface (`resolve_request_identity` orchestrator /
+   auth layer), retiring the per-surface hand-stamps.
+2. REST tenant middleware inserts `Extension<ResolvedRequestIdentity>`
+   (foundation type ⇒ visible to every crate); `MiddlewareTenantContext`
+   keeps surface-local extras and derives its identity core from it.
+3. `proximadb_runtime::PortIdentity<'a>` gains
+   `From<&ResolvedRequestIdentity>` and an `auth_class` field (audit-only at
+   the seam for now).
+
+Key locations: `crates/foundation/proximadb-tenant/src/identity_trust.rs`,
+`src/security/request_identity.rs`, `src/network/middleware/tenant.rs`,
+`src/network/grpc/auth.rs`, `src/network/arrow_ipc/service.rs`,
+`crates/platform/proximadb-runtime/src/service_ports.rs`.
+
+Deps: after #1391. Enables [[TD-ABAC-9]] (api-crate consumers) and
+[[TD-ABAC-10]] (pgwire) as mechanical constructors.

--- a/docs/10-quality/td/TD-ABAC-9-api-crate-identity-consumers.adoc
+++ b/docs/10-quality/td/TD-ABAC-9-api-crate-identity-consumers.adoc
@@ -1,0 +1,22 @@
+= TD-ABAC-9: api-crate handlers consume the foundation identity (hybrid SQL subject gap)
+:status: Open
+:dim: D5
+:pillar: SEC
+
+Problem: the live `proximadb-api` hybrid SQL route
+(`crates/platform/proximadb-api/src/rest/canonical/hybrid.rs` ~:413,
+`create_hybrid_search_router`) calls `execute_sql_v1(query, params,
+collection, None, None)` — no tenant, no subject — because the api crate
+cannot name the root-crate REST identity Extension (layering wall). This is
+the last live REST surface delegating a `None` subject. (The root-crate
+`execute_sql` handler in `canonical/handlers.rs` is UNROUTED dead code — do
+not wire it; verified 2026-08-02.)
+
+Next action: once TD-ABAC-8 lands (foundation `ResolvedRequestIdentity`
+Extension inserted by the REST middleware), the api-crate handlers add
+`Extension(identity): Extension<ResolvedRequestIdentity>` and thread
+`Some(&identity.tenant)` + `identity.subject.as_deref()` into
+`execute_sql_v1` (and audit the other api-crate routes for the same gap).
+Mechanical after ABAC-8; no layering change.
+
+Depends on [[TD-ABAC-8]]. Ref ADR-087.

--- a/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
+++ b/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
@@ -1,0 +1,134 @@
+= ADR-087: Caller-identity propagation — one foundation identity, resolved once, fail-closed composition
+:status: Proposed
+:date: 2026-08-02
+
+== Status
+
+Proposed (design review of the residual ABAC gaps after #1379/#1381/#1390/#1391).
+
+== Context
+
+The ABAC enforcement chain for record reads is complete at the seam
+(`unified_search_v1_inner` + the get-by-id admit-check) and every records door
+(REST, gRPC, Arrow Flight) now delivers a caller identity to it via
+`PortIdentity` (TD-ABAC-7). Closing those slices exposed three *structural*
+residues that patch-level threading cannot fix:
+
+1. **Identity-type proliferation (the bridge tax).** A request's identity is
+   re-represented per surface: `MiddlewareTenantContext` (root, REST),
+   `GrpcAuthContext` (root, gRPC), `AuthenticatedFlightContext` (root, Flight),
+   pgwire session state, `UnifiedUserContext`, storage `TenantContext`,
+   `PortIdentity` (runtime). Each new consumer pays a bridge, and each bridge is
+   a drift seam. The concrete casualty: the `proximadb-api` crate's live hybrid
+   SQL route cannot thread a subject at all, because the REST identity extension
+   is a *root-crate* type the api crate may not name (layering) — an
+   architectural wall, not a missing line.
+2. **The stable-id gap is silent-open.** `tenant_stable_id` (the ADR-0083
+   account projection, the ABAC *policy-lookup key*) is stamped per-surface by
+   optional resolvers. The seam's composition rule
+   (`records_read_context`) enforces only on
+   `(Some(subject), Some(stable_id))`; the cell
+   `(Some(subject), None)` — an authenticated subject whose tenant is unminted
+   or whose surface has no resolver wired — **falls through to passthrough**.
+   The `GrpcAuthContext` field doc claims "unminted ⇒ fail-closed deny"; the
+   seam does not implement that. Enforcement strength today equals
+   mint/resolver *coverage*, and the failure mode is silent-open.
+3. **Trust provenance is dropped at the seam.** The foundation already
+   classifies how an identity was established (`AuthClass`: Authenticated /
+   TrustAsserted / Anonymous), but `PortIdentity` does not carry it, so the
+   seam cannot distinguish a credentialed subject from a spoofable
+   trust-asserted one for audit or policy purposes.
+
+What the codebase already has — and this ADR builds on rather than replaces —
+is `proximadb_tenant::ResolvedRequestIdentity { tenant, subject, auth_class }`
+(foundation layer, TD-ABAC-6): "the resolved identity every network surface
+produces uniformly," with the root orchestrator
+`src/security/request_identity::resolve_request_identity` already adopted
+end-to-end by Arrow Flight. The gaps above exist because this primitive is
+*incomplete* (no `tenant_stable_id`) and *not yet the carrier* (surfaces
+produce it, then immediately re-encode into their local types).
+
+== Decision
+
+**One identity value, resolved once per request at the network boundary,
+carried unchanged to every consumer; everything else is a projection.**
+
+1. **Complete the primitive.** Extend `ResolvedRequestIdentity` with
+   `tenant_stable_id: Option<u64>`, stamped at the *single* resolution point by
+   the (already-foundation) `TenantStableIdResolver`. Per-surface hand-stamping
+   (the `GrpcAuthContext` field, the REST middleware resolver call, Flight's
+   inline `stable_id_of`) is retired in favor of the one stamp. This is also
+   the perf-correct shape: one sync catalog lookup per request instead of one
+   per surface-layer that happens to need it.
+2. **Make the foundation value the carrier.** The REST tenant middleware
+   inserts `Extension<ResolvedRequestIdentity>` alongside (eventually instead
+   of the identity core of) `MiddlewareTenantContext`. Because the type lives
+   in the foundation `proximadb-tenant` crate, **every crate in the workspace
+   can extract it** — the api-crate layering wall dissolves without moving the
+   middleware or violating one-way layering. Surface-local context types keep
+   only their genuinely surface-local extras (namespace tiers, capability
+   tokens, billing markers) and *embed or derive from* the foundation value.
+3. **Projections, not siblings.** `PortIdentity<'a>` (runtime) becomes a
+   borrowed projection: `From<&ResolvedRequestIdentity>`. It gains
+   `auth_class` so the seam can audit trust provenance (enforcement itself
+   stays deny-biased for any present subject; provenance-conditional policy is
+   explicitly out of scope until a policy knob demands it). Storage
+   `TenantContext`, io-trace attribution, and billing all project from the same
+   value — one source, no reconciliation.
+4. **Fail-closed composition (the truth-table fix).** The seam's rule becomes:
+   *if an enforcer is wired and a subject is present, an absent
+   `tenant_stable_id` DENIES* (it is the policy key; without it the policy
+   cannot be consulted, and "cannot consult" must not mean "allow"). This
+   flips the silent-open cell. **Sequencing constraint:** the flip ships in
+   the same release train as the default-tenant mint (which makes
+   `tenant_stable_id` total for real deployments); flipping earlier would
+   fail-close every unminted dev/embedded deployment that wires an enforcer.
+   Until the flip lands, the open cell is a documented, tracked known-gap
+   (TD-ABAC-11), no longer an undocumented one.
+5. **pgwire joins the same shape.** The pgwire startup path constructs the
+   same `ResolvedRequestIdentity` (tenant from startup/session resolution with
+   its existing `DEFAULT_TENANT` semantics; subject from the pg user under
+   `resolve_subject_assertion`'s trust policy; `auth_class` accordingly) and
+   session state carries it to the relational read boundary, which already
+   accepts a subject (TD-ABAC-3/5).
+
+== Consequences
+
+* The api-crate SQL gap, the pgwire slice, and any future surface become
+  *constructors* of one value plus mechanical projection — no new bridges, no
+  layering exceptions, no per-surface resolver wiring.
+* The ABAC bypass surface reduces to exactly one reviewable function: the
+  composition rule at the seam. Its truth table is testable in isolation and
+  ratchet-tested per surface.
+* `AuthClass` at the seam gives audit (and later policy) the
+  credentialed-vs-asserted distinction without a second enforcement path.
+* Costs: a one-time migration of the three existing surface types to
+  embed/derive the foundation value (mechanical, compiler-driven, same recipe
+  as TD-ABAC-7), and the mint becomes a hard prerequisite for the fail-closed
+  flip — which is the correct dependency direction: totality first, then
+  strictness.
+
+== Slices
+
+* TD-ABAC-8 — complete + carry: `tenant_stable_id` (+ stamp-once) on
+  `ResolvedRequestIdentity`; REST middleware inserts the foundation Extension;
+  `PortIdentity` becomes a projection (+ `auth_class`).
+* TD-ABAC-9 — api-crate consumers: hybrid SQL route extracts the foundation
+  identity and threads it (closes the last live REST `None` subject).
+* TD-ABAC-10 — pgwire constructor: startup/session → `ResolvedRequestIdentity`
+  → relational read boundary.
+* TD-ABAC-11 — mint + strictness: default-tenant mint, binding-provisioning
+  e2e fixture, flip the composition rule to fail-closed on the absent stable
+  id, cross-surface e2e ratchet (REST/gRPC/Flight/pgwire × admit/deny/
+  passthrough).
+
+== References
+
+* `crates/foundation/proximadb-tenant/src/identity_trust.rs`
+  (`ResolvedRequestIdentity`, `AuthClass`, `resolve_subject_assertion`)
+* `src/security/request_identity.rs` (root orchestrator)
+* `src/services/operations/vectors/legacy.rs` `records_read_context`
+  (the composition rule / silent-open cell)
+* ADR-0083 (composite identity; stable id = derived projection),
+  TD-ABAC-6 (unified identity seam), TD-ABAC-7 (PortIdentity),
+  TD-TENANT-1 (stable-id resolver)

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -415,6 +415,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Byte-weighted, process-wide compaction memory admission
 | Accepted (2026-08-01)
 | Converts immutable input-segment bytes to a conservative peak-RSS reservation (initially 12x from a measured 9.85x 3.3M-vector run), admits against the tightest of cgroup-visible capacity, live available memory, and an optional absolute ceiling, and shares one weighted reservation counter across collections. Discovery packs deterministic whole-file morsels before materialization; if no pair fits, the level remains horizontal instead of risking an OOM. Tracked: TD-COMPACT-2/4.
+| link:ADR-087-caller-identity-propagation.adoc[ADR-087]
+| Caller-identity propagation — one foundation identity, resolved once, fail-closed composition
+| Proposed (2026-08-02)
+| Design review of the residual ABAC gaps after the records-read enforcement chain (#1379→#1391). Names the structural traps: per-surface identity types (the bridge tax that walls off `proximadb-api` handlers from any subject), the per-surface optional stamping of `tenant_stable_id`, and the seam's silent-open composition cell — an authenticated subject with an absent stable id (unminted tenant / no resolver) currently bypasses enforcement. Decision: complete the existing foundation primitive (`ResolvedRequestIdentity` gains `tenant_stable_id`, stamped once at resolution), make it the request carrier (REST middleware inserts the foundation Extension every crate can see), reduce `PortIdentity`/storage-context/billing to projections, and flip the seam rule to fail-closed on the absent policy key — sequenced strictly AFTER the default-tenant mint makes the stable id total. Slices: TD-ABAC-8 (carrier), TD-ABAC-9 (api-crate consumers), TD-ABAC-10 (pgwire constructor), TD-ABAC-11 (mint + strictness + cross-surface e2e ratchet).
+
 | link:ADR-0083-consolidated-catalog-identity-model.adoc[ADR-0083]
 | Consolidated catalog identity model — the composite is the SOLE canonical identity; retire the global u64
 | Accepted — Revision 2 (2026-07-30)


### PR DESCRIPTION
## Summary

Strategic design review of the remaining ABAC gaps, done at architecture level per the co-design mandate (governance dimension) so the follow-on slices don't paint us into corners. Full analysis in `docs/12-design/adr/ADR-087-caller-identity-propagation.adoc`.

**Findings (verified in code, not asserted):**
1. **Bridge tax**: a request's identity is re-encoded per surface (`MiddlewareTenantContext`, `GrpcAuthContext`, `AuthenticatedFlightContext`, pgwire session, `UnifiedUserContext`, storage `TenantContext`, `PortIdentity`). Concrete casualty: the live `proximadb-api` hybrid SQL route cannot thread a subject at all — the REST identity Extension is a root-crate type the api crate may not name.
2. **Silent-open cell**: the seam enforces only on `(Some(subject), Some(stable_id))`; an authenticated subject with an absent `tenant_stable_id` (unminted tenant, unwired resolver) **bypasses enforcement**. The `GrpcAuthContext` doc claims fail-closed; the seam doesn't implement it. Today enforcement strength = mint/resolver coverage.
3. **Trust provenance dropped**: `AuthClass` (Authenticated/TrustAsserted/Anonymous) exists in foundation but never reaches the seam.

**Decision (build on the existing primitive, don't add another):** `proximadb_tenant::ResolvedRequestIdentity` — already "the identity every surface produces uniformly" (TD-ABAC-6) — gains `tenant_stable_id` stamped ONCE at resolution; the REST middleware inserts it as a foundation Extension every crate can extract (dissolves the layering wall without moving the middleware); `PortIdentity` et al. become projections; the seam composition rule flips to fail-closed on the absent policy key — sequenced strictly AFTER the default-tenant mint makes the stable id total (totality before strictness).

**Slices filed:** TD-ABAC-8 (carrier), TD-ABAC-9 (api-crate consumers), TD-ABAC-10 (pgwire constructor), TD-ABAC-11 (mint + fail-closed flip + cross-surface e2e ratchet).

Docs-only PR; guards green (`td-adr-unique`: 87 ADRs / 327 TDs, 0 errors; `work-commit-check` ✅).