### PR TITLE
refactor(decomp): extract cdc coordinator → proximadb-cdc (TD-DECOMP-13, completes cdc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7078,6 +7078,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "futures",
  "proximadb-config",
  "rand 0.8.6",
  "regex",

--- a/crates/integrations/proximadb-cdc/Cargo.toml
+++ b/crates/integrations/proximadb-cdc/Cargo.toml
@@ -28,6 +28,7 @@ serde_json.workspace = true
 tokio.workspace = true
 proximadb-config.workspace = true
 anyhow.workspace = true
+futures.workspace = true
 base64 = "0.22"
 # sinks: async-trait (CdcSink trait), tracing (logging), reqwest (webhook HTTP).
 async-trait.workspace = true

--- a/crates/integrations/proximadb-cdc/src/coordinator.rs
+++ b/crates/integrations/proximadb-cdc/src/coordinator.rs
@@ -344,9 +344,9 @@ impl CdcCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cdc::config::OffsetStorageConfig;
-    use crate::cdc::event::{ConnectorType, Operation, SourceInfo};
-    use crate::cdc::source::MockSource;
+    use crate::config::OffsetStorageConfig;
+    use crate::event::{ConnectorType, Operation, SourceInfo};
+    use crate::source::MockSource;
 
     fn test_config() -> CdcConfig {
         CdcConfig {

--- a/crates/integrations/proximadb-cdc/src/lib.rs
+++ b/crates/integrations/proximadb-cdc/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod config;
 pub mod connectors;
+pub mod coordinator;
 pub mod error;
 pub mod event;
 pub mod metrics;

--- a/docs/10-quality/td/TD-DECOMP-13-extract-cdc-coordinator.adoc
+++ b/docs/10-quality/td/TD-DECOMP-13-extract-cdc-coordinator.adoc
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-13: Extract cdc coordinator → proximadb-cdc (completes cdc module)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export
+| Component | `crates/integrations/proximadb-cdc` (`coordinator`); root `src/cdc/mod.rs`
+| Relates to | [[TD-DECOMP-1]] (recipe); [[TD-DECOMP-7..12]] (cdc crate prior slices)
+|===
+
+== Why
+
+`coordinator` (the CDC hub, **11 tests**) is the LAST cdc module to extract. It references
+`crate::cdc::{config,event,source}` (all now in the cdc crate). This slice **completes the cdc
+module extraction** — after this, `src/cdc/` is an empty shell of re-export shims, and the
+entire CDC subsystem (303 tests) lives in `proximadb-cdc`.
+
+== What moved (behavior-neutral)
+
+* `src/cdc/coordinator.rs` (585 LOC, 11 tests) → `crates/integrations/proximadb-cdc/src/coordinator.rs`.
+* Rewrite: `crate::cdc::{config,event,source}` → `crate::{config,event,source}`.
+* cdc crate: + `futures` dep (workspace). cdc crate 292→303 tests.
+* Root `src/cdc/mod.rs`: `pub mod coordinator;` → `pub use proximadb_cdc::coordinator;`.
+
+== Verification
+
+* `cargo check -p proximadb-cdc` green; `nextest` — 303 tests pass.
+* `cargo check -p proximadb` + `check_workspace_boundaries` + `check-layering` + server
+build + cdc-clippy + fmt + work-commit-check green.
+
+== Milestone
+
+* **Running total once merged: ~428 tests out of root lib binary** (417 + 11).
+* **The entire cdc module is now fully extracted** from the root monolith (303 tests across
+  event, transform, error, metrics, sinks, outbound, config, offset, source, connectors,
+  coordinator — all in `proximadb-cdc`, integration tier).

--- a/src/cdc/mod.rs
+++ b/src/cdc/mod.rs
@@ -110,7 +110,8 @@
 pub use proximadb_cdc::config;
 // `connectors` now lives in `proximadb-cdc` (TD-DECOMP-12); re-exported.
 pub use proximadb_cdc::connectors;
-pub mod coordinator;
+// `coordinator` now lives in `proximadb-cdc` (TD-DECOMP-13); re-exported.
+pub use proximadb_cdc::coordinator;
 // `error` now lives in `proximadb-cdc` (TD-DECOMP-8); re-exported so `crate::cdc::error::*`
 // paths resolve unchanged.
 pub use proximadb_cdc::error;


### PR DESCRIPTION
COMPLETES the cdc module extraction. coordinator (11 tests, the hub) → cdc crate (292→303). crate::cdc::{config,event,source}→crate::{config,event,source}. +dep futures. All 11 cdc subsystems (303 tests) now in proximadb-cdc. src/cdc/ is an empty shell of re-export shims. All verify green. Running total once merged: ~428 tests out of root (4.5% of 9,538).