### PR TITLE
test(abac): ratchet authenticated gRPC SQL enforcement

### DIFF
--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -20,9 +20,10 @@ Next action (strict ordering — totality before strictness):
 2. **Flip the rule** in the same release train: enforcer wired ∧ subject
    present ∧ stable id absent ⇒ DENY. Unit-test the full truth table
    (enforcer × subject × stable id × auth_class) in isolation.
-3. **Cross-surface e2e ratchet**: provisioned policy exercised over
-   REST/gRPC/Flight/pgwire × admit/deny-fail-closed/passthrough (needs the
-   provisioning e2e fixture from step 1).
+3. **Cross-surface e2e ratchet**: provisioned policy exercised over active
+   pgwire/gRPC SQL plus REST/gRPC/Flight record surfaces ×
+   admit/deny-fail-closed/passthrough (needs the provisioning e2e fixture from
+   step 1). Plain SQL-over-REST is retired and is not a test row.
 
 Do NOT flip before the mint lands — it would fail-close every unminted
 dev/embedded deployment that wires an enforcer.
@@ -55,9 +56,20 @@ dev/embedded deployment that wires an enforcer.
   defects the component matrix could not see: pgwire now receives the exact
   process-shared enforcer, and the default WAL-backed `SystemCatalog` now mints
   durable object + typed namespace/collection identity like `NativeCatalog`.
+* **DONE — live authenticated gRPC SQL ratchet.** The same transport test uses
+  credential-bound API keys for Alice and Bob and crosses the real
+  `ProximaRecordService.ExecuteQuery` server. It proves fail-closed before
+  provision, hot table permit, authenticated-principal isolation, and hot
+  revoke on an existing client. This is load-bearing authentication evidence,
+  not pgwire's deliberately trust-asserted user name.
+* **NOT APPLICABLE — REST SQL.** The supported-surface contract hard-removed
+  `/api/v1/sql/execute`; `/api/v2/query` is UQL/Federated/AQL and explicitly is
+  not SQL-over-REST. Reintroducing a retired route solely for an evidence row
+  would create a second, unsupported SQL surface.
 * **OPEN — remaining live surface rows.** Add provisioned-policy admit/deny/
