### PR TITLE
fix(axis): make HMGI partition lifecycle atomic

### DIFF
--- a/src/index/axis/hmgi/registry.rs
+++ b/src/index/axis/hmgi/registry.rs
@@ -60,40 +60,83 @@ impl HmgiRegistry {
         }
     }
 
-    /// Get or create a partition for the given key
+    /// Get or create an unowned partition for the given key.
+    ///
+    /// Collection-facing code should use
+    /// [`get_or_create_collection_partition`](Self::get_or_create_collection_partition)
+    /// so graph creation and lifecycle ownership are committed together. This
+    /// lower-level operation exists for partition migration and focused tests that
+    /// address a partition directly.
     pub async fn get_or_create_partition(
         &self,
         key: HmgiPartitionKey,
         config: AxisHnswConfig,
         dimension: usize,
     ) -> Result<Arc<AxisHnswIndex>> {
-        // Check if partition exists
-        {
-            let partitions = self.partitions.read().await;
-            if let Some(index) = partitions.get(&key) {
-                return Ok(index.clone());
-            }
+        if let Some(index) = self.partitions.read().await.get(&key).cloned() {
+            return Ok(index);
         }
 
-        // Create new partition
+        let mut partitions = self.partitions.write().await;
+        if let Some(index) = partitions.get(&key) {
+            return Ok(index.clone());
+        }
+
         let index = Arc::new(AxisHnswIndex::new_with_collection(
             Some(key.to_string()),
             config,
             dimension,
         )?);
+        partitions.insert(key, index.clone());
+        Ok(index)
+    }
+
+    /// Atomically get or create a partition and bind it to its collection owner.
+    ///
+    /// The ownership map is the authority used by query routing and collection
+    /// teardown. Keeping creation and registration under the same lock order
+    /// prevents a concurrent drop from interleaving between those operations and
+    /// leaving a live but unreachable HNSW graph behind.
+    pub async fn get_or_create_collection_partition(
+        &self,
+        collection_id: &str,
+        key: HmgiPartitionKey,
+        config: AxisHnswConfig,
+        dimension: usize,
+    ) -> Result<Arc<AxisHnswIndex>> {
+        // The steady-state insert path should not serialize all collections on the
+        // ownership write lock once its modality partition is established.
+        {
+            let collection_partitions = self.collection_partitions.read().await;
+            if collection_partitions
+                .get(collection_id)
+                .is_some_and(|keys| keys.contains(&key))
+                && let Some(index) = self.partitions.read().await.get(&key).cloned()
+            {
+                return Ok(index);
+            }
+        }
+
+        let mut collection_partitions = self.collection_partitions.write().await;
+        Self::ensure_owner_available(&collection_partitions, collection_id, &key)?;
 
         let mut partitions = self.partitions.write().await;
-        partitions.insert(key.clone(), index.clone());
+        let index = if let Some(index) = partitions.get(&key) {
+            index.clone()
+        } else {
+            let index = Arc::new(AxisHnswIndex::new_with_collection(
+                Some(key.to_string()),
+                config,
+                dimension,
+            )?);
+            partitions.insert(key.clone(), index.clone());
+            index
+        };
 
-        // Update reverse map
-        // For now, use a simple collection identifier from the key
-        let collection_id = format!("oid_{}_var_{}", key.oid, key.variation_id);
-        let mut collection_partitions = self.collection_partitions.write().await;
         collection_partitions
-            .entry(collection_id)
+            .entry(collection_id.to_string())
             .or_default()
             .insert(key);
-
         Ok(index)
     }
 
@@ -115,13 +158,22 @@ impl HmgiRegistry {
             .unwrap_or_default()
     }
 
-    /// Register an existing partition key under an explicit collection ID.
-    pub async fn register_collection_partition(&self, collection_id: &str, key: HmgiPartitionKey) {
+    /// Register an existing unowned partition under an explicit collection ID.
+    pub async fn register_collection_partition(
+        &self,
+        collection_id: &str,
+        key: HmgiPartitionKey,
+    ) -> Result<()> {
         let mut collection_partitions = self.collection_partitions.write().await;
+        Self::ensure_owner_available(&collection_partitions, collection_id, &key)?;
+        if !self.partitions.read().await.contains_key(&key) {
+            anyhow::bail!("cannot register missing HMGI partition '{key}'");
+        }
         collection_partitions
             .entry(collection_id.to_string())
             .or_default()
             .insert(key);
+        Ok(())
     }
 
     /// Drop all partitions for a collection
@@ -138,6 +190,28 @@ impl HmgiRegistry {
         } else {
             Ok(0)
         }
+    }
+
+    fn ensure_owner_available(
+        collection_partitions: &HashMap<String, HashSet<HmgiPartitionKey>>,
+        collection_id: &str,
+        key: &HmgiPartitionKey,
+    ) -> Result<()> {
+        if collection_partitions
+            .get(collection_id)
+            .is_some_and(|keys| keys.contains(key))
+        {
+            return Ok(());
+        }
+        if let Some((owner, _)) = collection_partitions
+            .iter()
+            .find(|(owner, keys)| owner.as_str() != collection_id && keys.contains(key))
+        {
+            anyhow::bail!(
+                "HMGI partition '{key}' is already owned by collection '{owner}', not '{collection_id}'"
+            );
+        }
+        Ok(())
     }
 
     /// Get total number of partitions
@@ -226,16 +300,84 @@ mod tests {
         let key = HmgiPartitionKey::new(123, 1, "text".to_string(), Some(456));
 
         registry
-            .get_or_create_partition(key, AxisHnswConfig::default(), 128)
+            .get_or_create_collection_partition("collection_a", key, AxisHnswConfig::default(), 128)
             .await
             .unwrap();
 
-        let collection_id = format!("oid_{}_var_{}", 123, 1);
         let dropped = registry
-            .drop_collection_partitions(&collection_id)
+            .drop_collection_partitions("collection_a")
             .await
             .unwrap();
         assert_eq!(dropped, 1);
         assert_eq!(registry.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn collection_partition_has_one_explicit_owner() {
+        let registry = HmgiRegistry::new();
+        let key = HmgiPartitionKey::new(123, 1, "text".to_string(), None);
+
+        registry
+            .get_or_create_collection_partition(
+                "collection_a",
+                key.clone(),
+                AxisHnswConfig::default(),
+                128,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.get_partitions_for_collection("collection_a").await,
+            vec![key.clone()]
+        );
+        assert!(
+            registry
+                .get_partitions_for_collection("oid_123_var_1")
+                .await
+                .is_empty(),
+            "partition creation must not synthesize a second lifecycle owner"
+        );
+
+        let error = registry
+            .get_or_create_collection_partition("collection_b", key, AxisHnswConfig::default(), 128)
+            .await
+            .err()
+            .expect("a partition key must not acquire a second owner");
+        assert!(error.to_string().contains("already owned"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_collection_creation_returns_the_registered_graph() {
+        let registry = Arc::new(HmgiRegistry::new());
+        let key = HmgiPartitionKey::new(123, 1, "text".to_string(), None);
+        let left_registry = registry.clone();
+        let left_key = key.clone();
+        let right_registry = registry.clone();
+        let right_key = key.clone();
+
+        let (left, right) = tokio::join!(
+            left_registry.get_or_create_collection_partition(
+                "collection_a",
+                left_key,
+                AxisHnswConfig::default(),
+                128,
+            ),
+            right_registry.get_or_create_collection_partition(
+                "collection_a",
+                right_key,
+                AxisHnswConfig::default(),
+                128,
+            )
+        );
+        let left = left.unwrap();
+        let right = right.unwrap();
+
+        assert!(Arc::ptr_eq(&left, &right));
+        assert!(Arc::ptr_eq(
+            &left,
+            &registry.get_partition(&key).await.unwrap()
+        ));
+        assert_eq!(registry.len().await, 1);
     }
 }

--- a/src/index/axis/management/manager.rs
+++ b/src/index/axis/management/manager.rs
@@ -4562,8 +4562,8 @@ impl AxisManager {
     /// ## Process
     ///
     /// 1. Initialize HMGI components if not already done
-    /// 2. Register collection as HMGI-enabled
-    /// 3. Migrate existing vectors to modality partitions
+    /// 2. Migrate existing vectors to owned modality partitions
+    /// 3. Publish the collection as HMGI-enabled
     ///
     /// ## Example
     ///
@@ -4576,22 +4576,50 @@ impl AxisManager {
         modality_field: Option<String>,
         oid: u64,
     ) -> Result<()> {
+        if self.is_hmgi_enabled(collection_id).await {
+            let existing_oid = self
+                .hmgi_collection_oids
+                .read()
+                .await
+                .get(collection_id)
+                .copied()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "HMGI lifecycle state for collection '{collection_id}' has no OID"
+                    )
+                })?;
+            if existing_oid == oid {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "HMGI collection '{collection_id}' is already bound to OID {existing_oid}; \
+                 disable it before binding OID {oid}"
+            );
+        }
+
         // Store the field for logging before moving
         let field_display = modality_field.clone();
 
         // Initialize HMGI components if not already done
         self.ensure_hmgi_initialized(modality_field).await?;
 
-        // Register collection as HMGI-enabled
-        {
-            let mut enabled = self.hmgi_enabled_collections.write().await;
-            enabled.insert(collection_id.to_string());
+        // Build and register every existing modality partition before publishing
+        // enablement. If migration fails, remove any partial graph state so callers
+        // never observe an enabled collection with an incomplete registry.
+        if let Err(error) = self.migrate_collection_to_hmgi(collection_id, oid).await {
+            if let Some(registry) = &self.hmgi_registry {
+                registry.drop_collection_partitions(collection_id).await?;
+            }
+            return Err(error);
         }
 
-        // Store OID for partition key generation
         {
             let mut oids = self.hmgi_collection_oids.write().await;
             oids.insert(collection_id.to_string(), oid);
+        }
+        {
+            let mut enabled = self.hmgi_enabled_collections.write().await;
+            enabled.insert(collection_id.to_string());
         }
 
         tracing::info!(
@@ -4599,9 +4627,6 @@ impl AxisManager {
             collection_id,
             field_display
         );
-
-        // Migrate existing vectors to HMGI partitions
-        self.migrate_collection_to_hmgi(collection_id).await?;
 
         Ok(())
     }
@@ -4855,11 +4880,13 @@ impl AxisManager {
             "HMGI partition HNSW config (metric + HNSW knobs)"
         );
         let index = registry
-            .get_or_create_partition(partition_key.clone(), config, dimension)
+            .get_or_create_collection_partition(
+                collection_id,
+                partition_key.clone(),
+                config,
+                dimension,
+            )
             .await?;
-        registry
-            .register_collection_partition(collection_id, partition_key.clone())
-            .await;
 
         use crate::index::axis::index_factory::AxisVectorIndex;
         if !record.oid.is_empty() && !vec_values.is_empty() {
@@ -5000,7 +5027,7 @@ impl AxisManager {
     }
 
     /// Migrate existing collection vectors to HMGI partitions
-    async fn migrate_collection_to_hmgi(&self, collection_id: &str) -> Result<()> {
+    async fn migrate_collection_to_hmgi(&self, collection_id: &str, oid: u64) -> Result<()> {
         let extractor = self
             .hmgi_extractor
             .as_ref()
@@ -5010,14 +5037,6 @@ impl AxisManager {
             .hmgi_registry
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("HMGI registry not initialized"))?;
-
-        // Get OID for this collection
-        let oid = {
-            let oids = self.hmgi_collection_oids.read().await;
-            *oids
-                .get(collection_id)
-                .ok_or_else(|| anyhow::anyhow!("No OID found for collection '{}'", collection_id))?
-        };
 
         // Get existing vectors
         let vectors = {
@@ -5066,12 +5085,9 @@ impl AxisManager {
             // contract used by steady-state inserts.
             let record_vector = self.record_dense_vector(&record);
             let dimension = record_vector.map_or(128, <[f32]>::len);
-            let _index = registry
-                .get_or_create_partition(partition_key.clone(), config.clone(), dimension)
+            let index = registry
+                .get_or_create_collection_partition(collection_id, partition_key, config, dimension)
                 .await?;
-            registry
-                .register_collection_partition(collection_id, partition_key)
-                .await;
             use crate::index::axis::index_factory::AxisVectorIndex;
             if let Some(record_vector) = record_vector
                 && !record.oid.is_empty()
@@ -5082,7 +5098,7 @@ impl AxisManager {
                         &record,
                         &crate::index::axis::filterable_metadata::FilterableFieldsConfig::default(),
                     );
-                _index
+                index
                     .add_with_metadata(
                         record.oid.clone(),
                         record_vector.to_vec(),
@@ -6737,5 +6753,60 @@ mod clear_collection_vectors_tests {
             1,
             "post-flush insert must repopulate the projection"
         );
+    }
+}
+
+#[cfg(test)]
+mod hmgi_lifecycle_tests {
+    use super::*;
+    use proximadb_records::{EmbeddingCell, EmbeddingValues};
+
+    #[tokio::test]
+    async fn failed_enable_does_not_publish_or_leave_owned_partitions() {
+        let manager = AxisManager::new(AxisConfig::default()).await.unwrap();
+        let collection_id = "invalid_hmgi";
+        let invalid_vector = vec![0.0; 100_001];
+        let record = ProximaRecord {
+            oid: "oversized_embedding".to_string(),
+            embeddings: vec![EmbeddingCell {
+                model_id: "test".to_string(),
+                modality: "dense_vector".to_string(),
+                dim: invalid_vector.len() as u32,
+                values: EmbeddingValues::Fp32(invalid_vector),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        manager
+            .collection_vectors
+            .write()
+            .await
+            .entry(collection_id.to_string())
+            .or_default()
+            .insert(record.oid.clone(), record);
+
+        let error = manager
+            .enable_hmgi(collection_id, None, 42)
+            .await
+            .err()
+            .expect("oversized partition migration must fail");
+
+        assert!(error.to_string().contains("dimension"));
+        assert!(!manager.is_hmgi_enabled(collection_id).await);
+        assert!(
+            !manager
+                .hmgi_collection_oids
+                .read()
+                .await
+                .contains_key(collection_id)
+        );
+        let registry = manager.hmgi_registry().unwrap();
+        assert!(
+            registry
+                .get_partitions_for_collection(collection_id)
+                .await
+                .is_empty()
+        );
+        assert!(registry.is_empty().await);
     }
 }

--- a/tests/hmgi_integration_test.rs
+++ b/tests/hmgi_integration_test.rs
@@ -94,10 +94,12 @@ async fn test_hmgi_end_to_end_workflow() {
     // Check collection partitions
     registry
         .register_collection_partition("test_collection", text_key.clone())
-        .await;
+        .await
+        .unwrap();
     registry
         .register_collection_partition("test_collection", image_key.clone())
-        .await;
+        .await
+        .unwrap();
     let partitions = registry
         .get_partitions_for_collection("test_collection")
         .await;
@@ -601,6 +603,25 @@ async fn test_axismanager_drop_collection_removes_hmgi_partitions() {
     );
 }
 
+/// Re-enabling is idempotent for the established collection identity and must
+/// reject OID mutation before it can create a second partition namespace.
+#[tokio::test]
+async fn test_axismanager_hmgi_enable_preserves_oid_identity() {
+    use proximadb::index::axis::types::AxisConfig;
+
+    let manager = AxisManager::new(AxisConfig::default()).await.unwrap();
+    manager.enable_hmgi("stable_oid", None, 41).await.unwrap();
+    manager.enable_hmgi("stable_oid", None, 41).await.unwrap();
+
+    let error = manager
+        .enable_hmgi("stable_oid", None, 42)
+        .await
+        .err()
+        .expect("changing the partition identity must require explicit disablement");
+    assert!(error.to_string().contains("already bound to OID 41"));
+    assert!(manager.is_hmgi_enabled("stable_oid").await);
+}
+
 /// Test AxisManager routes HMGI-safe vector queries to modality partitions.
 #[tokio::test]
 async fn test_axismanager_hmgi_query_routes_to_modality_partition() {
@@ -683,10 +704,12 @@ async fn test_hmgi_query_routing() {
     // Register collection
     registry
         .register_collection_partition("test_collection", text_key.clone())
-        .await;
+        .await
+        .unwrap();
     registry
         .register_collection_partition("test_collection", image_key.clone())
-        .await;
+        .await
+        .unwrap();
 
     // Route query with modality filter
     let query = HybridQuery {


### PR DESCRIPTION
## Summary
- make HMGI graph creation and collection ownership one registry operation
- remove synthetic oid owner aliases that survived collection drop
- reject cross-collection partition ownership and concurrent duplicate graph creation
- publish HMGI enablement only after migration succeeds, with rollback on failure
- make same-OID enablement idempotent and reject OID rebinding without disable
- preserve the steady-state read fast path after partition ownership is established

## Stack
Depends on #1424. Keep this PR based on fix/axis-hmgi-config-authority until #1424 lands, then retarget or rebase onto develop.

## Verification
- cargo test --lib index::axis::hmgi::registry::tests: 6 passed
- rollback lifecycle unit test: 1 passed
- cargo test --test hmgi_integration_test: 25 passed
- make work-commit-check: passed

## Execution impact
This closes lifecycle leaks and identity drift without adding another vector index. HMGI remains a modality router over AXIS HNSW partitions; PAX remains the separate durable segment-local cascade.