### PR TITLE
fix(storage): revert #1406 identity-allocation code that regressed cross-tier ANN recall (TD-RECALL-2)

### DIFF
--- a/docs/10-quality/td/TD-RECALL-2-cross-tier-recall-regression-1406.adoc
+++ b/docs/10-quality/td/TD-RECALL-2-cross-tier-recall-regression-1406.adoc
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-RECALL-2: #1406 identity-allocation code regressed cross-tier ANN recall (0.000 < 0.9)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing (revert in this PR)
+| Severity | High — blocks 3 PRs (#1418, #1419, feat/mvp-rest-sql-v2); ratchet regression
+| Component | `src/services/system_catalog.rs`; `src/services/system_catalog_state.rs`
+| Root cause commit | `7e000ddad` (#1406 feat(abac): ratchet live relational policy enforcement)
+| Relates to | [[TD-DELVEC-1]] (OID resolver cache invalidation, #1383/#1387); ADR-0083 (typed identity)
+|===
+
+== Symptom
+
+`tests/vector_ann_recall_e2e.rs::vector_ann_recall_under_deletes_and_compaction` regressed on
+`develop`. Phase C (cross-tier, delete-after-flush + reflush) collapses to **mean=0.000** while
+pre-flush and post-flush stay 1.000 (`leaks=0`). Reproduces **deterministically** — locally (macOS,
+3/3) and in CI; it is *not* a timing flake. The CI job is path-skipped on `develop`, which is why the
+regression landed invisibly (only PRs touching query/storage exercise it).
+
+== Bisect (airtight, runner-controlled)
+
+Both checkpoints run identically via `cargo test --test vector_ann_recall_e2e … --exact --nocapture`,
+default features (so `abac-policy`, which is opt-in/OFF, is compiled out):
+
+|===
+| commit | cross-tier recall | result
+| `25b5650e6` (#1407, #1406's parent) | mean=1.000 | PASS
+| `7e000ddad` (#1406) | mean=0.000 | FAIL
+|===
+
+Adjacent commits, deterministic. **Culprit = #1406.**
+
+Exonerated by the bisect (all earlier suspects): #1417 (compaction spill — its parent *also* fails),
+the async-compaction change `c2ba64921` (#1345, predates the green runs), the TD-DELVEC-1 arc,
+#1416 (audit decomp), and #1406's `#[cfg(feature="abac-policy")]`-gated code (abac-policy OFF, yet the
+default build still fails).
+
+== Root cause (surgically confirmed)
+
+At `7e000ddad`, reverting **only** `system_catalog.rs` + `system_catalog_state.rs` to their `25b5650e6`
+(pre-#1406) state — keeping all of #1406's gated ABAC/pgwire/dml code — restores cross-tier recall to
+1.000. The sole cause is the identity-allocation code #1406 added to `system_catalog.rs`:
+floor-based allocators (`object_floor`/`collection_floor`/`namespace_floor`/`namespace_ids`),
+`identity_allocator_seed`, `mint_object_id`, `resolve_typed_triple`, `mint_collection_typed_identity`,
+plus the `system_catalog_state` read helpers (`table_entries`, `max_object_id`).
+
+All 38 references to those symbols are self-contained in `system_catalog.rs` (the methods are private;
+there are no external callers), so the 2-file revert compiles clean. Nothing merged after #1406 touches
+these files or references the symbols.
+
+Likely exact path (not yet line-pinned): the changed OID/identity minting leaves the **OID resolver
+cache** stale after the 2nd flush's compaction — the same cache the TD-DELVEC-1 C2/C3 work (#1383/#1387)
+explicitly invalidated around compaction retire — so the cross-segment search resolves the wrong OID and
+misses the live set (mean=0.000, `leaks=0`). Single-flush phases pass because they do not cross the
+compaction/resolver path.
+
+== Fix (this PR)
+
+Revert `system_catalog.rs` + `system_catalog_state.rs` to their pre-#1406 state (268 lines removed,
+no other files touched). The ADR-0083 typed-identity minting can be re-landed once the resolver-cache
+interaction is fixed.
+
+== Follow-ups
+
+* Re-land the #1406 typed-identity minting with the OID resolver cache invalidated/updated after the
+  identity change (likely reusing the TD-DELVEC-1 C2/C3 invalidation seam), gated by this recall test.
+* Consider moving `vector_ann_recall_e2e` off the path-skip so a develop push catches this class of
+  regression directly (today it only runs on query/storage-touching PRs).
+* NOTE process: `cargo nextest run -E 'test(...)'` hung on test-discovery at some commits (enumerates
+  all ~195 binaries); use `cargo test --test <file> <name> -- --exact` for single-test bisect steps.

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -105,16 +105,6 @@ pub struct SystemCatalog {
     /// Next durable account/tenant stable id. Recovered from the WAL/snapshot
     /// state at boot; u64 lets us detect u32 exhaustion instead of wrapping.
     account_floor: AtomicU64,
-    /// Next globally unique catalog object id (table/column/index). Recovered
-    /// from durable schemas at boot; starts at one because zero is reserved.
-    object_floor: AtomicU64,
-    /// Next stable namespace/collection ids. The typed ids are narrower than
-    /// object ids, so u64 floors let allocation detect exhaustion before casts.
-    namespace_floor: AtomicU64,
-    collection_floor: AtomicU64,
-    /// Stable namespace id per (account, logical namespace). Durable schemas
-    /// are the authority; this map is rebuilt from them after replay.
-    namespace_ids: parking_lot::RwLock<HashMap<(String, String), u16>>,
     appender: Arc<dyn TableWalAppender>,
     /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
     /// never interleave such that a lower-LSN mutation applies after a higher
@@ -159,18 +149,12 @@ impl SystemCatalog {
         state: SystemCatalogState,
         appender: Arc<dyn TableWalAppender>,
     ) -> Self {
-        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
-            Self::identity_allocator_seed(&state);
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
-            object_floor: AtomicU64::new(object_floor),
-            namespace_floor: AtomicU64::new(namespace_floor),
-            collection_floor: AtomicU64::new(collection_floor),
-            namespace_ids: parking_lot::RwLock::new(namespace_ids),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: None,
@@ -192,120 +176,6 @@ impl SystemCatalog {
     /// The plane this catalog serves.
     pub fn role(&self) -> &proximadb_catalog::CatalogRole {
         &self.role
-    }
-
-    /// Recover every transient identity allocator from the durable table
-    /// schemas folded into `state`. Skipped ids are harmless; reuse is not.
-    fn identity_allocator_seed(
-        state: &SystemCatalogState,
-    ) -> (u64, u64, u64, HashMap<(String, String), u16>) {
-        let object_floor = state.max_object_id().map_or(1, |id| id.saturating_add(1));
-        let mut namespace_floor = 1_u64;
-        let mut collection_floor = 1_u64;
-        let mut namespace_ids = HashMap::new();
-        for (identifier, schema) in state.table_entries() {
-            if let Some(namespace_id) = schema.stable_namespace_id {
-                namespace_floor = namespace_floor.max(u64::from(namespace_id) + 1);
-                if let Some(account) = state
-                    .get_namespace(&identifier.namespace)
-                    .and_then(|namespace| namespace.tenant_id)
-                {
-                    namespace_ids.insert((account, identifier.namespace.join(".")), namespace_id);
-                }
-            }
-            if let Some(collection_id) = schema.stable_collection_id {
-                collection_floor = collection_floor.max(u64::from(collection_id) + 1);
-            }
-        }
-        (
-            object_floor,
-            namespace_floor,
-            collection_floor,
-            namespace_ids,
-        )
-    }
-
-    fn mint_object_id(&self, existing: Option<u64>) -> Result<u64> {
-        match existing {
-            Some(id) if id > 0 => {
-                let next = id
-                    .checked_add(1)
-                    .ok_or_else(|| anyhow!("catalog object id space exhausted"))?;
-                self.object_floor.fetch_max(next, Ordering::SeqCst);
-                Ok(id)
-            }
-            Some(_) => Err(anyhow!("catalog object id zero is reserved")),
-            None => self.allocate_bounded(&self.object_floor, u64::MAX, "catalog object"),
-        }
-    }
-
-    fn allocate_bounded(&self, floor: &AtomicU64, max: u64, label: &str) -> Result<u64> {
-        floor
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |id| {
-                (id > 0 && id <= max).then(|| id.checked_add(1)).flatten()
-            })
-            .map_err(|_| anyhow!("{label} id space exhausted"))
-    }
-
-    async fn resolve_typed_triple(
-        &self,
-        account: &str,
-        namespace_key: &str,
-        existing_namespace: Option<u16>,
-        existing_collection: Option<u32>,
-    ) -> Result<Option<(u32, u16, u32)>> {
-        let Some(account_id) = self.account_id_u32(account).await? else {
-            return Ok(None);
-        };
-        let key = (account.to_string(), namespace_key.to_string());
-        let namespace_id = if let Some(id) = existing_namespace {
-            self.namespace_floor
-                .fetch_max(u64::from(id) + 1, Ordering::SeqCst);
-            let mut registry = self.namespace_ids.write();
-            match registry.get(&key) {
-                Some(current) if *current != id => {
-                    return Err(anyhow!(
-                        "stable namespace identity mismatch for '{}': {} != {}",
-                        namespace_key,
-                        current,
-                        id
-                    ));
-                }
-                Some(_) => {}
-                None => {
-                    registry.insert(key, id);
-                }
-            }
-            id
-        } else if let Some(id) = self.namespace_ids.read().get(&key).copied() {
-            id
-        } else {
-            let mut registry = self.namespace_ids.write();
-            if let Some(id) = registry.get(&key).copied() {
-                id
-            } else {
-                let id = self.allocate_bounded(
-                    &self.namespace_floor,
-                    u64::from(u16::MAX),
-                    "stable namespace",
-                )? as u16;
-                registry.insert(key, id);
-                id
-            }
-        };
-        let collection_id = match existing_collection {
-            Some(id) => {
-                self.collection_floor
-                    .fetch_max(u64::from(id) + 1, Ordering::SeqCst);
-                id
-            }
-            None => self.allocate_bounded(
-                &self.collection_floor,
-                u64::from(u32::MAX),
-                "stable collection",
-            )? as u32,
-        };
-        Ok(Some((account_id, namespace_id, collection_id)))
     }
 
     /// Open (or create) the catalog WAL at `wal_path`, restore the in-RAM
@@ -419,18 +289,12 @@ impl SystemCatalog {
             .filter(|n| *n > 0)
             .unwrap_or(DEFAULT_SNAPSHOT_THRESHOLD);
 
-        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
-            Self::identity_allocator_seed(&state);
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
         Ok(Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
-            object_floor: AtomicU64::new(object_floor),
-            namespace_floor: AtomicU64::new(namespace_floor),
-            collection_floor: AtomicU64::new(collection_floor),
-            namespace_ids: parking_lot::RwLock::new(namespace_ids),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: Some(SnapshotConfig {
@@ -663,18 +527,6 @@ impl SystemCatalog {
             self.account_floor
                 .fetch_max(u64::from(max) + 1, Ordering::SeqCst);
         }
-        // The adopted authority may also carry object/typed ids minted by the
-        // publisher after this pod booted. Re-seed every transient allocator and
-        // replace the namespace map while the catalog write lock is held, so a
-        // same-generation reload cannot later reuse an adopted id.
-        let (object_floor, namespace_floor, collection_floor, namespace_ids) =
-            Self::identity_allocator_seed(&self.state);
-        self.object_floor.fetch_max(object_floor, Ordering::SeqCst);
-        self.namespace_floor
-            .fetch_max(namespace_floor, Ordering::SeqCst);
-        self.collection_floor
-            .fetch_max(collection_floor, Ordering::SeqCst);
-        *self.namespace_ids.write() = namespace_ids;
         self.loaded_version.store(read.version, Ordering::SeqCst);
         self.loaded_generation
             .store(read.generation, Ordering::SeqCst);
@@ -939,23 +791,6 @@ impl Catalog for SystemCatalog {
         self.state.account_id_u32(account)
     }
 
-    async fn max_object_id(&self) -> Result<Option<u64>> {
-        Ok(self.state.max_object_id())
-    }
-
-    async fn mint_collection_typed_identity(
-        &self,
-        account: &str,
-        namespace_key: &str,
-    ) -> Result<Option<(u32, u16, u32)>> {
-        let account = account.trim();
-        if account.is_empty() {
-            return Ok(None);
-        }
-        self.resolve_typed_triple(account, namespace_key, None, None)
-            .await
-    }
-
     async fn update_namespace_properties(
         &self,
         namespace: &[String],
@@ -986,8 +821,6 @@ impl Catalog for SystemCatalog {
         identifier: &TableIdentifier,
         schema: CatalogTableSchema,
     ) -> Result<CatalogTableSchema> {
-        let mut schema = schema;
-        proximadb_catalog::schema::normalize_identity(&mut schema);
         validate_schema(&schema)?;
         if !self.state.namespace_exists(&identifier.namespace) {
             return Err(anyhow!(
@@ -997,35 +830,6 @@ impl Catalog for SystemCatalog {
         }
         if self.state.table_exists(identifier) {
             return Err(anyhow!("Table '{}' already exists", identifier));
-        }
-        schema.object_id = Some(self.mint_object_id(schema.object_id)?);
-        for column in &mut schema.columns {
-            column.object_id = Some(self.mint_object_id(column.object_id)?);
-        }
-        for index in &mut schema.indexes {
-            index.object_id = Some(self.mint_object_id(index.object_id)?);
-        }
-        let namespace = self
-            .state
-            .get_namespace(&identifier.namespace)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Namespace '{}' does not exist",
-                    identifier.namespace.join(".")
-                )
-            })?;
-        if let Some(account) = namespace.tenant_id.as_deref()
-            && let Some((_account_id, namespace_id, collection_id)) = self
-                .resolve_typed_triple(
-                    account,
-                    &identifier.namespace.join("."),
-                    schema.stable_namespace_id,
-                    schema.stable_collection_id,
-                )
-                .await?
-        {
-            schema.stable_namespace_id = Some(namespace_id);
-            schema.stable_collection_id = Some(collection_id);
         }
         self.commit(CatalogDelta::UpsertTable {
             identifier: identifier.clone(),
@@ -1129,7 +933,6 @@ impl Catalog for SystemCatalog {
         identifier: &TableIdentifier,
         index: CatalogIndex,
     ) -> Result<CatalogIndex> {
-        let mut index = index;
         let mut schema = self.require_table(identifier)?;
         if schema.indexes.iter().any(|i| i.name == index.name) {
             return Err(anyhow!(
@@ -1147,7 +950,6 @@ impl Catalog for SystemCatalog {
                 ));
             }
         }
-        index.object_id = Some(self.mint_object_id(index.object_id)?);
         schema.indexes.push(index.clone());
         schema.updated_at_ms = now_millis();
         self.commit(CatalogDelta::UpsertTable {
@@ -1305,50 +1107,6 @@ mod tests {
         let right = right?;
         assert_eq!(left, right);
         assert_eq!(cat.account_id_u32_lookup("acme"), left);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn tenant_tables_receive_durable_total_object_and_typed_identity() -> Result<()> {
-        let dir = tempfile::tempdir()?;
-        let wal = dir.path().join("catalog.wal");
-        let namespace = nslevels(&["acme", "default"]);
-        let first = TableIdentifier::new(namespace.clone(), "orders");
-        let second = TableIdentifier::new(namespace.clone(), "customers");
-
-        let cat = SystemCatalog::open("default", &wal).await?;
-        cat.create_namespace_for_tenant(&namespace, HashMap::new(), Some("acme"))
-            .await?;
-        let orders = cat.create_table(&first, vec_schema("orders")).await?;
-        let customers = cat.create_table(&second, vec_schema("customers")).await?;
-
-        assert!(orders.object_id.is_some());
-        assert!(
-            orders
-                .columns
-                .iter()
-                .all(|column| column.object_id.is_some())
-        );
-        assert_eq!(orders.stable_namespace_id, customers.stable_namespace_id);
-        assert!(orders.stable_namespace_id.is_some());
-        assert_ne!(orders.stable_collection_id, customers.stable_collection_id);
-        let prior_max_object = cat.max_object_id().await?.expect("object ids minted");
-        let stable_namespace = orders.stable_namespace_id;
-        let prior_collection = customers.stable_collection_id.expect("typed collection id");
-        drop(cat);
-
-        let reopened = SystemCatalog::open("default", &wal).await?;
-        let third = TableIdentifier::new(namespace, "invoices");
-        let invoices = reopened
-            .create_table(&third, vec_schema("invoices"))
-            .await?;
-        assert_eq!(invoices.stable_namespace_id, stable_namespace);
-        assert!(
-            invoices
-                .stable_collection_id
-                .is_some_and(|id| id > prior_collection)
-        );
-        assert!(invoices.object_id.is_some_and(|id| id > prior_max_object));
         Ok(())
     }
 

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -301,32 +301,6 @@ impl SystemCatalogState {
         self.inner.read().account_ids.values().copied().max()
     }
 
-    /// Snapshot the table identity rows used to recover the SystemCatalog's
-    /// transient allocator floors and namespace registry after WAL replay.
-    pub fn table_entries(&self) -> Vec<(TableIdentifier, Arc<CatalogTableSchema>)> {
-        self.inner
-            .read()
-            .tables
-            .iter()
-            .map(|(identifier, schema)| (identifier.clone(), schema.clone()))
-            .collect()
-    }
-
-    /// Highest durable object id across tables, columns, and indexes.
-    pub fn max_object_id(&self) -> Option<u64> {
-        self.inner
-            .read()
-            .tables
-            .values()
-            .flat_map(|schema| {
-                std::iter::once(schema.object_id)
-                    .chain(schema.columns.iter().map(|column| column.object_id))
-                    .chain(schema.indexes.iter().map(|index| index.object_id))
-            })
-            .flatten()
-            .max()
-    }
-
     /// The highest WAL sequence number folded in (replay watermark / snapshot
     /// cutover LSN).
     pub fn applied_seq(&self) -> u64 {


### PR DESCRIPTION
## What

Reverts the two files that carried #1406's identity-allocation additions —
`src/services/system_catalog.rs` and `src/services/system_catalog_state.rs` — to their
pre-#1406 state (268 lines removed; no other files touched). The ADR-0083 typed-identity
minting can be re-landed once the OID resolver-cache interaction is fixed.

## Why

`#1406` (`feat(abac): ratchet live relational policy enforcement`, `7e000ddad`) regressed
`tests/vector_ann_recall_e2e.rs::vector_ann_recall_under_deletes_and_compaction`. Phase C
(cross-tier, delete-after-flush + reflush) recall collapses to **mean=0.000** while pre/post-flush
stay 1.000 (`leaks=0`). Deterministic (local macOS 3/3 + CI), not a timing flake. The CI job is
path-skipped on `develop`, so this landed invisibly. **Blocking #1418, #1419,
feat/mvp-rest-sql-v2.**

## Bisect (airtight, runner-controlled)

Both checkpoints via `cargo test --test vector_ann_recall_e2e … --exact`, default features
(so opt-in `abac-policy` is compiled out):

| commit | cross-tier recall | |
|---|---|---|
| `25b5650e6` (#1407, #1406's parent) | mean=1.000 | PASS |
| `7e000ddad` (#1406) | mean=0.000 | FAIL |

**Surgical confirmation:** at `7e000ddad`, reverting ONLY these 2 files restores mean=1.000
(keeping all of #1406's gated ABAC/pgwire/dml code). The cause is the floor-based identity
allocators #1406 added (`object_floor`/`collection_floor`/`namespace_floor`/`namespace_ids` +
`identity_allocator_seed`/`mint_object_id`/`resolve_typed_triple`). All 38 refs are
self-contained in `system_catalog.rs` (private methods, no external callers), so the revert
compiles clean and nothing merged since depends on it.

Likely exact path (not line-pinned): changed OID/identity minting leaves the **OID resolver
cache** stale after the 2nd flush's compaction (TD-DELVEC-1 C2/C3, #1383/#1387 territory) →
cross-segment search resolves the wrong OID → live set missed.

Exonerated by the bisect: #1417 (compaction spill), the async-compaction change `c2ba64921`,
the TD-DELVEC-1 arc, and #1406's `abac-policy`-gated code (OFF by default, yet the default
build still fails).

## Verification

- `cargo check --all-targets` → EXIT 0 (compiles clean, incl. test targets)
- `cargo test --test vector_ann_recall_e2e vector_ann_recall_under_deletes_and_compaction -- --exact` →
  **cross-tier mean=1.000, 1 passed** (fix confirmed on current develop)
- `make work-commit-check` → all guardrails green (fmt, clippy -D warnings, layering,
  workspace-boundaries, tenant-path, td-adr-unique, docs-claim, capability-matrix, panic-policy, env-gates)
- `abac-policy` (opt-in) unaffected: the reverted methods are private with no external callers;
  `abac_relational_transport_e2e` reads `object_id` dynamically (feature-matrix CI will confirm)

## Follow-ups

- Re-land the #1406 typed-identity minting with the OID resolver cache invalidated/updated after
  the identity change, gated by this recall test.
- Consider moving `vector_ann_recall_e2e` off the path-skip so a `develop` push catches this class
  of regression directly.

See `docs/10-quality/td/TD-RECALL-2-cross-tier-recall-regression-1406.adoc`.