### PR TITLE
test(abac): ratchet live REST record enforcement

### DIFF
--- a/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
+++ b/docs/10-quality/td/TD-ABAC-11-mint-and-fail-closed-composition.adoc
@@ -70,10 +70,15 @@ dev/embedded deployment that wires an enforcer.
   and legacy `SqlValue` exists only in `execute_sql_v1`. The live ratchet proves
   authenticated deny-before-provision, hot permit, principal isolation, and
   hot revoke.
+* **DONE — canonical REST record/search live ratchet.** The real `/api/v2`
+  collection-create, record-batch, vector-search, and point-get routes now have
+  provisioned-policy evidence. A stored `dept=eng` predicate admits only the
+  matching row, point-get post-filtering hides the non-matching row, an unbound
+  API-key principal remains denied, and policy revoke is hot-visible without a
+  server restart.
 * **OPEN — remaining live surface rows.** Add provisioned-policy admit/deny/
-  passthrough ratchets for canonical REST records/search, gRPC records/search,
-  and Flight. Their carrier and seam component tests are pinned; they are not
-  mislabeled as live evidence.
+  passthrough ratchets for gRPC records/search and Flight. Their carrier and
+  seam component tests are pinned; they are not mislabeled as live evidence.
 
 Depends on [[TD-ABAC-8]] (carrier), mint. Ref ADR-087, ADR-0083,
 [[project_codesigned_vector_abac_pushdown_2026_07_30]] (PR3 note).
@@ -93,6 +98,6 @@ seam:
 
 The cross-surface e2e ratchet includes pgwire's, authenticated gRPC's, and
 canonical REST SQL's *relational* paths in addition to REST/gRPC/Flight records.
-All three SQL rows are now pinned after [[TD-ABAC-10]] 10c; the remaining record/Flight rows stay open
-until they exercise live provisioned policy rather than only handler/seam
-components.
+All three SQL rows and canonical REST record search/point-get are now pinned
+after [[TD-ABAC-10]] 10c; the gRPC record and Flight rows stay open until they
+exercise live provisioned policy rather than only handler/seam components.

--- a/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
+++ b/docs/12-design/adr/ADR-087-caller-identity-propagation.adoc
@@ -121,8 +121,9 @@ carried unchanged to every consumer; everything else is a projection.**
   e2e fixture, flip the composition rule to fail-closed on the absent stable
   id, and live pgwire + credential-authenticated gRPC relational ratchets using
   the authenticated REST policy-control plane, plus canonical `POST /api/v2/sql`
-  as a thin adapter over the same typed SQL authority. Canonical REST/gRPC
-  record and Flight live data-plane rows remain the release-evidence tail.
+  as a thin adapter over the same typed SQL authority. Canonical REST record
+  search/point-get now have live row-policy evidence; gRPC record and Flight
+  live data-plane rows remain the release-evidence tail.
 
 == References
 

--- a/docs/SUPPORTED_SURFACE.adoc
+++ b/docs/SUPPORTED_SURFACE.adoc
@@ -249,7 +249,7 @@ for evidence/provenance, and event/history records for temporal state. The v1
 
 | Vector CRUD and search
 | Supported
-| Canonical REST `/api/v2` record batch/search/get/scan flows and gRPC `proximadb.v2.ProximaRecordService` record operations. REST `/api/v1` and gRPC v1 vector-shaped flows are deprecated compatibility adapters for existing clients only (see Canonical API Surface above); they lower into canonical v2 handlers and will be retired. Record metadata filters are enforced on typed `/search` (`filters:[{field,op,value}]`) and `/records/scan` (`filter`) across the supported ops (`eq,neq,gt,gte,lt,lte,in,contains,between,starts_with,ends_with`), including tenant/account scoping; array-valued props support `in`/`contains` membership.
+| Canonical REST `/api/v2` record batch/search/get/scan flows and gRPC `proximadb.v2.ProximaRecordService` record operations. REST `/api/v1` and gRPC v1 vector-shaped flows are deprecated compatibility adapters for existing clients only (see Canonical API Surface above); they lower into canonical v2 handlers and will be retired. Record metadata filters are enforced on typed `/search` (`filters:[{field,op,value}]`) and `/records/scan` (`filter`) across the supported ops (`eq,neq,gt,gte,lt,lte,in,contains,between,starts_with,ends_with`), including tenant/account scoping; array-valued props support `in`/`contains` membership. Canonical REST search and point-get have live provisioned-ABAC evidence for deny-before-provision, row-predicate filtering, principal isolation, and hot revoke.
 | Keep hybrid retrieval and distributed search claims separate from the supported vector surface. New clients must not target v1 `VectorRecord`/`SqlValue` payloads.
 
 | Federated SQL over function-backed sources

