### PR TITLE
ci(bench): install sccache in the benches-compile job (RUSTC_WRAPPER without the binary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1351,6 +1351,17 @@ jobs:
         with:
           prefix-key: "v1-rust-compile-benches"
           shared-key: "benches"
+      # sccache MUST be installed: this job sets RUSTC_WRAPPER=sccache, so without
+      # the action cargo dies instantly ("could not execute process `sccache`").
+      # The step was missing while the env + stats step were present — the job is
+      # gated on medium_tier, so it only runs on develop→qa promotions and the gap
+      # went unexercised until it hard-failed #1378 across every rerun.
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/sccache
+          key: sccache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: sccache-${{ runner.os }}-
       - name: Install Dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
Fixes the **deterministic** failure blocking promotion PR #1378 (13 reruns, never green on `Rust Compile (benches)`).

`rust-compile-benches` sets `RUSTC_WRAPPER: sccache` + `SCCACHE_DIR` and ends with a "Show sccache stats" step — but it never ran `mozilla-actions/sccache-action`, so sccache was never on PATH and `cargo check` died on the first invocation:

```
error: could not execute process `sccache …/rustc -vV` (never executed)
Caused by: No such file or directory (os error 2)
```

This is **not a flake** — it fails every time the job runs. It stayed hidden because the job is gated on `medium_tier`, so it only executes on develop→qa promotions (benches aren't compiled on feat→develop, TD-BENCH-1). The 2026-08-01 promotion was the first to exercise it, and it failed identically across all 13 attempts.

Fix: add the `sccache-action` install + `actions/cache` steps, mirroring the three sibling heavy-compile jobs (`rust-compile`, and the two at ci.yml:1706/1978) that "keep sccache (proven green)". Of the four jobs setting `RUSTC_WRAPPER: sccache`, this was the only one missing the install step.

After merge I refresh the #1378 release branch so its gates rerun with the fixed workflow.

## Test plan
- [x] YAML parses; the two added steps are copied verbatim from the sibling `rust-compile` job (ci.yml:1316–1321)
- [x] Attribution guard clean