### PR TITLE
feat(abac): ratchet live relational policy enforcement

### DIFF
--- a/crates/binding/proximadb-catalog-introspection/src/lib.rs
+++ b/crates/binding/proximadb-catalog-introspection/src/lib.rs
@@ -414,6 +414,16 @@ impl CatalogIntrospectionService {
                     .cloned()
                     .unwrap_or_default(),
                 schema.schema_version.to_string(),
+                // Stable catalog identity is an operator-facing contract: ABAC
+                // policy scopes, CDC, and object-id-keyed storage all consume
+                // this value. Keep it in the extended xcatalog view (never the
+                // SQL-standard information_schema.tables shape) so control-plane
+                // clients can provision policy without guessing an allocator
+                // result or reaching into catalog persistence.
+                schema
+                    .object_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             ]);
         }
 
@@ -429,6 +439,7 @@ impl CatalogIntrospectionService {
                 "table_format".to_string(),
                 "xcatalog_namespace".to_string(),
                 "schema_version".to_string(),
+                "object_id".to_string(),
             ],
             column_types: vec![
                 "text".to_string(),
@@ -440,6 +451,7 @@ impl CatalogIntrospectionService {
                 "text".to_string(),
                 "text".to_string(),
                 "int4".to_string(),
+                "int8".to_string(),
             ],
             rows,
         })
