### PR TITLE
feat(bench): add pgvector context corridor adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
       - name: Test canonical MVP smoke client
         run: python3 -m unittest discover -s tests/scripts -p 'test_mvp_smoke.py'
       - name: Validate context-corridor benchmark contract
-        run: python3 scripts/validate_context_benchmark.py
+        run: make context-benchmark-check
 
   # T4.2 (pre-release foundations) — Proto compatibility gate.
   # Runs `make proto-check`: cargo-checks the proximadb-proto crate AND

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ mvp-smoke-test:
 context-benchmark-check:
 	@echo "📐 Validating the context-corridor benchmark contract..."
 	python3 scripts/validate_context_benchmark.py
+	python3 -m unittest discover -s tests/scripts -p 'test_context_corridor.py'
 
 deterministic-commit-contract-check:
 	@echo "🧷 Validating deterministic commit contract..."

--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -42,8 +42,15 @@ comparison_surface = "REST v2 typed record + filtered vector search"
 [[system]]
 id = "pgvector"
 role = "baseline"
-adapter_status = "planned"
+adapter_status = "runnable"
 comparison_surface = "PostgreSQL table + JSONB filter + vector index"
+
+[system.adapter]
+runner_system = "pgvector"
+distance = "cosine"
+vector_index = "hnsw(vector_cosine_ops)"
+metadata_index = "btree((properties ->> 'partition'))"
+hnsw_ef_search = 40
 
 [[system]]
 id = "qdrant"

--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -51,6 +51,7 @@ distance = "cosine"
 vector_index = "hnsw(vector_cosine_ops)"
 metadata_index = "btree((properties ->> 'partition'))"
 hnsw_ef_search = 40
+hnsw_iterative_scan = "strict_order"
 
 [[system]]
 id = "qdrant"

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -29,7 +29,13 @@ Every report must include recall, filtered recall, ingest rate, p50/p95/p99, pea
 GET/PUT counts, bytes moved, cache hit ratio, and estimated cost per million queries. A performance
 claim that omits accuracy or physical-cost signals is not a ProximaDB co-design result.
 
-== Runnable slice
+== Runnable slices
+
+The runner streams deterministic batches instead of retaining the corpus in Python memory, so the
+declared one-million-record publication floor is executable with bounded client memory. Every run
+retains a deterministic dataset hash, exact configuration, failed-run artifact, and all thirteen
+metric keys; unavailable physical-cost metrics remain explicit `null` values and therefore block
+publication rather than being estimated.
 
 The ProximaDB adapter is available now:
 
@@ -47,11 +53,37 @@ This creates a deterministic SST collection, inserts typed records in batches, e
 queries behind metadata filters, records filtered Recall@10 and latency, and captures route-health
 signals. The resulting local baseline is explicitly `publication_eligible: false`.
 
+The pgvector baseline uses the identical generated record/query stream, JSONB-backed typed
+properties, a B-tree expression index on the JSONB partition field, and an HNSW cosine index:
+
+[source,bash]
+----
+docker run --rm -d --name context-pgvector \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 pgvector/pgvector:pg17
+
+python3 -m venv /tmp/proximadb-context-bench
+/tmp/proximadb-context-bench/bin/pip install 'psycopg[binary]'
+/tmp/proximadb-context-bench/bin/python scripts/bench/context_corridor.py \
+  --system pgvector \
+  --pg-dsn postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+  --records 1000 \
+  --dimension 32 \
+  --queries 200 \
+  --output artifacts/context-corridor/pgvector-local.json
+----
+
+The DSN is consumed only by the adapter and is never written to the result. The default cleanup
+drops the per-run table; pass `--keep-data` only for local diagnosis. Both adapters issue an
+unfiltered and metadata-filtered query for each deterministic target record. The current accuracy
+metric is explicitly scoped as target-record presence in the top ten, not full-neighbour
+ground-truth recall.
+
 == Publication gate
 
 No cross-system winner, price/performance, or TAM-facing benchmark claim may be published until:
 
-* all six adapters are runnable;
+* all six adapters are runnable (ProximaDB and pgvector are currently complete);
 * each system runs at least five trials over at least one million records;
 * local, S3, Azure, and GCS configurations are represented where supported;
 * raw results, failed runs, commit/version, configuration, hardware, and dataset hash are retained;

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -54,7 +54,10 @@ queries behind metadata filters, records filtered Recall@10 and latency, and cap
 signals. The resulting local baseline is explicitly `publication_eligible: false`.
 
 The pgvector baseline uses the identical generated record/query stream, JSONB-backed typed
