### PR TITLE
fix(storage): publish spill outputs once across backends

### DIFF
--- a/apps/proximadb-server/tests/object_store_restart_recovery.rs
+++ b/apps/proximadb-server/tests/object_store_restart_recovery.rs
@@ -11,7 +11,6 @@
 //! by default because it requires cloud credentials and
 //! `PROXIMADB_OBJECT_STORE_URL=s3://...` or `adls://...`.
 
-use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -19,10 +18,7 @@ use std::time::{Duration, Instant};
 use reqwest::Client;
 use serde_json::{Value, json};
 
-fn free_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
-    listener.local_addr().expect("local addr").port()
-}
+mod support;
 
 fn write_config(path: &Path, data_dir: &Path, root: &str, ports: [u16; 4]) {
     let [rest, grpc, flight, pg] = ports;
@@ -97,7 +93,8 @@ impl ServerProcess {
         config_path: &Path,
         extra_env: &[(&str, &str)],
     ) -> anyhow::Result<Self> {
-        let ports = [free_port(), free_port(), free_port(), free_port()];
+        let port_reservation = support::reserve_loopback_ports::<4>()?;
+        let ports = port_reservation.ports();
         write_config(config_path, data_dir, root, ports);
         let mut command = Command::new(env!("CARGO_BIN_EXE_proximadb-server"));
         command
@@ -109,6 +106,7 @@ impl ServerProcess {
         for (key, value) in extra_env {
             command.env(key, value);
         }
+        drop(port_reservation);
         let child = command.spawn()?;
         let server = Self {
             child,

--- a/apps/proximadb-server/tests/support/mod.rs
+++ b/apps/proximadb-server/tests/support/mod.rs
@@ -1,0 +1,57 @@
+use std::io;
+use std::net::TcpListener;
+
+/// Holds simultaneously allocated loopback ports until a subprocess is ready
+/// to bind them.
+///
+/// Binding every listener before collecting the port numbers prevents the OS
+/// from immediately recycling one ephemeral port into another slot in the
+/// same server configuration. The caller releases the reservation immediately
+/// before `Command::spawn`; retaining it through the spawn would make the
+/// server's binds fail with `Address already in use`.
+pub(crate) struct LoopbackPortReservation<const N: usize> {
+    ports: [u16; N],
+    _listeners: Vec<TcpListener>,
+}
+
+impl<const N: usize> LoopbackPortReservation<N> {
+    pub(crate) fn ports(&self) -> [u16; N] {
+        self.ports
+    }
+}
+
+pub(crate) fn reserve_loopback_ports<const N: usize>() -> io::Result<LoopbackPortReservation<N>> {
+    let mut listeners = Vec::with_capacity(N);
+    let mut ports = Vec::with_capacity(N);
+    for _ in 0..N {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        ports.push(listener.local_addr()?.port());
+        listeners.push(listener);
+    }
+    let ports = ports.try_into().map_err(|ports: Vec<u16>| {
+        io::Error::other(format!(
+            "allocated {} loopback ports, expected {N}",
+            ports.len()
+        ))
+    })?;
+    Ok(LoopbackPortReservation {
+        ports,
+        _listeners: listeners,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn one_reservation_cannot_reuse_a_port() -> std::io::Result<()> {
+        for _ in 0..128 {
+            let reservation = super::reserve_loopback_ports::<4>()?;
+            let ports = reservation.ports();
+            let unique = ports.into_iter().collect::<BTreeSet<_>>();
+            assert_eq!(unique.len(), ports.len(), "reserved ports: {ports:?}");
+        }
+        Ok(())
+    }
+}

--- a/apps/proximadb-server/tests/wal_fsync_crash_recovery.rs
+++ b/apps/proximadb-server/tests/wal_fsync_crash_recovery.rs
@@ -28,16 +28,15 @@
 //!    MAY or MAY NOT have fsync'd before the kill — we do not assert it
 //!    either way, keeping the test deterministic.
 //!
-//! This test reuses the `ServerProcess` subprocess harness pattern (free_port,
-//! write_config, start/wait_ready/crash) established by
-//! `object_store_restart_recovery.rs`; the helpers are duplicated here because
-//! Rust integration tests are separate crates and that module is private.
+//! This test reuses the `ServerProcess` subprocess harness pattern established
+//! by `object_store_restart_recovery.rs`. Loopback-port reservation is shared
+//! through `tests/support`; the scenario-specific config and lifecycle helpers
+//! stay local because Rust integration tests are separate crates.
 //!
 //! Run via:
 //!   cargo nextest run --test wal_fsync_crash_recovery -- --ignored
 //!   cargo test --test wal_fsync_crash_recovery -- --ignored --nocapture
 
-use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -45,10 +44,7 @@ use std::time::{Duration, Instant};
 use reqwest::Client;
 use serde_json::{Value, json};
 
-fn free_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
-    listener.local_addr().expect("local addr").port()
-}
+mod support;
 
 /// Write a `file://`-backed server config with `sync_mode = "PerBatch"` — the
 /// ADR-069 D5 contract under test. The SAME `root` (storage URL) + `data_dir`
@@ -116,15 +112,18 @@ struct ServerProcess {
 
 impl ServerProcess {
     async fn start(root: &str, data_dir: &Path, config_path: &Path) -> anyhow::Result<Self> {
-        let ports = [free_port(), free_port(), free_port(), free_port()];
+        let port_reservation = support::reserve_loopback_ports::<4>()?;
+        let ports = port_reservation.ports();
         write_config(config_path, data_dir, root, ports);
-        let child = Command::new(env!("CARGO_BIN_EXE_proximadb-server"))
+        let mut command = Command::new(env!("CARGO_BIN_EXE_proximadb-server"));
+        command
             .arg("--config")
             .arg(config_path)
             .env("RUST_LOG", "info")
             .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .spawn()?;
+            .stderr(Stdio::inherit());
+        drop(port_reservation);
+        let child = command.spawn()?;
         let server = Self {
             child,
             base_url: format!("http://127.0.0.1:{}", ports[0]),

--- a/apps/proximadb-server/tests/wal_same_key_orphan_recovery.rs
+++ b/apps/proximadb-server/tests/wal_same_key_orphan_recovery.rs
@@ -14,13 +14,12 @@
 //!
 //! Uses a local `file://` store (the live ADLS/S3/GCS proof is TD-OBJSTORE-2;
 //! the recovery LIST-authority + same-key resolution code path is identical).
-//! The `ServerProcess` subprocess harness is duplicated here (Rust integration
-//! tests are separate crates; the original is private in
-//! `object_store_restart_recovery.rs`).
+//! The scenario-specific `ServerProcess` harness stays local because Rust
+//! integration tests are separate crates; loopback-port reservation is shared
+//! through `tests/support`.
 //!
 //! Run: `cargo nextest run --test wal_same_key_orphan_recovery -- --ignored`
 
-use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -28,10 +27,7 @@ use std::time::{Duration, Instant};
 use reqwest::Client;
 use serde_json::{Value, json};
 
-fn free_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind port 0");
-    listener.local_addr().expect("local addr").port()
-}
+mod support;
 
 /// Local-`file://` config (no cloud creds): the WAL + SST persist on the same
 /// volume across restarts, so the stranded orphan WAL batches survive the crash.
@@ -96,7 +92,8 @@ struct ServerProcess {
 
 impl ServerProcess {
     async fn start(root: &str, data_dir: &Path, config_path: &Path) -> anyhow::Result<Self> {
-        let ports = [free_port(), free_port(), free_port(), free_port()];
+        let port_reservation = support::reserve_loopback_ports::<4>()?;
+        let ports = port_reservation.ports();
         write_config(config_path, data_dir, root, ports);
         let mut command = Command::new(env!("CARGO_BIN_EXE_proximadb-server"));
         command
@@ -105,6 +102,7 @@ impl ServerProcess {
             .env("RUST_LOG", "warn")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
+        drop(port_reservation);
         let child = command.spawn()?;
         let server = Self {
             child,

--- a/crates/storage/proximadb-storage-ports/src/lib.rs
+++ b/crates/storage/proximadb-storage-ports/src/lib.rs
@@ -31,7 +31,8 @@ pub use scan_strategy::{ScanCostEstimate, ScanIterator, ScanStatistics, ScanStra
 pub mod path_resolver;
 pub use path_resolver::{
     CollectionPathResolver, StorageAssignment, collection_data_path_typed,
-    typed_identity_from_storage_assignment,
+    typed_identity_from_storage_assignment, typed_path_identity, typed_path_identity_when,
+    typed_paths_enabled,
 };
 
 /// Read access to collection metadata that storage needs at flush/compaction

--- a/crates/storage/proximadb-storage-ports/src/path_resolver.rs
+++ b/crates/storage/proximadb-storage-ports/src/path_resolver.rs
@@ -161,6 +161,37 @@ pub fn typed_identity_from_storage_assignment(
     })
 }
 
+/// Select the catalog identity for a physical typed-path lookup.
+///
+/// ADR-0083 makes the numeric identity authoritative and therefore persists it
+/// regardless of path layout. ADR-031 keeps the physical base62 layout behind
+/// `PROXIMADB_TYPED_PATHS` until its mixed-read migration is complete. Keeping
+/// those decisions separate is essential: an identity being present must not
+/// silently opt a collection into a different object-store prefix.
+pub fn typed_path_identity(identity: Option<CollectionIdentity>) -> Option<CollectionIdentity> {
+    typed_path_identity_when(identity, typed_paths_enabled())
+}
+
+/// Pure policy seam for deterministic tests and config-driven callers.
+pub fn typed_path_identity_when(
+    identity: Option<CollectionIdentity>,
+    enabled: bool,
+) -> Option<CollectionIdentity> {
+    enabled.then_some(identity).flatten()
+}
+
+/// Whether the base62 account/namespace/collection path layout is enabled.
+///
+/// Read once per process so every engine path observes one layout decision and
+/// cannot split reads from writes if the process environment changes later.
+pub fn typed_paths_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| match std::env::var("PROXIMADB_TYPED_PATHS") {
+        Ok(value) => value == "1" || value.eq_ignore_ascii_case("true"),
+        Err(_) => false,
+    })
+}
+
 /// ADR-031 Phase 4c: typed collection **data** directory path.
 ///
 /// * `Some(identity)` → `{base}/accounts/{acct}/{ns}/{coll}/data`

--- a/crates/storage/proximadb-storage-traits/src/query.rs
+++ b/crates/storage/proximadb-storage-traits/src/query.rs
@@ -6,7 +6,9 @@
 use proximadb_proto::proximadb_v1::{Collection, CollectionConfig};
 pub use proximadb_quantization_types::QuantizationType;
 use proximadb_search_types::block_prune::BlockPruneMode;
-use proximadb_storage_ports::{collection_data_path_typed, typed_identity_from_storage_assignment};
+use proximadb_storage_ports::{
+    collection_data_path_typed, typed_identity_from_storage_assignment, typed_path_identity,
+};
 use proximadb_tenant::{RbacTenantContext as TenantContext, UnifiedUserContext};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -525,7 +527,7 @@ impl StorageQueryContext {
         self.storage_url().map(|base| {
             let identity =
                 typed_identity_from_storage_assignment(self.collection.storage_assignment.as_ref());
-            collection_data_path_typed(base, self.collection_id(), identity)
+            collection_data_path_typed(base, self.collection_id(), typed_path_identity(identity))
         })
     }
 }

--- a/crates/storage/proximadb-storage-traits/src/types.rs
+++ b/crates/storage/proximadb-storage-traits/src/types.rs
@@ -14,18 +14,6 @@ use proximadb_proto::proximadb_v1::Collection;
 // field types stay identical for back-compat.
 use proximadb_kernel::CompactBatchId as BatchId;
 
-/// Deterministic 64-bit hash of a string, used to derive a stable
-/// `CollectionObjectId` handle from legacy UUID/name collection ids
-/// (ADR-0083 rev2 D2). Uses the fixed-seed `DefaultHasher`, so the derived
-/// handle is stable across processes and restarts (and never collides for any
-/// realistic collection count).
-fn stable_collection_handle(id: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut h = std::collections::hash_map::DefaultHasher::new();
-    id.hash(&mut h);
-    h.finish()
-}
-
 /// Flexible flush parameters that work for all storage engines.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FlushParameters {
@@ -80,23 +68,22 @@ impl FlushParameters {
             .ok_or_else(|| anyhow!("No collection_id provided in flush parameters"))
     }
 
-    /// Resolve a stable native handle for admission / scheduling / WAL / cache
-    /// keying (ADR-0083 rev2 D2).
+    /// Resolve the native, globally unique catalog object identity used for
+    /// admission, scheduling, WAL, and cache keying.
     ///
-    /// This is a **derived** `u64` handle, NOT the collection's identity — the
-    /// composite `CollectionIdentity` on `StorageAssignment` is the authoritative
-    /// identity. Numeric catalog ids parse directly; legacy UUID/name ids hash to
-    /// a deterministic u64. Because the handle is derived (never independently
-    /// stored), it cannot drift from the identity the way a second stored u64 can
-    /// — which is exactly the #1325 regression this closes (the embedded flush
-    /// plan parsed `Collection.id` as `u64` while it held a UUID).
+    /// Aliases and UUID-shaped legacy identifiers must be resolved by the
+    /// catalog before they reach this storage boundary. Hashing one here would
+    /// create a second, collision-prone identity domain that cannot be joined
+    /// reliably with catalog, MVCC, deletion-vector, or compaction state.
     pub fn get_collection_object_id(
         &self,
     ) -> Result<proximadb_kernel::stable_id::CollectionObjectId> {
         let collection_id = self.get_collection_id()?;
-        Ok(collection_id
-            .parse()
-            .unwrap_or_else(|_| stable_collection_handle(&collection_id)))
+        collection_id.parse().map_err(|error| {
+            anyhow!(
+                "flush collection_id must be a decimal catalog object id, got {collection_id:?}: {error}"
+            )
+        })
     }
 
     /// Resolve the composite `CollectionIdentity` from the cached config's

--- a/docs/10-quality/td/TD-COMPACT-11-deterministic-local-spill-compaction.adoc
+++ b/docs/10-quality/td/TD-COMPACT-11-deterministic-local-spill-compaction.adoc
@@ -77,9 +77,16 @@ The current code cannot be fixed by adding a temporary `Vec` serialization:
 
 === S5 — Publication, invalidation, and recovery
 
-* Upload only the final output through the atomic coordinator.
+* Upload the completed local output once to its unique final object key. Treat
+  multipart completion as the remote visibility boundary; do not first upload
+  an object-store `__compact` key and then GET/COPY/re-PUT it. Keep local
+  staging plus atomic rename for `file://`.
 * Fail spill closed when a remote backend/decorator cannot guarantee bounded
-  local-file publication; Azure/S3 multipart are the initial qualified paths.
+  local-file publication; Azure block upload, S3 multipart, and GCS resumable
+  upload are qualified paths. Check this capability before compaction work.
+* For `file://`/bare local paths, write a hidden sibling and atomically rename
+  on the same filesystem; never use the configurable spill mount as the rename
+  source.
 * After publication, stream Region A/B from retained local staging into the
   rebuildable persistent cache without an object GET or segment-sized DRAM
   seed; degrade to bounded control-only admission when that tier is disabled.
@@ -105,6 +112,15 @@ the settled two-segment corpus measured recall 0.985/0.987/0.983 and
 4.98/1.17/48.69 GET/query after-write/disk-warm/object-cold. Whole-process RSS
 and the injected-failure/determinism matrix remain open; this evidence does not
 close the TD.
+
+The subsequent 10M qualification reached one fully constructed
+2,757,638,547-byte, 10,000,000-row PAX but exposed a publication defect before
+source retirement: the Azure `move_file` compatibility path reread the whole
+remote staging object and attempted a second PUT. The source segments remained
+authoritative, proving the retirement ordering, but the run is not accepted as
+10M query evidence. S5 now uses the already-admitted local spill file as the
+only upload source and publishes it directly by bounded multipart commit; the
+10M recall/GET/latency matrix must be rerun on that path.
 
 == Exit criteria
 

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -242,7 +242,7 @@ the emergency off) · *config-mirror* (env overrides a config field) ·
 | `PROXIMADB_TRACE_PAX_STAGES` | Emits PAX write-stage boundary tracing. | OFF | eval; — | src/storage/engines/sst/segment_format.rs:1654
 | `PROXIMADB_TRACE_PAX_WRITE` | Arms the PAX-writer phase timer/bucket histogram (read at writer construction). | OFF | eval; TD-COMPACT-1 | src/storage/engines/sst/segment_format.rs:459
 | `PROXIMADB_TRAINING_COMPACTION_MIN_MB` | min untrained-L0 size for the training arm | 32 | TD-COMPACT-5 | `src/storage/engines/sst/flush/mod.rs`
-| `PROXIMADB_TYPED_PATHS` | Enables typed (base62-id) storage/WAL path resolution. | OFF (legacy string paths; read once/process) | opt-in; ADR-031 | src/storage/trait_components/path_resolver.rs:464
+| `PROXIMADB_TYPED_PATHS` | Enables typed (base62-id) storage/WAL path resolution. | OFF (legacy string paths; read once/process) | opt-in; ADR-031 | crates/storage/proximadb-storage-ports/src/path_resolver.rs
 | `PROXIMADB_VECTOR_BOUNDS_PRUNE_DISABLE` | Kill-switch forcing full-read (disables vector-bounds row-group pruning). | OFF (prune on) | kill-switch; TD-040 | src/storage/engines/nova/operations/search.rs:25
 | `PROXIMADB_VECTOR_RABITQ_ENABLE` | Opt-in: encode vector stripes with RaBitQ binary quantization instead of SQ8. | OFF (SQ8) | opt-in; — | crates/storage/proximadb-block-format/src/writer.rs:1828
 | `PROXIMADB_VECTOR_SQ8_DISABLE` | Kill-switch: vector stripes fall back to raw f32 instead of SQ8. | OFF (SQ8 on) | kill-switch; — | crates/storage/proximadb-block-format/src/writer.rs:1821

--- a/docs/12-design/adr/ADR-088-deterministic-local-spill-compaction.adoc
+++ b/docs/12-design/adr/ADR-088-deterministic-local-spill-compaction.adoc
@@ -193,16 +193,43 @@ Startup may reclaim only a ProximaDB-prefixed owner whose lease lock can be
 acquired non-blocking; unknown directories and locked owners are preserved.
 Platforms without this lock contract fail spill initialization closed.
 
-No intermediate is query-visible. The final local PAX is validated, uploaded
-once to the final transaction staging target, and published through the existing
-atomic coordinator. Input files, input deletion vectors, and their cache entries
-are retired only after publication. Failure or cancellation leaves the source
-segments authoritative. Startup removes abandoned task directories whose owners
-hold no live filesystem lease; resume is not part of the first implementation.
+No intermediate is query-visible. The final local PAX is validated and, for an
+object store, multipart-uploaded once to its unique final object key. Multipart
+parts remain uncommitted and invisible; completion of the block/part manifest is
+the object visibility boundary. The coordinator tracks this caller-managed
+publication but does not upload a second remote `__compact` object and COPY it
+to the final key. `file://` retains local staging plus atomic rename. Input
+files, input deletion vectors, and their cache entries are retired only after
+the final-object commit succeeds. Failure or cancellation leaves the source
+segments authoritative. Startup removes abandoned task directories whose
+owners hold no live filesystem lease; resume is not part of the first
+implementation.
+
+This distinction is part of the memory bound, not only a throughput tweak. The
+10M/Azurite qualification constructed and uploaded a valid 2,757,638,547-byte
+PAX, then failed publication because the Azure compatibility `move_file`
+implemented COPY as whole-object GET into a `Vec<u8>` followed by PUT. Direct
+multipart publication removes that segment-sized allocation, one full read,
+one full write, and the temporary object-store copy. Azure's asynchronous
+`Copy Blob` is not substituted here: its initial success response may still
+carry `x-ms-copy-status: pending`, so deleting staging immediately would require
+an additional completion protocol.
+
 Remote publication is admitted only when the selected filesystem implementation
-declares a bounded local-file upload path. Azure and S3 multipart publication
-qualify; the current whole-object compatibility, encryption, and GCS paths fail
-spill closed until they gain streaming implementations.
+declares a bounded local-file upload path. Azure block upload, S3 multipart
+upload, and GCS resumable upload qualify. GCS advances only after the service
+acknowledges the complete requested range and cancels/fails closed on a partial
+acknowledgement. Whole-object compatibility and encryption paths fail closed.
+Decorators must forward the capability explicitly rather than infer it from a
+URL scheme. This capability is checked before run generation, training, or PAX
+construction so an unsupported publication target cannot waste compaction CPU.
+
+Local publication is deliberately different. `file://` and bare paths write a
+hidden temporary file in the final file's own directory, then rename that file
+to the final name. The temporary file must not live in the configurable spill
+directory: it may be a different filesystem, and cross-filesystem rename cannot
+provide the required atomic visibility boundary. Arrow sidecars, when present,
+are renamed first; the segment rename remains the reader-visible commit point.
 
 The training guard is also a rescan obligation. It remains held across every
 task in a follow-up chain, including a long higher-level spill. The terminal

--- a/src/services/collection/manager.rs
+++ b/src/services/collection/manager.rs
@@ -1112,7 +1112,9 @@ impl CollectionService {
                 &enriched_config.name,
                 &uuid,
                 tenant_id,
-                typed_identity,
+                crate::storage::trait_components::path_resolver::typed_path_identity(
+                    typed_identity,
+                ),
             )
             .await
             .context("Failed to create storage directories")?;

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1300,6 +1300,8 @@ impl VectorOperationsService {
             crate::storage::trait_components::path_resolver::typed_identity_from_storage_assignment(
                 Some(assignment),
             );
+        let typed_identity =
+            crate::storage::trait_components::path_resolver::typed_path_identity(typed_identity);
         let storage_url =
             crate::storage::trait_components::path_resolver::collection_data_path_typed(
                 &assignment.base_location,

--- a/src/storage/engine.rs
+++ b/src/storage/engine.rs
@@ -876,7 +876,9 @@ impl StorageEngine {
         // `None` branch is byte-identical to the legacy `StoragePath::collection_*_path`.
         use crate::storage::trait_components::path_resolver::{
             collection_data_path_typed, collection_index_path_typed, collection_wal_path_typed,
+            typed_path_identity,
         };
+        let typed_identity = typed_path_identity(typed_identity);
         let data_url = collection_data_path_typed(&base_location, &collection_id, typed_identity);
         let write_buffer_url =
             collection_wal_path_typed(&base_location, &collection_id, typed_identity);

--- a/src/storage/engines/nova/operations/search.rs
+++ b/src/storage/engines/nova/operations/search.rs
@@ -140,6 +140,8 @@ impl NovaSearchOperations {
             crate::storage::trait_components::path_resolver::typed_identity_from_storage_assignment(
                 ctx.collection.storage_assignment.as_ref(),
             );
+        let typed_identity =
+            crate::storage::trait_components::path_resolver::typed_path_identity(typed_identity);
         let data_path = crate::storage::trait_components::path_resolver::collection_data_path_typed(
             base_location,
             collection_id,

--- a/src/storage/engines/sst/compaction.rs
+++ b/src/storage/engines/sst/compaction.rs
@@ -1481,6 +1481,26 @@ impl Compaction {
             .map(|path| path.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         let output_path = task.output_file.to_string_lossy().into_owned();
+        let direct_remote_publication =
+            crate::storage::engines::sst::staged_write::StagedSegmentWrite::is_remote_target(
+                &output_path,
+            );
+        if direct_remote_publication {
+            let output_filesystem = self
+                .filesystem_factory
+                .get_filesystem(&output_path)
+                .map_err(|error| {
+                    crate::core::StorageError::SstEngine(format!(
+                        "resolve local-spill publication backend: {error}"
+                    ))
+                })?;
+            if !output_filesystem.supports_bounded_local_file_write() {
+                return Err(crate::core::StorageError::SstEngine(format!(
+                    "{} backend does not guarantee bounded local-file publication for {output_path}",
+                    output_filesystem.filesystem_type()
+                )));
+            }
+        }
         let mut task_scratch = SpillTaskScratch::begin(
             scratch_owner.path(),
             task.collection_object_id,
@@ -1621,22 +1641,35 @@ impl Compaction {
                     "update local-spill PAX manifest: {error}"
                 ))
             })?;
+        // The spill writer already owns a complete local PAX. Object-store
+        // multipart uploads keep parts invisible until their final block-list
+        // commit, so uploading that file once to its unique final key is the
+        // atomic publication boundary. A remote `__compact` upload followed by
+        // COPY adds another full-object operation; the Azure fallback also
+        // materializes the entire multi-GiB object in process. Local files keep
+        // the coordinator's staging + atomic rename path.
         let staging_config = atomic_coordinator_staging(task)?;
         let atomic_operation = if let Some(coordinator) = &self.atomic_coordinator {
             Some(
-                coordinator
-                    .begin_atomic_operation(&staging_config)
-                    .await
-                    .map_err(|error| {
-                        crate::core::StorageError::SstEngine(format!(
-                            "begin local-spill atomic publication: {error}"
-                        ))
-                    })?,
+                if direct_remote_publication {
+                    coordinator
+                        .begin_zero_copy_managed_operation(&staging_config)
+                        .await
+                } else {
+                    coordinator.begin_atomic_operation(&staging_config).await
+                }
+                .map_err(|error| {
+                    crate::core::StorageError::SstEngine(format!(
+                        "begin local-spill atomic publication: {error}"
+                    ))
+                })?,
             )
         } else {
             None
         };
-        let publication_target = if let Some(operation) = &atomic_operation {
+        let publication_target = if direct_remote_publication {
+            output_path.clone()
+        } else if let Some(operation) = &atomic_operation {
             let filename = task
                 .output_file
                 .file_name()
@@ -1652,7 +1685,7 @@ impl Compaction {
                 filename
             )
         } else {
-            task.output_file.to_string_lossy().into_owned()
+            output_path.clone()
         };
 
         let write_result: Result<(

--- a/src/storage/engines/sst/compaction_tests.rs
+++ b/src/storage/engines/sst/compaction_tests.rs
@@ -859,7 +859,7 @@ async fn forced_local_spill_compacts_real_pax_with_mvcc_and_reclaims_scratch() -
     assert!(
         failure
             .to_string()
-            .contains("upload local-spill PAX segment"),
+            .contains("local-spill publication backend"),
         "unexpected upload failure: {failure}"
     );
     assert!(

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -267,8 +267,12 @@ impl SstEngine {
                 let collection_id = params.collection_id.as_deref().ok_or_else(|| {
                     SstError::InvalidArgument("Collection ID is required".to_string())
                 })?;
-                let identity = crate::storage::trait_components::path_resolver::
-                    typed_identity_from_storage_assignment(Some(assignment));
+                let identity =
+                    crate::storage::trait_components::path_resolver::typed_path_identity(
+                     crate::storage::trait_components::path_resolver::typed_identity_from_storage_assignment(
+                         Some(assignment),
+                     ),
+                 );
                 let storage_url =
                     crate::storage::trait_components::path_resolver::collection_data_path_typed(
                         &assignment.base_location,

--- a/src/storage/engines/sst/flush/mod.rs
+++ b/src/storage/engines/sst/flush/mod.rs
@@ -1637,10 +1637,10 @@ mod tests {
     }
 
     #[test]
-    fn flush_storage_path_matches_typed_search_path() {
+    fn flush_storage_path_matches_search_layout_policy() {
         use crate::proto::proximadb_v1::{Collection, StorageAssignment};
         use crate::storage::trait_components::path_resolver::{
-            collection_data_path_typed, typed_identity_from_storage_assignment,
+            collection_data_path_typed, typed_identity_from_storage_assignment, typed_path_identity,
         };
 
         let assignment = StorageAssignment {
@@ -1663,18 +1663,11 @@ mod tests {
         let expected = collection_data_path_typed(
             &assignment.base_location,
             "13",
-            typed_identity_from_storage_assignment(Some(&assignment)),
+            typed_path_identity(typed_identity_from_storage_assignment(Some(&assignment))),
         );
         assert_eq!(
             SstEngine::get_collection_storage_url_from_params(&params).unwrap(),
             expected
-        );
-        assert_ne!(
-            expected,
-            proximadb_storage_common::storage_path::StoragePath::collection_data_path(
-                &assignment.base_location,
-                "13"
-            )
         );
     }
 

--- a/src/storage/engines/sst/staged_write.rs
+++ b/src/storage/engines/sst/staged_write.rs
@@ -7,10 +7,11 @@
 //! **false-succeeds** — on the flush path that let WAL deletion destroy the
 //! only durable copy (TD-OBJSTORE-4 defect 6); on the compaction path it
 //! would drop the merged output while the inputs get deleted. This primitive
-//! makes the write coherent for BOTH bases: write locally, then upload the
-//! bytes to the remote staging URL so the coordinator promotes a file that
-//! actually exists. `file://`/bare-local bases keep the zero-copy direct
-//! write (`remote_url = None`, finalize is a no-op).
+//! makes the write coherent for BOTH bases: cloud targets upload a local file
+//! through the backend's bounded multipart/resumable primitive; `file://` and
+//! bare-local targets write a hidden sibling and atomically rename it. The
+//! sibling placement is essential: configurable scratch may be another mount,
+//! where rename is neither available nor atomic.
 
 use std::sync::Arc;
 
@@ -20,13 +21,22 @@ use crate::storage::persistence::filesystem::FilesystemFactory;
 
 /// A segment write staged for a possibly-remote target URL.
 pub(crate) struct StagedSegmentWrite {
-    /// Remote URL to upload to on finalize (`None` ⇒ direct local write).
+    /// Remote URL to upload to on finalize (`None` ⇒ local atomic rename).
     remote_url: Option<String>,
     /// Path the local-file segment writer must write to.
     local_path: String,
+    /// Final local path published by a same-directory atomic rename.
+    local_final_path: Option<String>,
 }
 
 impl StagedSegmentWrite {
+    /// Whether `target_url` is an object-store key rather than a local path.
+    /// A completed multipart upload may publish such a key directly: its
+    /// uncommitted blocks are invisible until the final block-list commit.
+    pub(crate) fn is_remote_target(target_url: &str) -> bool {
+        target_url.contains("://") && !target_url.starts_with("file://")
+    }
+
     /// Prepare a staged write for `target_url` (the full staging FILE url,
     /// e.g. `az://c/…/__flush/L0_x.pax` or `file:///…/__flush/L0_x.pax`).
     pub(crate) async fn begin(target_url: &str) -> Result<Self> {
@@ -44,7 +54,7 @@ impl StagedSegmentWrite {
         target_url: &str,
         scratch_root: Option<&std::path::Path>,
     ) -> Result<Self> {
-        let is_remote = target_url.contains("://") && !target_url.starts_with("file://");
+        let is_remote = Self::is_remote_target(target_url);
         if is_remote {
             let scratch = scratch_root
                 .map(std::path::Path::to_path_buf)
@@ -57,20 +67,36 @@ impl StagedSegmentWrite {
             Ok(Self {
                 remote_url: Some(target_url.to_string()),
                 local_path: local.to_string_lossy().into_owned(),
+                local_final_path: None,
             })
         } else {
-            let local = target_url
+            let final_path = target_url
                 .strip_prefix("file://")
                 .unwrap_or(target_url)
                 .to_string();
-            if let Some(parent) = std::path::Path::new(&local).parent() {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .context("create local staging parent dir")?;
-            }
+            let final_path_ref = std::path::Path::new(&final_path);
+            let parent = final_path_ref
+                .parent()
+                .filter(|candidate| !candidate.as_os_str().is_empty())
+                .unwrap_or_else(|| std::path::Path::new("."));
+            tokio::fs::create_dir_all(parent)
+                .await
+                .context("create local staging parent dir")?;
+            let name = final_path_ref
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("segment.bin");
+            // The temp file MUST share the final file's directory. Only then
+            // is rename guaranteed to stay on one filesystem and provide the
+            // atomic visibility boundary required by embedded/file:// mode.
+            let local = parent.join(format!(
+                ".{name}.proximadb-{}.tmp",
+                uuid::Uuid::new_v4().simple()
+            ));
             Ok(Self {
                 remote_url: None,
-                local_path: local,
+                local_path: local.to_string_lossy().into_owned(),
+                local_final_path: Some(final_path),
             })
         }
     }
@@ -136,11 +162,38 @@ impl StagedSegmentWrite {
             tracing::debug!(remote = %remote, bytes, "staged segment uploaded and retained locally");
             Ok(bytes)
         } else {
-            let meta = tokio::fs::metadata(&self.local_path)
-                .await
-                .context("stat locally written segment")?;
-            Ok(meta.len())
+            self.publish_local_atomic().await
         }
+    }
+
+    async fn publish_local_atomic(&self) -> Result<u64> {
+        let final_path = self
+            .local_final_path
+            .as_deref()
+            .context("local staged segment is missing its final path")?;
+        let bytes = tokio::fs::metadata(&self.local_path)
+            .await
+            .context("stat locally staged segment")?
+            .len();
+
+        // Publish an Arrow sidecar first when present. The PAX/segment rename
+        // remains the visibility boundary, so a visible segment never points
+        // at a sidecar that has not yet been published. A crash between the
+        // two renames can leave only an unreferenced sidecar, which cleanup may
+        // reclaim; it cannot expose a partial segment.
+        let staged_sidecar = format!("{}.idx", self.local_path);
+        if tokio::fs::try_exists(&staged_sidecar)
+            .await
+            .context("probe locally staged Arrow sidecar")?
+        {
+            tokio::fs::rename(&staged_sidecar, format!("{final_path}.idx"))
+                .await
+                .context("atomically publish local Arrow sidecar")?;
+        }
+        tokio::fs::rename(&self.local_path, final_path)
+            .await
+            .context("atomically publish local segment")?;
+        Ok(bytes)
     }
 
     async fn finalize_with_policy(
@@ -179,20 +232,18 @@ impl StagedSegmentWrite {
             tracing::debug!(remote = %remote, bytes, "staged segment uploaded");
             Ok(bytes)
         } else {
-            let meta = tokio::fs::metadata(&self.local_path)
-                .await
-                .context("stat locally written segment")?;
-            Ok(meta.len())
+            self.publish_local_atomic().await
         }
     }
 }
 
 impl Drop for StagedSegmentWrite {
     /// Leak guard: a writer failure between `begin` and `finalize` must not
-    /// strand the scratch file (+ possible Arrow sidecar). After a successful
-    /// `finalize` (which takes `remote_url`) this is a no-op.
+    /// strand the scratch file (+ possible Arrow sidecar). After successful
+    /// cloud upload or local rename the scratch paths no longer exist, so this
+    /// cleanup is a no-op.
     fn drop(&mut self) {
-        if self.remote_url.is_some() {
+        if self.remote_url.is_some() || self.local_final_path.is_some() {
             let _ = std::fs::remove_file(&self.local_path);
             let _ = std::fs::remove_file(format!("{}.idx", self.local_path));
         }
@@ -281,23 +332,56 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn local_target_writes_direct_and_finalize_is_noop() {
+    async fn local_target_is_invisible_until_same_directory_atomic_rename() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let target = format!("file://{}/coll/data/__flush/L0_x.pax", tmp.path().display());
         let staged = StagedSegmentWrite::begin(&target).await.expect("begin");
-        // Direct local path (parent pre-created), no scratch indirection.
-        assert!(staged.local_path().ends_with("/coll/data/__flush/L0_x.pax"));
+        let final_path = tmp.path().join("coll/data/__flush/L0_x.pax");
+        let staging_path = std::path::PathBuf::from(staged.local_path());
+        assert_eq!(staging_path.parent(), final_path.parent());
+        assert_ne!(staging_path, final_path);
+        assert!(!final_path.exists(), "target must be absent before commit");
         assert!(!staged.local_path().contains("proximadb-flush-staging"));
         std::fs::write(staged.local_path(), b"segment").expect("write");
+        std::fs::write(format!("{}.idx", staged.local_path()), b"index").expect("write sidecar");
+        assert!(
+            !final_path.exists(),
+            "staged bytes must not be query-visible"
+        );
         let factory = Arc::new(
             FilesystemFactory::create(Default::default())
                 .await
                 .expect("factory"),
         );
         staged.finalize(&factory).await.expect("finalize");
+        assert_eq!(std::fs::read(&final_path).expect("read final"), b"segment");
+        assert_eq!(
+            std::fs::read(format!("{}.idx", final_path.display())).expect("read final sidecar"),
+            b"index"
+        );
+        assert!(!staging_path.exists(), "atomic rename must consume staging");
+    }
+
+    #[tokio::test]
+    async fn dropping_failed_local_write_reclaims_hidden_sibling() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = format!("file://{}/coll/data/L0_failed.pax", tmp.path().display());
+        let staged = StagedSegmentWrite::begin(&target).await.expect("begin");
+        let staging_path = std::path::PathBuf::from(staged.local_path());
+        std::fs::write(&staging_path, b"partial").expect("write partial segment");
+        std::fs::write(format!("{}.idx", staging_path.display()), b"partial-index")
+            .expect("write partial sidecar");
+
+        drop(staged);
+
+        assert!(!staging_path.exists(), "failed staging file must be reaped");
         assert!(
-            tmp.path().join("coll/data/__flush/L0_x.pax").exists(),
-            "local write must land at the target path"
+            !std::path::Path::new(&format!("{}.idx", staging_path.display())).exists(),
+            "failed staging sidecar must be reaped"
+        );
+        assert!(
+            !tmp.path().join("coll/data/L0_failed.pax").exists(),
+            "failed write must never publish its target"
         );
     }
 
@@ -310,5 +394,27 @@ mod tests {
         // `az:...` path (the URL-as-local-path artifact class).
         assert!(staged.local_path().contains("proximadb-flush-staging"));
         assert!(!staged.local_path().contains("az:"));
+    }
+
+    #[test]
+    fn remote_target_detection_keeps_local_paths_on_rename_path() {
+        assert!(StagedSegmentWrite::is_remote_target(
+            "az://container/coll/data/L3.pax"
+        ));
+        assert!(StagedSegmentWrite::is_remote_target(
+            "s3://bucket/coll/data/L3.pax"
+        ));
+        assert!(StagedSegmentWrite::is_remote_target(
+            "gs://bucket/coll/data/L3.pax"
+        ));
+        assert!(StagedSegmentWrite::is_remote_target(
+            "gcs://bucket/coll/data/L3.pax"
+        ));
+        assert!(!StagedSegmentWrite::is_remote_target(
+            "file:///var/lib/proximadb/L3.pax"
+        ));
+        assert!(!StagedSegmentWrite::is_remote_target(
+            "/var/lib/proximadb/L3.pax"
+        ));
     }
 }

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -311,14 +311,17 @@ impl UnifiedStorageFormat for SstEngine {
         ids: &[String],
         identity: Option<crate::core::stable_id::CollectionIdentity>,
     ) -> Result<Vec<proximadb_records::ProximaRecord>> {
-        use crate::storage::trait_components::path_resolver::collection_data_path_typed;
+        use crate::storage::trait_components::path_resolver::{
+            collection_data_path_typed, typed_path_identity,
+        };
         use std::collections::HashSet;
 
         if ids.is_empty() {
             return Ok(Vec::new());
         }
 
-        let data_path = collection_data_path_typed(base_path, collection_id, identity);
+        let data_path =
+            collection_data_path_typed(base_path, collection_id, typed_path_identity(identity));
         let all_records = self
             .read_all_records(collection_id, Some(&data_path))
             .await?;

--- a/src/storage/persistence/filesystem/gcs_store.rs
+++ b/src/storage/persistence/filesystem/gcs_store.rs
@@ -19,6 +19,8 @@ use google_cloud_storage::http::objects::download::Range;
 use google_cloud_storage::http::objects::get::GetObjectRequest;
 use google_cloud_storage::http::objects::list::ListObjectsRequest;
 use google_cloud_storage::http::objects::upload::{Media, UploadObjectRequest, UploadType};
+use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE, RANGE};
+use tokio::io::AsyncReadExt;
 
 use super::{
     DirEntry, FileOptions, FileSystem, FilesystemError, FilesystemFile, FsFileMetadata, FsResult,
@@ -48,6 +50,8 @@ impl std::fmt::Debug for GcsFileSystem {
 }
 
 impl GcsFileSystem {
+    const RESUMABLE_CHUNK_BYTES: u64 = 8 * 1024 * 1024;
+
     pub async fn new(cfg: GcsConfig) -> FsResult<Self> {
         let mut config = if cfg.anonymous {
             ClientConfig::default().anonymous()
@@ -85,6 +89,21 @@ impl GcsFileSystem {
 
     fn net(ctx: &str, e: impl std::fmt::Display) -> FilesystemError {
         FilesystemError::Network(format!("{ctx}: {e}"))
+    }
+
+    fn next_resumable_chunk(offset: u64, total: u64) -> Option<(usize, bool)> {
+        let remaining = total.checked_sub(offset)?;
+        if remaining == 0 {
+            return None;
+        }
+        let bytes = remaining.min(Self::RESUMABLE_CHUNK_BYTES);
+        Some((bytes as usize, bytes == remaining))
+    }
+
+    fn parse_resumable_range(value: &str) -> Option<u64> {
+        value
+            .strip_prefix("bytes=0-")
+            .and_then(|end| end.parse::<u64>().ok())
     }
 
     async fn list_paginated(
@@ -210,6 +229,100 @@ impl FileSystem for GcsFileSystem {
             .await
             .map_err(|e| Self::net("GCS upload_object", e))?;
         Ok(())
+    }
+
+    fn supports_bounded_local_file_write(&self) -> bool {
+        true
+    }
+
+    async fn write_local_file(
+        &self,
+        path: &str,
+        local_path: &std::path::Path,
+        _options: Option<FileOptions>,
+    ) -> FsResult<u64> {
+        let (bucket, object) = Self::parse(path)?;
+        let mut file = tokio::fs::File::open(local_path).await?;
+        let bytes = file.metadata().await?.len();
+        let mut media = Media::new(object);
+        media.content_length = Some(bytes);
+        let upload_type = UploadType::Simple(media);
+        let session = self
+            .client
+            .prepare_resumable_upload(
+                &UploadObjectRequest {
+                    bucket,
+                    ..Default::default()
+                },
+                &upload_type,
+            )
+            .await
+            .map_err(|error| Self::net("GCS resumable begin", error))?;
+
+        if bytes == 0 {
+            session
+                .upload_single_chunk(Vec::<u8>::new(), 0)
+                .await
+                .map_err(|error| Self::net("GCS resumable empty upload", error))?;
+            return Ok(0);
+        }
+
+        // The 0.15 SDK's `UploadStatus::ResumeIncomplete` drops GCS's `Range`
+        // response header. The JSON API explicitly requires clients to advance
+        // from the acknowledged range rather than assume a whole request was
+        // persisted. Use the authenticated session URL directly and fail
+        // closed on a partial acknowledgement; compaction can retry from its
+        // authoritative inputs without risking a corrupt final object.
+        let upload_http = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| Self::net("GCS resumable HTTP client", error))?;
+        let mut buffer = vec![0u8; Self::RESUMABLE_CHUNK_BYTES as usize];
+        let mut offset = 0u64;
+        while let Some((chunk_bytes, final_chunk)) = Self::next_resumable_chunk(offset, bytes) {
+            file.read_exact(&mut buffer[..chunk_bytes]).await?;
+            let end = offset + chunk_bytes as u64 - 1;
+            let response = match upload_http
+                .put(session.url())
+                .header(CONTENT_RANGE, format!("bytes {offset}-{end}/{bytes}"))
+                .header(CONTENT_LENGTH, chunk_bytes)
+                .body(buffer[..chunk_bytes].to_vec())
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    let _ = session.cancel().await;
+                    return Err(Self::net("GCS resumable chunk", error));
+                }
+            };
+            let accepted = if final_chunk {
+                response.status().is_success()
+            } else {
+                response.status().as_u16() == 308
+                    && response
+                        .headers()
+                        .get(RANGE)
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(Self::parse_resumable_range)
+                        == Some(end)
+            };
+            if !accepted {
+                let status = response.status();
+                let acknowledged = response
+                    .headers()
+                    .get(RANGE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("missing");
+                let _ = session.cancel().await;
+                return Err(FilesystemError::Network(format!(
+                    "GCS resumable chunk {offset}-{end}/{bytes} was not fully acknowledged: \
+                     status={status}, range={acknowledged}"
+                )));
+            }
+            offset = end + 1;
+        }
+        Ok(bytes)
     }
 
     async fn write_if_absent(
@@ -355,6 +468,40 @@ mod tests {
         assert!(GcsFileSystem::parse("gs://bucket-only").is_err());
         assert!(GcsFileSystem::parse("gs://b/").is_err());
         assert!(GcsFileSystem::parse("gs:///obj").is_err());
+    }
+
+    #[test]
+    fn resumable_chunk_plan_is_bounded_contiguous_and_finalized_once() {
+        let total = 2 * GcsFileSystem::RESUMABLE_CHUNK_BYTES + 19;
+        let first = GcsFileSystem::next_resumable_chunk(0, total).unwrap();
+        let second = GcsFileSystem::next_resumable_chunk(first.0 as u64, total).unwrap();
+        let third =
+            GcsFileSystem::next_resumable_chunk(first.0 as u64 + second.0 as u64, total).unwrap();
+
+        assert_eq!(
+            first,
+            (GcsFileSystem::RESUMABLE_CHUNK_BYTES as usize, false)
+        );
+        assert_eq!(
+            second,
+            (GcsFileSystem::RESUMABLE_CHUNK_BYTES as usize, false)
+        );
+        assert_eq!(third, (19, true));
+        assert_eq!(GcsFileSystem::next_resumable_chunk(total, total), None);
+    }
+
+    #[test]
+    fn resumable_range_parser_requires_a_contiguous_zero_based_ack() {
+        assert_eq!(
+            GcsFileSystem::parse_resumable_range("bytes=0-8388607"),
+            Some(8_388_607)
+        );
+        assert_eq!(
+            GcsFileSystem::parse_resumable_range("bytes=1-8388607"),
+            None
+        );
+        assert_eq!(GcsFileSystem::parse_resumable_range("8388607"), None);
+        assert_eq!(GcsFileSystem::parse_resumable_range("bytes=0-nope"), None);
     }
 
     #[tokio::test]

--- a/src/storage/trait_components/path_resolver.rs
+++ b/src/storage/trait_components/path_resolver.rs
@@ -64,7 +64,8 @@ use std::sync::Arc;
 // nothing outside the root calls them yet (no benefit to the move).
 pub use proximadb_storage_ports::{
     CollectionPathResolver, StorageAssignment, collection_data_path_typed,
-    typed_identity_from_storage_assignment,
+    typed_identity_from_storage_assignment, typed_path_identity, typed_path_identity_when,
+    typed_paths_enabled,
 };
 
 // ============================================================================
@@ -547,19 +548,6 @@ impl DrTenantSystemPath {
     pub fn cache_subprefix(&self) -> String {
         format!("{}_cache/", self.tenant_root())
     }
-}
-
-/// ADR-031 Phase 4b: whether the typed object-store path
-/// (`accounts/{base62}/{base62}/{base62}/`, no tenant slot) is enabled. Read
-/// **once per process** (cached in a `OnceLock`, mirroring the `oid_paths`
-/// pattern) to avoid env races across the multi-threaded runtime. Default OFF
-/// → legacy string-resolved `data/…` / `accounts/{str}/…` paths (mixed-read-safe).
-pub fn typed_paths_enabled() -> bool {
-    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| match std::env::var("PROXIMADB_TYPED_PATHS") {
-        Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),
-        Err(_) => false,
-    })
 }
 
 /// ADR-031 Phase 4c: typed collection **WAL** directory path.
@@ -1919,6 +1907,18 @@ mod tests {
         );
         // And it has the legacy shape {base}/{cid}/data (no trailing slash).
         assert_eq!(typed_none, "/data/store/my_collection/data");
+    }
+
+    #[test]
+    fn persisted_identity_does_not_bypass_typed_path_gate() {
+        let identity = Some(CollectionIdentity {
+            account_id: 7,
+            namespace_id: 5,
+            collection_id: 9,
+        });
+
+        assert_eq!(typed_path_identity_when(identity, false), None);
+        assert_eq!(typed_path_identity_when(identity, true), identity);
     }
 
     #[test]

--- a/tests/embedded_flush_recovery.rs
+++ b/tests/embedded_flush_recovery.rs
@@ -44,7 +44,7 @@ fn catalog_collection(
 
 fn collection_data_path(collection: &proximadb::proto::proximadb_v1::Collection) -> String {
     use proximadb::storage::trait_components::path_resolver::{
-        collection_data_path_typed, typed_identity_from_storage_assignment,
+        collection_data_path_typed, typed_identity_from_storage_assignment, typed_path_identity,
     };
 
     let assignment = collection
@@ -54,7 +54,7 @@ fn collection_data_path(collection: &proximadb::proto::proximadb_v1::Collection)
     collection_data_path_typed(
         &assignment.base_location,
         &collection.id,
-        typed_identity_from_storage_assignment(Some(assignment)),
+        typed_path_identity(typed_identity_from_storage_assignment(Some(assignment))),
     )
 }
 

--- a/tests/objstore_backend_contract_test.rs
+++ b/tests/objstore_backend_contract_test.rs
@@ -86,6 +86,10 @@ async fn contract_local_file_multipart_publish(base: &str) {
 
     let factory = factory().await;
     let fs = factory.get_filesystem(&key).expect("backend for key");
+    assert!(
+        fs.supports_bounded_local_file_write(),
+        "{base} must advertise bounded local-file publication before spill admission"
+    );
     let written = fs
         .write_local_file(&key, &local_path, None)
         .await
@@ -126,6 +130,16 @@ async fn s3_prefix_list_and_exists_contract() {
     contract_prefix_semantics("s3://proximadb-test").await;
 }
 
+#[tokio::test]
+#[ignore = "needs MinIO — set AWS_ENDPOINT to the emulator"]
+async fn s3_local_file_multipart_publish_contract() {
+    if std::env::var("AWS_ENDPOINT").is_err() {
+        eprintln!("skip: set AWS_ENDPOINT (MinIO) to run");
+        return;
+    }
+    contract_local_file_multipart_publish("s3://proximadb-test").await;
+}
+
 // GCS is best-effort (documented fake-gcs/object_store incompatibilities; never a
 // gate — TD-OBJSTORE-5 nightly tier). The backend needs `PROXIMADB_GCS_ENDPOINT`
 // + `PROXIMADB_GCS_ANONYMOUS=1` to register against fake-gcs; if it does not
@@ -143,6 +157,25 @@ async fn gcs_prefix_list_and_exists_contract_best_effort() {
         return;
     }
     contract_prefix_semantics("gs://proximadb-test").await;
+}
+
+#[tokio::test]
+#[ignore = "needs fake-gcs — set PROXIMADB_GCS_ENDPOINT + PROXIMADB_GCS_ANONYMOUS=1"]
+async fn gcs_local_file_resumable_publish_contract_best_effort() {
+    if std::env::var("PROXIMADB_GCS_ENDPOINT").is_err() {
+        eprintln!("skip: set PROXIMADB_GCS_ENDPOINT (fake-gcs) to run");
+        return;
+    }
+    let factory = factory().await;
+    let Ok(fs) = factory.get_filesystem("gs://proximadb-test/probe") else {
+        eprintln!("::warning:: GCS backend did not register (best-effort tier) — skipping");
+        return;
+    };
+    assert!(
+        fs.supports_bounded_local_file_write(),
+        "GCS spill publication must advertise only its bounded resumable path"
+    );
+    contract_local_file_multipart_publish("gs://proximadb-test").await;
 }
 
 /// GCS pagination contract: with the page size pinned to 2, five objects must


### PR DESCRIPTION
## Summary

- preserve the catalog-owned numeric collection identity while keeping physical base62 paths behind the default-OFF typed-path gate
- publish disk-backed spill compaction output once to a unique final object key through bounded Azure/S3 multipart or GCS resumable upload
- retain same-directory hidden staging plus atomic rename for file and bare local paths, including embedded mode without a transaction coordinator
- reject unsupported remote publication backends before sorting, training, or PAX construction
- document the 10M Azurite publication failure as diagnostic evidence and require the release query matrix to be rerun on the corrected path

## Verification

- storage-ports unit tests: 16 passed
- GCS resumable planning/range tests: 2 passed
- SST staged-write atomic visibility/cleanup tests: 4 passed
- forced local-spill PAX/MVCC integration: passed
- cloud-full object-store contract target: builds cleanly
- Azure/Azurite 17 MiB+19 multipart round trip: passed
- S3/MinIO 17 MiB+19 multipart round trip: passed
- GCS/fake-GCS 17 MiB+19 resumable round trip: passed (308, 308, 200)
- formatting, env-gate registry, diff whitespace, and TD/ADR uniqueness checks: passed

## Promotion notes

- zero behavior change when PROXIMADB_TYPED_PATHS is unset
- source segments and deletion vectors remain authoritative until final-object publication succeeds
- the 10M recall/GET/latency matrix remains an evidence gate and is not inferred from the earlier failed publication run
