### PR TITLE
feat(abac): close the three pgwire ABAC bypasses (TD-ABAC-10c, ADR-087)

### DIFF
--- a/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
+++ b/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
@@ -22,7 +22,7 @@ threads it to `execute_sql_v1`/the seam.
 Note: pgwire trust-auth subjects are spoofable by design — that is what
 `AuthClass::TrustAsserted` records; deployments gate via `HeaderTrustPolicy`.
 
-== Status: 10a DONE; 10b/10c open
+== Status: 10a + 10c DONE; 10b open
 
 **10a (done)** — `Session.identity: Option<ResolvedRequestIdentity>` built at
 the startup handshake by the pure, unit-tested `PostgresProtocol::startup_identity`
@@ -44,19 +44,41 @@ carry `PortIdentity`; update the off-pgwire caller
 (`ApiHandlersPort::execute_sql_v1`, `QueryAdapterPort::execute_sql`) still
 take flat `tenant_id`/`subject` with no stable id.
 
-**10c (open) — three pgwire read paths bypass ABAC** (found by the 2026-08-02
-live-path survey; each is a *distinct* bypass, not covered by 10a/10b):
+**10c (DONE) — the three pgwire read paths that bypassed ABAC** (found by the
+2026-08-02 live-path survey; each was a *distinct* bypass). All three are
+closed; how each was closed is recorded below because the choices differ:
 
-1. **pgvector search** — `protocol.rs` `execute_vector_search` (~:2221) calls
-   `unified_search_native` (~:2286) with a hardcoded
-   `ReadContext::system(Statistics, "pgwire [CLIENT-PLACEHOLDER]")` (~:2293):
-   ALL pgwire vector search is unenforced. Fix: pass the session identity, or
-   route through the enforced `unified_search_v1` seam.
-2. **Legacy single-table SELECT** — `execute_relational_query` (~:2896) →
-   `select_table_records_with_projection[_where]` (~:2926/:2945): tenant-scoped
-   only, no subject parameter at all.
-3. **EXPLAIN/ANALYZE** — `relational_pipeline.rs::build_snapshot` (~:2337)
-   hardcodes `subject: None` (~:2361), so an EXPLAIN can describe a plan over
-   rows the subject cannot read.
+1. **pgvector search** (was: hardcoded `ReadContext::system(Statistics,
+   "pgwire [CLIENT-PLACEHOLDER]")`, so ALL pgwire vector search was unenforced)
+   — now resolves the CLIENT context from the session identity through the ONE
+   composition rule `VectorOperationsService::records_read_context`, and emits
+   an EMPTY result set (fail-closed) when that rule denies.
+2. **Legacy single-table SELECT** (was: no subject parameter at all) — now
+   **fails closed**: under an armed enforcer + a governed subject the fallback
+   refuses with an actionable error instead of serving unenforced rows.
+   *Deliberately NOT enforced in place*: that path has its own scan machinery
+   with no row-filter wiring, so enforcing there would mean a SECOND
+   implementation of the one rule — the drift seam ADR-087 exists to remove.
+   The real fix is coverage: these shapes should be lowered by the enforcing
+   relational pipeline (the ANSI-SQL-over-pgwire direction anyway). Tracked as
+   the follow-on below.
+3. **EXPLAIN/ANALYZE** (was: `subject: None` hardcoded in `build_snapshot`) —
+   the subject is threaded through
+   `explain_select_route_with_catalog` / `explain_analyze_select_with_catalog`
+   → `route_and_plan_select` → `prepare_select_plan` → `build_snapshot`.
+   Severity note: EXPLAIN ANALYZE *executes* the query, so this was returning
+   actual rows the subject could not read — not merely plan estimates.
+
+**10c follow-on (open)**: grow relational-pipeline coverage so the legacy
+single-table fallback is unreachable for governed subjects, then delete the
+fail-closed guard with it.
+
+**Test posture**: the shared composition rule's truth table is pinned in
+`tests/abac_rest_record_search_integration_test.rs` (admit / deny / no-subject
+passthrough / **the TD-ABAC-11 known-open absent-stable-id cell**), so a
+surface that stops calling the rule is a bypass by construction and the
+TD-ABAC-11 flip must consciously update a failing test. Surface-level pgwire
+e2e (a real psql session against a provisioned policy) is gated on the
+binding-provisioning fixture in [[TD-ABAC-11]].
 
 Depends on [[TD-ABAC-8]]. Ref ADR-087, TD-ABAC-3, TD-ABAC-5, [[TD-ABAC-11]].

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -679,6 +679,24 @@ impl PostgresProtocol {
         .stamp_stable_id(stable_id_resolver)
     }
 