-properties, a B-tree expression index on the JSONB partition field, and an HNSW cosine index:
+properties, a B-tree expression index on the JSONB partition field, and an HNSW cosine index.
+It sets `hnsw.ef_search = 40` and `hnsw.iterative_scan = strict_order`; the latter is required
+because pgvector applies filters after the approximate index scan and otherwise may return fewer
+than `k` matching rows:
 
 [source,bash]
 ----

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -366,6 +366,12 @@ class PgvectorAdapter:
         with self.connection.cursor() as cursor:
             cursor.execute(f"ANALYZE {self.quoted_table}")
             cursor.execute("SET hnsw.ef_search = 40")
+            # pgvector applies WHERE predicates after an approximate HNSW scan.
+            # Iterative scanning lets the access method continue until it has
+            # enough predicate-matching rows instead of silently under-returning
+            # filtered top-k results. strict_order preserves exact distance order
+            # for a like-for-like accuracy comparison.
+            cursor.execute("SET hnsw.iterative_scan = strict_order")
         self.connection.commit()
 
     def search(
@@ -417,6 +423,7 @@ class PgvectorAdapter:
             "pgvector_version": self.extension_version,
             "index": "hnsw(vector_cosine_ops)",
             "hnsw_ef_search": 40,
+            "hnsw_iterative_scan": "strict_order",
             "filter_index": "btree((properties ->> 'partition'))",
             "distance": "cosine",
         }

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Run the ProximaDB adapter for context-corridor-v1.
+"""Run a context-corridor-v1 benchmark adapter.
 
-This runner deliberately emits a local baseline, not a competitor claim. The
-scenario contract forbids cross-system publication until every adapter is
-runnable under the same dataset and measurement protocol.
+The runner is intentionally publication-conservative. It preserves failed runs,
+emits every metric in the scenario contract, and never marks a single local run
+as publication eligible. Dataset generation is streaming so the declared 1M
+record scale does not require materializing the corpus in Python memory.
 """
 
 from __future__ import annotations
@@ -14,29 +15,63 @@ import json
 import math
 import platform
 import random
-import statistics
+import re
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - exercised on Windows runners.
+    resource = None  # type: ignore[assignment]
+
+SCENARIO_ID = "context-corridor-v1"
+TOP_K = 10
+REQUIRED_METRICS = (
+    "recall_at_10",
+    "filtered_recall_at_10",
+    "ingest_records_per_second",
+    "latency_p50_ms",
+    "latency_p95_ms",
+    "latency_p99_ms",
+    "peak_rss_bytes",
+    "object_gets",
+    "object_puts",
+    "bytes_read",
+    "bytes_written",
+    "cache_hit_ratio",
+    "estimated_cost_per_million_queries",
+)
 
 
-def request(base: str, method: str, path: str, body: dict | None, timeout: float) -> tuple[Any, float]:
+def request(
+    base: str, method: str, path: str, body: dict | None, timeout: float
+) -> tuple[Any, float]:
     headers = {"Accept": "application/json"}
     payload = None
     if body is not None:
         headers["Content-Type"] = "application/json"
         payload = json.dumps(body, separators=(",", ":")).encode()
-    req = urllib.request.Request(base.rstrip("/") + path, data=payload, headers=headers, method=method)
+    req = urllib.request.Request(
+        base.rstrip("/") + path,
+        data=payload,
+        headers=headers,
+        method=method,
+    )
     started = time.perf_counter()
     try:
         with urllib.request.urlopen(req, timeout=timeout) as response:
             status = response.status
             raw = response.read()
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"{method} {path}: HTTP {exc.code}: {exc.read()[:1000]!r}") from exc
+        raise RuntimeError(
+            f"{method} {path}: HTTP {exc.code}: {exc.read()[:1000]!r}"
+        ) from exc
     latency_ms = (time.perf_counter() - started) * 1000.0
     if status not in (200, 201, 202, 204):
         raise RuntimeError(f"{method} {path}: unexpected HTTP {status}")
@@ -54,7 +89,9 @@ def percentile(values: list[float], p: int) -> float:
 def ids(payload: Any) -> list[str]:
     if not isinstance(payload, dict):
         return []
-    values = payload.get("matches") or payload.get("results") or payload.get("records") or []
+    values = (
+        payload.get("matches") or payload.get("results") or payload.get("records") or []
+    )
     found: list[str] = []
     for value in values if isinstance(values, list) else []:
         if not isinstance(value, dict):
@@ -70,14 +107,504 @@ def ids(payload: Any) -> list[str]:
 
 def git_sha(root: Path) -> str:
     try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=root, text=True
+        ).strip()
     except (OSError, subprocess.CalledProcessError):
         return "unknown"
 
 