@@ -1721,6 +1733,11 @@ mod tests {
         assert_eq!(tables.rows[0][4], "SST");
         assert_eq!(tables.rows[0][5], "hybrid");
         assert_eq!(tables.rows[0][7], "agentic.langgraph");
+        assert_eq!(tables.columns[9], "object_id");
+        assert!(
+            tables.rows[0][9].parse::<u64>().is_ok_and(|id| id > 0),
+            "xcatalog.tables must expose the stable object id needed by policy provisioning"
+        );
 
         let columns = introspection
             .execute_select("SELECT * FROM xcatalog.columns WHERE table_name = 'agent_store'")

--- a/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
+++ b/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
@@ -76,8 +76,10 @@ fail-closed guard with it.
 tenant foundation; vector/record and relational seams both consume it.
 Relational tests pin permit, unbound deny, missing-key deny, internal
 passthrough, legacy-schema deny, and fast-path ineligibility. The extracted
-REST handler test proves all four identity fields cross the SQL port. A live
-provisioned-policy surface matrix remains the release-evidence follow-on in
-[[TD-ABAC-11]].
+REST handler test proves all four identity fields cross the SQL port.
+`abac_relational_transport_e2e` now boots the real server and proves live
+pgwire deny-before-provision -> authenticated REST provision -> hot permit ->
+unbound-subject deny -> hot revoke, without reconnect or restart. The remaining
+non-relational transport rows are tracked in [[TD-ABAC-11]].
 
 Depends on [[TD-ABAC-8]]. Ref ADR-087, TD-ABAC-3, TD-ABAC-5, [[TD-ABAC-11]].

--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -48,9 +48,16 @@ dev/embedded deployment that wires an enforcer.
   rule as vector/records; missing stable key denies. Governed reads cannot use
   the subject-agnostic result cache or enforcement-blind in-memory/Parquet
   shortcuts and instead route through DML row-policy enforcement.
-* **OPEN — live cross-surface ratchet.** The REST SQL carrier test and DML
-  enforcement matrix are pinned, but the release gate still needs provisioned
-  policy exercised over live REST/gRPC/Flight/pgwire transports.
+* **DONE — live relational ratchet.** `abac_relational_transport_e2e` crosses
+  real pgwire plus the authenticated REST policy-control plane and proves
+  fail-closed before provision, hot permit on the same session, unbound-subject
+  deny, and hot revoke. Building this evidence also closed two composition-root
+  defects the component matrix could not see: pgwire now receives the exact
+  process-shared enforcer, and the default WAL-backed `SystemCatalog` now mints
+  durable object + typed namespace/collection identity like `NativeCatalog`.
+* **OPEN — remaining live surface rows.** Add provisioned-policy admit/deny/
+  passthrough ratchets for REST SQL, gRPC SQL/records, and Flight. Their carrier
+  and seam component tests are pinned; they are not mislabeled as live evidence.
 
 Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
 [[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).
@@ -68,7 +75,7 @@ seam:
   row access; storage `TenantContext` remains a partition projection, not a
   second authorization carrier.
 
-The cross-surface e2e ratchet must therefore include pgwire's *relational*
-path in addition to REST/gRPC/Flight records — and must not be written until
-[[TD-ABAC-10]] 10c closes the three pgwire bypasses, or it will ratchet in a
-false green (a passing "deny" case on a path that never enforced).
+The cross-surface e2e ratchet includes pgwire's *relational* path in addition
+to REST/gRPC/Flight records. The pgwire row is now pinned after
+[[TD-ABAC-10]] 10c; the remaining rows stay open until they exercise live
+provisioned policy rather than only handler/seam components.

--- a/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
+++ b/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
@@ -119,8 +119,8 @@ carried unchanged to every consumer; everything else is a projection.**
   → relational read boundary.
 * TD-ABAC-11 — mint + strictness: default-tenant mint, binding-provisioning
   e2e fixture, flip the composition rule to fail-closed on the absent stable
-  id, cross-surface e2e ratchet (REST/gRPC/Flight/pgwire × admit/deny/
-  passthrough).
+  id, and the live pgwire-relational + authenticated REST control-plane ratchet.
+  REST SQL/gRPC/Flight live data-plane rows remain the release-evidence tail.
 
 == References
 

--- a/src/network/multi_server.rs
+++ b/src/network/multi_server.rs
@@ -936,6 +936,10 @@ impl MultiServer {
                 if let Some(direct_write_services) = direct_write_services {
                     server = server.with_direct_write_services(direct_write_services);
                 }
+                #[cfg(feature = "abac-policy")]
+                {
+                    server = server.with_abac_enforcer(services.abac_enforcer.clone());
+                }
                 server =
                     server.with_rank_pipeline(rank_services, rank_profile_store, function_store);
                 server = server.with_primary_pod_gate(primary_pod_registry, self_pod_id);
@@ -1308,6 +1312,10 @@ impl MultiServer {
                 );
                 if let Some(direct_write_services) = direct_write_services {
                     server = server.with_direct_write_services(direct_write_services);
+                }
+                #[cfg(feature = "abac-policy")]
+                {
+                    server = server.with_abac_enforcer(services.abac_enforcer.clone());
                 }
                 server = server.with_rank_pipeline(
                     services.rank_services.clone(),

--- a/src/network/postgres/mod.rs
+++ b/src/network/postgres/mod.rs
@@ -128,6 +128,10 @@ pub struct PostgresServer {
     tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
     /// Whether startup may omit the tenant/catalog and use a default.
     tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
+    /// The exact composition-root enforcer used by REST/gRPC and mutated by the
+    /// live ABAC admin API. Cloned into each pgwire DML façade at accept time.
+    #[cfg(feature = "abac-policy")]
+    abac_enforcer: Option<Arc<crate::security::rls::AbacEnforcer>>,
     /// Whether the server is running
     running: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -172,6 +176,8 @@ impl PostgresServer {
             rate_limiter: None,
             tenant_header_trust: proximadb_tenant::HeaderTrustPolicy::default(),
             tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode::single_tenant_default(),
+            #[cfg(feature = "abac-policy")]
+            abac_enforcer: None,
             running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
@@ -270,6 +276,18 @@ impl PostgresServer {
         self
     }
 
+    /// Wire the process-shared live ABAC enforcer into every accepted pgwire
+    /// connection. This is independent of the direct-record-write option: reads
+    /// must remain governed under either storage configuration.
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_enforcer(
+        mut self,
+        enforcer: Option<Arc<crate::security::rls::AbacEnforcer>>,
+    ) -> Self {
+        self.abac_enforcer = enforcer;
+        self
+    }
+
     /// Start the PostgreSQL server
     pub async fn start(&self) -> Result<()> {
         let listener = TcpListener::bind(self.bind_address).await?;
@@ -314,6 +332,8 @@ impl PostgresServer {
                     let rate_limiter = self.rate_limiter.clone();
                     let tenant_header_trust = self.tenant_header_trust;
                     let tenant_deployment_mode = self.tenant_deployment_mode.clone();
+                    #[cfg(feature = "abac-policy")]
+                    let abac_enforcer = self.abac_enforcer.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) = Self::handle_connection(
@@ -335,6 +355,8 @@ impl PostgresServer {
                             rate_limiter,
                             tenant_header_trust,
                             tenant_deployment_mode,
+                            #[cfg(feature = "abac-policy")]
+                            abac_enforcer,
                         )
                         .await
                         {
@@ -380,6 +402,9 @@ impl PostgresServer {
         rate_limiter: Option<Arc<crate::network::middleware::rate_limit::RateLimitState>>,
         tenant_header_trust: proximadb_tenant::HeaderTrustPolicy,
         tenant_deployment_mode: proximadb_tenant::TenantDeploymentMode,
+        #[cfg(feature = "abac-policy")] abac_enforcer: Option<
+            Arc<crate::security::rls::AbacEnforcer>,
+        >,
     ) -> Result<()> {
         // Create session
         let session = session_manager.create_session(addr).await?;
@@ -403,6 +428,7 @@ impl PostgresServer {
         let protocol = protocol.with_stable_id_resolver(Some(Arc::new(
             crate::security::CatalogTenantStableIdResolver::new(catalog_manager.clone()),
         )));
+        #[allow(unused_mut)] // feature build rebinds after attaching ABAC below
         let mut protocol = if let Some(direct_write_services) = direct_write_services {
             protocol.with_direct_catalog_manager(
                 catalog_manager,
@@ -412,6 +438,8 @@ impl PostgresServer {
         } else {
             protocol.with_catalog_manager(catalog_manager)
         };
+        #[cfg(feature = "abac-policy")]
+        let mut protocol = protocol.with_abac_enforcer(abac_enforcer);
         if let Some(pipeline) = rank_pipeline {
             protocol = protocol.with_rank_pipeline(
                 pipeline.services,

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -605,6 +605,30 @@ impl PostgresProtocol {
         self
     }
 
+    /// Attach the process-shared ABAC enforcer to this connection's DML service.
+    ///
+    /// pgwire constructs a small per-connection DML façade, unlike REST/gRPC's
+    /// shared façade. The underlying enforcer must nevertheless be the exact
+    /// composition-root instance so live admin writes and every transport read
+    /// one policy state. A non-unique DML Arc is a wiring error and remains
+    /// unenforced only with an explicit error log; production calls this before
+    /// any clone escapes the connection constructor.
+    #[cfg(feature = "abac-policy")]
+    pub fn with_abac_enforcer(
+        mut self,
+        enforcer: Option<Arc<crate::security::rls::AbacEnforcer>>,
+    ) -> Self {
+        if let Some(enforcer) = enforcer {
+            match self.dml_service.as_mut().and_then(Arc::get_mut) {
+                Some(dml) => dml.set_abac_enforcer(enforcer),
+                None => tracing::error!(
+                    "pgwire ABAC enforcer could not be attached to the per-connection DML service"
+                ),
+            }
+        }
+        self
+    }
+
     pub fn with_tenant_deployment_mode(
         mut self,
         mode: proximadb_tenant::TenantDeploymentMode,

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -380,6 +380,12 @@ pub struct SharedServices {
     #[cfg(feature = "abac-policy")]
     pub abac_predicate_store: Option<Arc<proximadb_abac::FileSystemPredicateObjectStore>>,
 
+    /// Process-shared ABAC enforcer wired into every data-plane surface,
+    /// including pgwire's per-connection DML façade. Sharing this handle keeps
+    /// policy epoch/cache state and the three live durable stores convergent.
+    #[cfg(feature = "abac-policy")]
+    pub abac_enforcer: Option<Arc<crate::security::rls::AbacEnforcer>>,
+
     /// The single canonical WAL-backed record store, built + WAL-recovered ONCE here and
     /// shared across ALL surfaces — the REST/gRPC `DmlService` and the pgwire direct-write
     /// path both route relational tables through this instance — so a write on any protocol
@@ -1594,6 +1600,8 @@ impl SharedServices {
         // is then hot-visible to every reader (TD-ABAC control-plane).
         #[cfg(feature = "abac-policy")]
         let abac_stores = Self::open_abac_stores(opt_config);
+        #[cfg(feature = "abac-policy")]
+        let abac_enforcer = abac_stores.as_ref().map(Self::build_enforcer_from_stores);
 
         // `directory_cache` constructed earlier (before SstEngine) so the
         // engine, the vector ops service, and the SharedServices public
@@ -1633,12 +1641,12 @@ impl SharedServices {
             // ⇒ no enforcer ⇒ no per-record filtering (the status quo). Mirrors the
             // DmlService wiring (`build_abac_enforcer`, TD-ABAC-2).
             #[cfg(feature = "abac-policy")]
-            let svc = match &abac_stores {
-                Some(stores) => {
+            let svc = match &abac_enforcer {
+                Some(enforcer) => {
                     debug!(
                         "✅ SharedServices::new - durable ABAC enforcer wired into VectorOperationsService"
                     );
-                    svc.with_abac_enforcer(Self::build_enforcer_from_stores(stores))
+                    svc.with_abac_enforcer(enforcer.clone())
                 }
                 None => svc,
             };
@@ -2580,10 +2588,10 @@ impl SharedServices {
         // DML read funnel. Fully behind `abac-policy` (default-OFF) ⇒ default
         // builds are byte-for-byte unchanged; `None` ⇒ no enforcement (status quo).
         #[cfg(feature = "abac-policy")]
-        let base_dml = match &abac_stores {
-            Some(stores) => {
+        let base_dml = match &abac_enforcer {
+            Some(enforcer) => {
                 debug!("✅ SharedServices::new - durable ABAC enforcer wired into DmlService");
-                base_dml.with_abac_enforcer(Self::build_enforcer_from_stores(stores))
+                base_dml.with_abac_enforcer(enforcer.clone())
             }
             None => base_dml,
         };
@@ -2981,6 +2989,8 @@ impl SharedServices {
                 abac_binding_store: abac_stores.as_ref().map(|s| s.bindings.clone()),
                 #[cfg(feature = "abac-policy")]
                 abac_predicate_store: abac_stores.as_ref().map(|s| s.predicate_objects.clone()),
+                #[cfg(feature = "abac-policy")]
+                abac_enforcer,
                 // TD-064 / LLD §5: per-collection recall-probe gate. Empty
                 // at startup; populated as the stats refresher / search path
                 // observe probe outcomes. Route-health surfaces per-scope

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1050,6 +1050,17 @@ impl DmlService {
         self
     }
 
+    /// Attach the process-shared ABAC enforcer after construction.
+    ///
+    /// The pgwire protocol builds its per-connection DML façade only after the
+    /// socket is accepted, so it cannot use the consuming builder without
+    /// rebuilding other already-attached dependencies. The composition root
+    /// calls this exactly once while its `Arc<DmlService>` is still unique.
+    #[cfg(feature = "abac-policy")]
+    pub fn set_abac_enforcer(&mut self, enforcer: Arc<crate::security::rls::AbacEnforcer>) {
+        self.abac_enforcer = Some(enforcer);
+    }
+
     /// TD-ABAC-10c: whether row-level enforcement is armed on this service.
     ///
     /// Read-paths that CANNOT enforce (they lack the row-filter wiring

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -105,6 +105,16 @@ pub struct SystemCatalog {
     /// Next durable account/tenant stable id. Recovered from the WAL/snapshot
     /// state at boot; u64 lets us detect u32 exhaustion instead of wrapping.
     account_floor: AtomicU64,
+    /// Next globally unique catalog object id (table/column/index). Recovered
+    /// from durable schemas at boot; starts at one because zero is reserved.
+    object_floor: AtomicU64,
+    /// Next stable namespace/collection ids. The typed ids are narrower than
+    /// object ids, so u64 floors let allocation detect exhaustion before casts.
+    namespace_floor: AtomicU64,
+    collection_floor: AtomicU64,
+    /// Stable namespace id per (account, logical namespace). Durable schemas
+    /// are the authority; this map is rebuilt from them after replay.
+    namespace_ids: parking_lot::RwLock<HashMap<(String, String), u16>>,
     appender: Arc<dyn TableWalAppender>,
     /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
     /// never interleave such that a lower-LSN mutation applies after a higher
@@ -149,12 +159,18 @@ impl SystemCatalog {
         state: SystemCatalogState,
         appender: Arc<dyn TableWalAppender>,
     ) -> Self {
+        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
+            Self::identity_allocator_seed(&state);
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
+            object_floor: AtomicU64::new(object_floor),
+            namespace_floor: AtomicU64::new(namespace_floor),
+            collection_floor: AtomicU64::new(collection_floor),
+            namespace_ids: parking_lot::RwLock::new(namespace_ids),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: None,
@@ -176,6 +192,120 @@ impl SystemCatalog {
     /// The plane this catalog serves.
     pub fn role(&self) -> &proximadb_catalog::CatalogRole {
         &self.role
+    }
+
+    /// Recover every transient identity allocator from the durable table
+    /// schemas folded into `state`. Skipped ids are harmless; reuse is not.
+    fn identity_allocator_seed(
+        state: &SystemCatalogState,
+    ) -> (u64, u64, u64, HashMap<(String, String), u16>) {
+        let object_floor = state.max_object_id().map_or(1, |id| id.saturating_add(1));
+        let mut namespace_floor = 1_u64;
+        let mut collection_floor = 1_u64;
+        let mut namespace_ids = HashMap::new();
+        for (identifier, schema) in state.table_entries() {
+            if let Some(namespace_id) = schema.stable_namespace_id {
+                namespace_floor = namespace_floor.max(u64::from(namespace_id) + 1);
+                if let Some(account) = state
+                    .get_namespace(&identifier.namespace)
+                    .and_then(|namespace| namespace.tenant_id)
+                {
+                    namespace_ids.insert((account, identifier.namespace.join(".")), namespace_id);
+                }
+            }
+            if let Some(collection_id) = schema.stable_collection_id {
+                collection_floor = collection_floor.max(u64::from(collection_id) + 1);
+            }
+        }
+        (
+            object_floor,
+            namespace_floor,
+            collection_floor,
+            namespace_ids,
+        )
+    }
+
+    fn mint_object_id(&self, existing: Option<u64>) -> Result<u64> {
+        match existing {
+            Some(id) if id > 0 => {
+                let next = id
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow!("catalog object id space exhausted"))?;
+                self.object_floor.fetch_max(next, Ordering::SeqCst);
+                Ok(id)
+            }
+            Some(_) => Err(anyhow!("catalog object id zero is reserved")),
+            None => self.allocate_bounded(&self.object_floor, u64::MAX, "catalog object"),
+        }
+    }
+
+    fn allocate_bounded(&self, floor: &AtomicU64, max: u64, label: &str) -> Result<u64> {
+        floor
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |id| {
+                (id > 0 && id <= max).then(|| id.checked_add(1)).flatten()
+            })
+            .map_err(|_| anyhow!("{label} id space exhausted"))
+    }
+
+    async fn resolve_typed_triple(
+        &self,
+        account: &str,
+        namespace_key: &str,
+        existing_namespace: Option<u16>,
+        existing_collection: Option<u32>,
+    ) -> Result<Option<(u32, u16, u32)>> {
+        let Some(account_id) = self.account_id_u32(account).await? else {
+            return Ok(None);
+        };
+        let key = (account.to_string(), namespace_key.to_string());
+        let namespace_id = if let Some(id) = existing_namespace {
+            self.namespace_floor
+                .fetch_max(u64::from(id) + 1, Ordering::SeqCst);
+            let mut registry = self.namespace_ids.write();
+            match registry.get(&key) {
+                Some(current) if *current != id => {
+                    return Err(anyhow!(
+                        "stable namespace identity mismatch for '{}': {} != {}",
+                        namespace_key,
+                        current,
+                        id
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    registry.insert(key, id);
+                }
+            }
+            id
+        } else if let Some(id) = self.namespace_ids.read().get(&key).copied() {
+            id
+        } else {
+            let mut registry = self.namespace_ids.write();
+            if let Some(id) = registry.get(&key).copied() {
+                id
+            } else {
+                let id = self.allocate_bounded(
+                    &self.namespace_floor,
+                    u64::from(u16::MAX),
+                    "stable namespace",
+                )? as u16;
+                registry.insert(key, id);
+                id
+            }
+        };
+        let collection_id = match existing_collection {
+            Some(id) => {
+                self.collection_floor
+                    .fetch_max(u64::from(id) + 1, Ordering::SeqCst);
+                id
+            }
+            None => self.allocate_bounded(
+                &self.collection_floor,
+                u64::from(u32::MAX),
+                "stable collection",
+            )? as u32,
+        };
+        Ok(Some((account_id, namespace_id, collection_id)))
     }
 
     /// Open (or create) the catalog WAL at `wal_path`, restore the in-RAM
@@ -289,12 +419,18 @@ impl SystemCatalog {
             .filter(|n| *n > 0)
             .unwrap_or(DEFAULT_SNAPSHOT_THRESHOLD);
 
+        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
+            Self::identity_allocator_seed(&state);
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Ok(Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
+            object_floor: AtomicU64::new(object_floor),
+            namespace_floor: AtomicU64::new(namespace_floor),
+            collection_floor: AtomicU64::new(collection_floor),
+            namespace_ids: parking_lot::RwLock::new(namespace_ids),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: Some(SnapshotConfig {
@@ -527,6 +663,18 @@ impl SystemCatalog {
             self.account_floor
                 .fetch_max(u64::from(max) + 1, Ordering::SeqCst);
         }
+        // The adopted authority may also carry object/typed ids minted by the
+        // publisher after this pod booted. Re-seed every transient allocator and
+        // replace the namespace map while the catalog write lock is held, so a
+        // same-generation reload cannot later reuse an adopted id.
+        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
+            Self::identity_allocator_seed(&self.state);
+        self.object_floor.fetch_max(object_floor, Ordering::SeqCst);
+        self.namespace_floor
+            .fetch_max(namespace_floor, Ordering::SeqCst);
+        self.collection_floor
+            .fetch_max(collection_floor, Ordering::SeqCst);
+        *self.namespace_ids.write() = namespace_ids;
         self.loaded_version.store(read.version, Ordering::SeqCst);
         self.loaded_generation
             .store(read.generation, Ordering::SeqCst);
@@ -791,6 +939,23 @@ impl Catalog for SystemCatalog {
         self.state.account_id_u32(account)
     }
 
+    async fn max_object_id(&self) -> Result<Option<u64>> {
+        Ok(self.state.max_object_id())
+    }
+
+    async fn mint_collection_typed_identity(
+        &self,
+        account: &str,
+        namespace_key: &str,
+    ) -> Result<Option<(u32, u16, u32)>> {
+        let account = account.trim();
+        if account.is_empty() {
+            return Ok(None);
+        }
+        self.resolve_typed_triple(account, namespace_key, None, None)
+            .await
+    }
+
     async fn update_namespace_properties(
         &self,
         namespace: &[String],
@@ -821,6 +986,8 @@ impl Catalog for SystemCatalog {
         identifier: &TableIdentifier,
         schema: CatalogTableSchema,
     ) -> Result<CatalogTableSchema> {
+        let mut schema = schema;
+        proximadb_catalog::schema::normalize_identity(&mut schema);
         validate_schema(&schema)?;
         if !self.state.namespace_exists(&identifier.namespace) {
             return Err(anyhow!(
@@ -830,6 +997,35 @@ impl Catalog for SystemCatalog {
         }
         if self.state.table_exists(identifier) {
             return Err(anyhow!("Table '{}' already exists", identifier));
+        }
+        schema.object_id = Some(self.mint_object_id(schema.object_id)?);
+        for column in &mut schema.columns {
+            column.object_id = Some(self.mint_object_id(column.object_id)?);
+        }
+        for index in &mut schema.indexes {
+            index.object_id = Some(self.mint_object_id(index.object_id)?);
+        }
+        let namespace = self
+            .state
+            .get_namespace(&identifier.namespace)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Namespace '{}' does not exist",
+                    identifier.namespace.join(".")
+                )
+            })?;
+        if let Some(account) = namespace.tenant_id.as_deref()
+            && let Some((_account_id, namespace_id, collection_id)) = self
+                .resolve_typed_triple(
+                    account,
+                    &identifier.namespace.join("."),
+                    schema.stable_namespace_id,
+                    schema.stable_collection_id,
+                )
+                .await?
+        {
+            schema.stable_namespace_id = Some(namespace_id);
+            schema.stable_collection_id = Some(collection_id);
         }
         self.commit(CatalogDelta::UpsertTable {
             identifier: identifier.clone(),
@@ -933,6 +1129,7 @@ impl Catalog for SystemCatalog {
         identifier: &TableIdentifier,
         index: CatalogIndex,
     ) -> Result<CatalogIndex> {
+        let mut index = index;
         let mut schema = self.require_table(identifier)?;
         if schema.indexes.iter().any(|i| i.name == index.name) {
             return Err(anyhow!(
@@ -950,6 +1147,7 @@ impl Catalog for SystemCatalog {
                 ));
             }
         }
+        index.object_id = Some(self.mint_object_id(index.object_id)?);
         schema.indexes.push(index.clone());
         schema.updated_at_ms = now_millis();
         self.commit(CatalogDelta::UpsertTable {
@@ -1107,6 +1305,50 @@ mod tests {
         let right = right?;
         assert_eq!(left, right);
         assert_eq!(cat.account_id_u32_lookup("acme"), left);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tenant_tables_receive_durable_total_object_and_typed_identity() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let wal = dir.path().join("catalog.wal");
+        let namespace = nslevels(&["acme", "default"]);
+        let first = TableIdentifier::new(namespace.clone(), "orders");
+        let second = TableIdentifier::new(namespace.clone(), "customers");
+
+        let cat = SystemCatalog::open("default", &wal).await?;
+        cat.create_namespace_for_tenant(&namespace, HashMap::new(), Some("acme"))
+            .await?;
+        let orders = cat.create_table(&first, vec_schema("orders")).await?;
+        let customers = cat.create_table(&second, vec_schema("customers")).await?;
+
+        assert!(orders.object_id.is_some());
+        assert!(
+            orders
+                .columns
+                .iter()
+                .all(|column| column.object_id.is_some())
+        );
+        assert_eq!(orders.stable_namespace_id, customers.stable_namespace_id);
+        assert!(orders.stable_namespace_id.is_some());
+        assert_ne!(orders.stable_collection_id, customers.stable_collection_id);
+        let prior_max_object = cat.max_object_id().await?.expect("object ids minted");
+        let stable_namespace = orders.stable_namespace_id;
+        let prior_collection = customers.stable_collection_id.expect("typed collection id");
+        drop(cat);
+
+        let reopened = SystemCatalog::open("default", &wal).await?;
+        let third = TableIdentifier::new(namespace, "invoices");
+        let invoices = reopened
+            .create_table(&third, vec_schema("invoices"))
+            .await?;
+        assert_eq!(invoices.stable_namespace_id, stable_namespace);
+        assert!(
+            invoices
+                .stable_collection_id
+                .is_some_and(|id| id > prior_collection)
+        );
+        assert!(invoices.object_id.is_some_and(|id| id > prior_max_object));
         Ok(())
     }
 

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -301,6 +301,32 @@ impl SystemCatalogState {
         self.inner.read().account_ids.values().copied().max()
     }
 
+    /// Snapshot the table identity rows used to recover the SystemCatalog's
+    /// transient allocator floors and namespace registry after WAL replay.
+    pub fn table_entries(&self) -> Vec<(TableIdentifier, Arc<CatalogTableSchema>)> {
+        self.inner
+            .read()
+            .tables
+            .iter()
+            .map(|(identifier, schema)| (identifier.clone(), schema.clone()))
+            .collect()
+    }
+
+    /// Highest durable object id across tables, columns, and indexes.
+    pub fn max_object_id(&self) -> Option<u64> {
+        self.inner
+            .read()
+            .tables
+            .values()
+            .flat_map(|schema| {
+                std::iter::once(schema.object_id)
+                    .chain(schema.columns.iter().map(|column| column.object_id))
+                    .chain(schema.indexes.iter().map(|index| index.object_id))
+            })
+            .flatten()
+            .max()
+    }
+
     /// The highest WAL sequence number folded in (replay watermark / snapshot
     /// cutover LSN).
     pub fn applied_seq(&self) -> u64 {

--- a/tests/abac_relational_transport_e2e.rs
+++ b/tests/abac_relational_transport_e2e.rs
@@ -1,0 +1,380 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Live relational ABAC provisioning ratchet (TD-ABAC-10b / TD-ABAC-11).
+//!
+//! This is deliberately a transport test, not another component test. It boots
+//! one real server and crosses both production surfaces involved in the operator
+//! journey:
+//!
+//! ```text
+//! pgwire CREATE/INSERT/SELECT
+//!          |                 authenticated REST PUT/POST/DELETE
+//!          v                              |
+//! relational DML scan <--- shared live FileSystem ABAC stores
+//! ```
+//!
+//! The test proves deny-before-provision, hot permit without reconnect/restart,
+//! isolation of an unbound subject, and hot revoke. It also discovers the table's
+//! stable object id through `xcatalog.tables`; policy tooling must never guess an
+//! allocator result or scrape catalog persistence.
+
+#![cfg(feature = "abac-policy")]
+
+use std::collections::HashMap;
+use std::net::TcpListener;
+use std::time::Duration;
+
+use proximadb::core::Config;
+use proximadb::database::ProximaDB;
+use proximadb::security::SecurityMode;
+use proximadb::security::auth_service::{
+    ApiKeyInfo, AuthenticationConfig, AuthenticationMethod, JwtConfig, MtlsConfig, SSOConfig,
+};
+use proximadb::security::rbac_service::RBACConfig;
+use proximadb::security::security_coordinator::{ComplianceConfig, TlsConfig};
+use proximadb::security::{AuditConfig, EncryptionConfig, KeyStoreConfig, SecurityConfig};
+use reqwest::{Client as HttpClient, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tokio_postgres::{Client as PgClient, SimpleQueryMessage};
+
+// The composition root mints this catalog tenant before listeners start, so the
+// pgwire handshake can stamp its stable id once and retain it for the session.
+const TENANT: &str = proximadb_tenant::DEFAULT_TENANT;
+const OPERATOR_KEY: &str = "abac-operator-key";
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+fn operator_security_config() -> SecurityConfig {
+    let mut api_keys = HashMap::new();
+    api_keys.insert(
+        OPERATOR_KEY.to_string(),
+        ApiKeyInfo {
+            user_id: "abac-operator".to_string(),
+            tenant_id: None,
+            permissions: vec!["*".to_string()],
+            created_at: None,
+            expires_at: None,
+            rate_limit_per_minute: None,
+            ip_restrictions: vec![],
+        },
+    );
+    SecurityConfig {
+        enabled: true,
+        mode: SecurityMode::Development,
+        authentication: AuthenticationConfig {
+            enabled: true,
+            methods: vec![AuthenticationMethod::ApiKey],
+            require_authentication: true,
+            default_session_timeout_minutes: 60,
+            api_keys,
+            jwt: JwtConfig {
+                enabled: false,
+                secret: "test-secret".to_string(),
+                access_token_expiration_minutes: 15,
+                refresh_token_expiration_days: 7,
+                issuer: "test".to_string(),
+                audience: "test".to_string(),
+                algorithm: "HS256".to_string(),
+            },
+            sso: SSOConfig {
+                enabled: false,
+                providers: vec![],
+                token_cache_ttl_minutes: 5,
+                aws_iam: None,
+                azure_ad: None,
+            },
+            mtls: MtlsConfig::default(),
+        },
+        rbac: RBACConfig::default(),
+        audit: AuditConfig::default(),
+        tls: TlsConfig {
+            enabled: false,
+            require_client_certificates: false,
+            cert_file: None,
+            key_file: None,
+            ca_file: None,
+        },
+        compliance: ComplianceConfig {
+            frameworks: vec![],
+            data_residency: None,
+            encryption_at_rest: false,
+            encryption_in_transit: false,
+        },
+        encryption: EncryptionConfig::default(),
+        key_store: KeyStoreConfig::default(),
+        tenant: Default::default(),
+    }
+}
+
+struct LiveServer {
+    rest_port: u16,
+    pg_port: u16,
+    db: Option<ProximaDB>,
+    _tmp: TempDir,
+}
+
+impl LiveServer {
+    async fn start() -> anyhow::Result<Self> {
+        let rest_port = free_port();
+        let grpc_port = free_port();
+        let pg_port = free_port();
+        let tmp = TempDir::new()?;
+        let mut config = Config::default();
+        config.server.bind_address = "127.0.0.1".to_string();
+        config.server.port = rest_port;
+        config.server.data_dir = tmp.path().to_path_buf();
+        config.api.unified_mode = false;
+        config.api.rest_port = rest_port;
+        config.api.grpc_port = grpc_port;
+        config.api.pg_port = Some(pg_port);
+        config.storage.storage_locations = vec![proximadb::core::config::StorageLocation {
+            url: format!("file://{}", tmp.path().display()),
+            ..Default::default()
+        }];
+        config.storage.metadata_url = format!("file://{}/metadata", tmp.path().display());
+        config.storage.wal_config.write_buffer_directory =
+            format!("file://{}/wal", tmp.path().display());
+        config.security = Some(operator_security_config());
+
+        let mut db = ProximaDB::new(config).await?;
+        db.start().await?;
+        let http = HttpClient::builder()
+            .timeout(Duration::from_secs(3))
+            .no_proxy()
+            .build()?;
+        let health = format!("http://127.0.0.1:{rest_port}/health");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            match http.get(&health).send().await {
+                Ok(response) if response.status().is_success() => break,
+                _ if std::time::Instant::now() > deadline => {
+                    anyhow::bail!("REST server did not become ready")
+                }
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+        Ok(Self {
+            rest_port,
+            pg_port,
+            db: Some(db),
+            _tmp: tmp,
+        })
+    }
+
+    fn pg_conn_str(&self, subject: &str) -> String {
+        format!(
+            "host=127.0.0.1 port={} user={subject} dbname={TENANT} sslmode=disable",
+            self.pg_port
+        )
+    }
+
+    fn admin_url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{path}", self.rest_port)
+    }
+}
+
+impl Drop for LiveServer {
+    fn drop(&mut self) {
+        if let Some(mut db) = self.db.take() {
+            tokio::spawn(async move {
+                let _ = db.shutdown().await;
+            });
+        }
+    }
+}
+
+async fn connect(server: &LiveServer, subject: &str) -> PgClient {
+    let (client, connection) =
+        tokio_postgres::connect(&server.pg_conn_str(subject), tokio_postgres::NoTls)
+            .await
+            .unwrap_or_else(|error| panic!("connect {subject}: {error}"));
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("pgwire connection error: {error}");
+        }
+    });
+    client
+}
+
+async fn exec(client: &PgClient, sql: &str) {
+    client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|error| panic!("execute `{sql}`: {error}"));
+}
+
+async fn scalar(client: &PgClient, sql: &str) -> String {
+    for message in client
+        .simple_query(sql)
+        .await
+        .unwrap_or_else(|error| panic!("query `{sql}`: {error}"))
+    {
+        if let SimpleQueryMessage::Row(row) = message {
+            return row.get(0).unwrap_or("NULL").to_string();
+        }
+    }
+    panic!("query `{sql}` returned no row")
+}
+
+async fn table_object_id(client: &PgClient, table: &str) -> u64 {
+    let sql = format!("SELECT * FROM xcatalog.tables WHERE table_name = '{table}'");
+    // `resolve_table_scoped` avoids duplicating the tenant when the default
+    // namespace already equals it; introspection renders that namespace as the
+    // PostgreSQL-compatible `public` alias.
+    let expected_namespace = "public";
+    for message in client
+        .simple_query(&sql)
+        .await
+        .unwrap_or_else(|error| panic!("catalog query `{sql}`: {error}"))
+    {
+        if let SimpleQueryMessage::Row(row) = message
+            && row.get(1) == Some(expected_namespace)
+        {
+            return row
+                .get(9)
+                .expect("xcatalog.tables object_id column")
+                .parse()
+                .expect("numeric stable table object id");
+        }
+    }
+    panic!("catalog query did not return tenant-scoped table {expected_namespace}.{table}")
+}
+
+async fn assert_admin_success(response: reqwest::Response, operation: &str) -> Value {
+    let status = response.status();
+    let body = response.text().await.expect("admin response body");
+    assert!(
+        status.is_success(),
+        "{operation} failed with {status}: {body}"
+    );
+    if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_str(&body)
+            .unwrap_or_else(|error| panic!("{operation} returned invalid JSON `{body}`: {error}"))
+    }
+}
+
+/// The root crate's debug-build server future exceeds Tokio's 2 MiB default
+/// worker stack in several existing pgwire E2Es. Use the repository's standard
+/// 8 MiB integration-test runtime so the test measures the transport contract,
+/// not debug-frame size (see `tpch_pgwire_e2e`).
+#[test]
+fn pgwire_reads_follow_live_rest_policy_provision_and_revoke() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    runtime.block_on(pgwire_reads_follow_live_rest_policy_provision_and_revoke_inner());
+}
+
+async fn pgwire_reads_follow_live_rest_policy_provision_and_revoke_inner() {
+    let server = LiveServer::start().await.expect("start live server");
+    let alice = connect(&server, "alice").await;
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let table = format!("abac_live_{suffix}");
+    exec(
+        &alice,
+        &format!("CREATE TABLE {table} (id INT PRIMARY KEY, value INT)"),
+    )
+    .await;
+    exec(&alice, &format!("INSERT INTO {table} VALUES (1, 10)")).await;
+    exec(&alice, &format!("INSERT INTO {table} VALUES (2, 20)")).await;
+
+    let object_id = table_object_id(&alice, &table).await;
+    let table_scope = u32::try_from(object_id).expect("ABAC table scope is u32");
+
+    // Empty durable stores are deny-by-default. The request carries all four
+    // identity fields through real pgwire, but neither subject membership nor a
+    // table permit exists yet.
+    assert_eq!(
+        scalar(&alice, &format!("SELECT COUNT(*) FROM {table}")).await,
+        "0",
+        "unprovisioned governed reads must fail closed"
+    );
+
+    let http = HttpClient::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let auth = format!("Api-Key {OPERATOR_KEY}");
+
+    let response = http
+        .post(server.admin_url("/api/v2/abac/attribute-bindings"))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .json(&json!({
+            "subject_id": "alice",
+            "tenant": TENANT,
+            "attrs": {}
+        }))
+        .send()
+        .await
+        .expect("provision alice binding");
+    let binding = assert_admin_success(response, "provision attribute binding").await;
+    assert_eq!(binding["subject_id"], "alice");
+
+    // The URL object id identifies this policy-binding object; the scope carries
+    // the independently discovered table object id.
+    let policy_object_id = object_id + 1_000_000_000;
+    let policy_path = format!("/api/v2/abac/policy-bindings/{TENANT}/{policy_object_id}");
+    let response = http
+        .put(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .json(&json!({
+            "scope": {"Table": table_scope},
+            "effect": "Permit"
+        }))
+        .send()
+        .await
+        .expect("provision table permit");
+    let policy = assert_admin_success(response, "provision table permit").await;
+    assert_eq!(
+        policy["tenant_stable_id"].as_u64(),
+        binding["tenant_stable_id"].as_u64()
+    );
+
+    assert_eq!(
+        scalar(&alice, &format!("SELECT COUNT(*) FROM {table}")).await,
+        "2",
+        "policy mutation must be hot-visible to the existing pgwire session"
+    );
+
+    let bob = connect(&server, "bob").await;
+    assert_eq!(
+        scalar(&bob, &format!("SELECT COUNT(*) FROM {table}")).await,
+        "0",
+        "a table permit must not admit a subject without an authority binding"
+    );
+
+    let response = http
+        .delete(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .send()
+        .await
+        .expect("revoke table permit");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "policy revoke must succeed"
+    );
+    assert_eq!(
+        scalar(&alice, &format!("SELECT COUNT(*) FROM {table}")).await,
+        "0",
+        "policy revoke must be hot-visible to the existing pgwire session"
+    );
+}


### PR DESCRIPTION
## Outcome

Adds a live, transport-level ABAC ratchet for relational reads. The test provisions authority through the authenticated REST control plane and proves permit, isolation, and revocation on a real pgwire session.

## What changed

- expose catalog-assigned table `object_id` through `xcatalog.tables` without changing existing column positions
- share the composition-root `Arc<AbacEnforcer>` with every pgwire connection instead of constructing an unenforced per-connection DML path
- make the default WAL-backed `SystemCatalog` mint total table/column/index object IDs plus stable namespace and collection IDs
- recover all allocator floors and stable mappings after reopen/snapshot load, rejecting exhaustion or namespace mismatches rather than wrapping or reusing identity
- add a live test covering authenticated REST provisioning, pgwire permit, cross-principal denial, and same-session revocation
- update TD-ABAC-10, TD-ABAC-11, and ADR-087 with the verified boundary and remaining transport work

## Live scenario

1. Alice creates and populates a table through pgwire.
2. The test discovers its stable object identity from `xcatalog.tables`.
3. Alice is denied before policy provisioning.
4. An authenticated REST caller creates Alice's attribute binding and a table-scoped permit.
5. The same pgwire session observes the permitted rows.
6. Bob, without the authority binding, observes no rows.
7. The REST caller revokes the policy; Alice's same session immediately observes no rows.

## Verification

- `cargo check --lib`
- `cargo check --lib --features abac-policy`
- `cargo test --lib services::system_catalog::tests --features abac-policy` (18 passed)
- `cargo test -p proximadb-catalog-introspection --lib` (4 passed)
- `cargo test --features abac-policy --test abac_relational_transport_e2e -- --nocapture` (1 passed)
- `make work-commit-check`
- `cargo fmt --all`
- `git diff --check`

## Stack and remaining boundary

Stacked on #1405, which is stacked on #1403. Retarget this PR to `develop` after its prerequisites merge.

This closes the live pgwire plus REST-control proof. Live data-row ratchets for REST SQL, gRPC SQL, and Flight remain explicitly open; the documentation does not claim those surfaces are closed.