+    /// TD-ABAC-10 (ADR-087): the connection's ABAC subject, read from the ONE
+    /// session identity built at the startup handshake — never re-derived from
+    /// `session.user` per query. `None` ⇒ no subject ⇒ passthrough (the
+    /// composition rule at the seam decides what that means).
+    ///
+    /// Every pgwire read path that enforces MUST source its subject here, so a
+    /// new path cannot silently become a bypass by forgetting to derive one.
+    #[cfg(feature = "abac-policy")]
+    async fn session_subject(&self) -> Option<proximadb_catalog::fc_metamodel::SubjectId> {
+        self.session
+            .read()
+            .await
+            .identity
+            .as_ref()
+            .and_then(|id| id.subject.clone())
+            .map(proximadb_catalog::fc_metamodel::SubjectId)
+    }
+
     /// TD-ABAC-3: gate a pgwire SUBJECT assertion (startup `user`) through the
     /// SAME [`HeaderTrustPolicy`](proximadb_tenant::HeaderTrustPolicy) the tenant
     /// assertion uses. pgwire is trust auth, so the binding is always `None`;
@@ -1867,16 +1885,7 @@ impl PostgresProtocol {
         // enforcement; otherwise the asserted user becomes the SubjectId ABAC
         // resolves the row filter against.
         #[cfg(feature = "abac-policy")]
-        // TD-ABAC-10 (ADR-087): the subject comes from the ONE session identity
-        // constructed at startup — no per-query re-derivation from `user`.
-        let subject = self
-            .session
-            .read()
-            .await
-            .identity
-            .as_ref()
-            .and_then(|id| id.subject.clone())
-            .map(proximadb_catalog::fc_metamodel::SubjectId);
+        let subject = self.session_subject().await;
         super::relational_pipeline::try_run_select(
             query,
             self.dml_service.as_ref(),
@@ -1958,12 +1967,18 @@ impl PostgresProtocol {
             // route-only disclosure when no DmlService is available.
             // TD-064: resolve EXPLAIN's schema/plan under the connection tenant.
             let explain_tenant = self.pgwire_resolve_read_tenant().await;
+            // TD-ABAC-10c: EXPLAIN (and especially EXPLAIN ANALYZE, which
+            // executes) must plan/run under the SAME subject execution uses.
+            #[cfg(feature = "abac-policy")]
+            let explain_subject = self.session_subject().await;
             let routing = match self.dml_service.clone() {
                 Some(dml) if is_analyze => {
                     crate::network::postgres::relational_pipeline::explain_analyze_select_with_catalog(
                         inner_query,
                         &dml,
                         Some(explain_tenant.as_str()),
+                        #[cfg(feature = "abac-policy")]
+                        explain_subject,
                     )
                     .await
                 }
@@ -1972,6 +1987,8 @@ impl PostgresProtocol {
                         inner_query,
                         &dml,
                         Some(explain_tenant.as_str()),
+                        #[cfg(feature = "abac-policy")]
+                        explain_subject,
                     )
                     .await
                 }
@@ -2337,6 +2354,47 @@ impl PostgresProtocol {
             metadata_filter.is_some()
         );
 
+        // TD-ABAC-10c (ADR-087): resolve the CLIENT read context from the
+        // session identity through the ONE composition rule every surface
+        // shares (`records_read_context`) — this path previously passed a
+        // hardcoded `System` context ("[CLIENT-PLACEHOLDER]"), so every pgwire
+        // pgvector search bypassed ABAC entirely. `None` ⇒ the subject was
+        // DENIED ⇒ fail closed: emit an empty result set, never rows.
+        #[cfg(feature = "abac-policy")]
+        let read_context = {
+            let (subject, tenant_stable_id) = {
+                let session = self.session.read().await;
+                match session.identity.as_ref() {
+                    Some(identity) => (identity.subject.clone(), identity.tenant_stable_id),
+                    None => (None, None),
+                }
+            };
+            match self
+                .vector_ops
+                .records_read_context(subject.as_deref(), tenant_stable_id, &table_name)
+                .await
+            {
+                Some(context) => context,
+                None => {
+                    warn!(
+                        target: "proximadb::tenant_audit",
+                        surface = "pgwire",
+                        collection = %table_name,
+                        subject = ?subject,
+                        "ABAC denied the pgwire vector search subject — failing closed (empty result)"
+                    );
+                    let fields = vec![
+                        FieldDescription::new("id", PgType::Text),
+                        FieldDescription::new("distance", PgType::Float8),
+                        FieldDescription::new("metadata", PgType::Jsonb),
+                    ];
+                    self.send_row_description(&fields).await?;
+                    self.send_command_complete("SELECT 0").await?;
+                    return Ok(());
+                }
+            }
+        };
+
         if let Some(ref vector) = query_vector {
             // Execute actual vector search
             match self
@@ -2348,10 +2406,7 @@ impl PostgresProtocol {
                     metadata_filter, // TD-100: mem0 metadata-scoped WHERE pushdown
                     None,            // Default config
                     #[cfg(feature = "abac-policy")]
-                    &proximadb_abac::ReadContext::system(
-                        proximadb_abac::SystemReadReason::Statistics,
-                        "pgwire [CLIENT-PLACEHOLDER]",
-                    ),
+                    &read_context,
                 )
                 .await
             {
@@ -2973,6 +3028,24 @@ impl PostgresProtocol {
         // machinery). If sqlparser can't parse the query (pg-specific syntax)
         // or its WHERE has an unsupported expression, fall back to the legacy
         // string-predicate path — over-inclusive full scan, never empty.
+        // TD-ABAC-10c (ADR-087): this LEGACY fallback has no row-filter wiring,
+        // so under an armed enforcer + a client subject it would serve
+        // unenforced rows — the bypass this closes. It fails CLOSED instead of
+        // growing a second enforcement implementation (two implementations of
+        // one rule is the drift seam ADR-087 removes). The real fix is
+        // coverage: shapes that reach this fallback should be lowered by the
+        // enforcing relational pipeline (the ANSI-SQL-over-pgwire mandate's
+        // direction anyway).
+        #[cfg(feature = "abac-policy")]
+        if self.session_subject().await.is_some() && dml_service.has_abac_enforcer() {
+            return Err(anyhow!(
+                "this query shape is not supported for a policy-governed subject: \
+                 it falls back to the legacy single-table reader, which cannot \
+                 apply row-level security. Rewrite it into a shape the relational \
+                 pipeline lowers, or run it as an ungoverned (no-subject) connection."
+            ));
+        }
+
         // TD-064: scope the legacy relational SELECT to the connection tenant.
         let read_tenant = self.pgwire_resolve_read_tenant().await;
         let read_tenant_ctx = (!read_tenant.is_empty())

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -2321,8 +2321,16 @@ async fn prepare_select_plan(
     query: &SqlQuery,
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Option<(SnapshotCatalog, PhysicalPlan)> {
-    let snapshot = build_snapshot(query, dml, tenant).await?;
+    let snapshot = build_snapshot(
+        query,
+        dml,
+        tenant,
+        #[cfg(feature = "abac-policy")]
+        subject,
+    )
+    .await?;
     match plan_over_snapshot(sql, &snapshot)? {
         Ok(physical) => Some((snapshot, physical)),
         Err(_) => None,
@@ -2338,6 +2346,7 @@ async fn build_snapshot(
     query: &SqlQuery,
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Option<SnapshotCatalog> {
     let mut names = Vec::new();
     collect_table_names(query, &mut names);
@@ -2358,10 +2367,13 @@ async fn build_snapshot(
         tenant: tenant
             .filter(|t| !t.is_empty())
             .map(TenantContext::for_tenant_id),
-        // EXPLAIN/ANALYZE path — no client subject threaded here (follow-on);
-        // `None` ⇒ no ABAC enforcement on this path.
+        // TD-ABAC-10c: the EXPLAIN/ANALYZE snapshot carries the SAME client
+        // subject execution does. This previously hardcoded `None`, so an
+        // EXPLAIN disclosed row estimates — and EXPLAIN ANALYZE, which really
+        // executes the query, returned actual rows — for data the subject
+        // cannot read.
         #[cfg(feature = "abac-policy")]
-        subject: None,
+        subject,
     })
 }
 
@@ -2382,8 +2394,17 @@ pub async fn explain_select_route_with_catalog(
     sql: &str,
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Result<SelectRouteExplanation, String> {
-    route_and_plan_select(sql, dml, false, tenant).await
+    route_and_plan_select(
+        sql,
+        dml,
+        false,
+        tenant,
+        #[cfg(feature = "abac-policy")]
+        subject,
+    )
+    .await
 }
 
 /// Catalog-aware `EXPLAIN ANALYZE SELECT`: like [`explain_select_route_with_catalog`]
@@ -2394,8 +2415,17 @@ pub async fn explain_analyze_select_with_catalog(
     sql: &str,
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Result<SelectRouteExplanation, String> {
-    route_and_plan_select(sql, dml, true, tenant).await
+    route_and_plan_select(
+        sql,
+        dml,
+        true,
+        tenant,
+        #[cfg(feature = "abac-policy")]
+        subject,
+    )
+    .await
 }
 
 /// Shared core for catalog-aware `EXPLAIN [ANALYZE] SELECT`. Routes the query, then for
@@ -2408,6 +2438,7 @@ async fn route_and_plan_select(
     dml: &Arc<DmlService>,
     analyze: bool,
     tenant: Option<&str>,
+    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Result<SelectRouteExplanation, String> {
     let statements =
         Parser::parse_sql(&GenericDialect {}, sql).map_err(|e| format!("parse: {e}"))?;
@@ -2521,7 +2552,16 @@ async fn route_and_plan_select(
             crate::query::table_write_plan::ComputeBackend::Native
         )
     {
-        match prepare_select_plan(sql, query, dml, tenant).await {
+        match prepare_select_plan(
+            sql,
+            query,
+            dml,
+            tenant,
+            #[cfg(feature = "abac-policy")]
+            subject.clone(),
+        )
+        .await
+        {
             Some((snapshot, physical)) => {
                 let base_lines = explain_physical(&physical);
                 if analyze {
@@ -2565,7 +2605,14 @@ async fn route_and_plan_select(
                 // reason (ADR-064 / TD-TRACE-1) — the same decline the legacy path
                 // otherwise re-guesses from SQL text. A re-lower here is cheap and
                 // EXPLAIN is a cold, diagnostic path (never the hot query path).
-                if let Some(snapshot) = build_snapshot(query, dml, tenant).await
+                if let Some(snapshot) = build_snapshot(
+                    query,
+                    dml,
+                    tenant,
+                    #[cfg(feature = "abac-policy")]
+                    subject.clone(),
+                )
+                .await
                     && let Err(e) = lower_sql(sql, &snapshot)
                 {
                     explanation.lowering.declines.push(e.decline());

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1049,6 +1049,19 @@ impl DmlService {
         self
     }
 
+    /// TD-ABAC-10c: whether row-level enforcement is armed on this service.
+    ///
+    /// Read-paths that CANNOT enforce (they lack the row-filter wiring
+    /// [`Self::abac_row_filter`] feeds) use this to fail closed rather than
+    /// serve unenforced rows — see the legacy single-table SELECT fallback in
+    /// the pgwire protocol. Deliberately not "enforce here too": a second
+    /// enforcement implementation for the same rows is the drift seam ADR-087
+    /// exists to remove.
+    #[cfg(feature = "abac-policy")]
+    pub fn has_abac_enforcer(&self) -> bool {
+        self.abac_enforcer.is_some()
+    }
+
     /// Execute a DML statement (single-tenant / unscoped).
     pub async fn execute(&self, statement: DmlStatement) -> Result<DmlResult> {
         self.execute_scoped(statement, None).await

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -688,8 +688,12 @@ impl VectorOperationsService {
         ))
     }
 
-    /// Resolve the REST records-search read context for `(subject,
-    /// tenant_stable_id)`. Returns:
+    /// **The ONE read-context composition rule** (ADR-087): resolve
+    /// `(subject, tenant_stable_id)` into the read context every client-serving
+    /// vector read must carry. Every surface calls THIS — never a copy — so the
+    /// enforcement truth table has exactly one reviewable definition.
+    ///
+    /// Returns:
     /// - `Some(ReadContext::Client(ctx))` — admitted; the caller ANDs the
     ///   subject's security filter into the search (pushdown) / post-filters.
     /// - `Some(ReadContext::System(_))` — no enforcer wired, or no client
@@ -698,8 +702,14 @@ impl VectorOperationsService {
     /// - `None` — the subject was **denied**; the caller MUST fail closed
     ///   (return empty results). Mirrors the fusion contract
     ///   (`fusion_service.rs:529-554`).
+    ///
+    /// NOTE (TD-ABAC-11): the `(Some(subject), None)` cell — an authenticated
+    /// subject whose tenant carries no stable id — is passthrough TODAY and
+    /// flips to DENY once the default-tenant mint makes the id total. Because
+    /// this is the single definition, that flip is a one-line change here
+    /// rather than a per-surface sweep.
     #[cfg(feature = "abac-policy")]
-    async fn records_read_context(
+    pub async fn records_read_context(
         &self,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -357,3 +357,77 @@ async fn v1_none_subject_is_passthrough() {
         "a None subject must see both records on the v1 path (passthrough); got {ids:?}"
     );
 }
+
+// ── The ONE composition rule (ADR-087 / TD-ABAC-10c) ────────────────────────
+//
+// `records_read_context` is the single definition of "what does this
+// (subject, tenant_stable_id) get to read" — the REST/v1 seam AND the pgwire
+// pgvector path both resolve through it, so its truth table is pinned here
+// rather than re-asserted per surface. A surface that stops calling it is a
+// bypass by construction.
+
+/// Admitted subject ⇒ a CLIENT context (the security predicate is applied).
+#[tokio::test]
+async fn composition_rule_admits_a_bound_subject_as_client() {
+    let (svc, _collections) = fixture().await;
+
+    let context = svc
+        .records_read_context(Some("alice"), Some(TENANT), COLLECTION)
+        .await;
+
+    assert!(
+        matches!(context, Some(proximadb_abac::ReadContext::Client(_))),
+        "alice (dept=eng) must resolve to a Client context; got {context:?}"
+    );
+}
+
+/// Denied subject ⇒ `None`. THIS is the cell every caller must fail closed on:
+/// the REST seam returns empty results, and pgwire's pgvector path now emits an
+/// empty result set instead of the rows it used to serve unfiltered.
+#[tokio::test]
+async fn composition_rule_denies_an_unbound_subject_so_callers_fail_closed() {
+    let (svc, _collections) = fixture().await;
+
+    let context = svc
+        .records_read_context(Some("mallory"), Some(TENANT), COLLECTION)
+        .await;
+
+    assert!(
+        context.is_none(),
+        "an unbound subject must DENY (None) so every caller fails closed; got {context:?}"
+    );
+}
+
+/// No subject ⇒ System passthrough (internal/unauthenticated callers).
+#[tokio::test]
+async fn composition_rule_passes_through_when_there_is_no_client_subject() {
+    let (svc, _collections) = fixture().await;
+
+    let context = svc.records_read_context(None, None, COLLECTION).await;
+
+    assert!(
+        matches!(context, Some(proximadb_abac::ReadContext::System(_))),
+        "no subject ⇒ System passthrough; got {context:?}"
+    );
+}
+
+/// ⚠ TD-ABAC-11 KNOWN-OPEN CELL, pinned deliberately.
+///
+/// A subject WITH no `tenant_stable_id` (unminted tenant, or a surface with no
+/// resolver wired) is passthrough TODAY — enforcement strength currently equals
+/// mint coverage. ADR-087 flips this to DENY once the default-tenant mint makes
+/// the stable id total; when it does, THIS TEST MUST FLIP with it. It exists so
+/// that change is a conscious edit rather than a silent behavioral drift.
+#[tokio::test]
+async fn composition_rule_still_passes_through_a_subject_without_a_stable_id() {
+    let (svc, _collections) = fixture().await;
+
+    let context = svc
+        .records_read_context(Some("alice"), None, COLLECTION)
+        .await;
+
+    assert!(
+        matches!(context, Some(proximadb_abac::ReadContext::System(_))),
+        "TD-ABAC-11: absent stable id is passthrough until the mint lands; got {context:?}"
+    );
+}


### PR DESCRIPTION
## Summary

A live-path survey of pgwire (recorded in TD-ABAC-10) found **three read paths that served rows with no row-level enforcement at all**. This closes all three. The fixes differ because the paths differ — the reasoning is the point:

**1. pgvector search — was a total bypass.** `execute_vector_search` passed a hardcoded `ReadContext::system(Statistics, "pgwire [CLIENT-PLACEHOLDER]")`, so *every* pgwire vector search ran unenforced regardless of policy. It now resolves the CLIENT context from the session identity through the **one composition rule** (`records_read_context`) and emits an empty result set — fail-closed — when that rule denies.

**2. Legacy single-table SELECT — now fails closed, deliberately not enforced in place.** This fallback has its own scan machinery with no row-filter wiring. Enforcing there would mean a *second implementation of the same rule*, which is exactly the drift seam ADR-087 exists to remove — and two copies of a security rule drift silently. So under an armed enforcer + a governed subject it now **refuses with an actionable error** instead of serving unenforced rows. The real fix is coverage: those shapes should be lowered by the enforcing relational pipeline (the ANSI-SQL-over-pgwire direction anyway), after which the guard is deleted with the fallback. Tracked as a follow-on in the TD.

**3. EXPLAIN/ANALYZE — worse than it looked.** `build_snapshot` hardcoded `subject: None`. Since `EXPLAIN ANALYZE` *executes* the query, this returned **actual rows** the subject could not read, not merely plan estimates. The subject is now threaded through the whole explain chain.

### Structural supporting changes

- `records_read_context` is promoted to the documented **canonical composition rule** — one definition, now called by both the records/v1 seam and pgwire. A surface that stops calling it is a bypass by construction.
- `session_subject()` is the **single** pgwire subject source, so a new read path cannot become a bypass by forgetting to derive one.
- `DmlService::has_abac_enforcer()` lets a reader that *cannot* enforce fail closed instead of pretending.

## Tests

+4 truth-table cases pinning the shared rule (16/16 green in the suite):
- admitted subject ⇒ Client context
- **denied subject ⇒ `None`** — the cell every caller must fail closed on (REST returns empty; pgwire now returns an empty result set instead of unfiltered rows)
- no subject ⇒ System passthrough
- **subject with no `tenant_stable_id` ⇒ passthrough** — the TD-ABAC-11 *known-open* cell, pinned on purpose so the future fail-closed flip must consciously update a failing test rather than drift silently

Surface-level pgwire e2e (a real psql session against a provisioned policy) remains gated on the binding-provisioning fixture in TD-ABAC-11 — noted honestly there rather than approximated here.

## Verification

- 16/16 ABAC integration tests ✅
- `cargo clippy -p proximadb --lib --features abac-policy -- -D warnings` ✅ · default-config clippy ✅
- `cargo fmt --check` ✅ · `make work-commit-check` ✅ · `td-adr-unique` (87 ADRs / 329 TDs) ✅

## Remaining (ADR-087 sequence)

TD-ABAC-10b (carry the full identity through the relational path so `tenant_stable_id` reaches its enforcement point) → TD-ABAC-11 (default-tenant mint → fail-closed flip → cross-surface e2e ratchet). Totality before strictness.