### PR TITLE
fix(abac): carry the policy key to the relational enforcement point; SQL ports take PortIdentity (TD-ABAC-10b)

### DIFF
--- a/crates/binding/proximadb-embedded/src/lib.rs
+++ b/crates/binding/proximadb-embedded/src/lib.rs
@@ -4394,8 +4394,9 @@ impl EmbeddedProximaDB {
                             .collect()
                     }),
                     collection.map(str::to_string),
-                    None, // embedded single-process: no per-request tenant
-                    None, // TD-ABAC-5: embedded single-process: no per-request subject
+                    // Embedded is single-process with no per-request tenant or
+                    // subject, so there is no identity to carry (TD-ABAC-10b).
+                    proximadb_runtime::PortIdentity::anonymous(),
                 )
                 .await
                 .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {

--- a/crates/platform/proximadb-api/src/lib.rs
+++ b/crates/platform/proximadb-api/src/lib.rs
@@ -120,6 +120,7 @@ pub(crate) mod test_support {
             collection: Option<String>,
             tenant_id: Option<String>,
             subject: Option<String>,
+            tenant_stable_id: Option<u64>,
         },
         Hybrid,
     }
@@ -270,15 +271,17 @@ pub(crate) mod test_support {
             query: String,
             parameters: Option<Vec<ProximaValue>>,
             collection: Option<String>,
-            tenant_id: Option<&str>,
-            subject: Option<&str>,
+            identity: PortIdentity<'_>,
         ) -> Result<ExecuteQueryResponse> {
             self.calls.lock().unwrap().push(ApiCall::Sql {
                 query,
                 parameter_count: parameters.as_ref().map(Vec::len),
                 collection,
-                tenant_id: tenant_id.map(ToOwned::to_owned),
-                subject: subject.map(ToOwned::to_owned),
+                tenant_id: identity.tenant_id.map(ToOwned::to_owned),
+                subject: identity.subject.map(ToOwned::to_owned),
+                // TD-ABAC-10b: assert the POLICY KEY reaches the port too — the
+                // gap that made governed SQL undeniably-deniable before.
+                tenant_stable_id: identity.tenant_stable_id,
             });
             Ok(self.sql_response.lock().unwrap().clone())
         }
@@ -396,8 +399,7 @@ pub(crate) mod test_support {
             &self,
             _query: String,
             _collection: Option<String>,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
+            _identity: PortIdentity<'_>,
         ) -> Result<JsonValue> {
             Ok(JsonValue::Array(Vec::new()))
         }
@@ -482,8 +484,7 @@ mod tests {
             "select * from docs".to_string(),
             None,
             Some("docs".to_string()),
-            None,
-            None,
+            PortIdentity::anonymous(),
         )
         .await
         .unwrap();
@@ -525,6 +526,7 @@ mod tests {
                     collection: Some("docs".to_string()),
                     tenant_id: None,
                     subject: None,
+                    tenant_stable_id: None,
                 },
             ]
         );
@@ -643,7 +645,11 @@ mod tests {
             .unwrap();
         assert!(
             query
-                .execute_sql("select 1".to_string(), Some("docs".to_string()), None, None)
+                .execute_sql(
+                    "select 1".to_string(),
+                    Some("docs".to_string()),
+                    PortIdentity::anonymous(),
+                )
                 .await
                 .unwrap()
                 .is_array()

--- a/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
+++ b/crates/platform/proximadb-api/src/rest/canonical/hybrid.rs
@@ -420,8 +420,12 @@ pub async fn execute_sql(
             query,
             parameters,
             request.collection,
-            identity.as_ref().map(|id| id.tenant.as_str()),
-            identity.as_ref().and_then(|id| id.subject.as_deref()),
+            // TD-ABAC-10b: project the foundation identity onto the port carrier
+            // so the tenant, the subject AND the policy key all arrive.
+            identity
+                .as_ref()
+                .map(|id| proximadb_runtime::PortIdentity::from(&id.0))
+                .unwrap_or_else(proximadb_runtime::PortIdentity::anonymous),
         )
         .await
     {
@@ -801,6 +805,8 @@ mod tests {
                 // TD-ABAC-9: the foundation identity Extension reaches the port.
                 tenant_id: Some("tenant-a".to_string()),
                 subject: Some("alice".to_string()),
+                // The policy key travels with the identity (TD-ABAC-10b).
+                tenant_stable_id: Some(7),
             }]
         );
     }