+def peak_rss_bytes() -> int | None:
+    if resource is None:
+        return None
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(peak if sys.platform == "darwin" else peak * 1024)
+
+
+def sanitized_error(error: Exception, dsn: str) -> str:
+    message = str(error).replace(dsn, "<redacted-dsn>")
+    return re.sub(r"(?i)(password\s*=\s*)\S+", r"\1<redacted>", message)
+
+
+def vector_literal(vector: list[float]) -> str:
+    return "[" + ",".join(format(value, ".9g") for value in vector) + "]"
+
+
+def make_record(index: int, dimension: int, rng: random.Random) -> dict[str, Any]:
+    return {
+        "id": f"rec-{index}",
+        "vector": [rng.uniform(-1.0, 1.0) for _ in range(dimension)],
+        "props": {"partition": f"p{index % 8}", "ordinal": index},
+    }
+
+
+@dataclass(frozen=True)
+class DatasetManifest:
+    sha256: str
+    query_records: list[dict[str, Any]]
+
+
+class Adapter(Protocol):
+    system_id: str
+
+    def prepare(self, dimension: int) -> None: ...
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None: ...
+
+    def finish_ingest(self) -> None: ...
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]: ...
+
+    def signals(self) -> dict[str, Any]: ...
+
+    def environment(self) -> dict[str, Any]: ...
+
+    def close(self, *, keep_data: bool) -> None: ...
+
+
+class ProximaAdapter:
+    system_id = "proximadb"
+
+    def __init__(self, base_url: str, timeout: float, collection: str) -> None:
+        self.base_url = base_url
+        self.timeout = timeout
+        self.collection = collection
+
+    def prepare(self, dimension: int) -> None:
+        request(
+            self.base_url,
+            "POST",
+            "/api/v2/collections",
+            {
+                "name": self.collection,
+                "dimension": dimension,
+                "engine": "sst",
+                "distance_metric": "cosine",
+                "enable_proxima_record": True,
+                "schema": {
+                    "columns": [
+                        {
+                            "name": "partition",
+                            "data_type": "text",
+                            "indexed": True,
+                            "filterable": True,
+                        },
+                        {
+                            "name": "ordinal",
+                            "data_type": "integer",
+                            "indexed": False,
+                            "filterable": True,
+                        },
+                    ],
+                    "enforcement": "hybrid",
+                    "allow_additional_fields": True,
+                },
+            },
+            self.timeout,
+        )
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        request(
+            self.base_url,
+            "POST",
+            f"/api/v2/collections/{self.collection}/records/batch",
+            {"records": records, "upsert": True},
+            self.timeout,
+        )
+
+    def finish_ingest(self) -> None:
+        # The current supported corridor does not expose a write-fence endpoint.
+        # Keep the historical bounded settle interval explicit in the report.
+        time.sleep(0.75)
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        body: dict[str, Any] = {"vector": record["vector"], "top_k": TOP_K}
+        if filtered:
+            body["filters"] = [
+                {
+                    "field": "partition",
+                    "op": "eq",
+                    "value": record["props"]["partition"],
+                }
+            ]
+        payload, latency = request(
+            self.base_url,
+            "POST",
+            f"/api/v2/collections/{self.collection}/search",
+            body,
+            self.timeout,
+        )
+        return ids(payload)[:TOP_K], latency
+
+    def signals(self) -> dict[str, Any]:
+        payload, _ = request(
+            self.base_url,
+            "GET",
+            f"/api/v2/_diagnostics/collections/{self.collection}/route-health",
+            None,
+            self.timeout,
+        )
+        return payload if isinstance(payload, dict) else {}
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "engine": "sst",
+            "distance": "cosine",
+            "settle_seconds": 0.75,
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if not keep_data:
+            request(
+                self.base_url,
+                "DELETE",
+                f"/api/v2/collections/{self.collection}",
+                None,
+                self.timeout,
+            )
+
+
+class PgvectorAdapter:
+    system_id = "pgvector"
+
+    def __init__(self, dsn: str, table: str) -> None:
+        if not table.replace("_", "").isalnum():
+            raise ValueError("generated pgvector table name is not a safe identifier")
+        self.dsn = dsn
+        self.table = table
+        self.quoted_table = f'"{table}"'
+        self.quoted_partition_index = f'"{table}_partition_idx"'
+        self.quoted_embedding_index = f'"{table}_embedding_hnsw_idx"'
+        self.connection: Any = None
+        self.driver = "unknown"
+        self.server_version = "unknown"
+        self.extension_version = "unknown"
+
+    def _connect(self) -> None:
+        try:
+            import psycopg
+
+            self.connection = psycopg.connect(self.dsn)
+            self.driver = "psycopg3"
+            return
+        except ImportError:
+            pass
+        try:
+            import psycopg2
+
+            self.connection = psycopg2.connect(self.dsn)
+            self.driver = "psycopg2"
+            return
+        except ImportError as exc:
+            raise RuntimeError(
+                "pgvector adapter requires 'psycopg[binary]' or 'psycopg2-binary'"
+            ) from exc
+
+    def prepare(self, dimension: int) -> None:
+        self._connect()
+        with self.connection.cursor() as cursor:
+            cursor.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            cursor.execute(f"""
+                CREATE TABLE {self.quoted_table} (
+                    id TEXT PRIMARY KEY,
+                    properties JSONB NOT NULL,
+                    embedding vector({dimension}) NOT NULL
+                )
+                """)
+            cursor.execute(
+                f"CREATE INDEX {self.quoted_partition_index} "
+                f"ON {self.quoted_table} ((properties ->> 'partition'))"
+            )
+            cursor.execute(
+                f"CREATE INDEX {self.quoted_embedding_index} "
+                f"ON {self.quoted_table} USING hnsw (embedding vector_cosine_ops)"
+            )
+            cursor.execute("SELECT version()")
+            self.server_version = str(cursor.fetchone()[0])
+            cursor.execute(
+                "SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+            )
+            self.extension_version = str(cursor.fetchone()[0])
+        self.connection.commit()
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        rows = [
+            (
+                record["id"],
+                json.dumps(record["props"], separators=(",", ":")),
+                vector_literal(record["vector"]),
+            )
+            for record in records
+        ]
+        statement = (
+            f"INSERT INTO {self.quoted_table} "
+            "(id, properties, embedding) VALUES (%s, %s::jsonb, %s::vector)"
+        )
+        with self.connection.cursor() as cursor:
+            if self.driver == "psycopg2":
+                from psycopg2.extras import execute_values
+
+                execute_values(
+                    cursor,
+                    statement.replace(
+                        "VALUES (%s, %s::jsonb, %s::vector)", "VALUES %s"
+                    ),
+                    rows,
+                    template="(%s, %s::jsonb, %s::vector)",
+                    page_size=len(rows),
+                )
+            else:
+                cursor.executemany(statement, rows)
+        self.connection.commit()
+
+    def finish_ingest(self) -> None:
+        with self.connection.cursor() as cursor:
+            cursor.execute(f"ANALYZE {self.quoted_table}")
+            cursor.execute("SET hnsw.ef_search = 40")
+        self.connection.commit()
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        where = "WHERE properties ->> 'partition' = %s" if filtered else ""
+        parameters: tuple[Any, ...]
+        if filtered:
+            parameters = (
+                record["props"]["partition"],
+                vector_literal(record["vector"]),
+                TOP_K,
+            )
+        else:
+            parameters = (vector_literal(record["vector"]), TOP_K)
+        statement = (
+            f"SELECT id FROM {self.quoted_table} {where} "
+            "ORDER BY embedding <=> %s::vector LIMIT %s"
+        )
+        started = time.perf_counter()
+        with self.connection.cursor() as cursor:
+            cursor.execute(statement, parameters)
+            found = [str(row[0]) for row in cursor.fetchall()]
+        return found, (time.perf_counter() - started) * 1000.0
+
+    def signals(self) -> dict[str, Any]:
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT blks_read, blks_hit, tup_returned, tup_fetched "
+                "FROM pg_stat_database WHERE datname = current_database()"
+            )
+            row = cursor.fetchone()
+        if not row:
+            return {}
+        reads, hits, returned, fetched = (int(value) for value in row)
+        return {
+            "pg_stat_database": {
+                "blocks_read": reads,
+                "blocks_hit": hits,
+                "tuples_returned": returned,
+                "tuples_fetched": fetched,
+            }
+        }
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "driver": self.driver,
+            "server_version": self.server_version,
+            "pgvector_version": self.extension_version,
+            "index": "hnsw(vector_cosine_ops)",
+            "hnsw_ef_search": 40,
+            "filter_index": "btree((properties ->> 'partition'))",
+            "distance": "cosine",
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if self.connection is None:
+            return
+        try:
+            if not keep_data:
+                with self.connection.cursor() as cursor:
+                    cursor.execute(f"DROP TABLE IF EXISTS {self.quoted_table}")
+                self.connection.commit()
+        finally:
+            self.connection.close()
+
+
+def ingest_stream(
+    adapter: Adapter,
+    *,
+    record_count: int,
+    dimension: int,
+    batch_size: int,
+    seed: int,
+    query_indexes: list[int],
+) -> tuple[DatasetManifest, float]:
+    selected = set(query_indexes)
+    query_records: dict[int, dict[str, Any]] = {}
+    hasher = hashlib.sha256()
+    hasher.update(b"[")
+    rng = random.Random(seed)
+    adapter.prepare(dimension)
+    started = time.perf_counter()
+    batch: list[dict[str, Any]] = []
+    for index in range(record_count):
+        record = make_record(index, dimension, rng)
+        if index:
+            hasher.update(b",")
+        hasher.update(
+            json.dumps(record, sort_keys=True, separators=(",", ":")).encode()
+        )
+        if index in selected:
+            query_records[index] = record
+        batch.append(record)
+        if len(batch) == batch_size:
+            adapter.insert_batch(batch)
+            batch = []
+    if batch:
+        adapter.insert_batch(batch)
+    adapter.finish_ingest()
+    ingest_seconds = time.perf_counter() - started
+    hasher.update(b"]")
+    missing = selected - query_records.keys()
+    if missing:
+        raise RuntimeError(f"query records were not generated: {sorted(missing)[:10]}")
+    return (
+        DatasetManifest(
+            sha256=hasher.hexdigest(),
+            query_records=[query_records[index] for index in query_indexes],
+        ),
+        ingest_seconds,
+    )
+
+
+def run_queries(
+    adapter: Adapter,
+    records: list[dict[str, Any]],
+    *,
+    warmup_count: int,
+) -> tuple[dict[str, float], list[float]]:
+    unfiltered_hits = 0
+    filtered_hits = 0
+    measured = 0
+    filtered_latencies: list[float] = []
+    for ordinal, record in enumerate(records):
+        unfiltered_ids, _ = adapter.search(record, filtered=False)
+        filtered_ids, filtered_latency = adapter.search(record, filtered=True)
+        if ordinal < warmup_count:
+            continue
+        measured += 1
+        filtered_latencies.append(filtered_latency)
+        unfiltered_hits += int(record["id"] in unfiltered_ids[:TOP_K])
+        filtered_hits += int(record["id"] in filtered_ids[:TOP_K])
+    if measured == 0:
+        raise RuntimeError("benchmark produced no measured queries")
+    return (
+        {
+            "recall_at_10": round(unfiltered_hits / measured, 6),
+            "filtered_recall_at_10": round(filtered_hits / measured, 6),
+        },
+        filtered_latencies,
+    )
+
+
+def unavailable_physical_metrics() -> dict[str, Any]:
+    return {
+        "object_gets": None,
+        "object_puts": None,
+        "bytes_read": None,
+        "bytes_written": None,
+        "cache_hit_ratio": None,
+        "estimated_cost_per_million_queries": None,
+    }
+
+
+def build_report(
+    adapter: Adapter,
+    *,
+    root: Path,
+    manifest: DatasetManifest,
+    record_count: int,
+    dimension: int,
+    seed: int,
+    query_count: int,
+    warmup_count: int,
+    ingest_seconds: float,
+    accuracy: dict[str, float],
+    latencies: list[float],
+) -> dict[str, Any]:
+    metrics: dict[str, Any] = {
+        **accuracy,
+        "ingest_records_per_second": round(record_count / ingest_seconds, 3),
+        "latency_p50_ms": round(percentile(latencies, 50), 3),
+        "latency_p95_ms": round(percentile(latencies, 95), 3),
+        "latency_p99_ms": round(percentile(latencies, 99), 3),
+        "peak_rss_bytes": peak_rss_bytes(),
+        **unavailable_physical_metrics(),
+    }
+    assert set(metrics) == set(REQUIRED_METRICS)
+    return {
+        "schema_version": 1,
+        "scenario_id": SCENARIO_ID,
+        "system": adapter.system_id,
+        "status": "measured-local-baseline",
+        "commit_sha": git_sha(root),
+        "dataset": {
+            "records": record_count,
+            "dimension": dimension,
+            "seed": seed,
+            "sha256": manifest.sha256,
+        },
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            **adapter.environment(),
+        },
+        "metrics": metrics,
+        "metric_scope": {
+            "recall_at_10": "inserted query-record target present in top 10",
+            "filtered_recall_at_10": "inserted query-record target present in filtered top 10",
+            "latency_percentiles": "filtered search client-observed latency",
+            "peak_rss_bytes": "benchmark runner peak RSS; not server RSS",
+            "unavailable": [key for key, value in metrics.items() if value is None],
+        },
+        "query_count": query_count,
+        "warmup_count": warmup_count,
+        "server_signals": adapter.signals(),
+        "publication_eligible": False,
+        "publication_blocker": (
+            "all adapters, five trials, >=1M records, four backends, and complete "
+            "server-side physical-cost metrics are required"
+        ),
+    }
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
+    if args.system == "proximadb":
+        return ProximaAdapter(args.base_url, args.timeout, run_name)
+    return PgvectorAdapter(args.pg_dsn, run_name)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--system", choices=("proximadb", "pgvector"), default="proximadb"
+    )
     parser.add_argument("--base-url", default="http://127.0.0.1:5678")
