### PR TITLE
feat(abac): carry canonical identity through relational reads (TD-ABAC-10b)

### DIFF
--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -4394,8 +4394,7 @@ impl EmbeddedProximaDB {
                             .collect()
                     }),
                     collection.map(str::to_string),
-                    None, // embedded single-process: no per-request tenant
-                    None, // TD-ABAC-5: embedded single-process: no per-request subject
+                    proximadb_runtime::PortIdentity::anonymous(),
                 )
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/crates/foundation/proximadb-tenant/src/identity_trust.rs
+++ b/crates/foundation/proximadb-tenant/src/identity_trust.rs
@@ -245,6 +245,36 @@ pub enum AuthClass {
     Anonymous,
 }
 
+/// Canonical authorization-composition decision shared by every data read
+/// seam. The authentication class is deliberately carried into the decision
+/// for audit provenance, but never weakens enforcement: once an enforcer and a
+/// subject are present, the stable tenant policy key is mandatory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadEnforcementComposition {
+    Passthrough,
+    ResolvePolicy,
+    DenyMissingStableId,
+}
+
+/// Resolve the structural read-authorization state without depending on an
+/// enforcement engine. Keeping this in the identity foundation prevents
+/// vector, record, relational, and future modalities from inventing subtly
+/// different fail-open cells.
+pub const fn read_enforcement_composition(
+    enforcer_wired: bool,
+    subject_present: bool,
+    stable_id_present: bool,
+    _auth_class: AuthClass,
+) -> ReadEnforcementComposition {
+    if !enforcer_wired || !subject_present {
+        ReadEnforcementComposition::Passthrough
+    } else if !stable_id_present {
+        ReadEnforcementComposition::DenyMissingStableId
+    } else {
+        ReadEnforcementComposition::ResolvePolicy
+    }
+}
+
 impl std::fmt::Display for AuthClass {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -335,6 +365,40 @@ pub trait TenantStableIdResolver: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn full_read_enforcement_composition_truth_table() {
+        for enforcer_wired in [false, true] {
+            for subject_present in [false, true] {
+                for stable_id_present in [false, true] {
+                    for auth_class in [
+                        AuthClass::Authenticated,
+                        AuthClass::TrustAsserted,
+                        AuthClass::Anonymous,
+                    ] {
+                        let expected = if !enforcer_wired || !subject_present {
+                            ReadEnforcementComposition::Passthrough
+                        } else if !stable_id_present {
+                            ReadEnforcementComposition::DenyMissingStableId
+                        } else {
+                            ReadEnforcementComposition::ResolvePolicy
+                        };
+                        assert_eq!(
+                            read_enforcement_composition(
+                                enforcer_wired,
+                                subject_present,
+                                stable_id_present,
+                                auth_class,
+                            ),
+                            expected,
+                            "enforcer={enforcer_wired} subject={subject_present} \
+                             stable_id={stable_id_present} auth_class={auth_class}"
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     fn binding(tenant: &str, gateway: bool) -> AuthenticatedTenantBinding {
         AuthenticatedTenantBinding {

--- a/crates/foundation/proximadb-tenant/src/lib.rs
+++ b/crates/foundation/proximadb-tenant/src/lib.rs
@@ -429,6 +429,7 @@ pub use rbac_context::{
 pub mod identity_trust;
 pub use identity_trust::{
     AuthClass, AuthenticatedTenantBinding, GATEWAY_ROLE, HeaderTrustPolicy, OPERATOR_ROLE,
-    ResolvedRequestIdentity, ResolvedTenantAssertion, TenantAssertionError, TenantStableIdResolver,
+    ReadEnforcementComposition, ResolvedRequestIdentity, ResolvedTenantAssertion,
+    TenantAssertionError, TenantStableIdResolver, read_enforcement_composition,
     resolve_subject_assertion, resolve_tenant_assertion,
 };

--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -120,6 +120,8 @@ pub(crate) mod test_support {
             collection: Option<String>,
             tenant_id: Option<String>,
             subject: Option<String>,
+            tenant_stable_id: Option<u64>,
+            auth_class: proximadb_tenant::AuthClass,
         },
         Hybrid,
     }
@@ -270,15 +272,16 @@ pub(crate) mod test_support {
             query: String,
             parameters: Option<Vec<ProximaValue>>,
             collection: Option<String>,
-            tenant_id: Option<&str>,
-            subject: Option<&str>,
+            identity: proximadb_runtime::PortIdentity<'_>,
         ) -> Result<ExecuteQueryResponse> {
             self.calls.lock().unwrap().push(ApiCall::Sql {
                 query,
                 parameter_count: parameters.as_ref().map(Vec::len),
                 collection,
-                tenant_id: tenant_id.map(ToOwned::to_owned),
-                subject: subject.map(ToOwned::to_owned),
+                tenant_id: identity.tenant_id.map(ToOwned::to_owned),
+                subject: identity.subject.map(ToOwned::to_owned),
+                tenant_stable_id: identity.tenant_stable_id,
+                auth_class: identity.auth_class,
             });
             Ok(self.sql_response.lock().unwrap().clone())
         }
@@ -396,8 +399,7 @@ pub(crate) mod test_support {
             &self,
             _query: String,
             _collection: Option<String>,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
+            _identity: PortIdentity<'_>,
         ) -> Result<JsonValue> {
             Ok(JsonValue::Array(Vec::new()))
         }
@@ -482,8 +484,7 @@ mod tests {
             "select * from docs".to_string(),
             None,
             Some("docs".to_string()),
-            None,
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .unwrap();
@@ -525,6 +526,8 @@ mod tests {
                     collection: Some("docs".to_string()),
                     tenant_id: None,
                     subject: None,
+                    tenant_stable_id: None,
+                    auth_class: proximadb_tenant::AuthClass::Anonymous,
                 },
             ]
         );
@@ -643,7 +646,11 @@ mod tests {
             .unwrap();
         assert!(
             query
-                .execute_sql("select 1".to_string(), Some("docs".to_string()), None, None)
+                .execute_sql(
+                    "select 1".to_string(),
+                    Some("docs".to_string()),
+                    PortIdentity::anonymous(),
+                )
                 .await
                 .unwrap()
                 .is_array()

--- a/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
+++ b/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
@@ -413,16 +413,14 @@ pub async fn execute_sql(
             .map(proximadb_records::conversions::sql_value_to_proxima)
             .collect()
     });
+    let port_identity = identity
+        .as_ref()
+        .map(|id| proximadb_runtime::PortIdentity::from(&id.0))
+        .unwrap_or_else(proximadb_runtime::PortIdentity::anonymous);
 
     match state
         .handlers
-        .execute_sql_v1(
-            query,
-            parameters,
-            request.collection,
-            identity.as_ref().map(|id| id.tenant.as_str()),
-            identity.as_ref().and_then(|id| id.subject.as_deref()),
-        )
+        .execute_sql_v1(query, parameters, request.collection, port_identity)
         .await
     {
         Ok(v1_resp) => {
@@ -801,6 +799,8 @@ mod tests {
                 // TD-ABAC-9: the foundation identity Extension reaches the port.
                 tenant_id: Some("tenant-a".to_string()),
                 subject: Some("alice".to_string()),
+                tenant_stable_id: Some(7),
+                auth_class: proximadb_tenant::AuthClass::Authenticated,
             }]
         );
     }

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -626,8 +626,7 @@ impl ApiHandlersPort for UnifiedHandlers {
         query: String,
         _parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: crate::service_ports::PortIdentity<'_>,
     ) -> Result<ExecuteQueryResponse> {
         let adapter = self
             .query_adapter
@@ -635,9 +634,7 @@ impl ApiHandlersPort for UnifiedHandlers {
             .ok_or_else(|| anyhow!("SQL execution requires QueryAdapterPort (not wired)"))?;
 
         let start = Instant::now();
-        let json_result = adapter
-            .execute_sql(query, collection, tenant_id, subject)
-            .await?;
+        let json_result = adapter.execute_sql(query, collection, identity).await?;
 
         let records = json_result
             .get("records")
@@ -898,8 +895,7 @@ mod tests {
             &self,
             _query: String,
             _collection: Option<String>,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
+            _identity: crate::service_ports::PortIdentity<'_>,
         ) -> Result<serde_json::Value> {
             Ok(json!({
                 "columns": ["id", "score", "flag", "none", "obj"],
@@ -1084,8 +1080,7 @@ mod tests {
                 "select * from docs".to_string(),
                 None,
                 Some("docs".to_string()),
-                None,
-                None,
+                crate::service_ports::PortIdentity::anonymous(),
             )
             .await
             .unwrap();
@@ -1142,7 +1137,12 @@ mod tests {
         );
         assert!(
             handlers
-                .execute_sql_v1("select 1".to_string(), None, None, None, None)
+                .execute_sql_v1(
+                    "select 1".to_string(),
+                    None,
+                    None,
+                    crate::service_ports::PortIdentity::anonymous(),
+                )
                 .await
                 .unwrap_err()
                 .to_string()
@@ -1171,8 +1171,7 @@ mod tests {
                 &self,
                 _query: String,
                 _collection: Option<String>,
-                _tenant_id: Option<&str>,
-                _subject: Option<&str>,
+                _identity: crate::service_ports::PortIdentity<'_>,
             ) -> Result<serde_json::Value> {
                 Ok(json!(["text", 7, false, null, {"shape": "object"}]))
             }
@@ -1184,7 +1183,12 @@ mod tests {
             Some(Arc::new(ArrayQueryAdapter)),
         );
         let sql = handlers
-            .execute_sql_v1("select values".to_string(), None, None, None, None)
+            .execute_sql_v1(
+                "select values".to_string(),
+                None,
+                None,
+                crate::service_ports::PortIdentity::anonymous(),
+            )
             .await
             .unwrap();
         assert_eq!(sql.rows_returned, 5);

--- a/crates/platform/proximadb-runtime/src/lib.rs
+++ b/crates/platform/proximadb-runtime/src/lib.rs
@@ -56,6 +56,8 @@ pub use rich_search::{
     RichSearchResult,
 };
 pub use security_port::{PortAuthCredential, PortUserContext, SecurityPort};
-pub use service_ports::{CollectionPort, PortIdentity, QueryAdapterPort, VectorOpsPort};
+pub use service_ports::{
+    CollectionPort, OwnedPortIdentity, PortIdentity, QueryAdapterPort, VectorOpsPort,
+};
 pub use streaming_port::StreamingPort;
 pub use unified_query_port::UnifiedQueryPort;

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -152,16 +152,8 @@ pub trait ApiHandlersPort: Send + Sync {
         query: String,
         parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
-        // TD-064: the authenticated tenant scopes relational SQL to the tenant's
-        // partition. `None` keeps the legacy unscoped behavior (callers that
-        // haven't been wired pass `None`); production gRPC/REST threads the real
-        // tenant from the request.
-        tenant_id: Option<&str>,
-        // TD-ABAC-5: the authenticated subject (principal id), threaded to ABAC
-        // enforcement at the relational read boundary. Opaque `&str` here because
-        // this port (runtime layer) cannot name `SubjectId` (catalog/control); the
-        // root-crate adapter converts it. `None` ⇒ anonymous/unwired ⇒ no
-        // enforcement (status quo). Enforcement is behind `abac-policy`.
-        subject: Option<&str>,
+        // ADR-087: one canonical caller identity. Tenant scopes the partition;
+        // subject + stable key + auth class reach the relational ABAC seam.
+        identity: crate::service_ports::PortIdentity<'_>,
     ) -> Result<ExecuteQueryResponse>;
 }

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -115,6 +115,29 @@ pub struct PortIdentity<'a> {
     pub auth_class: proximadb_tenant::AuthClass,
 }
 
+/// Owned form of [`PortIdentity`] for planners/readers that must retain the
+/// identity after the protocol call frame. Convert back with
+/// [`Self::as_borrowed`] at the enforcement seam; fields remain one canonical
+/// carrier rather than parallel tenant/subject parameters.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OwnedPortIdentity {
+    pub tenant_id: Option<String>,
+    pub subject: Option<String>,
+    pub tenant_stable_id: Option<u64>,
+    pub auth_class: proximadb_tenant::AuthClass,
+}
+
+impl OwnedPortIdentity {
+    pub fn as_borrowed(&self) -> PortIdentity<'_> {
+        PortIdentity {
+            tenant_id: self.tenant_id.as_deref(),
+            subject: self.subject.as_deref(),
+            tenant_stable_id: self.tenant_stable_id,
+            auth_class: self.auth_class,
+        }
+    }
+}
+
 impl<'a> PortIdentity<'a> {
     /// No identity at all — internal/system callers; enforcement passthrough.
     pub const fn anonymous() -> Self {
@@ -133,6 +156,15 @@ impl<'a> PortIdentity<'a> {
             subject: None,
             tenant_stable_id: None,
             auth_class: proximadb_tenant::AuthClass::Anonymous,
+        }
+    }
+
+    pub fn into_owned(self) -> OwnedPortIdentity {
+        OwnedPortIdentity {
+            tenant_id: self.tenant_id.map(str::to_string),
+            subject: self.subject.map(str::to_string),
+            tenant_stable_id: self.tenant_stable_id,
+            auth_class: self.auth_class,
         }
     }
 }
@@ -249,18 +281,13 @@ pub trait QueryAdapterPort: Send + Sync {
     /// to v1 `ExecuteQueryResponse`, v2 `ProximaValue` rows, or any wire format
     /// without the port accumulating v1 surface debt.
     ///
-    /// `tenant_id` scopes relational SQL to the tenant's partition (TD-064); the
-    /// adapter routes relational SELECT through the tenant-scoped relational
-    /// pipeline (`try_run_select`, TD-121) before falling back to the facade.
-    ///
-    /// `subject` (TD-ABAC-5) is the authenticated principal id, threaded to ABAC
-    /// enforcement. Opaque `&str` here (runtime layer can't name `SubjectId`);
-    /// the root-crate adapter converts it. `None` ⇒ no enforcement.
+    /// `identity` is the canonical ADR-087 carrier. Its string tenant scopes
+    /// storage/catalog resolution while subject + stable key drive ABAC at the
+    /// relational read seam; callers must not flatten or re-derive these fields.
     async fn execute_sql(
         &self,
         query: String,
         collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: PortIdentity<'_>,
     ) -> Result<JsonValue>;
 }

--- a/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
+++ b/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
@@ -22,7 +22,7 @@ threads it to `execute_sql_v1`/the seam.
 Note: pgwire trust-auth subjects are spoofable by design — that is what
 `AuthClass::TrustAsserted` records; deployments gate via `HeaderTrustPolicy`.
 
-== Status: 10a + 10c DONE; 10b open
+== Status: 10a + 10b + 10c DONE; pipeline-coverage follow-on open
 
 **10a (done)** — `Session.identity: Option<ResolvedRequestIdentity>` built at
 the startup handshake by the pure, unit-tested `PostgresProtocol::startup_identity`
@@ -32,17 +32,16 @@ plumbing — `catalog_manager` already reached it), so the ABAC policy key is
 stamped once per connection; the relational SELECT path reads
 `session.identity.subject` instead of re-deriving it per query.
 
-**10b (open) — carry the whole identity, not just the subject.** The
-relational read path still takes a bare `Option<SubjectId>`, so
-`tenant_stable_id`/`auth_class` do not survive to the enforcement point:
-widen `relational_pipeline::try_run_select` (~:253) → `SnapshotCatalog`
-(~:1606, ctors ~:554/:737/:763) → `DmlTableReader` (~:1702) →
-`services/dml/mod.rs::scan_table_relational` (~:1441, ABAC filter ~:1466) to
-carry `PortIdentity`; update the off-pgwire caller
-`query/facade/adapter.rs` (~:803). This is the prerequisite for
-[[TD-ABAC-11]]'s fail-closed flip on the relational path. Note the SQL ports
-(`ApiHandlersPort::execute_sql_v1`, `QueryAdapterPort::execute_sql`) still
-take flat `tenant_id`/`subject` with no stable id.
+**10b (DONE) — carry the whole identity, not just the subject.**
+`relational_pipeline::try_run_select` → `SnapshotCatalog` → `DmlTableReader`
+→ `services/dml/mod.rs::scan_table_relational` now carries the canonical
+`PortIdentity` (using `OwnedPortIdentity` only where the reader must retain it).
+The off-pgwire adapter and both SQL ports were widened at the same time, so
+REST and gRPC no longer flatten the foundation identity to tenant+subject and
+drop `tenant_stable_id`/`auth_class`. `EXPLAIN ANALYZE` carries the identical
+identity. Governed reads bypass the subject-agnostic result cache and are
+ineligible for the in-memory/bare-Parquet shortcuts until those engines can
+consume the authorized predicate; they route through the DML seam instead.
 
 **10c (DONE) — the three pgwire read paths that bypassed ABAC** (found by the
 2026-08-02 live-path survey; each was a *distinct* bypass). All three are
@@ -73,12 +72,12 @@ closed; how each was closed is recorded below because the choices differ:
 single-table fallback is unreachable for governed subjects, then delete the
 fail-closed guard with it.
 
-**Test posture**: the shared composition rule's truth table is pinned in
-`tests/abac_rest_record_search_integration_test.rs` (admit / deny / no-subject
-passthrough / **the TD-ABAC-11 known-open absent-stable-id cell**), so a
-surface that stops calling the rule is a bypass by construction and the
-TD-ABAC-11 flip must consciously update a failing test. Surface-level pgwire
-e2e (a real psql session against a provisioned policy) is gated on the
-binding-provisioning fixture in [[TD-ABAC-11]].
+**Test posture**: the one shared composition truth table is pinned in the
+tenant foundation; vector/record and relational seams both consume it.
+Relational tests pin permit, unbound deny, missing-key deny, internal
+passthrough, legacy-schema deny, and fast-path ineligibility. The extracted
+REST handler test proves all four identity fields cross the SQL port. A live
+provisioned-policy surface matrix remains the release-evidence follow-on in
+[[TD-ABAC-11]].
 
 Depends on [[TD-ABAC-8]]. Ref ADR-087, TD-ABAC-3, TD-ABAC-5, [[TD-ABAC-11]].

--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -42,10 +42,15 @@ dev/embedded deployment that wires an enforcer.
   `enforcer x subject x stable-id x auth-class` truth table pinned in a pure
   unit test. `AuthClass` is audit provenance and intentionally does not weaken
   the deny rule.
-* **OPEN — relational seam + cross-surface ratchet.** TD-ABAC-10 10b must carry
-  the stable id through `scan_table_relational`; only then can the relational
-  composition point flip and REST/gRPC/Flight/pgwire provisioned-policy e2e be
-  a truthful release gate.
+* **DONE — relational seam strictness and carrier.** TD-ABAC-10b carries the
+  complete `PortIdentity` through pgwire/off-pgwire planning to
+  `scan_table_relational`. The seam consumes the same foundation composition
+  rule as vector/records; missing stable key denies. Governed reads cannot use
+  the subject-agnostic result cache or enforcement-blind in-memory/Parquet
+  shortcuts and instead route through DML row-policy enforcement.
+* **OPEN — live cross-surface ratchet.** The REST SQL carrier test and DML
+  enforcement matrix are pinned, but the release gate still needs provisioned
+  policy exercised over live REST/gRPC/Flight/pgwire transports.
 
 Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
 [[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).
@@ -58,10 +63,10 @@ seam:
 * `records_read_context` (`services/operations/vectors/legacy.rs` ~:702) — the
   records/vector seam (the cell named above).
 * `services/dml/mod.rs::scan_table_relational` (~:1441, filter ~:1466) — the
-  relational read boundary pgwire/SQL reach. It keys ABAC off
-  `(subject, tenant_context.tenant_id)` and never sees a `tenant_stable_id`
-  today, so [[TD-ABAC-10]] 10b (carry the identity through the relational
-  path) is a hard prerequisite for flipping it.
+  relational read boundary pgwire/SQL reach. It now receives the same
+  `PortIdentity` carrier and resolves the shared composition rule before any
+  row access; storage `TenantContext` remains a partition projection, not a
+  second authorization carrier.
 
 The cross-surface e2e ratchet must therefore include pgwire's *relational*
 path in addition to REST/gRPC/Flight records — and must not be written until

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -2316,6 +2316,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // TD-ABAC-5: capture the authenticated subject before the request is moved;
         // threaded to ABAC enforcement at the relational read boundary.
         let user_id = grpc_auth::user_id(&request);
+        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -2328,8 +2329,16 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                 q.query,
                 None,
                 collection,
-                Some(tenant_id.as_str()),
-                user_id.as_deref(),
+                proximadb_runtime::PortIdentity {
+                    tenant_id: Some(tenant_id.as_str()),
+                    subject: user_id.as_deref(),
+                    tenant_stable_id,
+                    auth_class: if user_id.is_some() {
+                        proximadb_tenant::AuthClass::Authenticated
+                    } else {
+                        proximadb_tenant::AuthClass::Anonymous
+                    },
+                },
             )
             .await
             .map_err(|e| {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -1880,12 +1880,14 @@ impl PostgresProtocol {
         // to the pre-cache behavior.
         let namespace = self.session.read().await.current_schema();
         let olap_cache = super::relational_pipeline::olap_result_cache();
-        // TD-ABAC-3: build the ABAC subject from the (already trust-gated at the
-        // handshake) connection user. `anonymous`/empty ⇒ no subject ⇒ no
-        // enforcement; otherwise the asserted user becomes the SubjectId ABAC
-        // resolves the row filter against.
-        #[cfg(feature = "abac-policy")]
-        let subject = self.session_subject().await;
+        // TD-ABAC-10b: carry the one startup identity intact. The fallback is
+        // tenant-only for pre-startup/internal test sessions; it has no subject
+        // and therefore remains an explicit system passthrough.
+        let session_identity = self.session.read().await.identity.clone();
+        let identity = session_identity
+            .as_ref()
+            .map(proximadb_runtime::PortIdentity::from)
+            .unwrap_or_else(|| proximadb_runtime::PortIdentity::for_tenant(&read_tenant));
         super::relational_pipeline::try_run_select(
             query,
             self.dml_service.as_ref(),
@@ -1897,15 +1899,13 @@ impl PostgresProtocol {
             self.graph_service
                 .clone()
                 .map(|g| g as Arc<dyn proximadb_graph_query::service::GraphQueryReadService>),
-            Some(read_tenant.as_str()),
+            identity,
             controls,
             // pgwire keeps simple single-table SELECTs on its hardened legacy
             // path; only relational-engaging shapes go through this pipeline.
             true,
             Some(namespace.as_str()),
             olap_cache.as_deref(),
-            #[cfg(feature = "abac-policy")]
-            subject,
         )
         .await
     }
@@ -1967,18 +1967,19 @@ impl PostgresProtocol {
             // route-only disclosure when no DmlService is available.
             // TD-064: resolve EXPLAIN's schema/plan under the connection tenant.
             let explain_tenant = self.pgwire_resolve_read_tenant().await;
-            // TD-ABAC-10c: EXPLAIN (and especially EXPLAIN ANALYZE, which
-            // executes) must plan/run under the SAME subject execution uses.
-            #[cfg(feature = "abac-policy")]
-            let explain_subject = self.session_subject().await;
+            // TD-ABAC-10b: EXPLAIN ANALYZE executes, so carry the exact whole
+            // session identity used by normal SELECT execution.
+            let session_identity = self.session.read().await.identity.clone();
+            let explain_identity = session_identity
+                .as_ref()
+                .map(proximadb_runtime::PortIdentity::from)
+                .unwrap_or_else(|| proximadb_runtime::PortIdentity::for_tenant(&explain_tenant));
             let routing = match self.dml_service.clone() {
                 Some(dml) if is_analyze => {
                     crate::network::postgres::relational_pipeline::explain_analyze_select_with_catalog(
                         inner_query,
                         &dml,
-                        Some(explain_tenant.as_str()),
-                        #[cfg(feature = "abac-policy")]
-                        explain_subject,
+                        explain_identity,
                     )
                     .await
                 }
@@ -1986,9 +1987,7 @@ impl PostgresProtocol {
                     crate::network::postgres::relational_pipeline::explain_select_route_with_catalog(
                         inner_query,
                         &dml,
-                        Some(explain_tenant.as_str()),
-                        #[cfg(feature = "abac-policy")]
-                        explain_subject,
+                        explain_identity,
                     )
                     .await
                 }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -59,10 +59,7 @@ use crate::query::cache::invalidation_coordinator::CacheInvalidationCoordinator;
 use crate::query::cache::query_result_cache::{QueryKey, QueryResultCache, StructuralKey};
 use crate::services::dml::DmlService;
 use crate::storage::tenant::context::TenantContext;
-// TD-ABAC-3: the authenticated/Asserted subject threaded into the relational
-// read funnel so ABAC enforces on real client SELECTs (behind `abac-policy`).
-#[cfg(feature = "abac-policy")]
-use proximadb_catalog::fc_metamodel::SubjectId;
+use proximadb_runtime::{OwnedPortIdentity, PortIdentity};
 
 use super::types::PgType;
 
@@ -258,7 +255,7 @@ pub async fn try_run_select(
     #[cfg_attr(not(feature = "datafusion-integration"), allow(unused_variables))] graph_ops: Option<
         Arc<dyn proximadb_graph_query::service::GraphQueryReadService>,
     >,
-    tenant: Option<&str>,
+    identity: PortIdentity<'_>,
     controls: ExecutionControls,
     // pgwire passes `true`: only joins/GROUP BY/aggregates/set-ops engage the
     // real-data relational engine, leaving simple SELECTs on pgwire's hardened
@@ -276,16 +273,25 @@ pub async fn try_run_select(
     // execution; a miss falls through normally and the result is stamped on the
     // real-data success paths.
     result_cache: Option<&QueryResultCache<ExecutionPipelineResult>>,
-    // TD-ABAC-3: the connection subject, threaded into every SnapshotCatalog so
-    // `scan_table_relational` enforces ABAC. `None` ⇒ anonymous/internal ⇒ no
-    // enforcement. Behind `abac-policy` (default-OFF).
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
 ) -> Option<Result<ExecutionPipelineResult, String>> {
+    let identity = identity.into_owned();
+    let tenant = identity.tenant_id.as_deref();
+    // Governed identities must reach DML's canonical row-policy seam. The
+    // process-local demo engine, subject-agnostic result cache, and bare-Parquet
+    // engines cannot currently apply that predicate and are therefore
+    // ineligible rather than silently widening access.
+    #[cfg(feature = "abac-policy")]
+    let relational_abac_required =
+        dml.is_some_and(|service| service.relational_abac_required(identity.as_borrowed()));
+    #[cfg(not(feature = "abac-policy"))]
+    let relational_abac_required = false;
     // TD-064: the connection's tenant scopes every snapshot read to the tenant's
     // record partition (carried into the SnapshotCatalog → DmlTableReader).
-    let tenant_ctx: Option<TenantContext> = tenant
-        .filter(|t| !t.is_empty())
-        .map(TenantContext::for_tenant_id);
+    let tenant_ctx: Option<TenantContext> = tenant.filter(|t| !t.is_empty()).map(|tenant| {
+        let mut context = TenantContext::for_tenant_id(tenant);
+        context.tenant_stable_id = identity.tenant_stable_id;
+        context
+    });
     // ADR-018 Phase 2: Allow opting out with explicit "0" value
     if std::env::var("PROXIMADB_PGWIRE_RELATIONAL_PIPELINE")
         .ok()
@@ -304,7 +310,9 @@ pub async fn try_run_select(
     // WAL LSN, so any write since → guaranteed miss → read-after-write correct.
     // `cache_ctx` carries the (key, lsn) pair so the real-data success paths
     // below can stamp the result without recomputing it.
-    let cache_ctx: Option<(StructuralKey, u64)> = if let Some(cache) = result_cache {
+    let cache_ctx: Option<(StructuralKey, u64)> = if relational_abac_required {
+        None
+    } else if let Some(cache) = result_cache {
         let current_lsn = current_canonical_lsn().await;
         let skey = StructuralKey::new(
             tenant.unwrap_or(""),
@@ -337,7 +345,8 @@ pub async fn try_run_select(
     //    engine's own catalog; a catalog miss falls through to the real-data
     //    path below.
     let engine = GLOBAL_ENGINE.clone();
-    if let Ok(logical) = lower_sql(sql, &EngineCatalog(engine.clone())) {
+    if !relational_abac_required && let Ok(logical) = lower_sql(sql, &EngineCatalog(engine.clone()))
+    {
         let factory = EngineReaderFactory::new(engine);
         let resolver = StaticCapabilities {
             caps: ReaderCapabilities::full(),
@@ -421,8 +430,9 @@ pub async fn try_run_select(
     // DECISION and the physical DISPATCH come from ONE place. Mixed Parquet+native
     // queries report `false` (cross-engine join is a later phase) → Volcano.
     #[cfg(feature = "datafusion-integration")]
-    let parquet_backed =
-        !tables.is_empty() && tables.keys().all(|k| parquet_loc_by_key.contains_key(k));
+    let parquet_backed = !relational_abac_required
+        && !tables.is_empty()
+        && tables.keys().all(|k| parquet_loc_by_key.contains_key(k));
     #[cfg(not(feature = "datafusion-integration"))]
     let parquet_backed = false;
 
@@ -511,7 +521,8 @@ pub async fn try_run_select(
     // other `decision.backend` (never produced for a parquet-OLAP shape) falls
     // through to the Volcano path below — exactly as before.
     #[cfg(feature = "datafusion-integration")]
-    if parquet_backed
+    if !relational_abac_required
+        && parquet_backed
         && matches!(
             decision.backend,
             crate::query::table_write_plan::ComputeBackend::DataFusionLocal
@@ -555,8 +566,7 @@ pub async fn try_run_select(
                     dml: dml.clone(),
                     tables: tables.clone(),
                     tenant: tenant_ctx.clone(),
-                    #[cfg(feature = "abac-policy")]
-                    subject: subject.clone(),
+                    identity: identity.clone(),
                 };
                 // Setup (planning/route) time is attributed here; the native engine
                 // records its own `native-vectorized` compute sample inside the run.
@@ -738,8 +748,7 @@ pub async fn try_run_select(
                 dml: dml.clone(),
                 tables: tables.clone(),
                 tenant: tenant_ctx.clone(),
-                #[cfg(feature = "abac-policy")]
-                subject: subject.clone(),
+                identity: identity.clone(),
             };
             shadow_probe_native_parquet(
                 sql,
@@ -764,8 +773,7 @@ pub async fn try_run_select(
         dml: dml.clone(),
         tables,
         tenant: tenant_ctx,
-        #[cfg(feature = "abac-policy")]
-        subject,
+        identity,
     };
     // Lower + plan via the shared planning path (so EXPLAIN discloses exactly this
     // plan). `None` → lowering declined → fall through to legacy. From the planned
@@ -1609,12 +1617,10 @@ struct SnapshotCatalog {
     /// TD-064: connection tenant scope threaded into every snapshot reader so
     /// relational scans/point-lookups read the tenant's record partition.
     tenant: Option<TenantContext>,
-    /// TD-ABAC-3: the connection's subject (Asserted under `Open` trust, or
-    /// rejected at the handshake under strict). Threaded into every snapshot
-    /// reader so `scan_table_relational` can enforce ABAC on real client SELECTs.
-    /// `None` ⇒ no subject (anonymous/internal) ⇒ no enforcement (status quo).
-    #[cfg(feature = "abac-policy")]
-    subject: Option<SubjectId>,
+    /// ADR-087 canonical caller identity. Owned because readers outlive the
+    /// protocol stack frame; projected back to PortIdentity only at the DML
+    /// enforcement boundary.
+    identity: OwnedPortIdentity,
 }
 
 impl CatalogLookup for SnapshotCatalog {
@@ -1638,8 +1644,7 @@ impl ReaderFactory for SnapshotCatalog {
             full_schema: prepared.schema.clone(),
             pk_columns: prepared.pk_columns.clone(),
             tenant: self.tenant.clone(),
-            #[cfg(feature = "abac-policy")]
-            subject: self.subject.clone(),
+            identity: self.identity.clone(),
             open_state: None,
         }))
     }
@@ -1708,9 +1713,8 @@ struct DmlTableReader {
     pk_columns: Vec<usize>,
     /// TD-064: connection tenant scope for this reader's record partition.
     tenant: Option<TenantContext>,
-    /// TD-ABAC-3: connection subject for ABAC enforcement on this reader's scans.
-    #[cfg(feature = "abac-policy")]
-    subject: Option<SubjectId>,
+    /// ADR-087 whole caller identity retained to the enforcement seam.
+    identity: OwnedPortIdentity,
     open_state: Option<ReaderOpenState>,
 }
 
@@ -1806,13 +1810,7 @@ impl RelationalReader for DmlTableReader {
                 row_pred_ref,
                 limit,
                 self.tenant.as_ref(),
-                // TD-ABAC-3: the connection subject, threaded from the pgwire
-                // auth layer (Asserted `user`, gated by `HeaderTrustPolicy` at the
-                // handshake). When present, `scan_table_relational` AND-combines
-                // the ABAC row filter with the user WHERE (#1324); `None`
-                // (anonymous/internal) ⇒ no enforcement.
-                #[cfg(feature = "abac-policy")]
-                self.subject.as_ref(),
+                self.identity.as_borrowed(),
             )
             .await
             .map_err(|e| ReaderError::Storage(e.to_string()))?;
@@ -2320,17 +2318,9 @@ async fn prepare_select_plan(
     sql: &str,
     query: &SqlQuery,
     dml: &Arc<DmlService>,
-    tenant: Option<&str>,
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    identity: PortIdentity<'_>,
 ) -> Option<(SnapshotCatalog, PhysicalPlan)> {
-    let snapshot = build_snapshot(
-        query,
-        dml,
-        tenant,
-        #[cfg(feature = "abac-policy")]
-        subject,
-    )
-    .await?;
+    let snapshot = build_snapshot(query, dml, identity).await?;
     match plan_over_snapshot(sql, &snapshot)? {
         Ok(physical) => Some((snapshot, physical)),
         Err(_) => None,
@@ -2345,9 +2335,9 @@ async fn prepare_select_plan(
 async fn build_snapshot(
     query: &SqlQuery,
     dml: &Arc<DmlService>,
-    tenant: Option<&str>,
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    identity: PortIdentity<'_>,
 ) -> Option<SnapshotCatalog> {
+    let tenant = identity.tenant_id;
     let mut names = Vec::new();
     collect_table_names(query, &mut names);
     let mut tables: HashMap<String, PreparedTable> = HashMap::new();
@@ -2364,16 +2354,14 @@ async fn build_snapshot(
     Some(SnapshotCatalog {
         dml: dml.clone(),
         tables,
-        tenant: tenant
-            .filter(|t| !t.is_empty())
-            .map(TenantContext::for_tenant_id),
-        // TD-ABAC-10c: the EXPLAIN/ANALYZE snapshot carries the SAME client
-        // subject execution does. This previously hardcoded `None`, so an
-        // EXPLAIN disclosed row estimates — and EXPLAIN ANALYZE, which really
-        // executes the query, returned actual rows — for data the subject
-        // cannot read.
-        #[cfg(feature = "abac-policy")]
-        subject,
+        tenant: tenant.filter(|t| !t.is_empty()).map(|tenant| {
+            let mut context = TenantContext::for_tenant_id(tenant);
+            context.tenant_stable_id = identity.tenant_stable_id;
+            context
+        }),
+        // EXPLAIN ANALYZE executes the query, so it retains the exact same full
+        // identity and composition semantics as normal execution.
+        identity: identity.into_owned(),
     })
 }
 
@@ -2393,18 +2381,9 @@ pub fn explain_select_route(sql: &str) -> Result<SelectRouteExplanation, String>
 pub async fn explain_select_route_with_catalog(
     sql: &str,
     dml: &Arc<DmlService>,
-    tenant: Option<&str>,
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    identity: PortIdentity<'_>,
 ) -> Result<SelectRouteExplanation, String> {
-    route_and_plan_select(
-        sql,
-        dml,
-        false,
-        tenant,
-        #[cfg(feature = "abac-policy")]
-        subject,
-    )
-    .await
+    route_and_plan_select(sql, dml, false, identity).await
 }
 
 /// Catalog-aware `EXPLAIN ANALYZE SELECT`: like [`explain_select_route_with_catalog`]
@@ -2414,18 +2393,9 @@ pub async fn explain_select_route_with_catalog(
 pub async fn explain_analyze_select_with_catalog(
     sql: &str,
     dml: &Arc<DmlService>,
-    tenant: Option<&str>,
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    identity: PortIdentity<'_>,
 ) -> Result<SelectRouteExplanation, String> {
-    route_and_plan_select(
-        sql,
-        dml,
-        true,
-        tenant,
-        #[cfg(feature = "abac-policy")]
-        subject,
-    )
-    .await
+    route_and_plan_select(sql, dml, true, identity).await
 }
 
 /// Shared core for catalog-aware `EXPLAIN [ANALYZE] SELECT`. Routes the query, then for
@@ -2437,9 +2407,9 @@ async fn route_and_plan_select(
     sql: &str,
     dml: &Arc<DmlService>,
     analyze: bool,
-    tenant: Option<&str>,
-    #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    identity: PortIdentity<'_>,
 ) -> Result<SelectRouteExplanation, String> {
+    let tenant = identity.tenant_id;
     let statements =
         Parser::parse_sql(&GenericDialect {}, sql).map_err(|e| format!("parse: {e}"))?;
     let [Statement::Query(query)] = statements.as_slice() else {
@@ -2552,16 +2522,7 @@ async fn route_and_plan_select(
             crate::query::table_write_plan::ComputeBackend::Native
         )
     {
-        match prepare_select_plan(
-            sql,
-            query,
-            dml,
-            tenant,
-            #[cfg(feature = "abac-policy")]
-            subject.clone(),
-        )
-        .await
-        {
+        match prepare_select_plan(sql, query, dml, identity).await {
             Some((snapshot, physical)) => {
                 let base_lines = explain_physical(&physical);
                 if analyze {
@@ -2605,14 +2566,7 @@ async fn route_and_plan_select(
                 // reason (ADR-064 / TD-TRACE-1) — the same decline the legacy path
                 // otherwise re-guesses from SQL text. A re-lower here is cheap and
                 // EXPLAIN is a cold, diagnostic path (never the hot query path).
-                if let Some(snapshot) = build_snapshot(
-                    query,
-                    dml,
-                    tenant,
-                    #[cfg(feature = "abac-policy")]
-                    subject.clone(),
-                )
-                .await
+                if let Some(snapshot) = build_snapshot(query, dml, identity).await
                     && let Err(e) = lower_sql(sql, &snapshot)
                 {
                     explanation.lowering.declines.push(e.decline());

--- a/src/network/rest/canonical/handlers.rs
+++ b/src/network/rest/canonical/handlers.rs
@@ -978,10 +978,7 @@ pub async fn execute_sql(
             query_with_hint,
             sql_params_to_proxima_values(request.parameters.clone()),
             request.collection,
-            None,
-            // TD-ABAC-5: REST UnifiedUserContext extractor wiring is a follow-on;
-            // None ⇒ no ABAC enforcement on this surface yet.
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
     {

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -720,10 +720,10 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         &self,
         query: String,
         _collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> anyhow::Result<serde_json::Value> {
         use crate::query::QueryResultData;
+        let tenant_id = identity.tenant_id;
 
         // EXPLAIN [ANALYZE] <DML> routing — parity with the ROOT handler's
         // execute_sql_v1. Detected via the shared sql_frontend parser; routed
@@ -792,27 +792,17 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         // so this is a no-op unless the flag is set.
         // namespace=None: SQL port path has no pgwire search_path.
         let olap_result_cache = crate::network::postgres::relational_pipeline::olap_result_cache();
-        // TD-ABAC-5: convert the opaque runtime-trait subject string → SubjectId at
-        // this root-crate boundary (the runtime port can't name SubjectId). Behind
-        // `abac-policy`; when off the string is unused (no enforcement).
-        #[cfg(feature = "abac-policy")]
-        let subject_id = subject.map(|s| proximadb_catalog::fc_metamodel::SubjectId(s.to_string()));
-        #[cfg(not(feature = "abac-policy"))]
-        let _ = subject;
         if let Some(dml) = self.dml_service.as_ref()
             && let Some(outcome) = crate::network::postgres::relational_pipeline::try_run_select(
                 &query,
                 Some(dml),
                 None,
                 None,
-                tenant_id,
+                identity,
                 crate::query::execution::ExecutionControls::default(),
                 false,
                 None,
                 olap_result_cache.as_deref(),
-                // TD-ABAC-5: the authenticated subject (gRPC/REST) → ABAC enforcement.
-                #[cfg(feature = "abac-policy")]
-                subject_id,
             )
             .await
         {

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -53,6 +53,7 @@ use proximadb_data_model::ProximaType;
 use proximadb_data_model::ProximaValue;
 use proximadb_records::{EmbeddingCell, ProximaRecord, ProximaTreeNode};
 use proximadb_relational_types::ExprError;
+use proximadb_runtime::PortIdentity;
 use tracing::{debug, info, warn};
 
 use crate::catalog::CatalogManager;
@@ -1407,14 +1408,47 @@ impl DmlService {
     /// predicate. Fail-closed: a legacy table lacking stable object/namespace
     /// ids, or a tenant without a stable id, yields `Denied`.
     #[cfg(feature = "abac-policy")]
+    pub(crate) fn relational_abac_required(&self, identity: PortIdentity<'_>) -> bool {
+        !matches!(
+            proximadb_tenant::read_enforcement_composition(
+                self.abac_enforcer.is_some(),
+                identity.subject.is_some(),
+                identity.tenant_stable_id.is_some(),
+                identity.auth_class,
+            ),
+            proximadb_tenant::ReadEnforcementComposition::Passthrough
+        )
+    }
+
+    #[cfg(feature = "abac-policy")]
     fn abac_row_filter(
         &self,
-        subject: Option<&SubjectId>,
-        tenant_context: Option<&TenantContext>,
+        identity: PortIdentity<'_>,
         table_schema: &CatalogTableSchema,
     ) -> Option<crate::security::rls::AbacScanResult> {
+        match proximadb_tenant::read_enforcement_composition(
+            self.abac_enforcer.is_some(),
+            identity.subject.is_some(),
+            identity.tenant_stable_id.is_some(),
+            identity.auth_class,
+        ) {
+            proximadb_tenant::ReadEnforcementComposition::Passthrough => return None,
+            proximadb_tenant::ReadEnforcementComposition::DenyMissingStableId => {
+                tracing::warn!(
+                    target: "proximadb::tenant_audit",
+                    subject = identity.subject,
+                    auth_class = %identity.auth_class,
+                    table = table_schema.name,
+                    "ABAC denied a relational subject whose tenant has no stable policy key"
+                );
+                return Some(crate::security::rls::AbacScanResult::Denied(
+                    proximadb_abac::DenyReason::NoApplicablePolicy,
+                ));
+            }
+            proximadb_tenant::ReadEnforcementComposition::ResolvePolicy => {}
+        }
         let enforcer = self.abac_enforcer.as_ref()?;
-        let subject = subject?;
+        let subject = SubjectId(identity.subject?.to_string());
         // Enforcer + client subject are present ⇒ enforce. Fail-closed: a legacy
         // table lacking stable object/namespace ids, or an unknown tenant stable
         // id, denies rather than reading unfiltered.
@@ -1425,13 +1459,9 @@ impl DmlService {
                 proximadb_abac::DenyReason::NoApplicablePolicy,
             ));
         };
-        let Some(tenant) = tenant_context.and_then(|t| t.tenant_stable_id) else {
-            return Some(crate::security::rls::AbacScanResult::Denied(
-                proximadb_abac::DenyReason::NoApplicablePolicy,
-            ));
-        };
+        let tenant = identity.tenant_stable_id?;
         Some(enforcer.predicate_for(
-            subject,
+            &subject,
             tenant,
             Target {
                 namespace,
@@ -1460,8 +1490,31 @@ impl DmlService {
         >,
         limit: Option<usize>,
         tenant_context: Option<&TenantContext>,
-        #[cfg(feature = "abac-policy")] subject: Option<&SubjectId>,
+        identity: PortIdentity<'_>,
     ) -> Result<(CatalogTableSchema, Vec<Vec<ProximaValue>>)> {
+        if identity.subject.is_some() {
+            let identity_tenant = identity.tenant_id.ok_or_else(|| {
+                anyhow!("governed relational identity is missing its tenant string")
+            })?;
+            let storage_tenant = tenant_context.ok_or_else(|| {
+                anyhow!("governed relational identity is missing its storage tenant context")
+            })?;
+            if identity_tenant != storage_tenant.tenant_id {
+                return Err(anyhow!(
+                    "relational identity/storage tenant mismatch: identity '{}' != partition '{}'",
+                    identity_tenant,
+                    storage_tenant.tenant_id
+                ));
+            }
+            if let Some(storage_stable_id) = storage_tenant.tenant_stable_id
+                && identity.tenant_stable_id != Some(storage_stable_id)
+            {
+                return Err(anyhow!(
+                    "relational identity/storage stable-id mismatch for tenant '{}'",
+                    identity_tenant
+                ));
+            }
+        }
         let (table_schema, table_id_name) = self
             .resolve_select_table(table_name, tenant_context.map(|t| t.tenant_id.as_str()))
             .await?;
@@ -1483,7 +1536,7 @@ impl DmlService {
         // (or fail-closed) subject sees zero rows.
         #[cfg(feature = "abac-policy")]
         let abac_pred: Option<Box<dyn Fn(&ProximaRecord) -> bool + Send + Sync>> =
-            match self.abac_row_filter(subject, tenant_context, &table_schema) {
+            match self.abac_row_filter(identity, &table_schema) {
                 None => None,
                 Some(crate::security::rls::AbacScanResult::Denied(_)) => {
                     return Ok((table_schema, Vec::new()));
@@ -1491,6 +1544,8 @@ impl DmlService {
                 Some(crate::security::rls::AbacScanResult::Restricted(p)) => Some(p),
                 Some(crate::security::rls::AbacScanResult::Unrestricted) => None,
             };
+        #[cfg(not(feature = "abac-policy"))]
+        let _ = identity;
 
         // Push the predicate INTO the store scan: project each record to a full
         // row and apply the caller's full-row predicate. The scan-predicate API is
@@ -1624,8 +1679,7 @@ impl DmlService {
                 None,
                 None,
                 tenant_context,
-                #[cfg(feature = "abac-policy")]
-                None,
+                PortIdentity::anonymous(),
             )
             .await?;
 

--- a/src/services/dml/tests.rs
+++ b/src/services/dml/tests.rs
@@ -2874,8 +2874,7 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
             None,
             None,
             None,
-            #[cfg(feature = "abac-policy")]
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .expect("scan all");
@@ -2894,8 +2893,7 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
             Some(&pred),
             None,
             None,
-            #[cfg(feature = "abac-policy")]
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .expect("scan predicate");
@@ -2923,8 +2921,7 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
             Some(&failing_pred),
             None,
             None,
-            #[cfg(feature = "abac-policy")]
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .expect_err("a predicate eval error must surface, not silently drop rows");
@@ -2942,8 +2939,7 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
             None,
             None,
             None,
-            #[cfg(feature = "abac-policy")]
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .expect("scan projection");
@@ -2958,8 +2954,7 @@ async fn scan_table_relational_pushes_projection_predicate_limit() {
             None,
             Some(2),
             None,
-            #[cfg(feature = "abac-policy")]
-            None,
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
         .expect("scan limit");
@@ -3185,7 +3180,6 @@ async fn alter_table_materialize_via_ddl_flips_catalog_layout() {
 async fn materialize_is_tenant_isolated_by_request_tenant() {
     use crate::services::record_store::DirectWalTableRecordStore;
     use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
-    use crate::storage::tenant::context::TenantContext;
     use proximadb_iceberg_engine::IcebergObjectStoreBridge;
 
     let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -3262,7 +3256,6 @@ async fn materialize_is_tenant_isolated_by_request_tenant() {
 async fn materialize_drpath_layout_uses_opaque_namespace_id() {
     use crate::services::record_store::DirectWalTableRecordStore;
     use crate::services::{FramedTableWalAppender, MemtableRecordStorage};
-    use crate::storage::tenant::context::TenantContext;
     use proximadb_iceberg_engine::IcebergObjectStoreBridge;
 
     let temp_dir = tempfile::tempdir().expect("tempdir");
@@ -6063,12 +6056,11 @@ mod abac_relational_enforcement_tests {
     use super::*;
     use crate::core::search::{ComparisonOperator, FilterExpression};
     use crate::security::rls::{AbacEnforcer, AbacScanResult};
-    use crate::storage::tenant::context::TenantContext;
     use proximadb_abac::{
         AttributeAuthority, AttributeBinding, InMemoryAttributeAuthority, InMemoryPolicyEpochs,
         InMemoryPredicateObjectStore,
     };
-    use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope, SubjectId};
+    use proximadb_catalog::fc_metamodel::{AttrValue, Effect, PolicyBinding, Scope};
     use serde_json::json;
     use std::sync::Arc;
 
@@ -6115,10 +6107,20 @@ mod abac_relational_enforcement_tests {
         s
     }
 
-    fn tenant_ctx() -> TenantContext {
-        let mut tc = TenantContext::for_tenant_id("t7");
-        tc.tenant_stable_id = Some(TENANT);
-        tc
+    fn identity(
+        subject: Option<&str>,
+        stable_id: Option<u64>,
+    ) -> proximadb_runtime::PortIdentity<'_> {
+        proximadb_runtime::PortIdentity {
+            tenant_id: Some("t7"),
+            subject,
+            tenant_stable_id: stable_id,
+            auth_class: if subject.is_some() {
+                proximadb_tenant::AuthClass::Authenticated
+            } else {
+                proximadb_tenant::AuthClass::Anonymous
+            },
+        }
     }
 
     fn dml_with_enforcer() -> DmlService {
@@ -6133,8 +6135,10 @@ mod abac_relational_enforcement_tests {
     #[test]
     fn permitted_subject_resolves_restricted() {
         let dml = dml_with_enforcer();
-        let alice = SubjectId("alice".into());
-        let res = dml.abac_row_filter(Some(&alice), Some(&tenant_ctx()), &schema_with_stable_ids());
+        let res = dml.abac_row_filter(
+            identity(Some("alice"), Some(TENANT)),
+            &schema_with_stable_ids(),
+        );
         assert!(
             matches!(res, Some(AbacScanResult::Restricted(_))),
             "alice (bound, permitted, dept=eng predicate) must resolve to Restricted"
@@ -6144,10 +6148,8 @@ mod abac_relational_enforcement_tests {
     #[test]
     fn unbound_subject_is_denied_fail_closed() {
         let dml = dml_with_enforcer();
-        let mallory = SubjectId("mallory".into());
         let res = dml.abac_row_filter(
-            Some(&mallory),
-            Some(&tenant_ctx()),
+            identity(Some("mallory"), Some(TENANT)),
             &schema_with_stable_ids(),
         );
         assert!(
@@ -6160,7 +6162,7 @@ mod abac_relational_enforcement_tests {
     fn internal_read_has_no_enforcement() {
         let dml = dml_with_enforcer();
         // No subject ⇒ an internal/system read ⇒ no ABAC enforcement applies.
-        let res = dml.abac_row_filter(None, Some(&tenant_ctx()), &schema_with_stable_ids());
+        let res = dml.abac_row_filter(identity(None, Some(TENANT)), &schema_with_stable_ids());
         assert!(
             res.is_none(),
             "an internal read (no subject) must not enforce"
@@ -6170,13 +6172,53 @@ mod abac_relational_enforcement_tests {
     #[test]
     fn legacy_table_without_stable_ids_denies_fail_closed() {
         let dml = dml_with_enforcer();
-        let alice = SubjectId("alice".into());
         // `update_test_schema()` has no stable object/namespace ids ⇒ cannot build
         // a Target ⇒ fail-closed (Denied), never an unfiltered read.
-        let res = dml.abac_row_filter(Some(&alice), Some(&tenant_ctx()), &update_test_schema());
+        let res = dml.abac_row_filter(identity(Some("alice"), Some(TENANT)), &update_test_schema());
         assert!(
             matches!(res, Some(AbacScanResult::Denied(_))),
             "a legacy table lacking stable ids must deny (fail-closed), not leak"
+        );
+    }
+
+    #[test]
+    fn subject_without_stable_tenant_id_denies_fail_closed() {
+        let dml = dml_with_enforcer();
+        let res = dml.abac_row_filter(identity(Some("alice"), None), &schema_with_stable_ids());
+        assert!(
+            matches!(res, Some(AbacScanResult::Denied(_))),
+            "a subject without the policy key must be denied"
+        );
+    }
+
+    #[test]
+    fn governed_identity_is_ineligible_for_subject_agnostic_fast_paths() {
+        let dml = dml_with_enforcer();
+        assert!(dml.relational_abac_required(identity(Some("alice"), Some(TENANT))));
+        assert!(dml.relational_abac_required(identity(Some("alice"), None)));
+        assert!(!dml.relational_abac_required(identity(None, Some(TENANT))));
+    }
+
+    #[tokio::test]
+    async fn governed_identity_cannot_scan_a_different_tenant_partition() {
+        let dml = dml_with_enforcer();
+        let mut other = crate::storage::tenant::context::TenantContext::for_tenant_id("other");
+        other.tenant_stable_id = Some(TENANT + 1);
+        let error = dml
+            .scan_table_relational(
+                "any-table",
+                None,
+                None,
+                None,
+                Some(&other),
+                identity(Some("alice"), Some(TENANT)),
+            )
+            .await
+            .expect_err("identity/partition mismatch must fail before catalog or storage access");
+        assert!(
+            error
+                .to_string()
+                .contains("identity/storage tenant mismatch")
         );
     }
 }

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -606,75 +606,6 @@ fn abac_security_is_pushdown(
     abac_filter_is_conjunctive(security) && user_filter.is_none_or(abac_filter_is_conjunctive)
 }
 
-/// Pure ADR-087 composition decision. `auth_class` is deliberately an input
-/// even though it does not change authorization today: authenticated and
-/// trust-asserted subjects are equally deny-biased, while provenance remains
-/// available for audit. Keeping this pure pins the complete
-/// enforcer x subject x stable-id x auth-class truth table.
-#[cfg(feature = "abac-policy")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RecordsReadComposition {
-    Passthrough,
-    ResolvePolicy,
-    DenyMissingStableId,
-}
-
-#[cfg(feature = "abac-policy")]
-fn records_read_composition(
-    enforcer_wired: bool,
-    subject_present: bool,
-    stable_id_present: bool,
-    _auth_class: proximadb_tenant::AuthClass,
-) -> RecordsReadComposition {
-    if !enforcer_wired || !subject_present {
-        RecordsReadComposition::Passthrough
-    } else if !stable_id_present {
-        RecordsReadComposition::DenyMissingStableId
-    } else {
-        RecordsReadComposition::ResolvePolicy
-    }
-}
-
-#[cfg(all(test, feature = "abac-policy"))]
-mod records_read_composition_tests {
-    use super::{RecordsReadComposition, records_read_composition};
-    use proximadb_tenant::AuthClass;
-
-    #[test]
-    fn full_enforcer_subject_stable_id_auth_class_truth_table() {
-        for enforcer_wired in [false, true] {
-            for subject_present in [false, true] {
-                for stable_id_present in [false, true] {
-                    for auth_class in [
-                        AuthClass::Authenticated,
-                        AuthClass::TrustAsserted,
-                        AuthClass::Anonymous,
-                    ] {
-                        let expected = if !enforcer_wired || !subject_present {
-                            RecordsReadComposition::Passthrough
-                        } else if !stable_id_present {
-                            RecordsReadComposition::DenyMissingStableId
-                        } else {
-                            RecordsReadComposition::ResolvePolicy
-                        };
-                        assert_eq!(
-                            records_read_composition(
-                                enforcer_wired,
-                                subject_present,
-                                stable_id_present,
-                                auth_class,
-                            ),
-                            expected,
-                            "enforcer={enforcer_wired} subject={subject_present} \
-                             stable_id={stable_id_present} auth_class={auth_class}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
 impl VectorOperationsService {
     /// Create service with a shared context for cross-cutting concerns
     pub fn new_with_context(
@@ -785,13 +716,13 @@ impl VectorOperationsService {
         collection_id: &str,
     ) -> Option<proximadb_abac::ReadContext> {
         use proximadb_catalog::fc_metamodel::SubjectId;
-        match records_read_composition(
+        match proximadb_tenant::read_enforcement_composition(
             self.abac_enforcer.is_some(),
             subject.is_some(),
             tenant_stable_id.is_some(),
             auth_class,
         ) {
-            RecordsReadComposition::ResolvePolicy => {
+            proximadb_tenant::ReadEnforcementComposition::ResolvePolicy => {
                 let (Some(subject), Some(tenant_stable_id)) = (subject, tenant_stable_id) else {
                     tracing::error!(
                         target: "proximadb::tenant_audit",
@@ -815,7 +746,7 @@ impl VectorOperationsService {
                     )),
                 }
             }
-            RecordsReadComposition::DenyMissingStableId => {
+            proximadb_tenant::ReadEnforcementComposition::DenyMissingStableId => {
                 tracing::warn!(
                     target: "proximadb::tenant_audit",
                     subject = subject,
@@ -825,14 +756,16 @@ impl VectorOperationsService {
                 );
                 None
             }
-            RecordsReadComposition::Passthrough => Some(proximadb_abac::ReadContext::system(
-                proximadb_abac::SystemReadReason::Statistics,
-                if self.abac_enforcer.is_none() {
-                    "records_search (no abac enforcer)"
-                } else {
-                    "records_search (no client subject)"
-                },
-            )),
+            proximadb_tenant::ReadEnforcementComposition::Passthrough => {
+                Some(proximadb_abac::ReadContext::system(
+                    proximadb_abac::SystemReadReason::Statistics,
+                    if self.abac_enforcer.is_none() {
+                        "records_search (no abac enforcer)"
+                    } else {
+                        "records_search (no client subject)"
+                    },
+                ))
+            }
         }
     }
 


### PR DESCRIPTION
## Stack

Depends on #1403. This PR is intentionally based on its feature branch so review shows only the TD-ABAC-10b relational carrier and execution hardening. Retarget to develop after #1403 merges.

## Outcome

Closes TD-ABAC-10b: pgwire, REST SQL, and gRPC SQL now carry the complete canonical caller identity to DmlService::scan_table_relational. The relational seam consumes the same fail-closed composition rule as vector/record reads.

## Design and implementation

- Moves the pure enforcer x subject x stable-id x auth-class composition rule into proximadb-tenant and keeps its complete 24-cell truth table there.
- Adds OwnedPortIdentity for planners/readers that must retain the canonical borrowed PortIdentity without flattening it into parallel fields.
- Widens ApiHandlersPort and QueryAdapterPort SQL methods from tenant+subject parameters to one PortIdentity.
- Threads all four fields through pgwire, EXPLAIN ANALYZE, the off-pgwire adapter, extracted REST SQL, and gRPC SQL.
- Projects tenant and stable ID into storage TenantContext while retaining PortIdentity as the authorization authority.
- Makes enforcer + subject + missing stable ID deny at the relational DML seam.
- Rejects governed identity/storage tenant mismatches before catalog or record access.
- Prevents governed reads from using the subject-agnostic result cache, process-local demo engine, and bare-Parquet engine routes; they route through DML row-policy enforcement. Ungoverned/internal traffic preserves existing fast paths.
- Updates TD-ABAC-10/11 status-of-record documentation.

## Verification

- cargo check --lib
- cargo check --lib --features abac-policy
- proximadb-tenant 24-cell composition truth table
- proximadb-api REST SQL four-field carrier regression
- proximadb-runtime: 128 tests passed
- relational ABAC matrix: 7 tests passed (permit, unbound deny, missing-key deny, internal passthrough, legacy-schema deny, fast-path ineligibility, tenant-partition mismatch)
- make work-commit-check

All observed compiler warnings match the existing 25-warning baseline.