-  passthrough ratchets for REST SQL, gRPC SQL/records, and Flight. Their carrier
-  and seam component tests are pinned; they are not mislabeled as live evidence.
+  passthrough ratchets for canonical REST records/search, gRPC records/search,
+  and Flight. Their carrier and seam component tests are pinned; they are not
+  mislabeled as live evidence.
 
 Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
 [[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).
@@ -75,7 +87,8 @@ seam:
   row access; storage `TenantContext` remains a partition projection, not a
   second authorization carrier.
 
-The cross-surface e2e ratchet includes pgwire's *relational* path in addition
-to REST/gRPC/Flight records. The pgwire row is now pinned after
-[[TD-ABAC-10]] 10c; the remaining rows stay open until they exercise live
-provisioned policy rather than only handler/seam components.
+The cross-surface e2e ratchet includes pgwire's and authenticated gRPC's
+*relational* paths in addition to REST/gRPC/Flight records. Both SQL rows are
+now pinned after [[TD-ABAC-10]] 10c; the remaining record/Flight rows stay open
+until they exercise live provisioned policy rather than only handler/seam
+components.

--- a/docs/10-quality/td/TD-ABAC-5-sql-port-subject-threading.adoc
+++ b/docs/10-quality/td/TD-ABAC-5-sql-port-subject-threading.adoc
@@ -9,9 +9,9 @@
 
 [cols="1,3"]
 |===
-| Status | **Delivered.** The authenticated subject is threaded through the SQL port traits (`execute_sql_v1` / `execute_sql`) and activated on the gRPC surface — the first *unconditional, real-auth* ABAC enforcement (no trust-auth caveat). REST extractor wiring + the `execute_unified_query`/`federated_query` path are follow-ons.
+| Status | **Delivered.** The authenticated subject is threaded through the SQL port traits (`execute_sql_v1` / `execute_sql`) and activated on the gRPC surface — the first *unconditional, real-auth* ABAC enforcement (no trust-auth caveat). A live credential-authenticated transport ratchet now proves permit, principal isolation, and hot revoke.
 | Scope | Activation-completion across network surfaces. pgwire was activated in TD-ABAC-3 (advisory under trust auth); this activates gRPC with a genuinely-authenticated subject.
-| Out of scope | REST `Extension<UnifiedUserContext>` extractor wiring on the `execute_sql_v1` route; the REST prod `execute_unified_query`→`federated_query` path (separate surface that doesn't reach `try_run_select`). Durable policy-epoch source, column masking, graph trio, P2.
+| Out of scope | `/api/v2/query` UQL/Federated identity semantics (a separate non-relational-SQL surface that does not reach `try_run_select`). Durable policy-epoch source, column masking, graph trio, P2. Plain SQL-over-REST was hard-removed and is not a follow-on.
 |===
 
 NOTE: Code references are `file::symbol`. `develop` moves; trust the symbol, re-locate the line.
@@ -70,15 +70,15 @@ without waiting for P2 (SCRAM auth on pgwire).
 * `cargo check --workspace --all-targets --features abac-policy` — compiles the
   threaded path + all test impls/callers.
 * `cargo nextest run --features abac-policy -E 'test(abac)'` — no regression (21/21).
+* `cargo test --features abac-policy --test abac_relational_transport_e2e` —
+  live API-key-authenticated gRPC deny-before-provision → permit → other-principal
+  deny → hot revoke, alongside the pgwire ratchet.
 * `cargo clippy --features abac-policy -- -D warnings`, `cargo fmt --check`,
   `make work-commit-check` (panic-policy +0, env-gate, layering, capability-matrix).
 
 == 5. Follow-ons (under TD-FOUNDATION-3)
 
-1. **REST `execute_sql_v1` extractor** — add `Option<Extension<UnifiedUserContext>>`
-   to the REST SQL handler and pass `user_id` (currently `None`). The trait param is
-   already in place.
-2. **REST prod `execute_unified_query`→`federated_query` path** — a separate surface
-   that does not reach `try_run_select`; needs its own subject wiring.
-3. **Durable policy-epoch source** (S10 cache-key invalidation).
-4. **Column masking**, **graph trio** (layering), **P2** (real pgwire SCRAM auth).
+1. **`/api/v2/query` UQL/Federated path** — a separate non-SQL surface that
+   does not reach `try_run_select`; define and pin its own identity semantics.
+2. **Durable policy-epoch source** (S10 cache-key invalidation).
+3. **Column masking**, **graph trio** (layering), **P2** (real pgwire SCRAM auth).

--- a/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
+++ b/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
@@ -119,8 +119,10 @@ carried unchanged to every consumer; everything else is a projection.**
   → relational read boundary.
 * TD-ABAC-11 — mint + strictness: default-tenant mint, binding-provisioning
   e2e fixture, flip the composition rule to fail-closed on the absent stable
-  id, and the live pgwire-relational + authenticated REST control-plane ratchet.
-  REST SQL/gRPC/Flight live data-plane rows remain the release-evidence tail.
+  id, and live pgwire + credential-authenticated gRPC relational ratchets using
+  the authenticated REST policy-control plane. SQL-over-REST is retired and is
+  not an evidence row; canonical REST/gRPC record and Flight live data-plane
+  rows remain the release-evidence tail.
 
 == References
 

--- a/tests/abac_relational_transport_e2e.rs
+++ b/tests/abac_relational_transport_e2e.rs
@@ -4,19 +4,21 @@
 //! Live relational ABAC provisioning ratchet (TD-ABAC-10b / TD-ABAC-11).
 //!
 //! This is deliberately a transport test, not another component test. It boots
-//! one real server and crosses both production surfaces involved in the operator
+//! one real server and crosses the production surfaces involved in the operator
 //! journey:
 //!
 //! ```text
-//! pgwire CREATE/INSERT/SELECT
-//!          |                 authenticated REST PUT/POST/DELETE
-//!          v                              |
-//! relational DML scan <--- shared live FileSystem ABAC stores
+//! pgwire setup + trust-auth SELECT ----+
+//!                                      v
+//! authenticated gRPC ExecuteQuery -> relational DML scan
+//!                                      ^
+//! authenticated REST policy control -> shared live ABAC stores
 //! ```
 //!
 //! The test proves deny-before-provision, hot permit without reconnect/restart,
-//! isolation of an unbound subject, and hot revoke. It also discovers the table's
-//! stable object id through `xcatalog.tables`; policy tooling must never guess an
+//! isolation of an unbound subject, and hot revoke over both trust-auth pgwire
+//! and credential-authenticated gRPC. It also discovers the table's stable
+//! object id through `xcatalog.tables`; policy tooling must never guess an
 //! allocator result or scrape catalog persistence.
 
 #![cfg(feature = "abac-policy")]
@@ -27,6 +29,8 @@ use std::time::Duration;
 
 use proximadb::core::Config;
 use proximadb::database::ProximaDB;
+use proximadb::proto::proximadb_v2::V2QueryRequest;
+use proximadb::proto::proximadb_v2::proxima_record_service_client::ProximaRecordServiceClient;
 use proximadb::security::SecurityMode;
 use proximadb::security::auth_service::{
     ApiKeyInfo, AuthenticationConfig, AuthenticationMethod, JwtConfig, MtlsConfig, SSOConfig,
@@ -44,6 +48,8 @@ use tokio_postgres::{Client as PgClient, SimpleQueryMessage};
 // pgwire handshake can stamp its stable id once and retain it for the session.
 const TENANT: &str = proximadb_tenant::DEFAULT_TENANT;
 const OPERATOR_KEY: &str = "abac-operator-key";
+const ALICE_KEY: &str = "abac-alice-key";
+const BOB_KEY: &str = "abac-bob-key";
 
 fn free_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
@@ -52,20 +58,26 @@ fn free_port() -> u16 {
     port
 }
 
-fn operator_security_config() -> SecurityConfig {
+fn transport_security_config() -> SecurityConfig {
     let mut api_keys = HashMap::new();
-    api_keys.insert(
-        OPERATOR_KEY.to_string(),
-        ApiKeyInfo {
-            user_id: "abac-operator".to_string(),
-            tenant_id: None,
-            permissions: vec!["*".to_string()],
-            created_at: None,
-            expires_at: None,
-            rate_limit_per_minute: None,
-            ip_restrictions: vec![],
-        },
-    );
+    for (key, user_id) in [
+        (OPERATOR_KEY, "abac-operator"),
+        (ALICE_KEY, "alice"),
+        (BOB_KEY, "bob"),
+    ] {
+        api_keys.insert(
+            key.to_string(),
+            ApiKeyInfo {
+                user_id: user_id.to_string(),
+                tenant_id: Some(TENANT.to_string()),
+                permissions: vec!["*".to_string()],
+                created_at: None,
+                expires_at: None,
+                rate_limit_per_minute: None,
+                ip_restrictions: vec![],
+            },
+        );
+    }
     SecurityConfig {
         enabled: true,
         mode: SecurityMode::Development,
@@ -116,6 +128,7 @@ fn operator_security_config() -> SecurityConfig {
 
 struct LiveServer {
     rest_port: u16,
+    grpc_port: u16,
     pg_port: u16,
     db: Option<ProximaDB>,
     _tmp: TempDir,
@@ -142,7 +155,7 @@ impl LiveServer {
         config.storage.metadata_url = format!("file://{}/metadata", tmp.path().display());
         config.storage.wal_config.write_buffer_directory =
             format!("file://{}/wal", tmp.path().display());
-        config.security = Some(operator_security_config());
+        config.security = Some(transport_security_config());
 
         let mut db = ProximaDB::new(config).await?;
         db.start().await?;
@@ -164,6 +177,7 @@ impl LiveServer {
         sleep(Duration::from_millis(200)).await;
         Ok(Self {
             rest_port,
+            grpc_port,
             pg_port,
             db: Some(db),
             _tmp: tmp,
@@ -179,6 +193,10 @@ impl LiveServer {
 
     fn admin_url(&self, path: &str) -> String {
         format!("http://127.0.0.1:{}{path}", self.rest_port)
+    }
+
+    fn grpc_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.grpc_port)
     }
 }
 
@@ -262,6 +280,46 @@ async fn assert_admin_success(response: reqwest::Response, operation: &str) -> V
         serde_json::from_str(&body)
             .unwrap_or_else(|error| panic!("{operation} returned invalid JSON `{body}`: {error}"))
     }
+}
+
+type GrpcClient = ProximaRecordServiceClient<tonic::transport::Channel>;
+
+async fn connect_grpc(server: &LiveServer) -> GrpcClient {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        match ProximaRecordServiceClient::connect(server.grpc_url()).await {
+            Ok(client) => return client,
+            Err(error) if std::time::Instant::now() > deadline => {
+                panic!("gRPC server did not become ready: {error}")
+            }
+            Err(_) => sleep(Duration::from_millis(100)).await,
+        }
+    }
+}
+
+async fn grpc_row_count(client: &mut GrpcClient, api_key: &str, sql: &str) -> usize {
+    let mut request = tonic::Request::new(V2QueryRequest {
+        query: sql.to_string(),
+        collection_id: String::new(),
+        limit: None,
+        offset: None,
+    });
+    request.metadata_mut().insert(
+        "authorization",
+        format!("Api-Key {api_key}")
+            .parse()
+            .expect("authorization metadata"),
+    );
+    request
+        .metadata_mut()
+        .insert("x-tenant-id", TENANT.parse().expect("tenant metadata"));
+    client
+        .execute_query(request)
+        .await
+        .unwrap_or_else(|error| panic!("gRPC ExecuteQuery `{sql}`: {error}"))
+        .into_inner()
+        .rows
+        .len()
 }
 
 /// The root crate's debug-build server future exceeds Tokio's 2 MiB default
@@ -376,5 +434,119 @@ async fn pgwire_reads_follow_live_rest_policy_provision_and_revoke_inner() {
         scalar(&alice, &format!("SELECT COUNT(*) FROM {table}")).await,
         "0",
         "policy revoke must be hot-visible to the existing pgwire session"
+    );
+}
+
+/// The supported programmatic SQL surface is authenticated gRPC
+/// `ProximaRecordService.ExecuteQuery` (not the retired SQL-over-REST route).
+/// Keep this as a separate live ratchet from pgwire: gRPC obtains the subject
+/// from a verified API key and therefore proves the load-bearing authenticated
+/// carrier, not pgwire's deliberately trust-asserted user name.
+#[test]
+fn grpc_reads_follow_live_rest_policy_provision_and_revoke() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    runtime.block_on(grpc_reads_follow_live_rest_policy_provision_and_revoke_inner());
+}
+
+async fn grpc_reads_follow_live_rest_policy_provision_and_revoke_inner() {
+    let server = LiveServer::start().await.expect("start live server");
+
+    // Use pgwire only as the setup/operator SQL surface. The assertions below
+    // all cross the independently authenticated gRPC transport.
+    let setup = connect(&server, "setup-operator").await;
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let table = format!("abac_grpc_live_{suffix}");
+    exec(
+        &setup,
+        &format!("CREATE TABLE {table} (id INT PRIMARY KEY, value INT)"),
+    )
+    .await;
+    exec(&setup, &format!("INSERT INTO {table} VALUES (1, 10)")).await;
+    exec(&setup, &format!("INSERT INTO {table} VALUES (2, 20)")).await;
+
+    let object_id = table_object_id(&setup, &table).await;
+    let table_scope = u32::try_from(object_id).expect("ABAC table scope is u32");
+    let sql = format!("SELECT id FROM {table}");
+    let mut alice = connect_grpc(&server).await;
+    let mut bob = connect_grpc(&server).await;
+
+    assert_eq!(
+        grpc_row_count(&mut alice, ALICE_KEY, &sql).await,
+        0,
+        "an authenticated but unprovisioned gRPC subject must fail closed"
+    );
+
+    let http = HttpClient::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let auth = format!("Api-Key {OPERATOR_KEY}");
+    let response = http
+        .post(server.admin_url("/api/v2/abac/attribute-bindings"))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .json(&json!({
+            "subject_id": "alice",
+            "tenant": TENANT,
+            "attrs": {}
+        }))
+        .send()
+        .await
+        .expect("provision alice binding");
+    let binding = assert_admin_success(response, "provision attribute binding").await;
+    assert_eq!(binding["subject_id"], "alice");
+
+    let policy_object_id = object_id + 2_000_000_000;
+    let policy_path = format!("/api/v2/abac/policy-bindings/{TENANT}/{policy_object_id}");
+    let response = http
+        .put(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .json(&json!({
+            "scope": {"Table": table_scope},
+            "effect": "Permit"
+        }))
+        .send()
+        .await
+        .expect("provision table permit");
+    let policy = assert_admin_success(response, "provision table permit").await;
+    assert_eq!(
+        policy["tenant_stable_id"].as_u64(),
+        binding["tenant_stable_id"].as_u64()
+    );
+
+    assert_eq!(
+        grpc_row_count(&mut alice, ALICE_KEY, &sql).await,
+        2,
+        "the existing authenticated gRPC client must observe the hot permit"
+    );
+    assert_eq!(
+        grpc_row_count(&mut bob, BOB_KEY, &sql).await,
+        0,
+        "the table permit must not admit another authenticated principal"
+    );
+
+    let response = http
+        .delete(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &auth)
+        .send()
+        .await
+        .expect("revoke table permit");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "policy revoke must succeed"
+    );
+    assert_eq!(
+        grpc_row_count(&mut alice, ALICE_KEY, &sql).await,
+        0,
+        "the existing authenticated gRPC client must observe the hot revoke"
     );
 }


### PR DESCRIPTION
## Outcome

Closes the live authenticated gRPC SQL evidence row for relational ABAC. A real server now proves deny-before-provision, table-scoped permit, cross-principal isolation, and hot revoke through `proximadb.v2.ProximaRecordService.ExecuteQuery` using credential-bound API keys.

## First-principles surface correction

The original evidence ledger listed REST SQL as an open row. The product support contract and router composition show that plain SQL-over-REST was deliberately hard-removed: `/api/v1/sql/execute` is not mounted, and `/api/v2/query` is UQL/Federated/AQL rather than relational SQL. This PR marks REST SQL non-applicable instead of reintroducing a retired competing surface.

The supported authenticated programmatic SQL surface is gRPC `ExecuteQuery`, so the live ratchet is placed there.

## Live scenario

1. Start the real REST, gRPC, and pgwire servers with ABAC enabled.
2. Create and populate a relational table, then discover its stable catalog object ID.
3. Alice calls gRPC `ExecuteQuery` with her API key and is denied before provisioning.
4. An authenticated REST operator provisions Alice's attribute binding and a table-scoped permit.
5. Alice's existing gRPC client observes both rows.
6. Bob calls through the same authenticated gRPC surface and observes zero rows.
7. The REST operator revokes the policy; Alice's existing client immediately observes zero rows.

The existing pgwire ratchet runs alongside this test, so both trust-asserted and credential-authenticated relational carriers remain pinned.

## Verification

- `cargo test --features abac-policy --test abac_relational_transport_e2e -- --nocapture` (2 passed)
- `cargo check --lib`
- `cargo check --lib --features abac-policy`
- `cargo fmt --all`
- `git diff --check`
- `make work-commit-check`

## Stack and remaining boundary

Stacked on #1406, which is stacked on #1405. Retarget to `develop` after prerequisites merge.

Remaining live evidence is canonical REST records/search, gRPC records/search, and Flight. This PR does not claim those rows are closed.