+    parser.add_argument(
+        "--pg-dsn",
+        default="postgresql://postgres:postgres@127.0.0.1:5432/postgres",
+        help="pgvector PostgreSQL DSN; never written to the report",
+    )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
     parser.add_argument("--queries", type=int, default=200)
@@ -85,126 +612,70 @@ def main() -> int:
     parser.add_argument("--batch-size", type=int, default=100)
     parser.add_argument("--seed", type=int, default=20260803)
     parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--keep-data", action="store_true")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
     if min(args.records, args.dimension, args.queries, args.batch_size) <= 0:
         parser.error("records, dimension, queries, and batch-size must be positive")
+    if args.warmup < 0:
+        parser.error("warmup must be non-negative")
 
     root = Path(__file__).resolve().parents[2]
-    rng = random.Random(args.seed)
-    collection = f"context_bench_{int(time.time())}_{rng.randrange(100000):05d}"
-    records: list[dict] = []
-    for index in range(args.records):
-        vector = [rng.uniform(-1.0, 1.0) for _ in range(args.dimension)]
-        records.append(
-            {
-                "id": f"rec-{index}",
-                "vector": vector,
-                "props": {"partition": f"p{index % 8}", "ordinal": index},
-            }
+    run_rng = random.Random(args.seed ^ 0xC0DEC0DE)
+    query_indexes = [
+        run_rng.randrange(args.records) for _ in range(args.warmup + args.queries)
+    ]
+    run_name = f"context_bench_{int(time.time())}_{run_rng.randrange(100000):05d}"
+    adapter = make_adapter(args, run_name)
+    try:
+        manifest, ingest_seconds = ingest_stream(
+            adapter,
+            record_count=args.records,
+            dimension=args.dimension,
+            batch_size=args.batch_size,
+            seed=args.seed,
+            query_indexes=query_indexes,
         )
-    dataset_bytes = json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
-    dataset_hash = hashlib.sha256(dataset_bytes).hexdigest()
-
-    request(
-        args.base_url,
-        "POST",
-        "/api/v2/collections",
-        {
-            "name": collection,
-            "dimension": args.dimension,
-            "engine": "sst",
-            "distance_metric": "cosine",
-            "enable_proxima_record": True,
-            "schema": {
-                "columns": [
-                    {"name": "partition", "data_type": "text", "indexed": True, "filterable": True},
-                    {"name": "ordinal", "data_type": "integer", "indexed": False, "filterable": True},
-                ],
-                "enforcement": "hybrid",
-                "allow_additional_fields": True,
-            },
-        },
-        args.timeout,
-    )
-    ingest_started = time.perf_counter()
-    for offset in range(0, len(records), args.batch_size):
-        request(
-            args.base_url,
-            "POST",
-            f"/api/v2/collections/{collection}/records/batch",
-            {"records": records[offset : offset + args.batch_size], "upsert": True},
-            args.timeout,
+        accuracy, latencies = run_queries(
+            adapter,
+            manifest.query_records,
+            warmup_count=args.warmup,
         )
-    ingest_seconds = time.perf_counter() - ingest_started
-    time.sleep(0.75)
-
-    query_indexes = [rng.randrange(args.records) for _ in range(args.warmup + args.queries)]
-    latencies: list[float] = []
-    correct = 0
-    for ordinal, record_index in enumerate(query_indexes):
-        payload, latency = request(
-            args.base_url,
-            "POST",
-            f"/api/v2/collections/{collection}/search",
-            {
-                "vector": records[record_index]["vector"],
-                "top_k": 10,
-                "filters": [
-                    {
-                        "field": "partition",
-                        "op": "eq",
-                        "value": f"p{record_index % 8}",
-                    }
-                ],
-            },
-            args.timeout,
+        report = build_report(
+            adapter,
+            root=root,
+            manifest=manifest,
+            record_count=args.records,
+            dimension=args.dimension,
+            seed=args.seed,
+            query_count=args.queries,
+            warmup_count=args.warmup,
+            ingest_seconds=ingest_seconds,
+            accuracy=accuracy,
+            latencies=latencies,
         )
-        if ordinal >= args.warmup:
-            latencies.append(latency)
-            correct += int(f"rec-{record_index}" in ids(payload)[:10])
-
-    route_health, _ = request(
-        args.base_url,
-        "GET",
-        f"/api/v2/_diagnostics/collections/{collection}/route-health",
-        None,
-        args.timeout,
-    )
-    report = {
-        "schema_version": 1,
-        "scenario_id": "context-corridor-v1",
-        "system": "proximadb",
-        "status": "measured-local-baseline",
-        "commit_sha": git_sha(root),
-        "dataset": {
-            "records": args.records,
-            "dimension": args.dimension,
-            "seed": args.seed,
-            "sha256": dataset_hash,
-        },
-        "environment": {
-            "platform": platform.platform(),
-            "python": platform.python_version(),
-            "base_url": args.base_url,
-        },
-        "metrics": {
-            "ingest_records_per_second": round(args.records / ingest_seconds, 3),
-            "filtered_recall_at_10": round(correct / args.queries, 6),
-            "latency_p50_ms": round(statistics.median(latencies), 3),
-            "latency_p95_ms": round(percentile(latencies, 95), 3),
-            "latency_p99_ms": round(percentile(latencies, 99), 3),
-        },
-        "query_count": args.queries,
-        "warmup_count": args.warmup,
-        "server_signals": route_health,
-        "publication_eligible": False,
-        "publication_blocker": "competitor adapters, five trials, >=1M records, and four backends are required",
-    }
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps(report, indent=2, sort_keys=True))
-    return 0
+        write_report(args.output, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except Exception as exc:  # Failed runs are evidence and must be retained.
+        failure = {
+            "schema_version": 1,
+            "scenario_id": SCENARIO_ID,
+            "system": args.system,
+            "status": "failed",
+            "commit_sha": git_sha(root),
+            "error_type": type(exc).__name__,
+            "error": sanitized_error(exc, args.pg_dsn),
+            "publication_eligible": False,
+        }
+        write_report(args.output, failure)
+        print(f"context corridor FAILED: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        try:
+            adapter.close(keep_data=args.keep_data)
+        except Exception as cleanup_error:
+            print(f"context corridor cleanup warning: {cleanup_error}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_context_benchmark.py
+++ b/scripts/validate_context_benchmark.py
@@ -46,8 +46,8 @@ def main() -> int:
     runnable = {
         item.get("id") for item in data.get("system", []) if item.get("adapter_status") == "runnable"
     }
-    if runnable != {"proximadb"}:
-        errors.append("only the implemented ProximaDB adapter may be marked runnable")
+    if runnable != {"pgvector", "proximadb"}:
+        errors.append("the implemented ProximaDB and pgvector adapters must be marked runnable")
     protocol = data.get("protocol", {})
     metrics = set(protocol.get("required_metrics", []))
     missing_metrics = REQUIRED_METRICS - metrics
@@ -81,7 +81,7 @@ def main() -> int:
         return 1
     print(
         "Context benchmark contract OK: 6 systems, 13 metrics, 4 backends, "
-        "five-trial/1M publication floor; only ProximaDB adapter is runnable."
+        "five-trial/1M publication floor; ProximaDB and pgvector adapters are runnable."
     )
     return 0
 

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -157,6 +157,12 @@ class ContextCorridorTest(unittest.TestCase):
             CONTEXT.PgvectorAdapter("ignored", 'bad";drop table x')
         self.assertEqual(CONTEXT.vector_literal([1.0, -0.25]), "[1,-0.25]")
 
+    def test_pgvector_environment_discloses_filtered_ann_settings(self) -> None:
+        adapter = CONTEXT.PgvectorAdapter("ignored", "context_corridor")
+        environment = adapter.environment()
+        self.assertEqual(environment["hnsw_ef_search"], 40)
+        self.assertEqual(environment["hnsw_iterative_scan"], "strict_order")
+
     def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
         dsn = "postgresql://alice:secret@db.example/test"
         error = RuntimeError(f"could not use {dsn}; password=second-secret")

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import random
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "context_corridor", ROOT / "scripts/bench/context_corridor.py"
+)
+assert SPEC and SPEC.loader
+CONTEXT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CONTEXT
+SPEC.loader.exec_module(CONTEXT)
+
+
+class FakeAdapter:
+    system_id = "fake"
+
+    def __init__(self, *, fail_prepare: bool = False) -> None:
+        self.fail_prepare = fail_prepare
+        self.prepared_dimension = None
+        self.inserted = 0
+        self.max_batch = 0
+        self.search_calls = 0
+        self.closed = False
+
+    def prepare(self, dimension: int) -> None:
+        if self.fail_prepare:
+            raise RuntimeError("expected preparation failure")
+        self.prepared_dimension = dimension
+
+    def insert_batch(self, records: list[dict]) -> None:
+        self.inserted += len(records)
+        self.max_batch = max(self.max_batch, len(records))
+
+    def finish_ingest(self) -> None:
+        return None
+
+    def search(self, record: dict, *, filtered: bool) -> tuple[list[str], float]:
+        self.search_calls += 1
+        return [record["id"]], 2.0 if filtered else 1.0
+
+    def signals(self) -> dict:
+        return {"fake": True}
+
+    def environment(self) -> dict:
+        return {"adapter": "fake"}
+
+    def close(self, *, keep_data: bool) -> None:
+        self.closed = True
+
+
+class ContextCorridorTest(unittest.TestCase):
+    def test_streamed_dataset_is_bounded_and_hash_compatible(self) -> None:
+        adapter = FakeAdapter()
+        manifest, ingest_seconds = CONTEXT.ingest_stream(
+            adapter,
+            record_count=11,
+            dimension=4,
+            batch_size=3,
+            seed=7,
+            query_indexes=[0, 7, 7, 10],
+        )
+
+        rng = random.Random(7)
+        records = [CONTEXT.make_record(index, 4, rng) for index in range(11)]
+        expected_hash = hashlib.sha256(
+            json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+
+        self.assertEqual(manifest.sha256, expected_hash)
+        self.assertEqual(
+            [record["id"] for record in manifest.query_records],
+            ["rec-0", "rec-7", "rec-7", "rec-10"],
+        )
+        self.assertEqual(adapter.prepared_dimension, 4)
+        self.assertEqual(adapter.inserted, 11)
+        self.assertEqual(adapter.max_batch, 3)
+        self.assertGreater(ingest_seconds, 0)
+
+    def test_queries_measure_filtered_and_unfiltered_target_recall(self) -> None:
+        adapter = FakeAdapter()
+        records = [
+            {
+                "id": f"rec-{index}",
+                "vector": [float(index)],
+                "props": {"partition": "p0"},
+            }
+            for index in range(4)
+        ]
+        accuracy, latencies = CONTEXT.run_queries(adapter, records, warmup_count=1)
+
+        self.assertEqual(accuracy["recall_at_10"], 1.0)
+        self.assertEqual(accuracy["filtered_recall_at_10"], 1.0)
+        self.assertEqual(latencies, [2.0, 2.0, 2.0])
+        self.assertEqual(adapter.search_calls, 8)
+
+    def test_report_has_the_complete_metric_contract(self) -> None:
+        adapter = FakeAdapter()
+        report = CONTEXT.build_report(
+            adapter,
+            root=ROOT,
+            manifest=CONTEXT.DatasetManifest("abc", []),
+            record_count=100,
+            dimension=8,
+            seed=9,
+            query_count=3,
+            warmup_count=1,
+            ingest_seconds=2.0,
+            accuracy={"recall_at_10": 1.0, "filtered_recall_at_10": 1.0},
+            latencies=[1.0, 2.0, 3.0],
+        )
+
+        self.assertEqual(set(report["metrics"]), set(CONTEXT.REQUIRED_METRICS))
+        self.assertEqual(report["metrics"]["ingest_records_per_second"], 50.0)
+        self.assertFalse(report["publication_eligible"])
+        self.assertIn("object_gets", report["metric_scope"]["unavailable"])
+
+    def test_failed_run_is_written_and_cleanup_runs(self) -> None:
+        adapter = FakeAdapter(fail_prepare=True)
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "failure.json"
+            argv = [
+                "context_corridor.py",
+                "--records",
+                "1",
+                "--dimension",
+                "1",
+                "--queries",
+                "1",
+                "--warmup",
+                "0",
+                "--output",
+                str(output),
+            ]
+            with (
+                patch.object(CONTEXT, "make_adapter", return_value=adapter),
+                patch.object(sys, "argv", argv),
+            ):
+                result = CONTEXT.main()
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(result, 1)
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["error_type"], "RuntimeError")
+        self.assertTrue(adapter.closed)
+
+    def test_pgvector_identifiers_and_vector_literals_are_strict(self) -> None:
+        with self.assertRaises(ValueError):
+            CONTEXT.PgvectorAdapter("ignored", 'bad";drop table x')
+        self.assertEqual(CONTEXT.vector_literal([1.0, -0.25]), "[1,-0.25]")
+
+    def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
+        dsn = "postgresql://alice:secret@db.example/test"
+        error = RuntimeError(f"could not use {dsn}; password=second-secret")
+        sanitized = CONTEXT.sanitized_error(error, dsn)
+        self.assertNotIn("secret", sanitized)
+        self.assertIn("<redacted-dsn>", sanitized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- add the first runnable competitor adapter for the context-corridor economic benchmark
- stream deterministic datasets in bounded batches so the 1M-record protocol is executable
- compare ProximaDB and pgvector through common filtered/unfiltered query and artifact contracts
- retain failed-run evidence, redact DSNs, and block publication on unavailable physical-cost metrics
- gate the adapter contract and tests in CI

Validation:
- make work-commit-check
- python3 -m unittest discover -s tests/scripts -p test_context_corridor.py -v
- live PostgreSQL 17 + pgvector 0.8.6 run: 100 records, 32 dimensions, 20 measured queries, JSONB expression filter + HNSW cosine index

This PR is independent of the active ABAC stack and intentionally does not enable auto-merge ahead of PR #1409.