--- a/tests/abac_relational_transport_e2e.rs
+++ b/tests/abac_relational_transport_e2e.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
 
-//! Live relational ABAC provisioning ratchet (TD-ABAC-10b / TD-ABAC-11).
+//! Live cross-surface ABAC provisioning ratchet (TD-ABAC-10b / TD-ABAC-11).
 //!
 //! This is deliberately a transport test, not another component test. It boots
 //! one real server and crosses the production surfaces involved in the operator
@@ -12,6 +12,7 @@
 //!                                      v
 //! authenticated gRPC ExecuteQuery -> relational DML scan
 //! authenticated REST /api/v2/sql ----> shared typed SQL port
+//! authenticated REST record reads ---> shared record ABAC seam
 //!                                      ^
 //! authenticated REST policy control -> shared live ABAC stores
 //! ```
@@ -351,6 +352,59 @@ async fn rest_sql_row_count(
         .as_array()
         .unwrap_or_else(|| panic!("REST SQL response has no rows array: {body}"))
         .len()
+}
+
+async fn rest_record_search_ids(
+    client: &HttpClient,
+    server: &LiveServer,
+    api_key: &str,
+    collection: &str,
+) -> Vec<String> {
+    let response = client
+        .post(server.admin_url(&format!("/api/v2/collections/{collection}/search")))
+        .header(reqwest::header::AUTHORIZATION, format!("Api-Key {api_key}"))
+        .json(&json!({
+            "vector": [1.0, 0.0, 0.0, 0.0],
+            "top_k": 10
+        }))
+        .send()
+        .await
+        .unwrap_or_else(|error| panic!("REST record search: {error}"));
+    let status = response.status();
+    let body: Value = response.json().await.expect("REST search JSON body");
+    assert!(
+        status.is_success(),
+        "REST record search failed with {status}: {body}"
+    );
+    body["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("REST search response has no results: {body}"))
+        .iter()
+        .map(|result| {
+            result["id"]
+                .as_str()
+                .unwrap_or_else(|| panic!("REST search result has no id: {result}"))
+                .to_string()
+        })
+        .collect()
+}
+
+async fn rest_record_get_status(
+    client: &HttpClient,
+    server: &LiveServer,
+    api_key: &str,
+    collection: &str,
+    record_id: &str,
+) -> StatusCode {
+    client
+        .get(server.admin_url(&format!(
+            "/api/v2/collections/{collection}/records/{record_id}?include_vector=false"
+        )))
+        .header(reqwest::header::AUTHORIZATION, format!("Api-Key {api_key}"))
+        .send()
+        .await
+        .unwrap_or_else(|error| panic!("REST record get: {error}"))
+        .status()
 }
 
 /// The root crate's debug-build server future exceeds Tokio's 2 MiB default
@@ -694,5 +748,173 @@ async fn rest_sql_reads_follow_live_policy_provision_and_revoke_inner() {
         rest_sql_row_count(&http, &server, ALICE_KEY, &sql).await,
         0,
         "REST SQL must observe the hot revoke"
+    );
+}
+
+/// Canonical REST record search and point-get must consume the same hot policy
+/// stores as the operator control plane. The stored predicate is deliberately
+/// row-selective so this proves enforcement, not merely route authentication.
+#[test]
+fn rest_records_follow_live_row_policy_provision_and_revoke() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    runtime.block_on(rest_records_follow_live_row_policy_provision_and_revoke_inner());
+}
+
+async fn rest_records_follow_live_row_policy_provision_and_revoke_inner() {
+    let server = LiveServer::start().await.expect("start live server");
+    let http = HttpClient::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let operator_auth = format!("Api-Key {OPERATOR_KEY}");
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let collection = format!("abac_rest_records_{suffix}");
+    let eng_id = "record-eng";
+    let hr_id = "record-hr";
+
+    let response = http
+        .post(server.admin_url("/api/v2/collections"))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .json(&json!({
+            "name": collection,
+            "dimension": 4,
+            "engine": "sst",
+            "enable_proxima_record": true
+        }))
+        .send()
+        .await
+        .expect("create record collection");
+    assert_admin_success(response, "create record collection").await;
+
+    let response = http
+        .post(server.admin_url(&format!("/api/v2/collections/{collection}/records/batch")))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .json(&json!({
+            "records": [
+                {
+                    "id": eng_id,
+                    "vector": [1.0, 0.0, 0.0, 0.0],
+                    "props": {"dept": "eng"}
+                },
+                {
+                    "id": hr_id,
+                    "vector": [0.99, 0.01, 0.0, 0.0],
+                    "props": {"dept": "hr"}
+                }
+            ],
+            "validate_schema": false
+        }))
+        .send()
+        .await
+        .expect("insert record fixtures");
+    let inserted = assert_admin_success(response, "insert record fixtures").await;
+    assert_eq!(inserted["inserted_count"], 2);
+
+    assert!(
+        rest_record_search_ids(&http, &server, ALICE_KEY, &collection)
+            .await
+            .is_empty(),
+        "an unprovisioned REST record principal must fail closed"
+    );
+    assert_eq!(
+        rest_record_get_status(&http, &server, ALICE_KEY, &collection, eng_id).await,
+        StatusCode::NOT_FOUND,
+        "unprovisioned point-get must hide the record"
+    );
+
+    let response = http
+        .post(server.admin_url("/api/v2/abac/attribute-bindings"))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .json(&json!({
+            "subject_id": "alice",
+            "tenant": TENANT,
+            "attrs": {"dept": {"Str": "eng"}}
+        }))
+        .send()
+        .await
+        .expect("provision alice attributes");
+    let binding = assert_admin_success(response, "provision alice attributes").await;
+
+    let predicate_object_id = 4_000_000_000_u64;
+    let response = http
+        .put(server.admin_url(&format!(
+            "/api/v2/abac/predicate-objects/{predicate_object_id}"
+        )))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .json(&json!({
+            "Comparison": {
+                "field": "dept",
+                "operator": "Equals",
+                "value": "eng"
+            }
+        }))
+        .send()
+        .await
+        .expect("provision row predicate");
+    assert_admin_success(response, "provision row predicate").await;
+
+    let policy_object_id = predicate_object_id + 1;
+    let policy_path = format!("/api/v2/abac/policy-bindings/{TENANT}/{policy_object_id}");
+    let response = http
+        .put(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .json(&json!({
+            "scope": {"Namespace": 0},
+            "effect": "Permit",
+            "predicate_ref": predicate_object_id
+        }))
+        .send()
+        .await
+        .expect("provision record permit");
+    let policy = assert_admin_success(response, "provision record permit").await;
+    assert_eq!(
+        policy["tenant_stable_id"].as_u64(),
+        binding["tenant_stable_id"].as_u64()
+    );
+
+    let alice_ids = rest_record_search_ids(&http, &server, ALICE_KEY, &collection).await;
+    assert_eq!(alice_ids, vec![eng_id.to_string()]);
+    assert_eq!(
+        rest_record_get_status(&http, &server, ALICE_KEY, &collection, eng_id).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        rest_record_get_status(&http, &server, ALICE_KEY, &collection, hr_id).await,
+        StatusCode::NOT_FOUND,
+        "point-get must post-filter a row that violates the stored predicate"
+    );
+    assert!(
+        rest_record_search_ids(&http, &server, BOB_KEY, &collection)
+            .await
+            .is_empty(),
+        "an unbound authenticated principal must remain denied"
+    );
+
+    let response = http
+        .delete(server.admin_url(&policy_path))
+        .header(reqwest::header::AUTHORIZATION, &operator_auth)
+        .send()
+        .await
+        .expect("revoke record permit");
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(
+        rest_record_search_ids(&http, &server, ALICE_KEY, &collection)
+            .await
+            .is_empty(),
+        "record search must observe the hot revoke"
+    );
+    assert_eq!(
+        rest_record_get_status(&http, &server, ALICE_KEY, &collection, eng_id).await,
+        StatusCode::NOT_FOUND,
+        "point-get must observe the hot revoke"
     );
 }


### PR DESCRIPTION
## Outcome

Adds live provisioned-policy evidence for the canonical REST v2 record data plane using the real server, authentication middleware, operator control plane, collection/record write path, vector search, and point-get.

## Evidence proved

- Unprovisioned authenticated Alice fails closed on search and point-get.
- Operator REST hot-provisions Alice attributes, a stored dept=eng predicate, and a namespace permit.
- Search admits only the matching engineering record and filters the HR record.
- Point-get returns the matching record and hides the non-matching record as not found.
- Unbound authenticated Bob remains denied.
- Policy revoke is immediately visible to both search and point-get.

## Verification

- 4/4 live cross-surface ABAC tests pass serially: pgwire SQL, gRPC v2 SQL, REST v2 SQL, REST v2 records.
- make work-commit-check passes.
- Support and ADR evidence ledgers now narrow the remaining live tail to gRPC records/search and Flight.

## Stack

Depends on #1409. This PR intentionally targets the #1409 branch so the evidence slices remain independently reviewable and can retarget in order as their parents merge.