--- a/crates/platform/proximadb-runtime/src/handlers.rs
+++ b/crates/platform/proximadb-runtime/src/handlers.rs
@@ -626,8 +626,7 @@ impl ApiHandlersPort for UnifiedHandlers {
         query: String,
         _parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: PortIdentity<'_>,
     ) -> Result<ExecuteQueryResponse> {
         let adapter = self
             .query_adapter
@@ -635,9 +634,7 @@ impl ApiHandlersPort for UnifiedHandlers {
             .ok_or_else(|| anyhow!("SQL execution requires QueryAdapterPort (not wired)"))?;
 
         let start = Instant::now();
-        let json_result = adapter
-            .execute_sql(query, collection, tenant_id, subject)
-            .await?;
+        let json_result = adapter.execute_sql(query, collection, identity).await?;
 
         let records = json_result
             .get("records")
@@ -898,8 +895,7 @@ mod tests {
             &self,
             _query: String,
             _collection: Option<String>,
-            _tenant_id: Option<&str>,
-            _subject: Option<&str>,
+            _identity: PortIdentity<'_>,
         ) -> Result<serde_json::Value> {
             Ok(json!({
                 "columns": ["id", "score", "flag", "none", "obj"],
@@ -1084,8 +1080,7 @@ mod tests {
                 "select * from docs".to_string(),
                 None,
                 Some("docs".to_string()),
-                None,
-                None,
+                PortIdentity::anonymous(),
             )
             .await
             .unwrap();
@@ -1142,7 +1137,12 @@ mod tests {
         );
         assert!(
             handlers
-                .execute_sql_v1("select 1".to_string(), None, None, None, None)
+                .execute_sql_v1(
+                    "select 1".to_string(),
+                    None,
+                    None,
+                    PortIdentity::anonymous()
+                )
                 .await
                 .unwrap_err()
                 .to_string()
@@ -1171,8 +1171,7 @@ mod tests {
                 &self,
                 _query: String,
                 _collection: Option<String>,
-                _tenant_id: Option<&str>,
-                _subject: Option<&str>,
+                _identity: PortIdentity<'_>,
             ) -> Result<serde_json::Value> {
                 Ok(json!(["text", 7, false, null, {"shape": "object"}]))
             }
@@ -1184,7 +1183,12 @@ mod tests {
             Some(Arc::new(ArrayQueryAdapter)),
         );
         let sql = handlers
-            .execute_sql_v1("select values".to_string(), None, None, None, None)
+            .execute_sql_v1(
+                "select values".to_string(),
+                None,
+                None,
+                PortIdentity::anonymous(),
+            )
             .await
             .unwrap();
         assert_eq!(sql.rows_returned, 5);

--- a/crates/platform/proximadb-runtime/src/port.rs
+++ b/crates/platform/proximadb-runtime/src/port.rs
@@ -147,21 +147,15 @@ pub trait ApiHandlersPort: Send + Sync {
 
     // ── SQL ───────────────────────────────────────────────────────────────────
 
+    /// `identity` (TD-ABAC-10b, ADR-087): tenant scope (TD-064) + authenticated
+    /// principal (TD-ABAC-5) + the tenant stable id (the ABAC policy key) as ONE
+    /// value. The relational read boundary needs the key to consult policy —
+    /// without it a governed subject is denied, never admitted.
     async fn execute_sql_v1(
         &self,
         query: String,
         parameters: Option<Vec<ProximaValue>>,
         collection: Option<String>,
-        // TD-064: the authenticated tenant scopes relational SQL to the tenant's
-        // partition. `None` keeps the legacy unscoped behavior (callers that
-        // haven't been wired pass `None`); production gRPC/REST threads the real
-        // tenant from the request.
-        tenant_id: Option<&str>,
-        // TD-ABAC-5: the authenticated subject (principal id), threaded to ABAC
-        // enforcement at the relational read boundary. Opaque `&str` here because
-        // this port (runtime layer) cannot name `SubjectId` (catalog/control); the
-        // root-crate adapter converts it. `None` ⇒ anonymous/unwired ⇒ no
-        // enforcement (status quo). Enforcement is behind `abac-policy`.
-        subject: Option<&str>,
+        identity: PortIdentity<'_>,
     ) -> Result<ExecuteQueryResponse>;
 }

--- a/crates/platform/proximadb-runtime/src/service_ports.rs
+++ b/crates/platform/proximadb-runtime/src/service_ports.rs
@@ -253,14 +253,17 @@ pub trait QueryAdapterPort: Send + Sync {
     /// adapter routes relational SELECT through the tenant-scoped relational
     /// pipeline (`try_run_select`, TD-121) before falling back to the facade.
     ///
-    /// `subject` (TD-ABAC-5) is the authenticated principal id, threaded to ABAC
-    /// enforcement. Opaque `&str` here (runtime layer can't name `SubjectId`);
-    /// the root-crate adapter converts it. `None` ⇒ no enforcement.
+    /// `identity` (TD-ABAC-10b, ADR-087) carries the tenant scope, the
+    /// authenticated principal, AND the tenant stable id — the ABAC POLICY KEY.
+    /// The key matters: the relational boundary reads it to consult policy and
+    /// DENIES when it is absent, so a flat `tenant/subject` pair (the previous
+    /// shape) could never admit a governed subject. Subject ids stay opaque
+    /// `&str` here (the runtime layer cannot name `SubjectId`); the root-crate
+    /// adapter lifts them.
     async fn execute_sql(
         &self,
         query: String,
         collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: PortIdentity<'_>,
     ) -> Result<JsonValue>;
 }

--- a/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
+++ b/docs/10-quality/td/TD-ABAC-10-pgwire-identity-constructor.adoc
@@ -1,5 +1,5 @@
 = TD-ABAC-10: pgwire constructs the foundation identity (subject to the relational read boundary)
-:status: Partial
+:status: Resolved
 :dim: D5
 :pillar: SEC
 
@@ -22,7 +22,7 @@ threads it to `execute_sql_v1`/the seam.
 Note: pgwire trust-auth subjects are spoofable by design — that is what
 `AuthClass::TrustAsserted` records; deployments gate via `HeaderTrustPolicy`.
 
-== Status: 10a + 10c DONE; 10b open
+== Status: 10a + 10b + 10c DONE (TD resolved)
 
 **10a (done)** — `Session.identity: Option<ResolvedRequestIdentity>` built at
 the startup handshake by the pure, unit-tested `PostgresProtocol::startup_identity`
@@ -32,17 +32,38 @@ plumbing — `catalog_manager` already reached it), so the ABAC policy key is
 stamped once per connection; the relational SELECT path reads
 `session.identity.subject` instead of re-deriving it per query.
 
-**10b (open) — carry the whole identity, not just the subject.** The
-relational read path still takes a bare `Option<SubjectId>`, so
-`tenant_stable_id`/`auth_class` do not survive to the enforcement point:
-widen `relational_pipeline::try_run_select` (~:253) → `SnapshotCatalog`
-(~:1606, ctors ~:554/:737/:763) → `DmlTableReader` (~:1702) →
-`services/dml/mod.rs::scan_table_relational` (~:1441, ABAC filter ~:1466) to
-carry `PortIdentity`; update the off-pgwire caller
-`query/facade/adapter.rs` (~:803). This is the prerequisite for
-[[TD-ABAC-11]]'s fail-closed flip on the relational path. Note the SQL ports
-(`ApiHandlersPort::execute_sql_v1`, `QueryAdapterPort::execute_sql`) still
-take flat `tenant_id`/`subject` with no stable id.
+**10b (DONE) — carry the whole identity, and a LIVE BUG it uncovered.**
+
+`DmlService::abac_row_filter` reads `tenant_stable_id` off the storage
+`TenantContext`, but the relational pipeline built that context with
+`TenantContext::for_tenant_id()`, which always leaves it `None` — and the
+filter treats an absent policy key as `Denied`. With `abac-policy` enabled and
+ABAC stores provisioned (which DOES arm the enforcer in `SharedServices`),
+**every governed relational SELECT returned zero rows**: the relational
+boundary could never admit anyone.
+
+Note the symmetry with the vector seam: ONE root cause (the policy key does not
+reach the enforcement point) produced OPPOSITE failure modes — silent-open on
+the records/vector seam, deny-everything on the relational boundary. That is
+exactly the divergence ADR-087's "resolve once, carry unchanged" removes.
+
+Fixed by carrying the key end-to-end:
+
+* pgwire: `session_tenant_stable_id()` → `try_run_select` → the snapshot's
+  `TenantContext` → `scan_table_relational`; the EXPLAIN chain
+  (`explain_*_with_catalog` → `route_and_plan_select` → `prepare_select_plan`
+  → `build_snapshot`) carries it too, so ANALYZE executes under the same
+  decision it displays.
+* The SQL ports (`ApiHandlersPort::execute_sql_v1`,
+  `QueryAdapterPort::execute_sql`) were widened from the flat
+  `tenant_id`/`subject` pair to `PortIdentity` — the same consolidation
+  TD-ABAC-7 applied to the vector ports, rather than adding a third loose
+  parameter. gRPC SQL now supplies the key from `grpc_auth::tenant_stable_id`
+  (its records paths already did); the api-crate hybrid SQL route projects the
+  foundation identity. `RecordingApiPort` asserts the key reaches the port.
+* Embedded passes `PortIdentity::anonymous()` — single-process, genuinely no
+  per-request identity; the unrouted root REST `execute_sql` handler likewise
+  (dead code, not given an invented identity source).
 
 **10c (DONE) — the three pgwire read paths that bypassed ABAC** (found by the
 2026-08-02 live-path survey; each was a *distinct* bypass). All three are

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -2316,6 +2316,9 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // TD-ABAC-5: capture the authenticated subject before the request is moved;
         // threaded to ABAC enforcement at the relational read boundary.
         let user_id = grpc_auth::user_id(&request);
+        // TD-ABAC-10b: the ABAC policy key — the relational boundary denies a
+        // governed subject without it (the records paths already carried it).
+        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -2328,8 +2331,16 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                 q.query,
                 None,
                 collection,
-                Some(tenant_id.as_str()),
-                user_id.as_deref(),
+                proximadb_runtime::PortIdentity {
+                    tenant_id: Some(tenant_id.as_str()),
+                    subject: user_id.as_deref(),
+                    tenant_stable_id,
+                    auth_class: if user_id.is_some() {
+                        proximadb_tenant::AuthClass::Authenticated
+                    } else {
+                        proximadb_tenant::AuthClass::Anonymous
+                    },
+                },
             )
             .await
             .map_err(|e| {

--- a/src/network/postgres/protocol.rs
+++ b/src/network/postgres/protocol.rs
@@ -697,6 +697,20 @@ impl PostgresProtocol {
             .map(proximadb_catalog::fc_metamodel::SubjectId)
     }
 
+    /// TD-ABAC-10b (ADR-087): the connection's tenant stable id — the ABAC
+    /// POLICY KEY — read from the ONE session identity (stamped once at the
+    /// handshake). The relational boundary DENIES a governed read when this is
+    /// absent, so it must travel with the subject, never be re-derived.
+    #[cfg(feature = "abac-policy")]
+    async fn session_tenant_stable_id(&self) -> Option<u64> {
+        self.session
+            .read()
+            .await
+            .identity
+            .as_ref()
+            .and_then(|id| id.tenant_stable_id)
+    }
+
     /// TD-ABAC-3: gate a pgwire SUBJECT assertion (startup `user`) through the
     /// SAME [`HeaderTrustPolicy`](proximadb_tenant::HeaderTrustPolicy) the tenant
     /// assertion uses. pgwire is trust auth, so the binding is always `None`;
@@ -1886,6 +1900,8 @@ impl PostgresProtocol {
         // resolves the row filter against.
         #[cfg(feature = "abac-policy")]
         let subject = self.session_subject().await;
+        #[cfg(feature = "abac-policy")]
+        let tenant_stable_id = self.session_tenant_stable_id().await;
         super::relational_pipeline::try_run_select(
             query,
             self.dml_service.as_ref(),
@@ -1906,6 +1922,8 @@ impl PostgresProtocol {
             olap_cache.as_deref(),
             #[cfg(feature = "abac-policy")]
             subject,
+            #[cfg(feature = "abac-policy")]
+            tenant_stable_id,
         )
         .await
     }
@@ -1971,6 +1989,8 @@ impl PostgresProtocol {
             // executes) must plan/run under the SAME subject execution uses.
             #[cfg(feature = "abac-policy")]
             let explain_subject = self.session_subject().await;
+            #[cfg(feature = "abac-policy")]
+            let explain_stable_id = self.session_tenant_stable_id().await;
             let routing = match self.dml_service.clone() {
                 Some(dml) if is_analyze => {
                     crate::network::postgres::relational_pipeline::explain_analyze_select_with_catalog(
@@ -1979,6 +1999,8 @@ impl PostgresProtocol {
                         Some(explain_tenant.as_str()),
                         #[cfg(feature = "abac-policy")]
                         explain_subject,
+                        #[cfg(feature = "abac-policy")]
+                        explain_stable_id,
                     )
                     .await
                 }
@@ -1989,6 +2011,8 @@ impl PostgresProtocol {
                         Some(explain_tenant.as_str()),
                         #[cfg(feature = "abac-policy")]
                         explain_subject,
+                        #[cfg(feature = "abac-policy")]
+                        explain_stable_id,
                     )
                     .await
                 }

--- a/src/network/postgres/relational_pipeline.rs
+++ b/src/network/postgres/relational_pipeline.rs
@@ -280,12 +280,27 @@ pub async fn try_run_select(
     // `scan_table_relational` enforces ABAC. `None` ⇒ anonymous/internal ⇒ no
     // enforcement. Behind `abac-policy` (default-OFF).
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    // TD-ABAC-10b (ADR-087): the tenant's stable u64 — the ABAC POLICY KEY.
+    // `abac_row_filter` reads it off the storage `TenantContext`, so if it does
+    // not arrive here the relational boundary DENIES every governed read (it
+    // fail-closes on an absent key). Sourced from the caller's resolved
+    // identity, never re-derived. Behind `abac-policy` (default-OFF).
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Option<Result<ExecutionPipelineResult, String>> {
     // TD-064: the connection's tenant scopes every snapshot read to the tenant's
     // record partition (carried into the SnapshotCatalog → DmlTableReader).
     let tenant_ctx: Option<TenantContext> = tenant
         .filter(|t| !t.is_empty())
-        .map(TenantContext::for_tenant_id);
+        .map(TenantContext::for_tenant_id)
+        .map(|mut ctx| {
+            // TD-ABAC-10b: `for_tenant_id` leaves the stable id `None`; carry
+            // the resolved one so ABAC can consult policy instead of denying.
+            #[cfg(feature = "abac-policy")]
+            {
+                ctx.tenant_stable_id = tenant_stable_id;
+            }
+            ctx
+        });
     // ADR-018 Phase 2: Allow opting out with explicit "0" value
     if std::env::var("PROXIMADB_PGWIRE_RELATIONAL_PIPELINE")
         .ok()
@@ -2322,6 +2337,7 @@ async fn prepare_select_plan(
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Option<(SnapshotCatalog, PhysicalPlan)> {
     let snapshot = build_snapshot(
         query,
@@ -2329,6 +2345,8 @@ async fn prepare_select_plan(
         tenant,
         #[cfg(feature = "abac-policy")]
         subject,
+        #[cfg(feature = "abac-policy")]
+        tenant_stable_id,
     )
     .await?;
     match plan_over_snapshot(sql, &snapshot)? {
@@ -2347,6 +2365,7 @@ async fn build_snapshot(
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Option<SnapshotCatalog> {
     let mut names = Vec::new();
     collect_table_names(query, &mut names);
@@ -2366,7 +2385,17 @@ async fn build_snapshot(
         tables,
         tenant: tenant
             .filter(|t| !t.is_empty())
-            .map(TenantContext::for_tenant_id),
+            .map(TenantContext::for_tenant_id)
+            .map(|mut ctx| {
+                // TD-ABAC-10b: EXPLAIN/ANALYZE carries the policy key too, so
+                // it plans (and, for ANALYZE, executes) under the same
+                // enforcement decision as the real query.
+                #[cfg(feature = "abac-policy")]
+                {
+                    ctx.tenant_stable_id = tenant_stable_id;
+                }
+                ctx
+            }),
         // TD-ABAC-10c: the EXPLAIN/ANALYZE snapshot carries the SAME client
         // subject execution does. This previously hardcoded `None`, so an
         // EXPLAIN disclosed row estimates — and EXPLAIN ANALYZE, which really
@@ -2395,6 +2424,7 @@ pub async fn explain_select_route_with_catalog(
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Result<SelectRouteExplanation, String> {
     route_and_plan_select(
         sql,
@@ -2403,6 +2433,8 @@ pub async fn explain_select_route_with_catalog(
         tenant,
         #[cfg(feature = "abac-policy")]
         subject,
+        #[cfg(feature = "abac-policy")]
+        tenant_stable_id,
     )
     .await
 }
@@ -2416,6 +2448,7 @@ pub async fn explain_analyze_select_with_catalog(
     dml: &Arc<DmlService>,
     tenant: Option<&str>,
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Result<SelectRouteExplanation, String> {
     route_and_plan_select(
         sql,
@@ -2424,6 +2457,8 @@ pub async fn explain_analyze_select_with_catalog(
         tenant,
         #[cfg(feature = "abac-policy")]
         subject,
+        #[cfg(feature = "abac-policy")]
+        tenant_stable_id,
     )
     .await
 }
@@ -2439,6 +2474,7 @@ async fn route_and_plan_select(
     analyze: bool,
     tenant: Option<&str>,
     #[cfg(feature = "abac-policy")] subject: Option<SubjectId>,
+    #[cfg(feature = "abac-policy")] tenant_stable_id: Option<u64>,
 ) -> Result<SelectRouteExplanation, String> {
     let statements =
         Parser::parse_sql(&GenericDialect {}, sql).map_err(|e| format!("parse: {e}"))?;
@@ -2559,6 +2595,8 @@ async fn route_and_plan_select(
             tenant,
             #[cfg(feature = "abac-policy")]
             subject.clone(),
+            #[cfg(feature = "abac-policy")]
+            tenant_stable_id,
         )
         .await
         {
@@ -2611,6 +2649,8 @@ async fn route_and_plan_select(
                     tenant,
                     #[cfg(feature = "abac-policy")]
                     subject.clone(),
+                    #[cfg(feature = "abac-policy")]
+                    tenant_stable_id,
                 )
                 .await
                     && let Err(e) = lower_sql(sql, &snapshot)

--- a/src/network/rest/canonical/handlers.rs
+++ b/src/network/rest/canonical/handlers.rs
@@ -978,10 +978,11 @@ pub async fn execute_sql(
             query_with_hint,
             sql_params_to_proxima_values(request.parameters.clone()),
             request.collection,
-            None,
-            // TD-ABAC-5: REST UnifiedUserContext extractor wiring is a follow-on;
-            // None ⇒ no ABAC enforcement on this surface yet.
-            None,
+            // NOTE: this handler is UNROUTED (dead code — the live REST SQL
+            // surface is the api-crate `create_hybrid_search_router`, which
+            // threads the real identity). Kept anonymous deliberately rather
+            // than inventing an identity source for a route nobody can reach.
+            proximadb_runtime::PortIdentity::anonymous(),
         )
         .await
     {

--- a/src/query/facade/adapter.rs
+++ b/src/query/facade/adapter.rs
@@ -720,9 +720,14 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
         &self,
         query: String,
         _collection: Option<String>,
-        tenant_id: Option<&str>,
-        subject: Option<&str>,
+        identity: proximadb_runtime::PortIdentity<'_>,
     ) -> anyhow::Result<serde_json::Value> {
+        // TD-ABAC-10b (ADR-087): destructure the ONE carrier once; the policy
+        // key (`tenant_stable_id`) now reaches the relational boundary, so a
+        // governed gRPC/REST SQL subject can be ADMITTED instead of always
+        // denied for want of a key.
+        let tenant_id = identity.tenant_id;
+        let subject = identity.subject;
         use crate::query::QueryResultData;
 
         // EXPLAIN [ANALYZE] <DML> routing — parity with the ROOT handler's
@@ -813,6 +818,9 @@ impl proximadb_runtime::QueryAdapterPort for QueryFacadeAdapter {
                 // TD-ABAC-5: the authenticated subject (gRPC/REST) → ABAC enforcement.
                 #[cfg(feature = "abac-policy")]
                 subject_id,
+                // TD-ABAC-10b: the policy key, carried on the identity.
+                #[cfg(feature = "abac-policy")]
+                identity.tenant_stable_id,
             )
             .await
         {


### PR DESCRIPTION
## The bug

`DmlService::abac_row_filter` reads `tenant_stable_id` off the storage `TenantContext` — but the relational pipeline built that context with `TenantContext::for_tenant_id()`, which **always leaves it `None`**, and the filter treats an absent policy key as `Denied`.

With `abac-policy` enabled and ABAC stores provisioned (which *does* arm the enforcer in `SharedServices`), **every governed relational SELECT returned zero rows.** The relational boundary could not admit anyone — TD-ABAC-3's subject plumbing was effectively inert in production.

**The symmetry is the interesting part:** one root cause — the policy key never reaches the enforcement point — produced *opposite* failure modes on the two boundaries: **silent-open** on the records/vector seam (ADR-087's P1), **deny-everything** here. That divergence is precisely what ADR-087's "resolve once, carry unchanged" decision exists to remove, and it's why this is a functional fix, not just preparation for TD-ABAC-11's flip.

## The fix

**Carry the key end-to-end**
- **pgwire**: `session_tenant_stable_id()` → `try_run_select` → the snapshot's `TenantContext` → `scan_table_relational`. The EXPLAIN chain (`explain_*_with_catalog` → `route_and_plan_select` → `prepare_select_plan` → `build_snapshot`) carries it too, so `EXPLAIN ANALYZE` *executes* under the same decision it displays.
- **SQL ports**: `ApiHandlersPort::execute_sql_v1` and `QueryAdapterPort::execute_sql` widened from the flat `tenant_id`/`subject` pair to **`PortIdentity`** — the same consolidation TD-ABAC-7 applied to the vector ports, rather than bolting on a third loose parameter. gRPC SQL now supplies the key from `grpc_auth::tenant_stable_id` (its *records* paths already carried it); the api-crate hybrid SQL route projects the foundation identity.
- **Honest anonymity**: embedded (single-process, genuinely no per-request identity) and the unrouted root REST `execute_sql` handler (dead code) pass `PortIdentity::anonymous()` rather than being given an invented identity source.

**Test**: `RecordingApiPort` now records and asserts `tenant_stable_id`, so the port test fails if the key stops arriving — the exact regression that caused this bug.

## Verification

- 16/16 ABAC integration tests ✅ · 205/205 runtime+api lib tests ✅
- `cargo check --workspace --lib` (default features) ✅ — the embedded binding was the last caller
- clippy: root lib `--features abac-policy` ✅, leaf crates `--all-targets` strict ✅
- `cargo fmt --check` ✅ · `make work-commit-check` ✅ · `td-adr-unique` (87 ADRs / 331 TDs) ✅

TD-ABAC-10 is now **Resolved** (10a constructor + 10b carrier/bug + 10c the three bypasses).

## Next

TD-ABAC-11 only: default-tenant mint → flip the composition rule to fail-closed on an absent key (now that the key actually arrives, the flip is safe *and* meaningful) → cross-surface e2e ratchet. Note the flip must cover **both** composition points — `records_read_context` and `scan_table_relational` — as recorded in the TD-ABAC-11 addendum.