### PR TITLE
feat(abac): make tenant stable IDs total and fail closed (TD-ABAC-11)

### DIFF
--- a/crates/control/proximadb-catalog/src/manager.rs
+++ b/crates/control/proximadb-catalog/src/manager.rs
@@ -615,6 +615,10 @@ impl CatalogManager {
     /// deny (safe; the next request retries). Also `None` when no default
     /// catalog is configured or the account is unminted.
     pub fn account_id_u32_lookup(&self, account: &str) -> Option<u32> {
+        let account = account.trim();
+        if account.is_empty() {
+            return None;
+        }
         let name = self
             .default_catalog
             .try_read()
@@ -622,6 +626,27 @@ impl CatalogManager {
             .and_then(|n| n.as_ref().cloned())?;
         let catalogs = self.catalogs.try_read().ok()?;
         catalogs.get(&name)?.account_id_u32_lookup(account)
+    }
+
+    /// Mint-or-return a tenant's stable policy key in the default catalog.
+    ///
+    /// This is deliberately async and control-plane-only: request hot paths use
+    /// [`Self::account_id_u32_lookup`], while bootstrap and ABAC provisioning
+    /// call this method before publishing state keyed by the id. NativeCatalog
+    /// persists its account registry sidecar; SystemCatalog commits the mapping
+    /// to its canonical WAL/snapshot. Other catalog kinds return `None` and the
+    /// caller must fail closed.
+    pub async fn ensure_tenant_stable_id(&self, tenant: &str) -> Result<Option<u64>> {
+        let tenant = tenant.trim();
+        if tenant.is_empty() {
+            return Ok(None);
+        }
+        Ok(self
+            .default_catalog()
+            .await?
+            .account_id_u32(tenant)
+            .await?
+            .map(u64::from))
     }
 
     /// Set the default catalog

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -46,7 +46,7 @@ use dashmap::DashMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
@@ -54,7 +54,7 @@ use async_trait::async_trait;
 use proximadb_storage_filesystem_types::{FileOptions, FileSystem, FilesystemError};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, info, warn};
 
 use crate::cache::CatalogCache;
@@ -147,7 +147,11 @@ pub struct NativeCatalog {
     /// Phase 4b makes it durable (for path stability); in 4a it only keys
     /// in-memory minting.
     account_registry: DashMap<String, u32>,
-    account_floor: AtomicU32,
+    /// Serializes mint + sidecar persistence. Without this, concurrent mints
+    /// can publish whole-map snapshots out of order and lose the later tenant.
+    account_registry_write_lock: Mutex<()>,
+    /// u64 lets the allocator report u32 exhaustion instead of wrapping.
+    account_floor: AtomicU64,
     /// ADR-031 Phase 4a: transient namespace-key → u16 map, so every collection
     /// in the same namespace gets the SAME `stable_namespace_id` (per-account,
     /// compact). Keyed by the namespace levels joined (`a.b`). Rebuilt from
@@ -262,25 +266,43 @@ impl NativeCatalog {
     /// registry-derived value, numeric in-memory). Returns `None` for an
     /// empty/absent account string (legacy/anonymous namespaces get no typed
     /// identity — mixed-read-safe).
-    async fn account_u32(&self, account_str: &str) -> Option<u32> {
+    async fn ensure_account_u32(&self, account_str: &str) -> Result<Option<u32>> {
+        let account_str = account_str.trim();
         if account_str.is_empty() {
-            return None;
+            return Ok(None);
         }
+
+        // Existing values are checked under the same lock as first mint. A
+        // concurrent waiter must not observe success until the first caller's
+        // durable sidecar write has completed.
+        let _guard = self.account_registry_write_lock.lock().await;
         if let Some(entry) = self.account_registry.get(account_str) {
-            return Some(*entry.value());
+            return Ok(Some(*entry.value()));
         }
-        let next = self
-            .account_floor
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.account_registry.insert(account_str.to_string(), next);
-        // ADR-031 Phase 4b: persist the new account-string→u32 mapping so the
-        // typed object-store path is stable across restarts (best-effort,
-        // mirrors `object_name_index`). The lookup path above is read-only → no
-        // save; only the mint branch writes.
-        if let Err(e) = self.save_account_registry().await {
-            warn!("account-registry persist failed (continuing in-memory): {e}");
+        let next = self.account_floor.fetch_add(1, Ordering::SeqCst);
+        let stable_id = u32::try_from(next)
+            .map_err(|_| anyhow!("tenant stable-id space exhausted at {next}"))?;
+        self.account_registry
+            .insert(account_str.to_string(), stable_id);
+
+        // Persist before reporting success. Roll the in-memory entry back on a
+        // write failure so a later retry cannot mistake an uncommitted id for a
+        // durable policy key. The consumed numeric id may remain skipped.
+        if let Err(error) = self.save_account_registry().await {
+            self.account_registry.remove(account_str);
+            return Err(error);
         }
-        Some(next)
+        Ok(Some(stable_id))
+    }
+
+    async fn account_u32(&self, account_str: &str) -> Option<u32> {
+        match self.ensure_account_u32(account_str).await {
+            Ok(account) => account,
+            Err(error) => {
+                warn!("account-registry persist failed; stable identity not minted: {error}");
+                None
+            }
+        }
     }
 
     /// ADR-031 Phase 4a: mint the per-scope typed identity (`stable_namespace_id`
@@ -424,7 +446,8 @@ impl NativeCatalog {
             oid_paths: std::sync::atomic::AtomicBool::new(Self::object_id_paths_enabled()),
             stable_ids: crate::id_allocator::CatalogIdService::new(),
             account_registry: DashMap::new(),
-            account_floor: AtomicU32::new(1),
+            account_registry_write_lock: Mutex::new(()),
+            account_floor: AtomicU64::new(1),
             namespace_registry: DashMap::new(),
             namespace_floor: AtomicU32::new(1),
         };
@@ -648,7 +671,7 @@ impl NativeCatalog {
         // Raise the floor above the max persisted u32 so the next mint is new.
         if let Some(max) = file.entries.iter().map(|(_, u)| *u).max() {
             self.account_floor
-                .fetch_max(max + 1, std::sync::atomic::Ordering::Relaxed);
+                .fetch_max(u64::from(max) + 1, Ordering::SeqCst);
         }
         debug!("Loaded {} account-registry entries", file.entries.len());
         Ok(())
@@ -1394,12 +1417,13 @@ impl Catalog for NativeCatalog {
     async fn account_id_u32(&self, account: &str) -> Result<Option<u32>> {
         // Thin public wrapper over the private registry lookup-or-mint. The
         // root path-resolver calls this to compose a `CollectionIdentity`.
-        Ok(self.account_u32(account).await)
+        self.ensure_account_u32(account).await
     }
 
     fn account_id_u32_lookup(&self, account: &str) -> Option<u32> {
         // TD-TENANT-1 item 3: sync read-only lookup (no mint, no persist) for the
         // request-hot TenantStableIdResolver. None when unminted/empty.
+        let account = account.trim();
         if account.is_empty() {
             return None;
         }
@@ -2080,6 +2104,14 @@ mod tests {
         // And namespace siblings share the namespace id (covered above) because
         // they share the account u32.
         assert_eq!(a.stable_namespace_id, Some(1));
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_account_mint_returns_one_id() {
+        let (cat, _d) = catalog_in_tempdir().await;
+        let (left, right) = tokio::join!(cat.account_u32("acct"), cat.account_u32("acct"));
+        assert_eq!(left, right, "one account string must never receive two ids");
+        assert_eq!(cat.account_id_u32_lookup("acct"), left);
     }
 
     #[tokio::test]

--- a/crates/foundation/proximadb-tenant/src/identity_trust.rs
+++ b/crates/foundation/proximadb-tenant/src/identity_trust.rs
@@ -273,8 +273,8 @@ pub struct ResolvedRequestIdentity {
     /// stamped ONCE at identity resolution by the wired
     /// [`TenantStableIdResolver`] — never re-derived downstream. `None` = no
     /// resolver wired or the tenant is unminted; the enforcement seam treats
-    /// that cell per the composition rule (passthrough today; fail-closed once
-    /// the default-tenant mint lands, TD-ABAC-11).
+    /// that cell fail-closed (TD-ABAC-11). Catalog bootstrap/provisioning makes
+    /// the id total on supported production catalog backends.
     pub tenant_stable_id: Option<u64>,
 }
 

--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -1,5 +1,5 @@
 = TD-ABAC-11: Default-tenant mint + flip the seam composition rule to fail-closed on absent stable id
-:status: Open
+:status: In Progress
 :dim: D5
 :pillar: SEC
 
@@ -26,6 +26,26 @@ Next action (strict ordering — totality before strictness):
 
 Do NOT flip before the mint lands — it would fail-close every unminted
 dev/embedded deployment that wires an enforcer.
+
+== Implementation status (2026-08-03)
+
+* **DONE — stable-id totality on production catalog backends.** The normal
+  WAL-backed `SystemCatalog` now commits account/tenant mappings through its
+  canonical WAL and snapshot, recovers the allocator floor, and serializes
+  concurrent first mint. `NativeCatalog` serializes its existing durable
+  registry mint. `SharedServices` mints `default` before serving requests.
+* **DONE — provisioning mint.** ABAC policy and attribute writes mint-or-resolve
+  the path/body tenant string through the catalog before persisting a binding;
+  no dummy table is required. Read/delete paths remain lookup-only.
+* **DONE — vector/record seam strictness.** Enforcer + subject + absent stable id
+  now denies for search and point-get, with the full
+  `enforcer x subject x stable-id x auth-class` truth table pinned in a pure
+  unit test. `AuthClass` is audit provenance and intentionally does not weaken
+  the deny rule.
+* **OPEN — relational seam + cross-surface ratchet.** TD-ABAC-10 10b must carry
+  the stable id through `scan_table_relational`; only then can the relational
+  composition point flip and REST/gRPC/Flight/pgwire provisioned-policy e2e be
+  a truthful release gate.
 
 Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
 [[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).

--- a/docs/10-quality/td/TD-TENANT-1-header-trust-policy.adoc
+++ b/docs/10-quality/td/TD-TENANT-1-header-trust-policy.adoc
@@ -73,17 +73,16 @@ silently running `open`. Unset ⇒ config value; default-safe, no flag-day.
    `database.rs` via `HeaderTrustPolicy::effective` (env > config > mode
    preset; unparseable env tightens to `authenticated-only`) and threaded
    through `MultiServer::with_tenant_header_trust` into every surface.
-3. **[PARTIAL] Stable-id resolution at the boundary (ADR-031).** The port
+3. **[DONE] Stable-id resolution at the boundary (ADR-031/ADR-087).** The port
    (`proximadb_tenant::TenantStableIdResolver`) + carry
    (`MiddlewareTenantContext::tenant_stable_id`, stamped when a resolver is
    wired via `TenantExtractor::with_stable_id_resolver`) shipped. REMAINING:
-   catalog-side tenant stable-id minting (a tenant-type `IdAllocator` space +
-   durable id on the tenant entity) — no tenant→u64 mapping exists in the
-   catalog yet, so no production resolver is wired. The string `tenant_id`
-   stays authoritative; the stable id is an optimization, never a second
-   source of truth. PR #956 already routes /documents auto-create through
-   `create_table → mint_stable_identity`; audit remaining DDL paths for bare
-   catalog writes when minting lands.
+   production resolver and both production mint authorities are wired. The
+   WAL-backed `SystemCatalog` persists the mapping as a canonical catalog delta
+   and snapshot state; `NativeCatalog` persists its account-registry sidecar.
+   Bootstrap mints `default`, and ABAC provisioning mints any new tenant before
+   its first policy write. The string `tenant_id` stays authoritative; the
+   stable id is a derived policy/path key, never a second source of truth.
 4. **[DONE] Gateway principal marker.** First-class
    `UnifiedUserContext::is_gateway_principal()` (a `gateway`/`operator` role
    or `gateway: "true"` metadata, stamped from credential data). The REST
@@ -92,8 +91,6 @@ silently running `open`. Unset ⇒ config value; default-safe, no flag-day.
 
 == Follow-ups (still open)
 
-* Catalog-side tenant stable-id minting + a production
-  `TenantStableIdResolver` (see item 3 above).
 * Credential-side stamping of the gateway role beyond JWTs (API-key config
   schema carries no roles today; SSO/mTLS untouched).
 * pgwire authenticated bindings: the surface still runs trust auth, so

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -2362,16 +2362,25 @@ impl PostgresProtocol {
         // DENIED ⇒ fail closed: emit an empty result set, never rows.
         #[cfg(feature = "abac-policy")]
         let read_context = {
-            let (subject, tenant_stable_id) = {
+            let (subject, tenant_stable_id, auth_class) = {
                 let session = self.session.read().await;
                 match session.identity.as_ref() {
-                    Some(identity) => (identity.subject.clone(), identity.tenant_stable_id),
-                    None => (None, None),
+                    Some(identity) => (
+                        identity.subject.clone(),
+                        identity.tenant_stable_id,
+                        identity.auth_class,
+                    ),
+                    None => (None, None, proximadb_tenant::AuthClass::Anonymous),
                 }
             };
             match self
                 .vector_ops
-                .records_read_context(subject.as_deref(), tenant_stable_id, &table_name)
+                .records_read_context(
+                    subject.as_deref(),
+                    tenant_stable_id,
+                    auth_class,
+                    &table_name,
+                )
                 .await
             {
                 Some(context) => context,

--- a/src/network/rest/canonical/abac_admin.rs
+++ b/src/network/rest/canonical/abac_admin.rs
@@ -23,10 +23,10 @@
 //! * **Resolve-at-write, never a raw u64.** The path carries a tenant *string*;
 //!   the handler resolves it server-side via
 //!   [`CatalogTenantStableIdResolver`](crate::security::CatalogTenantStableIdResolver).
-//!   An unminted tenant is rejected with **422** (provisioning never mints a u32
-//!   — it stays a pure policy op). This is the consistency guarantee: the request
-//!   path and this admin both derive the u64 from the ONE `account_registry`, so
-//!   they cannot drift.
+//!   Provisioning mints-or-resolves the tenant through the catalog before the
+//!   policy write. This is the consistency guarantee: the request path and this
+//!   admin both derive the u64 from the ONE durable catalog registry, so they
+//!   cannot drift and a tenant does not need a dummy table before policy setup.
 //! * **Fail-closed by construction.** ABAC is deny-by-default; provisioning only
 //!   *adds* permits. An unprovisioned tenant stays denied; a dangling
 //!   `predicate_ref` resolves to the unsatisfiable deny (safe), so it is accepted.
@@ -148,6 +148,28 @@ pub enum ProvisionError {
         /// The tenant string the operator supplied.
         tenant: String,
     },
+    /// The authoritative catalog could not durably mint the mapping. Maps to
+    /// 503; no policy state is written with an unstable key.
+    TenantMintFailed { tenant: String, message: String },
+}
+
+/// Ensure the tenant has a durable stable id before a policy mutation. The
+/// subsequent sync resolve in the provisioning core intentionally re-reads the
+/// same authority, catching any wiring mismatch before the store write.
+async fn ensure_tenant(
+    resolver: &CatalogTenantStableIdResolver,
+    tenant: &str,
+) -> Result<u64, ProvisionError> {
+    resolver
+        .ensure_stable_id(tenant)
+        .await
+        .map_err(|error| ProvisionError::TenantMintFailed {
+            tenant: tenant.to_string(),
+            message: error.to_string(),
+        })?
+        .ok_or_else(|| ProvisionError::TenantUnresolved {
+            tenant: tenant.to_string(),
+        })
 }
 
 /// Resolve a tenant string to its stable u64 via `resolver`, or fail closed.
@@ -169,10 +191,20 @@ fn map_provision_err(e: ProvisionError) -> (StatusCode, Json<OperatorErrorRespon
             Json(OperatorErrorResponse {
                 error: "tenant_unresolved",
                 message: format!(
-                    "tenant '{tenant}' has no stable id; create a table under the tenant first \
-                     so the catalog mints its account id"
+                    "tenant '{tenant}' has no stable id and the configured catalog did not mint \
+                     one; use the native or system catalog authority"
                 ),
                 code: 422,
+            }),
+        ),
+        ProvisionError::TenantMintFailed { tenant, message } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(OperatorErrorResponse {
+                error: "tenant_mint_failed",
+                message: format!(
+                    "tenant '{tenant}' stable id could not be durably minted: {message}"
+                ),
+                code: 503,
             }),
         ),
     }
@@ -362,6 +394,9 @@ pub async fn put_policy_binding(
     let user_id = authorize_operator(user_context.as_ref().map(|e| &e.0))?;
     let store = require_binding_store(&state)?;
     let resolver = CatalogTenantStableIdResolver::new(state.catalog_manager.clone());
+    ensure_tenant(&resolver, &tenant)
+        .await
+        .map_err(map_provision_err)?;
     let binding = provision_policy_binding(store, &resolver, &tenant, object_id, body)
         .map_err(map_provision_err)?;
     tracing::info!(
@@ -410,6 +445,9 @@ pub async fn post_attribute_binding(
     let user_id = authorize_operator(user_context.as_ref().map(|e| &e.0))?;
     let authority = require_authority(&state)?;
     let resolver = CatalogTenantStableIdResolver::new(state.catalog_manager.clone());
+    ensure_tenant(&resolver, &body.tenant)
+        .await
+        .map_err(map_provision_err)?;
     let binding = provision_attribute_binding(
         authority,
         &resolver,
@@ -685,6 +723,42 @@ mod tests {
                 tenant: "ghost".into()
             }
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn provisioning_mints_tenant_without_a_dummy_table() {
+        let dir = unique_dir("catalog-mint");
+        let manager = Arc::new(crate::catalog::CatalogManager::new());
+        manager
+            .create_native_catalog("default", &format!("file://{}", dir.display()))
+            .await
+            .expect("native catalog");
+        let resolver = CatalogTenantStableIdResolver::new(manager.clone());
+
+        let minted = ensure_tenant(&resolver, "new-tenant")
+            .await
+            .expect("policy provisioning must mint the tenant");
+        assert_eq!(resolver.stable_id_of("new-tenant"), Some(minted));
+
+        let store = Arc::new(
+            FileSystemPolicyBindingStore::open(dir.join("policy.json")).expect("policy store"),
+        );
+        let binding = provision_policy_binding(
+            &store,
+            &resolver,
+            "new-tenant",
+            9,
+            PutPolicyBindingRequest {
+                scope: Scope::Table(200),
+                effect: Effect::Permit,
+                predicate_ref: None,
+                field_mask: None,
+            },
+        )
+        .expect("resolved-at-write binding");
+        assert_eq!(binding.tenant_stable_id, minted);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -921,6 +921,27 @@ impl SharedServices {
             }
         }
 
+        // TD-ABAC-11 / ADR-087: make the policy-lookup key total before any
+        // authenticated request can reach an armed enforcer. This is an
+        // explicit bootstrap mutation, not an incidental side effect of the
+        // first table create. Both production catalog backends persist it
+        // (SystemCatalog WAL/snapshot; NativeCatalog account sidecar).
+        let default_tenant_stable_id = catalog_manager
+            .ensure_tenant_stable_id(proximadb_tenant::DEFAULT_TENANT)
+            .await
+            .context("Failed to mint the default tenant stable id at catalog bootstrap")?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "default catalog cannot mint a stable id for tenant '{}'",
+                    proximadb_tenant::DEFAULT_TENANT
+                )
+            })?;
+        info!(
+            tenant = proximadb_tenant::DEFAULT_TENANT,
+            tenant_stable_id = default_tenant_stable_id,
+            "✅ SharedServices: default tenant stable id is durable"
+        );
+
         // Phase P (Quantization Trait Convergence Plan): hoist the
         // TurboQuant store registry construction to BEFORE the
         // `collection_service` is built, so the SAME `Arc<dyn>` instance

--- a/src/query/aql/sources/memory.rs
+++ b/src/query/aql/sources/memory.rs
@@ -273,6 +273,7 @@ impl AqlSource for MemoryAqlSource {
                 None,
                 None,
                 None,
+                proximadb_tenant::AuthClass::Anonymous,
             )
             .await
             .map_err(|e| ProximaDBError::Query(QueryError::VectorSearch(e.to_string())))?;

--- a/src/query/aql/sources/vector.rs
+++ b/src/query/aql/sources/vector.rs
@@ -126,6 +126,7 @@ impl AqlSource for VectorAqlSource {
                 None, // No specific search config
                 None,
                 None,
+                proximadb_tenant::AuthClass::Anonymous,
             )
             .await
             .map_err(|e| {

--- a/src/query/execution/executor.rs
+++ b/src/query/execution/executor.rs
@@ -781,6 +781,7 @@ impl MultiModalQueryExecutor {
                     Some(search_config),
                     None,
                     None,
+                    proximadb_tenant::AuthClass::Anonymous,
                 )
                 .await?
             } else {

--- a/src/security/tenant_stable_id.rs
+++ b/src/security/tenant_stable_id.rs
@@ -31,6 +31,15 @@ impl CatalogTenantStableIdResolver {
     pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
         Self { catalog_manager }
     }
+
+    /// Control-plane mint-or-return path. Request paths remain lookup-only via
+    /// [`TenantStableIdResolver::stable_id_of`]; bootstrap and ABAC provisioning
+    /// use this before publishing any state keyed by the stable id.
+    pub async fn ensure_stable_id(&self, tenant_id: &str) -> anyhow::Result<Option<u64>> {
+        self.catalog_manager
+            .ensure_tenant_stable_id(tenant_id)
+            .await
+    }
 }
 
 impl TenantStableIdResolver for CatalogTenantStableIdResolver {

--- a/src/services/agent_memory.rs
+++ b/src/services/agent_memory.rs
@@ -565,6 +565,7 @@ impl MemoryStore for VectorMemoryStore {
                 None,
                 None,
                 None,
+                proximadb_tenant::AuthClass::Anonymous,
             )
             .await
             .map_err(|e| anyhow!("memory retrieve failed: {e}"))?;

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -606,6 +606,75 @@ fn abac_security_is_pushdown(
     abac_filter_is_conjunctive(security) && user_filter.is_none_or(abac_filter_is_conjunctive)
 }
 
+/// Pure ADR-087 composition decision. `auth_class` is deliberately an input
+/// even though it does not change authorization today: authenticated and
+/// trust-asserted subjects are equally deny-biased, while provenance remains
+/// available for audit. Keeping this pure pins the complete
+/// enforcer x subject x stable-id x auth-class truth table.
+#[cfg(feature = "abac-policy")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordsReadComposition {
+    Passthrough,
+    ResolvePolicy,
+    DenyMissingStableId,
+}
+
+#[cfg(feature = "abac-policy")]
+fn records_read_composition(
+    enforcer_wired: bool,
+    subject_present: bool,
+    stable_id_present: bool,
+    _auth_class: proximadb_tenant::AuthClass,
+) -> RecordsReadComposition {
+    if !enforcer_wired || !subject_present {
+        RecordsReadComposition::Passthrough
+    } else if !stable_id_present {
+        RecordsReadComposition::DenyMissingStableId
+    } else {
+        RecordsReadComposition::ResolvePolicy
+    }
+}
+
+#[cfg(all(test, feature = "abac-policy"))]
+mod records_read_composition_tests {
+    use super::{RecordsReadComposition, records_read_composition};
+    use proximadb_tenant::AuthClass;
+
+    #[test]
+    fn full_enforcer_subject_stable_id_auth_class_truth_table() {
+        for enforcer_wired in [false, true] {
+            for subject_present in [false, true] {
+                for stable_id_present in [false, true] {
+                    for auth_class in [
+                        AuthClass::Authenticated,
+                        AuthClass::TrustAsserted,
+                        AuthClass::Anonymous,
+                    ] {
+                        let expected = if !enforcer_wired || !subject_present {
+                            RecordsReadComposition::Passthrough
+                        } else if !stable_id_present {
+                            RecordsReadComposition::DenyMissingStableId
+                        } else {
+                            RecordsReadComposition::ResolvePolicy
+                        };
+                        assert_eq!(
+                            records_read_composition(
+                                enforcer_wired,
+                                subject_present,
+                                stable_id_present,
+                                auth_class,
+                            ),
+                            expected,
+                            "enforcer={enforcer_wired} subject={subject_present} \
+                             stable_id={stable_id_present} auth_class={auth_class}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl VectorOperationsService {
     /// Create service with a shared context for cross-cutting concerns
     pub fn new_with_context(
@@ -703,21 +772,33 @@ impl VectorOperationsService {
     ///   (return empty results). Mirrors the fusion contract
     ///   (`fusion_service.rs:529-554`).
     ///
-    /// NOTE (TD-ABAC-11): the `(Some(subject), None)` cell — an authenticated
-    /// subject whose tenant carries no stable id — is passthrough TODAY and
-    /// flips to DENY once the default-tenant mint makes the id total. Because
-    /// this is the single definition, that flip is a one-line change here
-    /// rather than a per-surface sweep.
+    /// TD-ABAC-11: when an enforcer and subject are present, an absent stable id
+    /// DENIES. The policy key is required to consult the authority; inability to
+    /// consult cannot mean allow. Default-tenant bootstrap and provisioning mint
+    /// the key before this strictness rule is reached.
     #[cfg(feature = "abac-policy")]
     pub async fn records_read_context(
         &self,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
         collection_id: &str,
     ) -> Option<proximadb_abac::ReadContext> {
         use proximadb_catalog::fc_metamodel::SubjectId;
-        match (subject, tenant_stable_id) {
-            (Some(subject), Some(tenant_stable_id)) => {
+        match records_read_composition(
+            self.abac_enforcer.is_some(),
+            subject.is_some(),
+            tenant_stable_id.is_some(),
+            auth_class,
+        ) {
+            RecordsReadComposition::ResolvePolicy => {
+                let (Some(subject), Some(tenant_stable_id)) = (subject, tenant_stable_id) else {
+                    tracing::error!(
+                        target: "proximadb::tenant_audit",
+                        "ABAC composition invariant violated; denying"
+                    );
+                    return None;
+                };
                 match self
                     .resolve_vector_read_context(
                         &SubjectId(subject.to_string()),
@@ -734,9 +815,23 @@ impl VectorOperationsService {
                     )),
                 }
             }
-            _ => Some(proximadb_abac::ReadContext::system(
+            RecordsReadComposition::DenyMissingStableId => {
+                tracing::warn!(
+                    target: "proximadb::tenant_audit",
+                    subject = subject,
+                    auth_class = %auth_class,
+                    collection = collection_id,
+                    "ABAC denied a subject whose tenant has no stable policy key"
+                );
+                None
+            }
+            RecordsReadComposition::Passthrough => Some(proximadb_abac::ReadContext::system(
                 proximadb_abac::SystemReadReason::Statistics,
-                "records_search (no client subject)",
+                if self.abac_enforcer.is_none() {
+                    "records_search (no abac enforcer)"
+                } else {
+                    "records_search (no client subject)"
+                },
             )),
         }
     }
@@ -867,6 +962,7 @@ impl VectorOperationsService {
                 tenant_context,
                 identity.subject,
                 identity.tenant_stable_id,
+                identity.auth_class,
             )
             .await;
         if result.is_err() {
@@ -883,6 +979,7 @@ impl VectorOperationsService {
         tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
     ) -> Result<RichSearchResponse> {
         // Authorize before touching data, matching `search_v1_with_tenant_context`.
         let collection_id = self
@@ -910,6 +1007,7 @@ impl VectorOperationsService {
                 filter,
                 subject,
                 tenant_stable_id,
+                auth_class,
             )
             .await?;
         let Some(search_result) = response.results else {
@@ -989,6 +1087,7 @@ impl VectorOperationsService {
                 record,
                 identity.subject,
                 identity.tenant_stable_id,
+                identity.auth_class,
                 &collection_id,
             )
             .await;
@@ -1009,13 +1108,14 @@ impl VectorOperationsService {
         record: Option<RichSearchResult>,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
         collection_id: &str,
     ) -> Option<RichSearchResult> {
         use crate::core::search::sql_value_filter::proxima_value_to_json;
         use crate::security::rls::filter_lattice::admits_with_security;
 
         match self
-            .records_read_context(subject, tenant_stable_id, collection_id)
+            .records_read_context(subject, tenant_stable_id, auth_class, collection_id)
             .await
         {
             // Denied ⇒ fail-closed: the record is not returned.
@@ -1426,6 +1526,7 @@ impl VectorOperationsService {
             filter,
             identity.subject,
             identity.tenant_stable_id,
+            identity.auth_class,
         )
         .await
     }
@@ -1449,6 +1550,7 @@ impl VectorOperationsService {
         filter: Option<FilterExpression>,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
     ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         // P4 advisor observability: capture per-search latency so
         // the post-search hook can populate the recall-residual /
@@ -1478,6 +1580,7 @@ impl VectorOperationsService {
                 cfg,
                 subject,
                 tenant_stable_id,
+                auth_class,
             )
             .await?;
 
@@ -2810,6 +2913,7 @@ impl VectorOperationsService {
         config: Option<UnifiedSearchConfig>,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
     ) -> Result<Vec<crate::proto::proximadb_v1::SearchResult>> {
         let (results, _explain) = self
             .unified_search_v1_inner(
@@ -2820,6 +2924,7 @@ impl VectorOperationsService {
                 config,
                 subject,
                 tenant_stable_id,
+                auth_class,
             )
             .await?;
         Ok(results)
@@ -2839,6 +2944,7 @@ impl VectorOperationsService {
         config: Option<UnifiedSearchConfig>,
         subject: Option<&str>,
         tenant_stable_id: Option<u64>,
+        auth_class: proximadb_tenant::AuthClass,
     ) -> Result<(
         Vec<crate::proto::proximadb_v1::SearchResult>,
         Option<crate::query::explain::VectorObjectEconomyExplain>,
@@ -2852,14 +2958,14 @@ impl VectorOperationsService {
         // key can't distinguish subjects — see below. Denied ⇒ fail-closed empty.
         #[cfg(feature = "abac-policy")]
         let (filter, post_filter) = match self
-            .records_read_context(subject, tenant_stable_id, collection_id)
+            .records_read_context(subject, tenant_stable_id, auth_class, collection_id)
             .await
         {
             None => return Ok((Vec::new(), None)),
             Some(read_ctx) => self.apply_abac_vector_filter(filter, &read_ctx),
         };
         #[cfg(not(feature = "abac-policy"))]
-        let _ = (subject, tenant_stable_id);
+        let _ = (subject, tenant_stable_id, auth_class);
         #[cfg(not(feature = "abac-policy"))]
         let post_filter: Option<FilterExpression> = None;
 
@@ -3740,7 +3846,16 @@ impl VectorOperationsService {
         // For StaleOk requests and cache hits the explain is None,
         // matching the helper's documented contract.
         let (results, explain) = self
-            .unified_search_v1_inner(collection_id, query_vector, k, filter, config, None, None)
+            .unified_search_v1_inner(
+                collection_id,
+                query_vector,
+                k,
+                filter,
+                config,
+                None,
+                None,
+                proximadb_tenant::AuthClass::Anonymous,
+            )
             .await?;
         hints.vector_object_economy = explain;
         Ok((results, hints))
@@ -6362,6 +6477,7 @@ impl VectorQueryService for VectorOperationsService {
                 None, // Use default config
                 None,
                 None,
+                proximadb_tenant::AuthClass::Anonymous,
             )
             .await
             .map_err(|e| proximadb_kernel::error::QueryError::VectorSearch(e.to_string()))?;

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -102,6 +102,9 @@ pub struct SystemCatalog {
     /// provisioning splits data-plane catalogs out per account.
     role: proximadb_catalog::CatalogRole,
     state: Arc<SystemCatalogState>,
+    /// Next durable account/tenant stable id. Recovered from the WAL/snapshot
+    /// state at boot; u64 lets us detect u32 exhaustion instead of wrapping.
+    account_floor: AtomicU64,
     appender: Arc<dyn TableWalAppender>,
     /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
     /// never interleave such that a lower-LSN mutation applies after a higher
@@ -146,10 +149,12 @@ impl SystemCatalog {
         state: SystemCatalogState,
         appender: Arc<dyn TableWalAppender>,
     ) -> Self {
+        let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
+            account_floor: AtomicU64::new(account_floor),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: None,
@@ -284,10 +289,12 @@ impl SystemCatalog {
             .filter(|n| *n > 0)
             .unwrap_or(DEFAULT_SNAPSHOT_THRESHOLD);
 
+        let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Ok(Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
+            account_floor: AtomicU64::new(account_floor),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: Some(SnapshotConfig {
@@ -317,6 +324,13 @@ impl SystemCatalog {
             ));
         }
         let _guard = self.write_lock.lock().await;
+        self.commit_batch_locked(deltas).await
+    }
+
+    /// Commit with [`Self::write_lock`] already held. Account-id minting needs
+    /// to check-and-insert under the same lock so two first requests for one
+    /// tenant cannot receive different ids.
+    async fn commit_batch_locked(&self, deltas: Vec<CatalogDelta>) -> Result<()> {
         let ops = deltas
             .iter()
             .map(|d| d.to_operation())
@@ -341,6 +355,26 @@ impl SystemCatalog {
                 self.commits_since_snapshot.store(0, Ordering::SeqCst);
             }
         }
+        Ok(())
+    }
+
+    /// Retry a failed object-store publication before a control-plane caller
+    /// treats an already-visible account id as durable. `commit_batch_locked`
+    /// applies the WAL entry before publishing the required snapshot; if that
+    /// publication fails, `commits_since_snapshot` intentionally stays nonzero
+    /// and the next mint-or-return call repairs it here.
+    async fn publish_pending_snapshot_locked(&self) -> Result<()> {
+        let Some(cfg) = &self.snapshot else {
+            return Ok(());
+        };
+        if self.read_only.load(Ordering::SeqCst)
+            || !cfg.store.requires_snapshot_on_commit()
+            || self.commits_since_snapshot.load(Ordering::SeqCst) == 0
+        {
+            return Ok(());
+        }
+        self.checkpoint_locked(cfg).await?;
+        self.commits_since_snapshot.store(0, Ordering::SeqCst);
         Ok(())
     }
 
@@ -485,6 +519,14 @@ impl SystemCatalog {
                     cfg.store.describe()
                 )
             })?;
+        // The snapshot may contain account ids minted by another pod after
+        // this instance booted. Keep the local allocator strictly above every
+        // adopted id even when the reload is same-generation (and therefore
+        // does not force this instance read-only).
+        if let Some(max) = self.state.max_account_id() {
+            self.account_floor
+                .fetch_max(u64::from(max) + 1, Ordering::SeqCst);
+        }
         self.loaded_version.store(read.version, Ordering::SeqCst);
         self.loaded_generation
             .store(read.generation, Ordering::SeqCst);
@@ -677,6 +719,76 @@ impl Catalog for SystemCatalog {
         self.state
             .get_namespace(namespace)
             .ok_or_else(|| anyhow!("Namespace '{}' not found", namespace.join(".")))
+    }
+
+    /// Mint-or-return the durable tenant/account stable id through the same
+    /// canonical WAL as every other SystemCatalog mutation. This is the normal
+    /// server path (SystemCatalog is the default backend), so inheriting the
+    /// trait's `None` implementation would leave ABAC silently unkeyed.
+    async fn account_id_u32(&self, account: &str) -> Result<Option<u32>> {
+        let account = account.trim();
+        if account.is_empty() {
+            return Ok(None);
+        }
+        if let Some(id) = self.state.account_id_u32(account) {
+            if self
+                .snapshot
+                .as_ref()
+                .is_some_and(|cfg| cfg.store.requires_snapshot_on_commit())
+                && self.commits_since_snapshot.load(Ordering::SeqCst) > 0
+                && !self.read_only.load(Ordering::SeqCst)
+            {
+                let _guard = self.write_lock.lock().await;
+                self.publish_pending_snapshot_locked().await?;
+                // A fencing reload can replace the state while repairing the
+                // publication, so never return the pre-lock value blindly.
+                return Ok(self.state.account_id_u32(account));
+            }
+            return Ok(Some(id));
+        }
+        if self.read_only.load(Ordering::SeqCst) {
+            return Err(anyhow!(
+                "tenant '{account}' has no stable id and system catalog '{}' is read-only; \
+                 mint it on the owning pod",
+                self.name
+            ));
+        }
+
+        // Check + allocate + durable append are one writer critical section.
+        // Without the second check, concurrent first requests could return two
+        // different policy keys for the same tenant.
+        let _guard = self.write_lock.lock().await;
+        if let Some(id) = self.state.account_id_u32(account) {
+            self.publish_pending_snapshot_locked().await?;
+            if self.read_only.load(Ordering::SeqCst) {
+                return Ok(self.state.account_id_u32(account));
+            }
+            return Ok(Some(id));
+        }
+        if self.read_only.load(Ordering::SeqCst) {
+            return Err(anyhow!(
+                "tenant '{account}' has no stable id and system catalog '{}' became read-only; \
+                 mint it on the owning pod",
+                self.name
+            ));
+        }
+        let next = self.account_floor.fetch_add(1, Ordering::SeqCst);
+        let stable_id = u32::try_from(next)
+            .map_err(|_| anyhow!("tenant stable-id space exhausted at {next}"))?;
+        self.commit_batch_locked(vec![CatalogDelta::UpsertAccount {
+            account: account.to_string(),
+            stable_id,
+        }])
+        .await?;
+        Ok(Some(stable_id))
+    }
+
+    fn account_id_u32_lookup(&self, account: &str) -> Option<u32> {
+        let account = account.trim();
+        if account.is_empty() {
+            return None;
+        }
+        self.state.account_id_u32(account)
     }
 
     async fn update_namespace_properties(
@@ -957,6 +1069,45 @@ mod tests {
             .with_column(CatalogColumn::new(1, "id", ProximaType::Int64).nullable(false))
             .with_column(CatalogColumn::new(2, "body", ProximaType::String))
             .with_primary_key(vec!["id".to_string()])
+    }
+
+    #[tokio::test]
+    async fn tenant_stable_ids_are_durable_and_allocator_floor_recovers() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let wal = dir.path().join("catalog.wal");
+
+        let cat = SystemCatalog::open("default", &wal).await?;
+        let default_id = cat
+            .account_id_u32(proximadb_tenant::DEFAULT_TENANT)
+            .await?
+            .expect("default tenant must mint");
+        assert_eq!(default_id, 1);
+        drop(cat);
+
+        let reopened = SystemCatalog::open("default", &wal).await?;
+        assert_eq!(
+            reopened.account_id_u32_lookup(proximadb_tenant::DEFAULT_TENANT),
+            Some(default_id),
+            "WAL replay must restore the policy key"
+        );
+        assert_eq!(
+            reopened.account_id_u32("acme").await?,
+            Some(2),
+            "a new tenant must mint above the replayed floor"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_mint_returns_one_id_for_one_tenant() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let cat = Arc::new(catalog(dir.path()).await);
+        let (left, right) = tokio::join!(cat.account_id_u32("acme"), cat.account_id_u32("acme"));
+        let left = left?;
+        let right = right?;
+        assert_eq!(left, right);
+        assert_eq!(cat.account_id_u32_lookup("acme"), left);
+        Ok(())
     }
 
     #[tokio::test]
@@ -1504,6 +1655,7 @@ mod tests {
         owner
             .create_namespace(&nslevels(&["s"]), HashMap::new())
             .await?;
+        assert_eq!(owner.account_id_u32("tenant-one").await?, Some(1));
         owner.create_table(&tid("t1"), vec_schema("t1")).await?;
         owner.checkpoint().await?;
 
@@ -1525,6 +1677,7 @@ mod tests {
         // Owner commits more DDL and republishes. The follower is stale until it
         // polls; a no-publish probe is cheap and a no-op.
         owner.create_table(&tid("t2"), vec_schema("t2")).await?;
+        assert_eq!(owner.account_id_u32("tenant-two").await?, Some(2));
         owner.checkpoint().await?;
 
         // Sinval: the follower observes the newer pointer version and reloads.
@@ -1536,6 +1689,12 @@ mod tests {
             other => panic!("expected a reload, got {other:?}"),
         }
         assert!(follower.table_exists(&tid("t2")).await?);
+        assert_eq!(follower.account_id_u32_lookup("tenant-two"), Some(2));
+        assert_eq!(
+            follower.account_floor.load(Ordering::SeqCst),
+            3,
+            "snapshot reload must advance the local account allocator floor"
+        );
         // Polling again with nothing new is a no-op.
         assert_eq!(follower.reload_if_stale().await?, ReloadOutcome::UpToDate);
         Ok(())

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -44,6 +44,11 @@ use proximadb_storage_common::{CanonicalOperation, CanonicalWalEntry};
 /// implement it (it absorbs storage-plane fields that are not comparable).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CatalogDelta {
+    /// Mint (or replay) the durable account/tenant string -> stable u32 used by
+    /// ADR-0083 paths and ABAC policy lookup. The mapping is append-only: callers
+    /// serialize first mint under the SystemCatalog write lock, and replay simply
+    /// restores the committed value.
+    UpsertAccount { account: String, stable_id: u32 },
     /// Create or replace a namespace. Boxed to keep the enum small (the
     /// namespace carries the account/tenant/DR authority fields).
     UpsertNamespace { namespace: Box<CatalogNamespace> },
@@ -69,6 +74,7 @@ impl CatalogDelta {
     /// the bytes.
     pub fn routing_key(&self) -> String {
         match self {
+            CatalogDelta::UpsertAccount { account, .. } => format!("account:{account}"),
             CatalogDelta::UpsertNamespace { namespace } => {
                 format!("ns:{}", namespace.levels.join("."))
             }
@@ -109,6 +115,10 @@ impl CatalogDelta {
 /// contention is a non-issue; reads take the cheap shared lock.
 #[derive(Debug, Default)]
 struct CatalogInner {
+    /// Durable account/tenant string -> stable u32 registry. This is the
+    /// SystemCatalog equivalent of NativeCatalog's account_registry and is the
+    /// single policy-lookup key authority for normal server deployments.
+    account_ids: HashMap<String, u32>,
     /// Namespaces keyed by their `levels` path.
     namespaces: HashMap<Vec<String>, CatalogNamespace>,
     /// Tables keyed by full identifier. `Arc` so reads clone a pointer, not the
@@ -127,6 +137,9 @@ struct CatalogInner {
 impl CatalogInner {
     fn apply(&mut self, delta: CatalogDelta) {
         match delta {
+            CatalogDelta::UpsertAccount { account, stable_id } => {
+                self.account_ids.insert(account, stable_id);
+            }
             CatalogDelta::UpsertNamespace { namespace } => {
                 let key = namespace.levels.clone();
                 self.ns_children.entry(key.clone()).or_default();
@@ -168,6 +181,8 @@ impl CatalogInner {
 /// derivation of `tables` and is rebuilt on load.
 #[derive(Debug, Serialize, Deserialize)]
 struct CatalogSnapshot {
+    #[serde(default)]
+    account_ids: HashMap<String, u32>,
     namespaces: HashMap<Vec<String>, CatalogNamespace>,
     tables: HashMap<TableIdentifier, CatalogTableSchema>,
     #[serde(default)]
@@ -275,6 +290,17 @@ impl SystemCatalogState {
         self.inner.read().statistics.get(identifier).cloned()
     }
 
+    /// Read-only hot-path lookup used by TenantStableIdResolver.
+    pub fn account_id_u32(&self, account: &str) -> Option<u32> {
+        self.inner.read().account_ids.get(account).copied()
+    }
+
+    /// Highest committed account id, used to recover the allocator floor after
+    /// WAL/snapshot replay so ids are never reused across restarts.
+    pub fn max_account_id(&self) -> Option<u32> {
+        self.inner.read().account_ids.values().copied().max()
+    }
+
     /// The highest WAL sequence number folded in (replay watermark / snapshot
     /// cutover LSN).
     pub fn applied_seq(&self) -> u64 {
@@ -287,6 +313,7 @@ impl SystemCatalogState {
     pub fn to_snapshot_bytes(&self) -> Result<Vec<u8>> {
         let inner = self.inner.read();
         let snapshot = CatalogSnapshot {
+            account_ids: inner.account_ids.clone(),
             namespaces: inner.namespaces.clone(),
             tables: inner
                 .tables
@@ -343,6 +370,7 @@ impl SystemCatalogState {
             tables.insert(id, Arc::new(schema));
         }
         Ok(CatalogInner {
+            account_ids: snapshot.account_ids,
             namespaces: snapshot.namespaces,
             tables,
             ns_children,

--- a/src/storage/entity_store_legacy.rs
+++ b/src/storage/entity_store_legacy.rs
@@ -660,6 +660,7 @@ impl EntityStore for ProximaEntityStore {
                         Some(search_config),
                         None,
                         None,
+                        proximadb_tenant::AuthClass::Anonymous,
                     )
                     .await?;
 

--- a/tests/abac_rest_record_search_integration_test.rs
+++ b/tests/abac_rest_record_search_integration_test.rs
@@ -372,7 +372,12 @@ async fn composition_rule_admits_a_bound_subject_as_client() {
     let (svc, _collections) = fixture().await;
 
     let context = svc
-        .records_read_context(Some("alice"), Some(TENANT), COLLECTION)
+        .records_read_context(
+            Some("alice"),
+            Some(TENANT),
+            proximadb_tenant::AuthClass::Authenticated,
+            COLLECTION,
+        )
         .await;
 
     assert!(
@@ -389,7 +394,12 @@ async fn composition_rule_denies_an_unbound_subject_so_callers_fail_closed() {
     let (svc, _collections) = fixture().await;
 
     let context = svc
-        .records_read_context(Some("mallory"), Some(TENANT), COLLECTION)
+        .records_read_context(
+            Some("mallory"),
+            Some(TENANT),
+            proximadb_tenant::AuthClass::Authenticated,
+            COLLECTION,
+        )
         .await;
 
     assert!(
@@ -403,7 +413,14 @@ async fn composition_rule_denies_an_unbound_subject_so_callers_fail_closed() {
 async fn composition_rule_passes_through_when_there_is_no_client_subject() {
     let (svc, _collections) = fixture().await;
 
-    let context = svc.records_read_context(None, None, COLLECTION).await;
+    let context = svc
+        .records_read_context(
+            None,
+            None,
+            proximadb_tenant::AuthClass::Anonymous,
+            COLLECTION,
+        )
+        .await;
 
     assert!(
         matches!(context, Some(proximadb_abac::ReadContext::System(_))),
@@ -411,23 +428,23 @@ async fn composition_rule_passes_through_when_there_is_no_client_subject() {
     );
 }
 
-/// ⚠ TD-ABAC-11 KNOWN-OPEN CELL, pinned deliberately.
-///
-/// A subject WITH no `tenant_stable_id` (unminted tenant, or a surface with no
-/// resolver wired) is passthrough TODAY — enforcement strength currently equals
-/// mint coverage. ADR-087 flips this to DENY once the default-tenant mint makes
-/// the stable id total; when it does, THIS TEST MUST FLIP with it. It exists so
-/// that change is a conscious edit rather than a silent behavioral drift.
+/// TD-ABAC-11 strict cell: an armed enforcer cannot consult policy without the
+/// tenant stable id, so a present subject MUST be denied.
 #[tokio::test]
-async fn composition_rule_still_passes_through_a_subject_without_a_stable_id() {
+async fn composition_rule_denies_a_subject_without_a_stable_id() {
     let (svc, _collections) = fixture().await;
 
     let context = svc
-        .records_read_context(Some("alice"), None, COLLECTION)
+        .records_read_context(
+            Some("alice"),
+            None,
+            proximadb_tenant::AuthClass::Authenticated,
+            COLLECTION,
+        )
         .await;
 
     assert!(
-        matches!(context, Some(proximadb_abac::ReadContext::System(_))),
-        "TD-ABAC-11: absent stable id is passthrough until the mint lands; got {context:?}"
+        context.is_none(),
+        "TD-ABAC-11: subject + absent stable id must deny; got {context:?}"
     );
 }


### PR DESCRIPTION
## Outcome

Completes the vector/record portion of TD-ABAC-11 after merged prerequisite #1400: authenticated or trust-asserted subjects can no longer bypass an armed ABAC enforcer when their tenant stable ID is absent.

## Design and implementation

- Makes SystemCatalog the durable tenant-string to stable-u32 authority via canonical WAL deltas and snapshots.
- Recovers allocator floors after boot and in-place snapshot reload; serializes concurrent first mint; retries pending object-store snapshot publication before reporting an existing key as durable.
- Hardens NativeCatalog minting: serialized durable sidecar publication, rollback on persistence failure, concurrent-first-mint consistency, canonical tenant trimming, and explicit u32 exhaustion detection.
- Mints the default tenant during SharedServices bootstrap before requests can reach an armed enforcer.
- Mints or resolves tenants during ABAC policy and attribute provisioning, eliminating the dummy-table prerequisite; persistence failures return 503 and do not publish policy state.
- Centralizes the vector/record composition rule and threads AuthClass as audit provenance across REST/internal/pgwire call sites.
- Enforces the rule: enforcer + subject + missing stable ID = deny. No enforcer or no client subject remains system passthrough.
- Pins all 24 enforcer x subject x stable-id x auth-class cells and flips the integration ratchet for the formerly open bypass.

## Scope boundary

TD-ABAC-11 remains In Progress. Relational composition and cross-surface REST/gRPC/Flight/pgwire policy E2E remain explicitly open until TD-ABAC-10b carries the stable ID through scan_table_relational.

## Verification

- cargo check -p proximadb-catalog
- cargo check --lib --features abac-policy
- SystemCatalog stable-ID WAL/reopen and concurrent mint tests
- SystemCatalog follower snapshot reload/allocator-floor regression
- NativeCatalog registry restart and concurrent mint tests
- 24-cell composition truth-table unit test
- ABAC provisioning-without-dummy-table test
- Four ABAC record-search composition integration tests
- Full SystemCatalog module tests: 17 passed
- make work-commit-check
- TD status consistency and ADR/TD uniqueness checks

All observed compiler warnings pre-existed this change.