### PR TITLE
bench(search): separate natural nprobe knee from recall SLA

### DIFF
--- a/docs/10-quality/td/TD-SEARCH-3-per-operation-read-coalescing.adoc
+++ b/docs/10-quality/td/TD-SEARCH-3-per-operation-read-coalescing.adoc
@@ -333,6 +333,25 @@ link:../../_internal/status/BIGANN_NPROBE_GEOMETRY_100K_3M3_2026_07_31.adoc[the
 dated evidence artifact] for the full curves, hashes, shape distribution, and
 the single-segment 10M memory limitation.
 
+== Partial 10M natural-knee evidence (2026-08-04)
+
+A later spill-enabled run produced one 10M PAX v3 segment with natural
+`k_c=305`. Five provenance-identical interruption-safe checkpoints contain 7
+of 20 unique planned `(nprobe, top_k)` points. The measured top-10 physical-GET,
+byte, p50, and p95 knees all select `nprobe=30`: recall 0.9744, 66.119 GET/query,
+163.04 MB/query, and 558.37 ms local-Azurite p50. The best sampled recall is
+0.9782 at nprobe 64, so the 0.98 target is explicitly unattained in the partial
+curve. Top-20 has only one point and no defensible knee.
+
+This changes the interpretation, not the quality ratchet. The economy knee is
+an observed cost/recall bend; the quality floor is the first point attaining an
+explicit target. They must not share one field, and neither is a production
+default without its own policy. The prior four-scale quality fit remains useful
+as a validation schedule but did not predict a passing 10M point. See
+link:../../_internal/status/BIGANN_NPROBE_GEOMETRY_100K_10M_2026_08_04.adoc[the
+five-scale partial evidence artifact] for source hashes, coverage, fits, charts,
+and remaining measurement gates.
+
 == Remaining inefficiencies
 
 * The filesystem trait's generic `read_ranges()` is bounded-concurrent but

--- a/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
+++ b/docs/_internal/roadmap/BENCHMARK_EVIDENCE.toml
@@ -774,6 +774,23 @@ version = "3.3M develop-derived PR #1345 @ 06c9e5678fa7de6a782563bdeb2625e74ba6b
 notes = "3.3M matrix: 20 points, 1000 queries/point, status pass, no failures, SHA-256 5d32b83cf4987956d1bfb71ae93a77e67d76682c6b7b9464f167cea0066e8cc6. Exact binary SHA-256 d6b660cf425f4251f841d882d64420a137060668d6cdde150be215849598e431. Azurite is operation-count and relative-latency evidence, not Azure WAN latency. Cluster radii are persisted shape metadata but do not participate in current centroid-distance probe selection. The four-scale fit is cross-revision calibration evidence; rerun all scales on one binary before a canonical five-point publication."
 
 [[claims]]
+id = "bigann_nprobe_natural_knee_100k_10m_partial"
+claim = "Natural economy knees and recall quality floors are distinct decisions. Across complete 100K/330K/1M/3.3M matrices, the top-10 physical-GET knees are nprobe 2/3/4/7, while the recall>=0.98 floors are 3/5/7/11. Five provenance-identical partial 10M checkpoints provide 7 of 20 unique planned points: top-10 GET/byte/p50/p95 knees agree at nprobe=30 (recall 0.9744, 66.119 GET/query, 163.04 MB/query, 558.37 ms local-Azurite p50); the best measured recall is 0.9782 at nprobe=64, so 0.98 is explicitly unattained rather than lowered. The top-20 10M curve has one point and no defensible knee."
+metric = "natural Kneedle nprobe by physical cost + explicit recall-target attainment + checkpoint coverage/provenance"
+status = "measured"
+asserted_in = [
+  "docs/_internal/status/BIGANN_NPROBE_GEOMETRY_100K_10M_2026_08_04.adoc",
+  "docs/10-quality/td/TD-SEARCH-3-per-operation-read-coalescing.adoc",
+]
+bench_source = "scripts/bench/nprobe_sweep.py"
+bench_command = "Run release/Azurite PAX v3 query-only matrices, using --quality-policy=report for discovery; analyze_nprobe_geometry.py merges the four complete lower scales plus five provenance-identical incomplete 10M checkpoints"
+artifact = "docs/_internal/status/BIGANN_NPROBE_GEOMETRY_100K_10M_2026_08_04.adoc"
+hardware = "Local macOS arm64 Apple Silicon, 64 GiB RAM, serialized release-server runs, Azurite localhost HTTP backend"
+date = "2026-08-04"
+version = "10M source/binary revision 955990254988bbf68acbfd616d8b1d7e12aa27c1; lower four matrices retain the revisions recorded by bigann_nprobe_geometry_100k_3m3"
+notes = "The 10M result is deliberately partial and the five-point natural-knee fit is labeled provisional_partial_input (log R2 0.8828, LOOCV MAPE 47.6%). The complete four-scale quality fits are unchanged. Input checkpoint SHA-256 values and generated SVG hashes are recorded in the artifact. Azurite supports physical-operation and relative-latency conclusions, not Azure WAN latency."
+
+[[claims]]
 id = "compaction_memory_amplification_3m3"
 claim = "After canonical-record and in-place-MVCC copy removal, a release-profile 3.3M-vector PAX compaction over the production Azure backend/Azurite path still consumes 9.85x incremental RSS per input-segment byte; input bytes are therefore a usable conservative admission currency, with 12x initial headroom"
 metric = "incremental_peak_rss_bytes / input_segment_bytes + compaction wall time + settled segment count + recall@10"

--- a/docs/_internal/status/BIGANN_NPROBE_GEOMETRY_100K_10M_2026_08_04.adoc
+++ b/docs/_internal/status/BIGANN_NPROBE_GEOMETRY_100K_10M_2026_08_04.adoc
@@ -1,0 +1,197 @@
+= BIGANN PAX natural nprobe knees: 100K through partial 10M (2026-08-04)
+:toc:
+
+This dated artifact separates two questions that the earlier four-scale
+analysis combined:
+
+* the *natural economy knee* is the Kneedle bend of recall against a measured
+  physical-cost Pareto frontier; and
+* the *quality floor* is the least measured `nprobe` attaining the explicit
+  recall target, or `unattained` when the sweep does not reach it.
+
+The recall target remains 0.98. An unattained target is evidence about the
+curve, not permission to lower the ratchet.
+
+== Evidence status
+
+The 100K, 330K, 1M, and 3.3M matrices are complete. The 10M result is
+*partial*: five interruption-safe checkpoints contain 7 of 20 unique planned
+`(nprobe, top_k)` points. The analyzer merges same-scale checkpoints only when
+their immutable binary, dataset, query slice, storage URL, segment path/ETag,
+layout, `k_c`, and seed provenance are equal. Snapshot timestamps are excluded
+because rematerializing the same immutable blob changes them.
+
+All five 10M checkpoints use source revision
+`955990254988bbf68acbfd616d8b1d7e12aa27c1`, release binary SHA-256
+`4c064a7e129acca99ace08e0bd2aad78ac0f805b40efaea7f5e8c2d46e1f8a76`,
+bed-config SHA-256
+`a139b4189515319b7b92067710f5907e3129f12d104e735a4715c6d410646d85`,
+and one 2,757,638,547-byte PAX v3 segment with `k_c=305`.
+
+[cols="1,2,2", options="header"]
+|===
+| 10M source | Measured points | SHA-256
+
+| Initial matrix | top-10: 14, 16; top-20: 14
+| `c1222abd612dd1817d2a048049e78277bc0b343f5452807d56aa856e0fa8206d`
+
+| Probe 22 | top-10: 22
+| `35b5a598ef8b95f8b80236546572597f44d1a049bdc9bc871e84e46078815a8d`
+
+| Probe 30 | top-10: 30
+| `fece5aae7de8d684f504af99d0b23f7920357dab80a6c4fd81a00a70ed44b676`
+
+| Probe 46 | top-10: 46
+| `da39b7e7731bf2cbcb9fb66cf18cef9abaa8732b5bb16bca9a9752b8190ff14e`
+
+| Probe 64 | top-10: 64
+| `67985e4cdbbed6eacbb1ee8cc7ebfdaaff7d16a8b9c03ce7e01296b30e1fca10`
+|===
+
+The earlier four complete matrix hashes remain recorded in
+link:BIGANN_NPROBE_GEOMETRY_100K_3M3_2026_07_31.adoc[the four-scale artifact].
+Those lower-scale matrices are cross-revision calibration evidence; this is
+not a same-binary canonical five-scale publication.
+
+== Method
+
+* Dataset: BIGANN/SIFT prefixes, 128d L2, independently generated exact
+  corpus-matched top-20 ground truth, 1,000 diverse queries per point.
+* Layout: one fully materialized PAX v3 segment per scale. Natural cell law:
+  `k_c = clamp(floor(rows * dimension / 4 MiB), 2, 4096)`.
+* Query isolation: fresh release server and empty process-local caches for each
+  point; persistent local tier disabled.
+* Storage: production Azure HTTP backend against localhost Azurite. GET counts
+  are the primary physical-cost evidence. Latencies are relative local-host
+  observations, not Azure WAN SLAs, and are more sensitive to host scheduling
+  or sleep than operation counts.
+* Knee method: remove any point dominated by a cheaper point with equal or
+  higher recall, then maximize normalized `recall - log(cost)` Kneedle distance
+  over an interior point. The primary economy objective is physical GET/query;
+  nprobe, bytes/query, p50, and p95 knees are also reported independently.
+
+== Natural GET knees
+
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+| Corpus | `k_c` | top-k | Knee nprobe | nprobe / `k_c` | Recall | GET/q / p50
+
+| 100K | 3 | 10 | 2 | 66.7% | 0.9778 | 1.701 / 45.04 ms
+| 100K | 3 | 20 | 2 | 66.7% | 0.9771 | 0.735 / 18.83 ms
+| 330K | 10 | 10 | 3 | 30.0% | 0.9571 | 4.077 / 52.49 ms
+| 330K | 10 | 20 | 3 | 30.0% | 0.95155 | 3.270 / 46.62 ms
+| 1M | 30 | 10 | 4 | 13.3% | 0.9456 | 6.604 / 110.08 ms
+| 1M | 30 | 20 | 6 | 20.0% | 0.9770 | 9.822 / 148.31 ms
+| 3.3M | 100 | 10 | 7 | 7.0% | 0.9495 | 16.978 / 174.31 ms
+| 3.3M | 100 | 20 | 7 | 7.0% | 0.9436 | 17.398 / 186.36 ms
+| 10M (partial) | 305 | 10 | 30 | 9.84% | 0.9744 | 66.119 / 558.37 ms
+| 10M (partial) | 305 | 20 | unavailable | unavailable | 0.9487 max | one point only
+|===
+
+For 10M top-10, the GET-, byte-, p50-, and p95-normalized knees all select
+`nprobe=30`; it reads 163.04 MB/query. This agreement makes 30 a useful
+*measured economy candidate*, but the partial matrix makes the five-scale fit
+provisional. Missing planned points and the top-20 curve must still be run.
+
+The economy knee is not a deployment default. Several natural knees sit well
+below the quality SLA. This is precisely why a natural knee and a quality
+floor cannot be represented by one field.
+
+== Quality-floor result
+
+[cols="1,1,2,2", options="header"]
+|===
+| Corpus | `k_c` | top-10 floor | top-20 floor
+
+| 100K | 3 | 3 / 0.9887 | 3 / 0.9898
+| 330K | 10 | 5 / 0.9850 | 5 / 0.98375
+| 1M | 30 | 7 / 0.9852 | 7 / 0.98425
+| 3.3M | 100 | 11 / 0.9800 | 12 / 0.9812
+| 10M (partial) | 305 | unattained; max 0.9782 at 64 | unattained; only 0.9487 at 14
+|===
+
+At 10M, increasing top-10 nprobe from 30 to 64 raises recall only from 0.9744
+to 0.9782 while GET/query rises from 66.119 to 110.923 and p50 from 558.37 to
+926.60 ms. This does not prove that 0.98 is unreachable: the curve stops at 64
+of 305 cells. It does prove that the four-scale quality-floor extrapolation
+does not supply a validated 10M default.
+
+The complete four-scale quality fits remain:
+
+[cols="1,3,1,1", options="header"]
+|===
+| Result size | Fit | log R-squared | leave-one-scale-out MAPE
+
+| top-10 | `nprobe = 2.05985 * k_c ^ 0.364786` | 0.9965 | 4.82%
+| top-20 | `nprobe = 1.97377 * k_c ^ 0.387382` | 0.9955 | 5.51%
+|===
+
+The provisional five-point top-10 natural-knee fit is
+`nprobe = 0.860874 * k_c ^ 0.541468`, log R-squared 0.8828 and leave-one-scale-
+out MAPE 47.6%. Its poor cross-validation error is evidence against treating a
+single global power law as settled. The per-collection decision should remain
+measurement-driven until more complete and same-binary curves exist.
+
+== Implications
+
+* There is no constant knee fraction. Absolute nprobe generally rises while
+  `nprobe / k_c` falls, and the partial 10M curve is not evidence for a fixed
+  23-25% rule.
+* Reducing cell size increases `k_c`; without better range coalescing it can
+  exchange byte selectivity for more billable GET opportunities. The measured
+  objective must include physical reads, not cells alone.
+* At 10M, nprobe tuning alone does not reach the `<=20 GET/query` serving goal.
+  Coalescing, miss singleflight, warm local-disk tiers, and low segment count
+  remain multiplicative requirements.
+* Cluster radii remain persisted shape evidence only. Current centroid-distance
+  routing does not consume them, so they cannot explain these recall or GET
+  changes.
+* If the completed 10M curve still plateaus below 0.98, attribution must split
+  IVF coverage, RaBitQ survivor retention, and SQ8 rerank recall before changing
+  the SLA or layout.
+
+== Analyzer and sweep contract
+
+`scripts/bench/nprobe_sweep.py` now writes measurement failures separately from
+quality outcomes. Its default `--quality-policy=require` preserves the 0.98
+ratchet. Exploratory natural-knee collection can use
+`--quality-policy=report`; this permits a valid matrix to report `unattained`
+without claiming a quality pass.
+
+`scripts/bench/analyze_nprobe_geometry.py` accepts complete matrices and
+non-empty, internally consistent incomplete checkpoints. It rejects active
+checkpoints, measurement failures, duplicate points, truncated terminal
+matrices, and same-scale provenance mismatches. Sparse curves report an
+unavailable knee rather than failing the entire multi-scale analysis.
+
+The focused contract is covered by
+`tests/python/test_nprobe_geometry_analysis.py` and
+`tests/python/test_nprobe_sweep.py`.
+
+== Charts and hashes
+
+Analysis JSON SHA-256:
+`fed84b56d71b124415a1a694d0e5163ba44ed7f39f07fa8901344a5680601b48`.
+This JSON is retained in the local evidence directory; the reviewable SVGs are
+checked in below.
+
+* bubble SVG:
+  `63271f412f6fc23e6cdf5f1f336b766234f5518aa00bd61c5355a62287e3ce7b`;
+* dual-axis SVG:
+  `c182835f7bde5aed6c97bb0a2f155eb702e0adf0806fc5b2e23a7f27ad5df6b3`;
+* Pareto SVG:
+  `7b86bcf02884203d6a734906177d876d88849003a9cb5874d6936dde049fa5e0`.
+
+image::assets/bigann_nprobe_geometry_2026_08_04/bubble.svg[Five-scale recall bubble chart]
+
+image::assets/bigann_nprobe_geometry_2026_08_04/dual-axis.svg[Recall and physical GET cost by normalized probe fraction]
+
+image::assets/bigann_nprobe_geometry_2026_08_04/pareto.svg[Recall to physical GET-per-query Pareto frontier]
+
+== Remaining measurement gates
+
+. Complete the missing 10M top-10 points 17-20 and the top-20 sweep.
+. Add lower 10M probes if needed to stabilize the left side of the knee.
+. Rerun all five scales on one release binary before promoting a global formula.
+. Preserve the exact ground-truth/query slice and report prefix checkpoints so
+  query-prefix variance cannot masquerade as a geometry effect.

--- a/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/bubble.svg
+++ b/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/bubble.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760">
+<style>
+text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#18212b}
+.grid{stroke:#d9e1e8;stroke-width:1}.axis{stroke:#536272;stroke-width:1.5}
+.natural-knee{stroke:#111827;stroke-width:2.5;fill:none}
+.quality-floor{stroke:#111827;stroke-width:2.5;fill:none;stroke-dasharray:5 4}
+</style>
+<rect width="100%" height="100%" fill="#fbfdff"/>
+<text x="95" y="34" font-size="22" font-weight="700">PAX nprobe scale geometry — release/Azurite evidence</text>
+<text x="95" y="56" font-size="13">Bubble area scales with nprobe; color scales with physical GET/query; solid ring = GET knee; dashed ring = first recall ≥ 0.980 when attained; x jitter only separates bubbles.</text>
+<line class="grid" x1="95" y1="660.00" x2="1145" y2="660.00"/>
+<text x="83" y="664.00" text-anchor="end" font-size="12">0.600</text>
+<line class="grid" x1="95" y1="544.88" x2="1145" y2="544.88"/>
+<text x="83" y="548.88" text-anchor="end" font-size="12">0.680</text>
+<line class="grid" x1="95" y1="429.76" x2="1145" y2="429.76"/>
+<text x="83" y="433.76" text-anchor="end" font-size="12">0.760</text>
+<line class="grid" x1="95" y1="314.63" x2="1145" y2="314.63"/>
+<text x="83" y="318.63" text-anchor="end" font-size="12">0.840</text>
+<line class="grid" x1="95" y1="199.51" x2="1145" y2="199.51"/>
+<text x="83" y="203.51" text-anchor="end" font-size="12">0.920</text>
+<line class="grid" x1="95" y1="84.39" x2="1145" y2="84.39"/>
+<text x="83" y="88.39" text-anchor="end" font-size="12">1.000</text>
+<line x1="95" y1="113.17" x2="1145" y2="113.17" stroke="#111827" stroke-dasharray="7 5"/>
+<line class="axis" x1="121.25" y1="660" x2="121.25" y2="666"/>
+<text x="121.25" y="684" text-anchor="middle" font-size="13">100K</text>
+<text x="121.25" y="702" text-anchor="middle" font-size="11">k_c=3</text>
+<circle cx="92.38" cy="244.70" r="5.12" fill="rgb(49,150,209)" fill-opacity="0.72" stroke="rgb(49,150,209)"><title>N=100,000; top_k=10; nprobe=1; recall=0.88860; GET/q=0.43</title></circle>
+<circle cx="98.50" cy="116.34" r="5.80" fill="rgb(51,149,208)" fill-opacity="0.72" stroke="rgb(51,149,208)"><title>N=100,000; top_k=10; nprobe=2; recall=0.97780; GET/q=1.70</title></circle>
+<circle cx="102.08" cy="100.65" r="6.31" fill="rgb(54,147,206)" fill-opacity="0.72" stroke="rgb(54,147,206)"><title>N=100,000; top_k=10; nprobe=3; recall=0.98870; GET/q=3.40</title></circle>
+<circle cx="113.38" cy="252.76" r="5.12" fill="rgb(48,150,210)" fill-opacity="0.38" stroke="rgb(48,150,210)" stroke-dasharray="3 2"><title>N=100,000; top_k=20; nprobe=1; recall=0.88300; GET/q=0.02</title></circle>
+<circle cx="119.50" cy="117.34" r="5.80" fill="rgb(49,149,209)" fill-opacity="0.38" stroke="rgb(49,149,209)" stroke-dasharray="3 2"><title>N=100,000; top_k=20; nprobe=2; recall=0.97710; GET/q=0.73</title></circle>
+<circle cx="123.08" cy="99.07" r="6.31" fill="rgb(53,148,207)" fill-opacity="0.38" stroke="rgb(53,148,207)" stroke-dasharray="3 2"><title>N=100,000; top_k=20; nprobe=3; recall=0.98980; GET/q=2.59</title></circle>
+<circle class="natural-knee" cx="98.50" cy="116.34" r="8.30"/>
+<circle class="quality-floor" cx="102.08" cy="100.65" r="8.81"/>
+<circle class="natural-knee" cx="119.50" cy="117.34" r="8.30"/>
+<circle class="quality-floor" cx="123.08" cy="99.07" r="8.81"/>
+<line class="axis" x1="379.86" y1="660" x2="379.86" y2="666"/>
+<text x="379.86" y="684" text-anchor="middle" font-size="13">330K</text>
+<text x="379.86" y="702" text-anchor="middle" font-size="11">k_c=10</text>
+<circle cx="350.98" cy="488.61" r="5.12" fill="rgb(49,150,209)" fill-opacity="0.72" stroke="rgb(49,150,209)"><title>N=330,000; top_k=10; nprobe=1; recall=0.71910; GET/q=0.58</title></circle>
+<circle cx="357.11" cy="228.00" r="5.80" fill="rgb(53,148,207)" fill-opacity="0.72" stroke="rgb(53,148,207)"><title>N=330,000; top_k=10; nprobe=2; recall=0.90020; GET/q=2.59</title></circle>
+<circle cx="360.69" cy="146.12" r="6.31" fill="rgb(55,147,205)" fill-opacity="0.72" stroke="rgb(55,147,205)"><title>N=330,000; top_k=10; nprobe=3; recall=0.95710; GET/q=4.08</title></circle>
+<circle cx="363.23" cy="117.63" r="6.75" fill="rgb(58,146,203)" fill-opacity="0.72" stroke="rgb(58,146,203)"><title>N=330,000; top_k=10; nprobe=4; recall=0.97690; GET/q=5.51</title></circle>
+<circle cx="365.21" cy="105.98" r="7.13" fill="rgb(60,144,201)" fill-opacity="0.72" stroke="rgb(60,144,201)"><title>N=330,000; top_k=10; nprobe=5; recall=0.98500; GET/q=6.79</title></circle>
+<circle cx="368.18" cy="99.93" r="7.80" fill="rgb(63,143,199)" fill-opacity="0.72" stroke="rgb(63,143,199)"><title>N=330,000; top_k=10; nprobe=7; recall=0.98920; GET/q=8.37</title></circle>
+<circle cx="371.33" cy="99.64" r="8.64" fill="rgb(67,141,196)" fill-opacity="0.72" stroke="rgb(67,141,196)"><title>N=330,000; top_k=10; nprobe=10; recall=0.98940; GET/q=10.66</title></circle>
+<circle cx="371.98" cy="506.46" r="5.12" fill="rgb(48,150,210)" fill-opacity="0.38" stroke="rgb(48,150,210)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=1; recall=0.70670; GET/q=0.06</title></circle>
+<circle cx="378.11" cy="237.00" r="5.80" fill="rgb(50,149,208)" fill-opacity="0.38" stroke="rgb(50,149,208)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=2; recall=0.89395; GET/q=1.37</title></circle>
+<circle cx="381.69" cy="154.11" r="6.31" fill="rgb(54,147,206)" fill-opacity="0.38" stroke="rgb(54,147,206)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=3; recall=0.95155; GET/q=3.27</title></circle>
+<circle cx="384.23" cy="122.45" r="6.75" fill="rgb(57,146,204)" fill-opacity="0.38" stroke="rgb(57,146,204)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=4; recall=0.97355; GET/q=4.91</title></circle>
+<circle cx="386.21" cy="107.77" r="7.13" fill="rgb(59,145,202)" fill-opacity="0.38" stroke="rgb(59,145,202)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=5; recall=0.98375; GET/q=6.26</title></circle>
+<circle cx="389.18" cy="101.59" r="7.80" fill="rgb(63,143,199)" fill-opacity="0.38" stroke="rgb(63,143,199)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=7; recall=0.98805; GET/q=8.19</title></circle>
+<circle cx="392.33" cy="101.15" r="8.64" fill="rgb(67,141,196)" fill-opacity="0.38" stroke="rgb(67,141,196)" stroke-dasharray="3 2"><title>N=330,000; top_k=20; nprobe=10; recall=0.98835; GET/q=10.78</title></circle>
+<circle class="natural-knee" cx="360.69" cy="146.12" r="8.81"/>
+<circle class="quality-floor" cx="365.21" cy="105.98" r="9.63"/>
+<circle class="natural-knee" cx="381.69" cy="154.11" r="8.81"/>
+<circle class="quality-floor" cx="386.21" cy="107.77" r="9.63"/>
+<line class="axis" x1="620.00" y1="660" x2="620.00" y2="666"/>
+<text x="620.00" y="684" text-anchor="middle" font-size="13">1.0M</text>
+<text x="620.00" y="702" text-anchor="middle" font-size="11">k_c=30</text>
+<circle cx="591.12" cy="599.56" r="5.12" fill="rgb(50,149,209)" fill-opacity="0.72" stroke="rgb(50,149,209)"><title>N=1,000,000; top_k=10; nprobe=1; recall=0.64200; GET/q=1.02</title></circle>
+<circle cx="597.25" cy="327.15" r="5.80" fill="rgb(54,147,206)" fill-opacity="0.72" stroke="rgb(54,147,206)"><title>N=1,000,000; top_k=10; nprobe=2; recall=0.83130; GET/q=3.09</title></circle>
+<circle cx="600.83" cy="220.95" r="6.31" fill="rgb(57,146,204)" fill-opacity="0.72" stroke="rgb(57,146,204)"><title>N=1,000,000; top_k=10; nprobe=3; recall=0.90510; GET/q=4.83</title></circle>
+<circle cx="603.38" cy="162.67" r="6.75" fill="rgb(60,145,201)" fill-opacity="0.72" stroke="rgb(60,145,201)"><title>N=1,000,000; top_k=10; nprobe=4; recall=0.94560; GET/q=6.60</title></circle>
+<circle cx="605.35" cy="132.17" r="7.13" fill="rgb(63,143,199)" fill-opacity="0.72" stroke="rgb(63,143,199)"><title>N=1,000,000; top_k=10; nprobe=5; recall=0.96680; GET/q=8.31</title></circle>
+<circle cx="606.96" cy="114.32" r="7.48" fill="rgb(66,142,197)" fill-opacity="0.72" stroke="rgb(66,142,197)"><title>N=1,000,000; top_k=10; nprobe=6; recall=0.97920; GET/q=9.98</title></circle>
+<circle cx="608.32" cy="105.69" r="7.80" fill="rgb(69,141,195)" fill-opacity="0.72" stroke="rgb(69,141,195)"><title>N=1,000,000; top_k=10; nprobe=7; recall=0.98520; GET/q=11.51</title></circle>
+<circle cx="609.50" cy="97.92" r="8.10" fill="rgb(71,140,193)" fill-opacity="0.72" stroke="rgb(71,140,193)"><title>N=1,000,000; top_k=10; nprobe=8; recall=0.99060; GET/q=12.78</title></circle>
+<circle cx="610.54" cy="93.89" r="8.38" fill="rgb(74,138,191)" fill-opacity="0.72" stroke="rgb(74,138,191)"><title>N=1,000,000; top_k=10; nprobe=9; recall=0.99340; GET/q=14.51</title></circle>
+<circle cx="612.31" cy="87.99" r="8.89" fill="rgb(79,136,188)" fill-opacity="0.72" stroke="rgb(79,136,188)"><title>N=1,000,000; top_k=10; nprobe=11; recall=0.99750; GET/q=17.21</title></circle>
+<circle cx="615.05" cy="85.54" r="9.79" fill="rgb(89,132,181)" fill-opacity="0.72" stroke="rgb(89,132,181)"><title>N=1,000,000; top_k=10; nprobe=15; recall=0.99920; GET/q=22.47</title></circle>
+<circle cx="617.60" cy="84.39" r="10.77" fill="rgb(96,128,175)" fill-opacity="0.72" stroke="rgb(96,128,175)"><title>N=1,000,000; top_k=10; nprobe=20; recall=1.00000; GET/q=26.62</title></circle>
+<circle cx="621.18" cy="84.39" r="12.40" fill="rgb(102,125,171)" fill-opacity="0.72" stroke="rgb(102,125,171)"><title>N=1,000,000; top_k=10; nprobe=30; recall=1.00000; GET/q=30.20</title></circle>
+<circle cx="612.12" cy="617.69" r="5.12" fill="rgb(48,150,210)" fill-opacity="0.38" stroke="rgb(48,150,210)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=1; recall=0.62940; GET/q=0.14</title></circle>
+<circle cx="618.25" cy="347.37" r="5.80" fill="rgb(52,148,207)" fill-opacity="0.38" stroke="rgb(52,148,207)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=2; recall=0.81725; GET/q=2.24</title></circle>
+<circle cx="621.83" cy="234.84" r="6.31" fill="rgb(56,146,204)" fill-opacity="0.38" stroke="rgb(56,146,204)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=3; recall=0.89545; GET/q=4.34</title></circle>
+<circle cx="624.38" cy="173.90" r="6.75" fill="rgb(59,145,202)" fill-opacity="0.38" stroke="rgb(59,145,202)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=4; recall=0.93780; GET/q=6.34</title></circle>
+<circle cx="626.35" cy="138.64" r="7.13" fill="rgb(63,143,199)" fill-opacity="0.38" stroke="rgb(63,143,199)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=5; recall=0.96230; GET/q=8.08</title></circle>
+<circle cx="627.96" cy="117.49" r="7.48" fill="rgb(66,142,197)" fill-opacity="0.38" stroke="rgb(66,142,197)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=6; recall=0.97700; GET/q=9.82</title></circle>
+<circle cx="629.32" cy="107.05" r="7.80" fill="rgb(69,141,195)" fill-opacity="0.38" stroke="rgb(69,141,195)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=7; recall=0.98425; GET/q=11.46</title></circle>
+<circle cx="630.50" cy="99.79" r="8.10" fill="rgb(71,140,193)" fill-opacity="0.38" stroke="rgb(71,140,193)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=8; recall=0.98930; GET/q=12.82</title></circle>
+<circle cx="631.54" cy="95.61" r="8.38" fill="rgb(75,138,191)" fill-opacity="0.38" stroke="rgb(75,138,191)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=9; recall=0.99220; GET/q=14.82</title></circle>
+<circle cx="633.31" cy="89.21" r="8.89" fill="rgb(81,135,186)" fill-opacity="0.38" stroke="rgb(81,135,186)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=11; recall=0.99665; GET/q=18.11</title></circle>
+<circle cx="636.05" cy="85.76" r="9.79" fill="rgb(90,131,179)" fill-opacity="0.38" stroke="rgb(90,131,179)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=15; recall=0.99905; GET/q=23.43</title></circle>
+<circle cx="638.60" cy="84.46" r="10.77" fill="rgb(99,127,173)" fill-opacity="0.38" stroke="rgb(99,127,173)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=20; recall=0.99995; GET/q=28.04</title></circle>
+<circle cx="642.18" cy="84.39" r="12.40" fill="rgb(108,123,167)" fill-opacity="0.38" stroke="rgb(108,123,167)" stroke-dasharray="3 2"><title>N=1,000,000; top_k=20; nprobe=30; recall=1.00000; GET/q=33.07</title></circle>
+<circle class="natural-knee" cx="603.38" cy="162.67" r="9.25"/>
+<circle class="quality-floor" cx="608.32" cy="105.69" r="10.30"/>
+<circle class="natural-knee" cx="627.96" cy="117.49" r="9.98"/>
+<circle class="quality-floor" cx="629.32" cy="107.05" r="10.30"/>
+<line class="axis" x1="878.61" y1="660" x2="878.61" y2="666"/>
+<text x="878.61" y="684" text-anchor="middle" font-size="13">3.3M</text>
+<text x="878.61" y="702" text-anchor="middle" font-size="11">k_c=100</text>
+<circle cx="859.44" cy="341.98" r="6.31" fill="rgb(61,144,200)" fill-opacity="0.72" stroke="rgb(61,144,200)"><title>N=3,300,000; top_k=10; nprobe=3; recall=0.82100; GET/q=7.48</title></circle>
+<circle cx="863.96" cy="211.46" r="7.13" fill="rgb(71,140,194)" fill-opacity="0.72" stroke="rgb(71,140,194)"><title>N=3,300,000; top_k=10; nprobe=5; recall=0.91170; GET/q=12.62</title></circle>
+<circle cx="866.93" cy="157.06" r="7.80" fill="rgb(79,136,188)" fill-opacity="0.72" stroke="rgb(79,136,188)"><title>N=3,300,000; top_k=10; nprobe=7; recall=0.94950; GET/q=16.98</title></circle>
+<circle cx="869.15" cy="130.01" r="8.38" fill="rgb(86,133,183)" fill-opacity="0.72" stroke="rgb(86,133,183)"><title>N=3,300,000; top_k=10; nprobe=9; recall=0.96830; GET/q=20.92</title></circle>
+<circle cx="870.08" cy="119.93" r="8.64" fill="rgb(89,131,180)" fill-opacity="0.72" stroke="rgb(89,131,180)"><title>N=3,300,000; top_k=10; nprobe=10; recall=0.97530; GET/q=22.84</title></circle>
+<circle cx="870.92" cy="113.17" r="8.89" fill="rgb(92,130,178)" fill-opacity="0.72" stroke="rgb(92,130,178)"><title>N=3,300,000; top_k=10; nprobe=11; recall=0.98000; GET/q=24.48</title></circle>
+<circle cx="871.69" cy="107.13" r="9.13" fill="rgb(96,129,176)" fill-opacity="0.72" stroke="rgb(96,129,176)"><title>N=3,300,000; top_k=10; nprobe=12; recall=0.98420; GET/q=26.39</title></circle>
+<circle cx="872.40" cy="103.24" r="9.36" fill="rgb(99,127,173)" fill-opacity="0.72" stroke="rgb(99,127,173)"><title>N=3,300,000; top_k=10; nprobe=13; recall=0.98690; GET/q=28.02</title></circle>
+<circle cx="873.66" cy="97.05" r="9.79" fill="rgb(104,125,169)" fill-opacity="0.72" stroke="rgb(104,125,169)"><title>N=3,300,000; top_k=10; nprobe=15; recall=0.99120; GET/q=31.11</title></circle>
+<circle cx="876.21" cy="89.28" r="10.77" fill="rgb(117,119,160)" fill-opacity="0.72" stroke="rgb(117,119,160)"><title>N=3,300,000; top_k=10; nprobe=20; recall=0.99660; GET/q=38.32</title></circle>
+<circle cx="880.44" cy="353.49" r="6.31" fill="rgb(61,144,201)" fill-opacity="0.38" stroke="rgb(61,144,201)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=3; recall=0.81300; GET/q=7.26</title></circle>
+<circle cx="884.96" cy="222.97" r="7.13" fill="rgb(71,140,193)" fill-opacity="0.38" stroke="rgb(71,140,193)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=5; recall=0.90370; GET/q=12.72</title></circle>
+<circle cx="887.93" cy="165.55" r="7.80" fill="rgb(79,136,187)" fill-opacity="0.38" stroke="rgb(79,136,187)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=7; recall=0.94360; GET/q=17.40</title></circle>
+<circle cx="890.15" cy="137.13" r="8.38" fill="rgb(87,132,182)" fill-opacity="0.38" stroke="rgb(87,132,182)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=9; recall=0.96335; GET/q=21.58</title></circle>
+<circle cx="891.08" cy="125.69" r="8.64" fill="rgb(90,131,179)" fill-opacity="0.38" stroke="rgb(90,131,179)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=10; recall=0.97130; GET/q=23.35</title></circle>
+<circle cx="891.92" cy="117.78" r="8.89" fill="rgb(93,130,177)" fill-opacity="0.38" stroke="rgb(93,130,177)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=11; recall=0.97680; GET/q=25.22</title></circle>
+<circle cx="892.69" cy="111.44" r="9.13" fill="rgb(97,128,174)" fill-opacity="0.38" stroke="rgb(97,128,174)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=12; recall=0.98120; GET/q=27.32</title></circle>
+<circle cx="893.40" cy="107.20" r="9.36" fill="rgb(100,126,172)" fill-opacity="0.38" stroke="rgb(100,126,172)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=13; recall=0.98415; GET/q=29.00</title></circle>
+<circle cx="894.66" cy="100.58" r="9.79" fill="rgb(107,124,167)" fill-opacity="0.38" stroke="rgb(107,124,167)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=15; recall=0.98875; GET/q=32.64</title></circle>
+<circle cx="897.21" cy="90.29" r="10.77" fill="rgb(122,117,156)" fill-opacity="0.38" stroke="rgb(122,117,156)" stroke-dasharray="3 2"><title>N=3,300,000; top_k=20; nprobe=20; recall=0.99590; GET/q=41.12</title></circle>
+<circle class="natural-knee" cx="866.93" cy="157.06" r="10.30"/>
+<circle class="quality-floor" cx="870.92" cy="113.17" r="11.39"/>
+<circle class="natural-knee" cx="887.93" cy="165.55" r="10.30"/>
+<circle class="quality-floor" cx="892.69" cy="111.44" r="11.63"/>
+<line class="axis" x1="1118.75" y1="660" x2="1118.75" y2="666"/>
+<text x="1118.75" y="684" text-anchor="middle" font-size="13">10.0M</text>
+<text x="1118.75" y="702" text-anchor="middle" font-size="11">k_c=305</text>
+<circle cx="1113.20" cy="154.33" r="9.58" fill="rgb(116,120,161)" fill-opacity="0.72" stroke="rgb(116,120,161)"><title>N=10,000,000; top_k=10; nprobe=14; recall=0.95140; GET/q=37.58</title></circle>
+<circle cx="1114.38" cy="144.54" r="10.00" fill="rgb(123,116,155)" fill-opacity="0.72" stroke="rgb(123,116,155)"><title>N=10,000,000; top_k=10; nprobe=16; recall=0.95820; GET/q=41.72</title></circle>
+<circle cx="1117.19" cy="129.43" r="11.12" fill="rgb(143,107,141)" fill-opacity="0.72" stroke="rgb(143,107,141)"><title>N=10,000,000; top_k=10; nprobe=22; recall=0.96870; GET/q=52.94</title></circle>
+<circle cx="1119.93" cy="121.23" r="12.40" fill="rgb(167,96,124)" fill-opacity="0.72" stroke="rgb(167,96,124)"><title>N=10,000,000; top_k=10; nprobe=30; recall=0.97440; GET/q=66.12</title></circle>
+<circle cx="1123.71" cy="116.77" r="14.52" fill="rgb(207,78,95)" fill-opacity="0.72" stroke="rgb(207,78,95)"><title>N=10,000,000; top_k=10; nprobe=46; recall=0.97750; GET/q=88.25</title></circle>
+<circle cx="1126.62" cy="115.76" r="16.50" fill="rgb(248,60,65)" fill-opacity="0.72" stroke="rgb(248,60,65)"><title>N=10,000,000; top_k=10; nprobe=64; recall=0.97820; GET/q=110.92</title></circle>
+<circle cx="1134.20" cy="158.21" r="9.58" fill="rgb(119,118,158)" fill-opacity="0.38" stroke="rgb(119,118,158)" stroke-dasharray="3 2"><title>N=10,000,000; top_k=20; nprobe=14; recall=0.94870; GET/q=39.53</title></circle>
+<circle class="natural-knee" cx="1119.93" cy="121.23" r="14.90"/>
+<line class="axis" x1="95" y1="70" x2="95" y2="660"/>
+<line class="axis" x1="95" y1="660" x2="1145" y2="660"/>
+<text x="620.00" y="736" text-anchor="middle" font-size="14">Corpus vectors (log scale)</text>
+<text x="24" y="365.00" text-anchor="middle" font-size="14" transform="rotate(-90 24 365.00)">Recall</text>
+<circle cx="980" cy="40" r="7" fill="#308fd2" fill-opacity=".72"/>
+<text x="994" y="44" font-size="12">top-10</text>
+<circle cx="1060" cy="40" r="7" fill="#308fd2" fill-opacity=".38" stroke="#308fd2" stroke-dasharray="3 2"/>
+<text x="1074" y="44" font-size="12">top-20</text>
+</svg>

--- a/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/dual-axis.svg
+++ b/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/dual-axis.svg
@@ -1,0 +1,223 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1380" height="820" viewBox="0 0 1380 820">
+<style>
+text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#18212b}
+.grid{stroke:#d9e1e8;stroke-width:1}.axis{stroke:#536272;stroke-width:1.5}
+</style>
+<rect width="100%" height="100%" fill="#fbfdff"/>
+<text x="92" y="35" font-size="22" font-weight="700">Recall and GET cost by normalized PAX probe fraction</text>
+<text x="92" y="58" font-size="13">Solid = recall (left axis); dashed = physical GET/query (right axis); circle = top-10; square = top-20. Axis crossings are not optima.</text>
+<line class="grid" x1="92.00" y1="110" x2="92.00" y2="715"/>
+<text x="92.00" y="739" text-anchor="middle" font-size="12">0.0</text>
+<line class="grid" x1="92" y1="715.00" x2="1280" y2="715.00"/>
+<text x="82" y="719.00" text-anchor="end" font-size="12">0.600</text>
+<text x="1290" y="719.00" font-size="12">0.0</text>
+<line class="grid" x1="329.60" y1="110" x2="329.60" y2="715"/>
+<text x="329.60" y="739" text-anchor="middle" font-size="12">0.2</text>
+<line class="grid" x1="92" y1="595.49" x2="1280" y2="595.49"/>
+<text x="82" y="599.49" text-anchor="end" font-size="12">0.680</text>
+<text x="1290" y="598.00" font-size="12">23.3</text>
+<line class="grid" x1="567.20" y1="110" x2="567.20" y2="715"/>
+<text x="567.20" y="739" text-anchor="middle" font-size="12">0.4</text>
+<line class="grid" x1="92" y1="475.99" x2="1280" y2="475.99"/>
+<text x="82" y="479.99" text-anchor="end" font-size="12">0.760</text>
+<text x="1290" y="477.00" font-size="12">46.6</text>
+<line class="grid" x1="804.80" y1="110" x2="804.80" y2="715"/>
+<text x="804.80" y="739" text-anchor="middle" font-size="12">0.6</text>
+<line class="grid" x1="92" y1="356.48" x2="1280" y2="356.48"/>
+<text x="82" y="360.48" text-anchor="end" font-size="12">0.840</text>
+<text x="1290" y="356.00" font-size="12">69.9</text>
+<line class="grid" x1="1042.40" y1="110" x2="1042.40" y2="715"/>
+<text x="1042.40" y="739" text-anchor="middle" font-size="12">0.8</text>
+<line class="grid" x1="92" y1="236.98" x2="1280" y2="236.98"/>
+<text x="82" y="240.98" text-anchor="end" font-size="12">0.920</text>
+<text x="1290" y="235.00" font-size="12">93.2</text>
+<line class="grid" x1="1280.00" y1="110" x2="1280.00" y2="715"/>
+<text x="1280.00" y="739" text-anchor="middle" font-size="12">1.0</text>
+<line class="grid" x1="92" y1="117.47" x2="1280" y2="117.47"/>
+<text x="82" y="121.47" text-anchor="end" font-size="12">1.000</text>
+<text x="1290" y="114.00" font-size="12">116.5</text>
+<line x1="92" y1="147.35" x2="1280" y2="147.35" stroke="#111827" stroke-dasharray="9 5"><title>recall target 0.980</title></line>
+<line x1="92" y1="663.05" x2="1280" y2="663.05" stroke="#b91c1c" stroke-dasharray="3 5"><title>10 GET/query budget</title></line>
+<polyline points="488.00,283.88 884.00,150.63 1280.00,134.35" fill="none" stroke="#2563eb" stroke-width="2.4" opacity="1.0"/>
+<polyline points="488.00,712.76 884.00,706.16 1280.00,697.35" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="8 5" opacity="1.0"/>
+<circle cx="488.00" cy="283.88" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=1; recall=0.88860; GET/q=0.431</title></circle>
+<circle cx="488.00" cy="712.76" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=1; recall=0.88860; GET/q=0.431</title></circle>
+<circle cx="884.00" cy="150.63" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=2; recall=0.97780; GET/q=1.701</title></circle>
+<circle cx="884.00" cy="706.16" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=2; recall=0.97780; GET/q=1.701</title></circle>
+<circle cx="1280.00" cy="134.35" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=3; recall=0.98870; GET/q=3.397</title></circle>
+<circle cx="1280.00" cy="697.35" r="3.5" fill="#2563eb" opacity="1.0"><title>N=100,000; k_c=3; top_k=10; nprobe=3; recall=0.98870; GET/q=3.397</title></circle>
+<polyline points="488.00,292.25 884.00,151.68 1280.00,132.71" fill="none" stroke="#2563eb" stroke-width="2.4" opacity="0.55"/>
+<polyline points="488.00,714.91 884.00,711.18 1280.00,701.53" fill="none" stroke="#2563eb" stroke-width="2" stroke-dasharray="8 5" opacity="0.55"/>
+<rect x="484.50" y="288.75" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=1; recall=0.88300; GET/q=0.018</title></rect>
+<rect x="484.50" y="711.41" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=1; recall=0.88300; GET/q=0.018</title></rect>
+<rect x="880.50" y="148.18" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=2; recall=0.97710; GET/q=0.735</title></rect>
+<rect x="880.50" y="707.68" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=2; recall=0.97710; GET/q=0.735</title></rect>
+<rect x="1276.50" y="129.21" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=3; recall=0.98980; GET/q=2.593</title></rect>
+<rect x="1276.50" y="698.03" width="7" height="7" fill="#2563eb" opacity="0.55"><title>N=100,000; k_c=3; top_k=20; nprobe=3; recall=0.98980; GET/q=2.593</title></rect>
+<line x1="92" y1="82" x2="122" y2="82" stroke="#2563eb" stroke-width="3"/>
+<text x="131" y="86" font-size="12">100K (k_c=3)</text>
+<polyline points="210.80,537.09 329.60,266.55 448.40,181.55 567.20,151.98 686.00,139.88 923.60,133.60 1280.00,133.30" fill="none" stroke="#059669" stroke-width="2.4" opacity="1.0"/>
+<polyline points="210.80,711.97 329.60,701.54 448.40,693.82 567.20,686.35 686.00,679.74 923.60,671.51 1280.00,659.60" fill="none" stroke="#059669" stroke-width="2" stroke-dasharray="8 5" opacity="1.0"/>
+<circle cx="210.80" cy="537.09" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=1; recall=0.71910; GET/q=0.583</title></circle>
+<circle cx="210.80" cy="711.97" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=1; recall=0.71910; GET/q=0.583</title></circle>
+<circle cx="329.60" cy="266.55" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=2; recall=0.90020; GET/q=2.591</title></circle>
+<circle cx="329.60" cy="701.54" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=2; recall=0.90020; GET/q=2.591</title></circle>
+<circle cx="448.40" cy="181.55" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=3; recall=0.95710; GET/q=4.077</title></circle>
+<circle cx="448.40" cy="693.82" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=3; recall=0.95710; GET/q=4.077</title></circle>
+<circle cx="567.20" cy="151.98" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=4; recall=0.97690; GET/q=5.515</title></circle>
+<circle cx="567.20" cy="686.35" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=4; recall=0.97690; GET/q=5.515</title></circle>
+<circle cx="686.00" cy="139.88" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=5; recall=0.98500; GET/q=6.787</title></circle>
+<circle cx="686.00" cy="679.74" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=5; recall=0.98500; GET/q=6.787</title></circle>
+<circle cx="923.60" cy="133.60" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=7; recall=0.98920; GET/q=8.372</title></circle>
+<circle cx="923.60" cy="671.51" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=7; recall=0.98920; GET/q=8.372</title></circle>
+<circle cx="1280.00" cy="133.30" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=10; recall=0.98940; GET/q=10.665</title></circle>
+<circle cx="1280.00" cy="659.60" r="3.5" fill="#059669" opacity="1.0"><title>N=330,000; k_c=10; top_k=10; nprobe=10; recall=0.98940; GET/q=10.665</title></circle>
+<polyline points="210.80,555.61 329.60,275.89 448.40,189.85 567.20,156.98 686.00,141.74 923.60,135.32 1280.00,134.87" fill="none" stroke="#059669" stroke-width="2.4" opacity="0.55"/>
+<polyline points="210.80,714.68 329.60,707.86 448.40,698.01 567.20,689.50 686.00,682.50 923.60,672.47 1280.00,659.01" fill="none" stroke="#059669" stroke-width="2" stroke-dasharray="8 5" opacity="0.55"/>
+<rect x="207.30" y="552.11" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=1; recall=0.70670; GET/q=0.061</title></rect>
+<rect x="207.30" y="711.18" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=1; recall=0.70670; GET/q=0.061</title></rect>
+<rect x="326.10" y="272.39" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=2; recall=0.89395; GET/q=1.374</title></rect>
+<rect x="326.10" y="704.36" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=2; recall=0.89395; GET/q=1.374</title></rect>
+<rect x="444.90" y="186.35" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=3; recall=0.95155; GET/q=3.270</title></rect>
+<rect x="444.90" y="694.51" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=3; recall=0.95155; GET/q=3.270</title></rect>
+<rect x="563.70" y="153.48" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=4; recall=0.97355; GET/q=4.909</title></rect>
+<rect x="563.70" y="686.00" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=4; recall=0.97355; GET/q=4.909</title></rect>
+<rect x="682.50" y="138.24" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=5; recall=0.98375; GET/q=6.256</title></rect>
+<rect x="682.50" y="679.00" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=5; recall=0.98375; GET/q=6.256</title></rect>
+<rect x="920.10" y="131.82" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=7; recall=0.98805; GET/q=8.187</title></rect>
+<rect x="920.10" y="668.97" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=7; recall=0.98805; GET/q=8.187</title></rect>
+<rect x="1276.50" y="131.37" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=10; recall=0.98835; GET/q=10.779</title></rect>
+<rect x="1276.50" y="655.51" width="7" height="7" fill="#059669" opacity="0.55"><title>N=330,000; k_c=10; top_k=20; nprobe=10; recall=0.98835; GET/q=10.779</title></rect>
+<line x1="277" y1="82" x2="307" y2="82" stroke="#059669" stroke-width="3"/>
+<text x="316" y="86" font-size="12">330K (k_c=10)</text>
+<polyline points="131.60,652.26 171.20,369.48 210.80,259.23 250.40,198.73 290.00,167.06 329.60,148.54 369.20,139.58 408.80,131.51 448.40,127.33 527.60,121.20 686.00,118.66 884.00,117.47 1280.00,117.47" fill="none" stroke="#d97706" stroke-width="2.4" opacity="1.0"/>
+<polyline points="131.60,709.68 171.20,698.93 210.80,689.90 250.40,680.70 290.00,671.82 329.60,663.15 369.20,655.23 408.80,648.62 448.40,639.64 527.60,625.61 686.00,598.29 884.00,576.70 1280.00,558.11" fill="none" stroke="#d97706" stroke-width="2" stroke-dasharray="8 5" opacity="1.0"/>
+<circle cx="131.60" cy="652.26" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=1; recall=0.64200; GET/q=1.024</title></circle>
+<circle cx="131.60" cy="709.68" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=1; recall=0.64200; GET/q=1.024</title></circle>
+<circle cx="171.20" cy="369.48" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=2; recall=0.83130; GET/q=3.093</title></circle>
+<circle cx="171.20" cy="698.93" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=2; recall=0.83130; GET/q=3.093</title></circle>
+<circle cx="210.80" cy="259.23" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=3; recall=0.90510; GET/q=4.832</title></circle>
+<circle cx="210.80" cy="689.90" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=3; recall=0.90510; GET/q=4.832</title></circle>
+<circle cx="250.40" cy="198.73" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=4; recall=0.94560; GET/q=6.604</title></circle>
+<circle cx="250.40" cy="680.70" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=4; recall=0.94560; GET/q=6.604</title></circle>
+<circle cx="290.00" cy="167.06" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=5; recall=0.96680; GET/q=8.312</title></circle>
+<circle cx="290.00" cy="671.82" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=5; recall=0.96680; GET/q=8.312</title></circle>
+<circle cx="329.60" cy="148.54" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=6; recall=0.97920; GET/q=9.981</title></circle>
+<circle cx="329.60" cy="663.15" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=6; recall=0.97920; GET/q=9.981</title></circle>
+<circle cx="369.20" cy="139.58" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=7; recall=0.98520; GET/q=11.507</title></circle>
+<circle cx="369.20" cy="655.23" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=7; recall=0.98520; GET/q=11.507</title></circle>
+<circle cx="408.80" cy="131.51" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=8; recall=0.99060; GET/q=12.778</title></circle>
+<circle cx="408.80" cy="648.62" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=8; recall=0.99060; GET/q=12.778</title></circle>
+<circle cx="448.40" cy="127.33" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=9; recall=0.99340; GET/q=14.508</title></circle>
+<circle cx="448.40" cy="639.64" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=9; recall=0.99340; GET/q=14.508</title></circle>
+<circle cx="527.60" cy="121.20" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=11; recall=0.99750; GET/q=17.209</title></circle>
+<circle cx="527.60" cy="625.61" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=11; recall=0.99750; GET/q=17.209</title></circle>
+<circle cx="686.00" cy="118.66" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=15; recall=0.99920; GET/q=22.468</title></circle>
+<circle cx="686.00" cy="598.29" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=15; recall=0.99920; GET/q=22.468</title></circle>
+<circle cx="884.00" cy="117.47" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=20; recall=1.00000; GET/q=26.625</title></circle>
+<circle cx="884.00" cy="576.70" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=20; recall=1.00000; GET/q=26.625</title></circle>
+<circle cx="1280.00" cy="117.47" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=30; recall=1.00000; GET/q=30.203</title></circle>
+<circle cx="1280.00" cy="558.11" r="3.5" fill="#d97706" opacity="1.0"><title>N=1,000,000; k_c=30; top_k=10; nprobe=30; recall=1.00000; GET/q=30.203</title></circle>
+<polyline points="131.60,671.08 171.20,390.47 210.80,273.65 250.40,210.39 290.00,173.79 329.60,151.83 369.20,141.00 408.80,133.45 448.40,129.12 527.60,122.47 686.00,118.89 884.00,117.54 1280.00,117.47" fill="none" stroke="#d97706" stroke-width="2.4" opacity="0.55"/>
+<polyline points="131.60,714.27 171.20,703.35 210.80,692.47 250.40,682.09 290.00,673.04 329.60,663.98 369.20,655.46 408.80,648.43 448.40,638.00 527.60,620.92 686.00,593.31 884.00,569.35 1280.00,543.21" fill="none" stroke="#d97706" stroke-width="2" stroke-dasharray="8 5" opacity="0.55"/>
+<rect x="128.10" y="667.58" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=1; recall=0.62940; GET/q=0.141</title></rect>
+<rect x="128.10" y="710.77" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=1; recall=0.62940; GET/q=0.141</title></rect>
+<rect x="167.70" y="386.97" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=2; recall=0.81725; GET/q=2.243</title></rect>
+<rect x="167.70" y="699.85" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=2; recall=0.81725; GET/q=2.243</title></rect>
+<rect x="207.30" y="270.15" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=3; recall=0.89545; GET/q=4.338</title></rect>
+<rect x="207.30" y="688.97" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=3; recall=0.89545; GET/q=4.338</title></rect>
+<rect x="246.90" y="206.89" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=4; recall=0.93780; GET/q=6.336</title></rect>
+<rect x="246.90" y="678.59" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=4; recall=0.93780; GET/q=6.336</title></rect>
+<rect x="286.50" y="170.29" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=5; recall=0.96230; GET/q=8.077</title></rect>
+<rect x="286.50" y="669.54" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=5; recall=0.96230; GET/q=8.077</title></rect>
+<rect x="326.10" y="148.33" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=6; recall=0.97700; GET/q=9.822</title></rect>
+<rect x="326.10" y="660.48" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=6; recall=0.97700; GET/q=9.822</title></rect>
+<rect x="365.70" y="137.50" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=7; recall=0.98425; GET/q=11.463</title></rect>
+<rect x="365.70" y="651.96" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=7; recall=0.98425; GET/q=11.463</title></rect>
+<rect x="405.30" y="129.95" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=8; recall=0.98930; GET/q=12.816</title></rect>
+<rect x="405.30" y="644.93" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=8; recall=0.98930; GET/q=12.816</title></rect>
+<rect x="444.90" y="125.62" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=9; recall=0.99220; GET/q=14.824</title></rect>
+<rect x="444.90" y="634.50" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=9; recall=0.99220; GET/q=14.824</title></rect>
+<rect x="524.10" y="118.97" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=11; recall=0.99665; GET/q=18.111</title></rect>
+<rect x="524.10" y="617.42" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=11; recall=0.99665; GET/q=18.111</title></rect>
+<rect x="682.50" y="115.39" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=15; recall=0.99905; GET/q=23.426</title></rect>
+<rect x="682.50" y="589.81" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=15; recall=0.99905; GET/q=23.426</title></rect>
+<rect x="880.50" y="114.04" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=20; recall=0.99995; GET/q=28.039</title></rect>
+<rect x="880.50" y="565.85" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=20; recall=0.99995; GET/q=28.039</title></rect>
+<rect x="1276.50" y="113.97" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=30; recall=1.00000; GET/q=33.071</title></rect>
+<rect x="1276.50" y="539.71" width="7" height="7" fill="#d97706" opacity="0.55"><title>N=1,000,000; k_c=30; top_k=20; nprobe=30; recall=1.00000; GET/q=33.071</title></rect>
+<line x1="462" y1="82" x2="492" y2="82" stroke="#d97706" stroke-width="3"/>
+<text x="501" y="86" font-size="12">1M (k_c=30)</text>
+<polyline points="127.64,384.86 151.40,249.37 175.16,192.91 198.92,164.82 210.80,154.37 222.68,147.35 234.56,141.07 246.44,137.04 270.20,130.61 329.60,122.55" fill="none" stroke="#dc2626" stroke-width="2.4" opacity="1.0"/>
+<polyline points="127.64,676.13 151.40,649.46 175.16,626.81 198.92,606.32 210.80,596.36 222.68,587.85 234.56,577.93 246.44,569.43 270.20,553.42 329.60,515.95" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="8 5" opacity="1.0"/>
+<circle cx="127.64" cy="384.86" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=3; recall=0.82100; GET/q=7.482</title></circle>
+<circle cx="127.64" cy="676.13" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=3; recall=0.82100; GET/q=7.482</title></circle>
+<circle cx="151.40" cy="249.37" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=5; recall=0.91170; GET/q=12.617</title></circle>
+<circle cx="151.40" cy="649.46" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=5; recall=0.91170; GET/q=12.617</title></circle>
+<circle cx="175.16" cy="192.91" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=7; recall=0.94950; GET/q=16.978</title></circle>
+<circle cx="175.16" cy="626.81" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=7; recall=0.94950; GET/q=16.978</title></circle>
+<circle cx="198.92" cy="164.82" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=9; recall=0.96830; GET/q=20.923</title></circle>
+<circle cx="198.92" cy="606.32" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=9; recall=0.96830; GET/q=20.923</title></circle>
+<circle cx="210.80" cy="154.37" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=10; recall=0.97530; GET/q=22.840</title></circle>
+<circle cx="210.80" cy="596.36" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=10; recall=0.97530; GET/q=22.840</title></circle>
+<circle cx="222.68" cy="147.35" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=11; recall=0.98000; GET/q=24.478</title></circle>
+<circle cx="222.68" cy="587.85" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=11; recall=0.98000; GET/q=24.478</title></circle>
+<circle cx="234.56" cy="141.07" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=12; recall=0.98420; GET/q=26.388</title></circle>
+<circle cx="234.56" cy="577.93" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=12; recall=0.98420; GET/q=26.388</title></circle>
+<circle cx="246.44" cy="137.04" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=13; recall=0.98690; GET/q=28.023</title></circle>
+<circle cx="246.44" cy="569.43" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=13; recall=0.98690; GET/q=28.023</title></circle>
+<circle cx="270.20" cy="130.61" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=15; recall=0.99120; GET/q=31.105</title></circle>
+<circle cx="270.20" cy="553.42" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=15; recall=0.99120; GET/q=31.105</title></circle>
+<circle cx="329.60" cy="122.55" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=20; recall=0.99660; GET/q=38.320</title></circle>
+<circle cx="329.60" cy="515.95" r="3.5" fill="#dc2626" opacity="1.0"><title>N=3,300,000; k_c=100; top_k=10; nprobe=20; recall=0.99660; GET/q=38.320</title></circle>
+<polyline points="127.64,396.81 151.40,261.32 175.16,201.72 198.92,172.22 210.80,160.34 222.68,152.13 234.56,145.55 246.44,141.15 270.20,134.27 329.60,123.59" fill="none" stroke="#dc2626" stroke-width="2.4" opacity="0.55"/>
+<polyline points="127.64,677.30 151.40,648.94 175.16,624.63 198.92,602.92 210.80,593.70 222.68,584.00 234.56,573.09 246.44,564.34 270.20,545.45 329.60,501.41" fill="none" stroke="#dc2626" stroke-width="2" stroke-dasharray="8 5" opacity="0.55"/>
+<rect x="124.14" y="393.31" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=3; recall=0.81300; GET/q=7.257</title></rect>
+<rect x="124.14" y="673.80" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=3; recall=0.81300; GET/q=7.257</title></rect>
+<rect x="147.90" y="257.82" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=5; recall=0.90370; GET/q=12.718</title></rect>
+<rect x="147.90" y="645.44" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=5; recall=0.90370; GET/q=12.718</title></rect>
+<rect x="171.66" y="198.22" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=7; recall=0.94360; GET/q=17.398</title></rect>
+<rect x="171.66" y="621.13" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=7; recall=0.94360; GET/q=17.398</title></rect>
+<rect x="195.42" y="168.72" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=9; recall=0.96335; GET/q=21.576</title></rect>
+<rect x="195.42" y="599.42" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=9; recall=0.96335; GET/q=21.576</title></rect>
+<rect x="207.30" y="156.84" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=10; recall=0.97130; GET/q=23.352</title></rect>
+<rect x="207.30" y="590.20" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=10; recall=0.97130; GET/q=23.352</title></rect>
+<rect x="219.18" y="148.63" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=11; recall=0.97680; GET/q=25.218</title></rect>
+<rect x="219.18" y="580.50" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=11; recall=0.97680; GET/q=25.218</title></rect>
+<rect x="231.06" y="142.05" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=12; recall=0.98120; GET/q=27.320</title></rect>
+<rect x="231.06" y="569.59" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=12; recall=0.98120; GET/q=27.320</title></rect>
+<rect x="242.94" y="137.65" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=13; recall=0.98415; GET/q=29.003</title></rect>
+<rect x="242.94" y="560.84" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=13; recall=0.98415; GET/q=29.003</title></rect>
+<rect x="266.70" y="130.77" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=15; recall=0.98875; GET/q=32.640</title></rect>
+<rect x="266.70" y="541.95" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=15; recall=0.98875; GET/q=32.640</title></rect>
+<rect x="326.10" y="120.09" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=20; recall=0.99590; GET/q=41.119</title></rect>
+<rect x="326.10" y="497.91" width="7" height="7" fill="#dc2626" opacity="0.55"><title>N=3,300,000; k_c=100; top_k=20; nprobe=20; recall=0.99590; GET/q=41.119</title></rect>
+<line x1="647" y1="82" x2="677" y2="82" stroke="#dc2626" stroke-width="3"/>
+<text x="686" y="86" font-size="12">3.3M (k_c=100)</text>
+<polyline points="146.53,190.07 154.32,179.91 177.69,164.23 208.85,155.71 271.17,151.08 341.29,150.03" fill="none" stroke="#7c3aed" stroke-width="2.4" opacity="1.0"/>
+<polyline points="146.53,519.81 154.32,498.29 177.69,440.03 208.85,371.54 271.17,256.60 341.29,138.81" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="8 5" opacity="1.0"/>
+<circle cx="146.53" cy="190.07" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=14; recall=0.95140; GET/q=37.577</title></circle>
+<circle cx="146.53" cy="519.81" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=14; recall=0.95140; GET/q=37.577</title></circle>
+<circle cx="154.32" cy="179.91" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=16; recall=0.95820; GET/q=41.719</title></circle>
+<circle cx="154.32" cy="498.29" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=16; recall=0.95820; GET/q=41.719</title></circle>
+<circle cx="177.69" cy="164.23" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=22; recall=0.96870; GET/q=52.935</title></circle>
+<circle cx="177.69" cy="440.03" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=22; recall=0.96870; GET/q=52.935</title></circle>
+<circle cx="208.85" cy="155.71" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=30; recall=0.97440; GET/q=66.119</title></circle>
+<circle cx="208.85" cy="371.54" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=30; recall=0.97440; GET/q=66.119</title></circle>
+<circle cx="271.17" cy="151.08" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=46; recall=0.97750; GET/q=88.247</title></circle>
+<circle cx="271.17" cy="256.60" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=46; recall=0.97750; GET/q=88.247</title></circle>
+<circle cx="341.29" cy="150.03" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=64; recall=0.97820; GET/q=110.923</title></circle>
+<circle cx="341.29" cy="138.81" r="3.5" fill="#7c3aed" opacity="1.0"><title>N=10,000,000; k_c=305; top_k=10; nprobe=64; recall=0.97820; GET/q=110.923</title></circle>
+<polyline points="146.53,194.10" fill="none" stroke="#7c3aed" stroke-width="2.4" opacity="0.55"/>
+<polyline points="146.53,509.64" fill="none" stroke="#7c3aed" stroke-width="2" stroke-dasharray="8 5" opacity="0.55"/>
+<rect x="143.03" y="190.60" width="7" height="7" fill="#7c3aed" opacity="0.55"><title>N=10,000,000; k_c=305; top_k=20; nprobe=14; recall=0.94870; GET/q=39.534</title></rect>
+<rect x="143.03" y="506.14" width="7" height="7" fill="#7c3aed" opacity="0.55"><title>N=10,000,000; k_c=305; top_k=20; nprobe=14; recall=0.94870; GET/q=39.534</title></rect>
+<line x1="832" y1="82" x2="862" y2="82" stroke="#7c3aed" stroke-width="3"/>
+<text x="871" y="86" font-size="12">10M (k_c=305)</text>
+<line class="axis" x1="92" y1="110" x2="92" y2="715"/>
+<line class="axis" x1="1280" y1="110" x2="1280" y2="715"/>
+<line class="axis" x1="92" y1="715" x2="1280" y2="715"/>
+<text x="686.00" y="792" text-anchor="middle" font-size="14">Normalized probe fraction (nprobe / k_c)</text>
+<text x="24" y="412.50" text-anchor="middle" font-size="14" transform="rotate(-90 24 412.50)">Recall</text>
+<text x="1356" y="412.50" text-anchor="middle" font-size="14" transform="rotate(90 1356 412.50)">Physical GET/query</text>
+</svg>

--- a/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/pareto.svg
+++ b/docs/_internal/status/assets/bigann_nprobe_geometry_2026_08_04/pareto.svg
@@ -1,0 +1,151 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820">
+<style>
+text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#18212b}
+.grid{stroke:#d9e1e8;stroke-width:1}.axis{stroke:#536272;stroke-width:1.5}
+.natural-knee{stroke:#111827;stroke-width:2.5;fill:none}
+.quality-floor{stroke:#111827;stroke-width:2.5;fill:none;stroke-dasharray:5 4}
+</style>
+<rect width="100%" height="100%" fill="#fbfdff"/>
+<text x="95" y="34" font-size="22" font-weight="700">Recall → GET/query Pareto frontier</text>
+<text x="95" y="57" font-size="13">Bubble area scales with actual rows probed / corpus rows; solid ring = GET knee; dashed ring = first point at recall ≥ 0.980 when attained; circle = top-10; square = top-20.</text>
+<line class="grid" x1="95.00" y1="110" x2="95.00" y2="720"/>
+<text x="95.00" y="744" text-anchor="middle" font-size="12">0.600</text>
+<line class="grid" x1="95" y1="720.00" x2="1225" y2="720.00"/>
+<text x="85" y="724.00" text-anchor="end" font-size="12">0.0</text>
+<line class="grid" x1="318.21" y1="110" x2="318.21" y2="720"/>
+<text x="318.21" y="744" text-anchor="middle" font-size="12">0.680</text>
+<line class="grid" x1="95" y1="598.00" x2="1225" y2="598.00"/>
+<text x="85" y="602.00" text-anchor="end" font-size="12">23.3</text>
+<line class="grid" x1="541.42" y1="110" x2="541.42" y2="720"/>
+<text x="541.42" y="744" text-anchor="middle" font-size="12">0.760</text>
+<line class="grid" x1="95" y1="476.00" x2="1225" y2="476.00"/>
+<text x="85" y="480.00" text-anchor="end" font-size="12">46.6</text>
+<line class="grid" x1="764.63" y1="110" x2="764.63" y2="720"/>
+<text x="764.63" y="744" text-anchor="middle" font-size="12">0.840</text>
+<line class="grid" x1="95" y1="354.00" x2="1225" y2="354.00"/>
+<text x="85" y="358.00" text-anchor="end" font-size="12">69.9</text>
+<line class="grid" x1="987.84" y1="110" x2="987.84" y2="720"/>
+<text x="987.84" y="744" text-anchor="middle" font-size="12">0.920</text>
+<line class="grid" x1="95" y1="232.00" x2="1225" y2="232.00"/>
+<text x="85" y="236.00" text-anchor="end" font-size="12">93.2</text>
+<line class="grid" x1="1211.05" y1="110" x2="1211.05" y2="720"/>
+<text x="1211.05" y="744" text-anchor="middle" font-size="12">1.000</text>
+<line class="grid" x1="95" y1="110.00" x2="1225" y2="110.00"/>
+<text x="85" y="114.00" text-anchor="end" font-size="12">116.5</text>
+<line x1="1155.25" y1="110" x2="1155.25" y2="720" stroke="#111827" stroke-dasharray="9 5"/>
+<line x1="95" y1="667.63" x2="1225" y2="667.63" stroke="#b91c1c" stroke-dasharray="3 5"/>
+<polyline points="900.23,717.74 1149.11,711.09 1179.52,702.21" fill="none" stroke="#2563eb" stroke-width="2" opacity="1.0"/>
+<circle cx="900.23" cy="717.74" r="9.98" fill="#2563eb" fill-opacity=".68" stroke="#2563eb"><title>N=100,000; top_k=10; nprobe=1; recall=0.88860; GET/q=0.431; rows probed=34665</title></circle>
+<circle cx="1149.11" cy="711.09" r="12.48" fill="#2563eb" fill-opacity=".68" stroke="#2563eb"><title>N=100,000; top_k=10; nprobe=2; recall=0.97780; GET/q=1.701; rows probed=66633</title></circle>
+<circle cx="1179.52" cy="702.21" r="14.50" fill="#2563eb" fill-opacity=".68" stroke="#2563eb"><title>N=100,000; top_k=10; nprobe=3; recall=0.98870; GET/q=3.397; rows probed=100000</title></circle>
+<circle class="natural-knee" cx="1149.11" cy="711.09" r="17"/>
+<circle class="quality-floor" cx="1179.52" cy="702.21" r="17"/>
+<polyline points="884.60,719.91 1147.16,716.15 1182.59,706.42" fill="none" stroke="#2563eb" stroke-width="2" opacity="0.55"/>
+<rect x="874.63" y="709.93" width="19.95" height="19.95" fill="#2563eb" fill-opacity=".38" stroke="#2563eb"><title>N=100,000; top_k=20; nprobe=1; recall=0.88300; GET/q=0.018; rows probed=34665</title></rect>
+<rect x="1134.68" y="703.67" width="24.96" height="24.96" fill="#2563eb" fill-opacity=".38" stroke="#2563eb"><title>N=100,000; top_k=20; nprobe=2; recall=0.97710; GET/q=0.735; rows probed=66633</title></rect>
+<rect x="1168.09" y="691.92" width="29.00" height="29.00" fill="#2563eb" fill-opacity=".38" stroke="#2563eb"><title>N=100,000; top_k=20; nprobe=3; recall=0.98980; GET/q=2.593; rows probed=100000</title></rect>
+<circle class="natural-knee" cx="1147.16" cy="716.15" r="17"/>
+<circle class="quality-floor" cx="1182.59" cy="706.42" r="17"/>
+<circle cx="95" cy="82" r="5" fill="#2563eb"/>
+<text x="107" y="86" font-size="12">100K (k_c=3)</text>
+<polyline points="427.30,716.95 932.60,706.43 1091.35,698.65 1146.60,691.12 1169.20,684.45 1180.92,676.15 1181.47,664.14" fill="none" stroke="#059669" stroke-width="2" opacity="1.0"/>
+<circle cx="427.30" cy="716.95" r="7.02" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=1; recall=0.71910; GET/q=0.583; rows probed=33699</title></circle>
+<circle cx="932.60" cy="706.43" r="8.48" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=2; recall=0.90020; GET/q=2.591; rows probed=67520</title></circle>
+<circle cx="1091.35" cy="698.65" r="9.57" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=3; recall=0.95710; GET/q=4.077; rows probed=100403</title></circle>
+<circle cx="1146.60" cy="691.12" r="10.47" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=4; recall=0.97690; GET/q=5.515; rows probed=132560</title></circle>
+<circle cx="1169.20" cy="684.45" r="11.26" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=5; recall=0.98500; GET/q=6.787; rows probed=164345</title></circle>
+<circle cx="1180.92" cy="676.15" r="12.66" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=7; recall=0.98920; GET/q=8.372; rows probed=229066</title></circle>
+<circle cx="1181.47" cy="664.14" r="14.50" fill="#059669" fill-opacity=".68" stroke="#059669"><title>N=330,000; top_k=10; nprobe=10; recall=0.98940; GET/q=10.665; rows probed=330000</title></circle>
+<circle class="natural-knee" cx="1091.35" cy="698.65" r="17"/>
+<circle class="quality-floor" cx="1169.20" cy="684.45" r="17"/>
+<polyline points="392.71,719.68 915.16,712.80 1075.87,702.87 1137.25,694.29 1165.71,687.23 1177.71,677.12 1178.54,663.55" fill="none" stroke="#059669" stroke-width="2" opacity="0.55"/>
+<rect x="385.69" y="712.67" width="14.03" height="14.03" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=1; recall=0.70670; GET/q=0.061; rows probed=33699</title></rect>
+<rect x="906.68" y="704.33" width="16.95" height="16.95" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=2; recall=0.89395; GET/q=1.374; rows probed=67520</title></rect>
+<rect x="1066.30" y="693.31" width="19.13" height="19.13" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=3; recall=0.95155; GET/q=3.270; rows probed=100403</title></rect>
+<rect x="1126.78" y="683.82" width="20.94" height="20.94" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=4; recall=0.97355; GET/q=4.909; rows probed=132560</title></rect>
+<rect x="1154.45" y="675.97" width="22.53" height="22.53" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=5; recall=0.98375; GET/q=6.256; rows probed=164345</title></rect>
+<rect x="1165.04" y="664.46" width="25.33" height="25.33" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=7; recall=0.98805; GET/q=8.187; rows probed=229066</title></rect>
+<rect x="1164.04" y="649.05" width="29.00" height="29.00" fill="#059669" fill-opacity=".38" stroke="#059669"><title>N=330,000; top_k=20; nprobe=10; recall=0.98835; GET/q=10.779; rows probed=330000</title></rect>
+<circle class="natural-knee" cx="1075.87" cy="702.87" r="17"/>
+<circle class="quality-floor" cx="1165.71" cy="687.23" r="17"/>
+<circle cx="280" cy="82" r="5" fill="#059669"/>
+<text x="292" y="86" font-size="12">330K (k_c=10)</text>
+<polyline points="212.19,714.64 740.36,703.80 946.27,694.69 1059.27,685.41 1118.42,676.47 1153.01,667.73 1169.76,659.73 1184.82,653.08 1192.63,644.02 1204.07,629.87 1208.82,602.33 1211.05,580.55 1211.05,561.81" fill="none" stroke="#d97706" stroke-width="2" opacity="1.0"/>
+<circle cx="212.19" cy="714.64" r="5.53" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=1; recall=0.64200; GET/q=1.024; rows probed=34195</title></circle>
+<circle cx="740.36" cy="703.80" r="6.37" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=2; recall=0.83130; GET/q=3.093; rows probed=67987</title></circle>
+<circle cx="946.27" cy="694.69" r="7.00" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=3; recall=0.90510; GET/q=4.832; rows probed=101483</title></circle>
+<circle cx="1059.27" cy="685.41" r="7.54" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=4; recall=0.94560; GET/q=6.604; rows probed=134843</title></circle>
+<circle cx="1118.42" cy="676.47" r="8.01" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=5; recall=0.96680; GET/q=8.312; rows probed=167825</title></circle>
+<circle cx="1153.01" cy="667.73" r="8.43" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=6; recall=0.97920; GET/q=9.981; rows probed=200766</title></circle>
+<circle cx="1169.76" cy="659.73" r="8.82" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=7; recall=0.98520; GET/q=11.507; rows probed=233898</title></circle>
+<circle cx="1184.82" cy="653.08" r="9.18" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=8; recall=0.99060; GET/q=12.778; rows probed=266842</title></circle>
+<circle cx="1192.63" cy="644.02" r="9.52" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=9; recall=0.99340; GET/q=14.508; rows probed=299888</title></circle>
+<circle cx="1204.07" cy="629.87" r="10.15" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=11; recall=0.99750; GET/q=17.209; rows probed=365073</title></circle>
+<circle cx="1208.82" cy="602.33" r="11.25" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=15; recall=0.99920; GET/q=22.468; rows probed=496062</title></circle>
+<circle cx="1211.05" cy="580.55" r="12.44" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=20; recall=1.00000; GET/q=26.625; rows probed=660977</title></circle>
+<circle cx="1211.05" cy="561.81" r="14.50" fill="#d97706" fill-opacity=".68" stroke="#d97706"><title>N=1,000,000; top_k=10; nprobe=30; recall=1.00000; GET/q=30.203; rows probed=1000000</title></circle>
+<circle class="natural-knee" cx="1059.27" cy="685.41" r="17"/>
+<circle class="quality-floor" cx="1169.76" cy="659.73" r="17"/>
+<polyline points="177.03,719.26 701.15,708.25 919.34,697.28 1037.50,686.82 1105.86,677.70 1146.88,668.56 1167.10,659.96 1181.20,652.88 1189.29,642.36 1201.70,625.14 1208.40,597.31 1210.91,573.15 1211.05,546.79" fill="none" stroke="#d97706" stroke-width="2" opacity="0.55"/>
+<rect x="171.50" y="713.73" width="11.07" height="11.07" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=1; recall=0.62940; GET/q=0.141; rows probed=34195</title></rect>
+<rect x="694.79" y="701.88" width="12.74" height="12.74" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=2; recall=0.81725; GET/q=2.243; rows probed=67987</title></rect>
+<rect x="912.34" y="690.28" width="14.01" height="14.01" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=3; recall=0.89545; GET/q=4.338; rows probed=101483</title></rect>
+<rect x="1029.96" y="679.28" width="15.08" height="15.08" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=4; recall=0.93780; GET/q=6.336; rows probed=134843</title></rect>
+<rect x="1097.86" y="669.69" width="16.01" height="16.01" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=5; recall=0.96230; GET/q=8.077; rows probed=167825</title></rect>
+<rect x="1138.45" y="660.13" width="16.86" height="16.86" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=6; recall=0.97700; GET/q=9.822; rows probed=200766</title></rect>
+<rect x="1158.29" y="651.14" width="17.64" height="17.64" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=7; recall=0.98425; GET/q=11.463; rows probed=233898</title></rect>
+<rect x="1172.01" y="643.69" width="18.36" height="18.36" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=8; recall=0.98930; GET/q=12.816; rows probed=266842</title></rect>
+<rect x="1179.76" y="632.84" width="19.05" height="19.05" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=9; recall=0.99220; GET/q=14.824; rows probed=299888</title></rect>
+<rect x="1191.56" y="615.00" width="20.29" height="20.29" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=11; recall=0.99665; GET/q=18.111; rows probed=365073</title></rect>
+<rect x="1197.15" y="586.06" width="22.49" height="22.49" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=15; recall=0.99905; GET/q=23.426; rows probed=496062</title></rect>
+<rect x="1198.47" y="560.70" width="24.89" height="24.89" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=20; recall=0.99995; GET/q=28.039; rows probed=660977</title></rect>
+<rect x="1196.55" y="532.29" width="29.00" height="29.00" fill="#d97706" fill-opacity=".38" stroke="#d97706"><title>N=1,000,000; top_k=20; nprobe=30; recall=1.00000; GET/q=33.071; rows probed=1000000</title></rect>
+<circle class="natural-knee" cx="1146.88" cy="668.56" r="17"/>
+<circle class="quality-floor" cx="1167.10" cy="659.96" r="17"/>
+<circle cx="465" cy="82" r="5" fill="#d97706"/>
+<text x="477" y="86" font-size="12">1M (k_c=30)</text>
+<polyline points="711.62,680.81 964.68,653.92 1070.15,631.08 1122.60,610.42 1142.13,600.38 1155.25,591.80 1166.97,581.79 1174.50,573.23 1186.50,557.09 1201.56,519.30" fill="none" stroke="#dc2626" stroke-width="2" opacity="1.0"/>
+<circle cx="711.62" cy="680.81" r="5.43" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=3; recall=0.82100; GET/q=7.482; rows probed=101829</title></circle>
+<circle cx="964.68" cy="653.92" r="5.98" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=5; recall=0.91170; GET/q=12.617; rows probed=168026</title></circle>
+<circle cx="1070.15" cy="631.08" r="6.43" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=7; recall=0.94950; GET/q=16.978; rows probed=233496</title></circle>
+<circle cx="1122.60" cy="610.42" r="6.81" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=9; recall=0.96830; GET/q=20.923; rows probed=298473</title></circle>
+<circle cx="1142.13" cy="600.38" r="6.98" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=10; recall=0.97530; GET/q=22.840; rows probed=331151</title></circle>
+<circle cx="1155.25" cy="591.80" r="7.15" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=11; recall=0.98000; GET/q=24.478; rows probed=363686</title></circle>
+<circle cx="1166.97" cy="581.79" r="7.31" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=12; recall=0.98420; GET/q=26.388; rows probed=395950</title></circle>
+<circle cx="1174.50" cy="573.23" r="7.46" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=13; recall=0.98690; GET/q=28.023; rows probed=428375</title></circle>
+<circle cx="1186.50" cy="557.09" r="7.75" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=15; recall=0.99120; GET/q=31.105; rows probed=493012</title></circle>
+<circle cx="1201.56" cy="519.30" r="8.40" fill="#dc2626" fill-opacity=".68" stroke="#dc2626"><title>N=3,300,000; top_k=10; nprobe=20; recall=0.99660; GET/q=38.320; rows probed=654075</title></circle>
+<circle class="natural-knee" cx="1070.15" cy="631.08" r="17"/>
+<circle class="quality-floor" cx="1155.25" cy="591.80" r="17"/>
+<polyline points="689.30,681.99 942.36,653.39 1053.69,628.88 1108.79,607.00 1130.97,597.70 1146.32,587.92 1158.60,576.91 1166.83,568.10 1179.66,549.05 1199.61,504.64" fill="none" stroke="#dc2626" stroke-width="2" opacity="0.55"/>
+<rect x="683.86" y="676.56" width="10.86" height="10.86" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=3; recall=0.81300; GET/q=7.257; rows probed=101829</title></rect>
+<rect x="936.38" y="647.41" width="11.96" height="11.96" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=5; recall=0.90370; GET/q=12.718; rows probed=168026</title></rect>
+<rect x="1047.26" y="622.45" width="12.85" height="12.85" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=7; recall=0.94360; GET/q=17.398; rows probed=233496</title></rect>
+<rect x="1101.98" y="600.19" width="13.62" height="13.62" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=9; recall=0.96335; GET/q=21.576; rows probed=298473</title></rect>
+<rect x="1123.99" y="590.71" width="13.97" height="13.97" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=10; recall=0.97130; GET/q=23.352; rows probed=331151</title></rect>
+<rect x="1139.17" y="580.77" width="14.30" height="14.30" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=11; recall=0.97680; GET/q=25.218; rows probed=363686</title></rect>
+<rect x="1151.28" y="569.60" width="14.62" height="14.62" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=12; recall=0.98120; GET/q=27.320; rows probed=395950</title></rect>
+<rect x="1159.36" y="560.64" width="14.93" height="14.93" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=13; recall=0.98415; GET/q=29.003; rows probed=428375</title></rect>
+<rect x="1171.91" y="541.30" width="15.50" height="15.50" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=15; recall=0.98875; GET/q=32.640; rows probed=493012</title></rect>
+<rect x="1191.21" y="496.24" width="16.79" height="16.79" fill="#dc2626" fill-opacity=".38" stroke="#dc2626"><title>N=3,300,000; top_k=20; nprobe=20; recall=0.99590; GET/q=41.119; rows probed=654075</title></rect>
+<circle class="natural-knee" cx="1053.69" cy="628.88" r="17"/>
+<circle class="quality-floor" cx="1158.60" cy="576.91" r="17"/>
+<circle cx="650" cy="82" r="5" fill="#dc2626"/>
+<text x="662" y="86" font-size="12">3.3M (k_c=100)</text>
+<polyline points="1075.45,523.19 1094.42,501.50 1123.72,442.76 1139.62,373.71 1148.27,257.81 1150.22,139.05" fill="none" stroke="#7c3aed" stroke-width="2" opacity="1.0"/>
+<circle cx="1075.45" cy="523.19" r="5.87" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=14; recall=0.95140; GET/q=37.577; rows probed=464960</title></circle>
+<circle cx="1094.42" cy="501.50" r="6.03" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=16; recall=0.95820; GET/q=41.719; rows probed=530053</title></circle>
+<circle cx="1123.72" cy="442.76" r="6.46" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=22; recall=0.96870; GET/q=52.935; rows probed=723676</title></circle>
+<circle cx="1139.62" cy="373.71" r="6.94" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=30; recall=0.97440; GET/q=66.119; rows probed=979524</title></circle>
+<circle cx="1148.27" cy="257.81" r="7.75" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=46; recall=0.97750; GET/q=88.247; rows probed=1490766</title></circle>
+<circle cx="1150.22" cy="139.05" r="8.49" fill="#7c3aed" fill-opacity=".68" stroke="#7c3aed"><title>N=10,000,000; top_k=10; nprobe=64; recall=0.97820; GET/q=110.923; rows probed=2059589</title></circle>
+<circle class="natural-knee" cx="1139.62" cy="373.71" r="17"/>
+<polyline points="1067.92,512.94" fill="none" stroke="#7c3aed" stroke-width="2" opacity="0.55"/>
+<rect x="1062.04" y="507.07" width="11.74" height="11.74" fill="#7c3aed" fill-opacity=".38" stroke="#7c3aed"><title>N=10,000,000; top_k=20; nprobe=14; recall=0.94870; GET/q=39.534; rows probed=464960</title></rect>
+<circle cx="835" cy="82" r="5" fill="#7c3aed"/>
+<text x="847" y="86" font-size="12">10M (k_c=305)</text>
+<line class="axis" x1="95" y1="110" x2="95" y2="720"/>
+<line class="axis" x1="95" y1="720" x2="1225" y2="720"/>
+<text x="660.00" y="792" text-anchor="middle" font-size="14">Recall</text>
+<text x="24" y="415.00" text-anchor="middle" font-size="14" transform="rotate(-90 24 415.00)">Physical GET/query</text>
+</svg>

--- a/scripts/bench/analyze_nprobe_geometry.py
+++ b/scripts/bench/analyze_nprobe_geometry.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""Fit and visualize the PAX nprobe/recall scale relationship.
+"""Analyze and visualize measured PAX nprobe/recall/cost geometry.
 
-The input is the auditable JSON emitted by ``nprobe_sweep.py``.  Two knees are
-reported because they answer different questions:
+The input is auditable JSON emitted by :mod:`nprobe_sweep`. The analyzer keeps
+two decisions separate:
 
-* ``curve_bend`` is the unconstrained diminishing-return elbow (Kneedle on
-  log-nprobe versus recall).
-* ``quality_floor`` is the smallest measured nprobe satisfying the requested
-  recall ratchet.  This is the deployable cost/quality recommendation.
+* ``economy_profile`` is the unconstrained diminishing-return knee on a
+  measured recall/cost Pareto frontier. Physical GET/query is the primary
+  objective for Azure/Azurite evidence because Azure bills hot-tier reads per
+  operation.
+* ``quality_profile`` is the least measured nprobe satisfying an explicit
+  recall target. It reports ``unattained`` instead of redefining that target.
 
-The power law is fit only to measured quality floors.  It is descriptive
-evidence, not permission to extrapolate beyond the measured cell-count range.
+Power laws are descriptive fits over the independently measured knees/floors.
+They are not permission to extrapolate outside the measured cell-count range.
 """
 
 from __future__ import annotations
@@ -31,51 +33,101 @@ def sorted_points(points: list[dict]) -> list[dict]:
     return ordered
 
 
-def quality_floor(points: list[dict], target_recall: float) -> dict:
-    """Return the least-work measured point satisfying the recall contract."""
+def metric_value(point: dict, key: str) -> float:
+    """Read a numeric point metric, including dotted nested keys."""
+    value: object = point
+    for component in key.split("."):
+        if not isinstance(value, dict) or component not in value:
+            raise RuntimeError(f"point is missing cost metric {key!r}")
+        value = value[component]
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"point cost metric {key!r} is not numeric") from error
+    if not math.isfinite(numeric):
+        raise RuntimeError(f"point cost metric {key!r} is not finite")
+    return numeric
+
+
+def quality_profile(points: list[dict], target_recall: float) -> dict:
+    """Report whether, and where, the measured curve attains the SLA."""
+    ordered = sorted_points(points)
     candidates = [
-        point
-        for point in sorted_points(points)
-        if float(point["recall_at_k"]) >= target_recall
+        point for point in ordered if float(point["recall_at_k"]) >= target_recall
     ]
     if not candidates:
-        raise RuntimeError(
-            f"no measured nprobe reaches recall target {target_recall:.6f}"
+        maximum = max(
+            ordered,
+            key=lambda point: (float(point["recall_at_k"]), int(point["nprobe"])),
         )
+        return {
+            "status": "unattained",
+            "target_recall": target_recall,
+            "point": None,
+            "max_measured_recall": float(maximum["recall_at_k"]),
+            "max_measured_nprobe": int(maximum["nprobe"]),
+        }
     # nprobe is the stable work coordinate. GETs can be non-monotone because
     # adjacent ranges coalesce and are therefore a secondary tie-break only.
-    return min(
+    point = min(
         candidates,
-        key=lambda point: (
-            int(point["nprobe"]),
-            float(point["gets_per_query"]),
+        key=lambda candidate: (
+            int(candidate["nprobe"]),
+            float(candidate["gets_per_query"]),
         ),
     )
+    return {
+        "status": "attained",
+        "target_recall": target_recall,
+        "point": point,
+        "max_measured_recall": max(
+            float(candidate["recall_at_k"]) for candidate in ordered
+        ),
+        "max_measured_nprobe": max(int(candidate["nprobe"]) for candidate in ordered),
+    }
 
 
-def curve_bend(points: list[dict]) -> dict:
-    """Return the Kneedle elbow for a monotone recall curve.
+def pareto_frontier(points: list[dict], cost_key: str) -> list[dict]:
+    """Return points not dominated by a cheaper point with equal recall."""
+    ordered = sorted(
+        sorted_points(points),
+        key=lambda point: (
+            metric_value(point, cost_key),
+            -float(point["recall_at_k"]),
+            int(point["nprobe"]),
+        ),
+    )
+    if any(metric_value(point, cost_key) <= 0.0 for point in ordered):
+        raise RuntimeError(f"curve bend requires positive {cost_key}")
+    frontier = []
+    best_recall = -math.inf
+    for point in ordered:
+        recall = float(point["recall_at_k"])
+        if recall > best_recall:
+            frontier.append(point)
+            best_recall = recall
+    return frontier
 
-    X is log(nprobe), because probe sweeps are geometric.  Y is the monotone
-    envelope of recall, preventing sampling noise from inventing a false bend.
-    The selected interior point maximizes normalized ``y - x``.
+
+def curve_bend(points: list[dict], cost_key: str) -> dict:
+    """Return the Kneedle elbow for a measured recall/cost Pareto frontier.
+
+    X is log(cost), because probe sweeps and their physical costs are geometric.
+    Dominated samples are removed before the selected interior point maximizes
+    normalized ``y - x``.
     """
-    ordered = sorted_points(points)
+    ordered = pareto_frontier(points, cost_key)
     if len(ordered) < 3:
         raise RuntimeError("curve bend requires at least three points")
-    monotone_recall = []
-    high = -math.inf
-    for point in ordered:
-        high = max(high, float(point["recall_at_k"]))
-        monotone_recall.append(high)
-    x_values = [math.log(float(point["nprobe"])) for point in ordered]
+    recalls = [float(point["recall_at_k"]) for point in ordered]
+    x_values = [math.log(metric_value(point, cost_key)) for point in ordered]
     x_span = x_values[-1] - x_values[0]
-    y_span = monotone_recall[-1] - monotone_recall[0]
+    y_span = recalls[-1] - recalls[0]
     if x_span <= 0.0 or y_span <= 0.0:
-        raise RuntimeError("curve bend requires increasing probe and recall ranges")
+        raise RuntimeError("curve bend requires increasing cost and recall ranges")
     distances = [
         (
-            (monotone_recall[index] - monotone_recall[0]) / y_span
+            (recalls[index] - recalls[0]) / y_span
             - (x_values[index] - x_values[0]) / x_span,
             index,
         )
@@ -83,6 +135,27 @@ def curve_bend(points: list[dict]) -> dict:
     ]
     _, best_index = max(distances, key=lambda candidate: (candidate[0], candidate[1]))
     return ordered[best_index]
+
+
+def natural_knee_profile(points: list[dict], cost_key: str) -> dict:
+    """Return a structured knee so sparse curves remain valid evidence."""
+    frontier = pareto_frontier(points, cost_key)
+    try:
+        point = curve_bend(points, cost_key)
+    except RuntimeError as error:
+        return {
+            "status": "unavailable",
+            "cost_metric": cost_key,
+            "point": None,
+            "frontier_point_count": len(frontier),
+            "reason": str(error),
+        }
+    return {
+        "status": "measured",
+        "cost_metric": cost_key,
+        "point": point,
+        "frontier_point_count": len(frontier),
+    }
 
 
 def _ordinary_log_fit(samples: list[dict]) -> tuple[float, float]:
@@ -156,28 +229,97 @@ def load_matrix(path: Path) -> dict:
         raise RuntimeError(f"{path}: fit requires exactly one settled PAX segment")
     if geometry.get("row_count") != result.get("dataset", {}).get("corpus_rows"):
         raise RuntimeError(f"{path}: settled rows differ from corpus rows")
-    if result.get("status") != "pass":
-        raise RuntimeError(f"{path}: matrix did not pass its evidence gates")
+    status = result.get("status")
+    if status == "running":
+        raise RuntimeError(f"{path}: matrix checkpoint is still running")
+    if status not in {"pass", "fail", "incomplete"}:
+        raise RuntimeError(f"{path}: unexpected matrix status {status!r}")
+    measurement_failures = result.get("measurement_failures")
+    if measurement_failures is None:
+        # Read-only evidence compatibility for checkpoints emitted before
+        # quality outcomes were separated from measurement failures.
+        measurement_failures = result.get("failures", [])
+    if measurement_failures:
+        raise RuntimeError(f"{path}: matrix has measurement failures")
+    checkpoint = result.get("checkpoint", {})
+    matrix = result.get("matrix", {})
+    points = matrix.get("points", [])
+    configured_point_count = len(matrix.get("nprobes", [])) * len(
+        matrix.get("top_k_values", [])
+    )
+    if status == "incomplete":
+        if checkpoint.get("state") != "incomplete":
+            raise RuntimeError(f"{path}: inconsistent incomplete checkpoint")
+        if checkpoint.get("completed_points") != len(points) or not points:
+            raise RuntimeError(f"{path}: incomplete checkpoint point count differs")
+        if checkpoint.get("expected_points") != configured_point_count:
+            raise RuntimeError(f"{path}: incomplete checkpoint plan differs")
+    if status in {"pass", "fail"}:
+        if checkpoint:
+            if checkpoint.get("state") != status:
+                raise RuntimeError(f"{path}: terminal checkpoint state differs")
+            if checkpoint.get("completed_points") != len(points):
+                raise RuntimeError(f"{path}: terminal checkpoint point count differs")
+            if checkpoint.get("expected_points") != len(points):
+                raise RuntimeError(
+                    f"{path}: terminal matrix is missing measured points"
+                )
+        elif status == "pass":
+            # Read-only evidence compatibility for complete matrices emitted
+            # before atomic checkpoints were added to this benchmark harness.
+            if configured_point_count != len(points):
+                raise RuntimeError(
+                    f"{path}: terminal matrix is missing measured points"
+                )
+    if status == "fail":
+        if "measurement_failures" not in result:
+            raise RuntimeError(f"{path}: legacy failed matrix cannot attribute failure")
+        quality_outcomes = result.get("quality_outcomes", [])
+        if result.get("matrix", {}).get("quality_policy") != "require" or not any(
+            outcome.get("status") == "unattained" for outcome in quality_outcomes
+        ):
+            raise RuntimeError(f"{path}: failed matrix has no attributable failure")
     return result
 
 
-def summarize_matrix(result: dict, target_recall: float, source: Path) -> dict:
+KNEE_COST_METRICS = (
+    "nprobe",
+    "gets_per_query",
+    "bytes_per_query",
+    "latency_ms.p50",
+    "latency_ms.p95",
+)
+
+
+def summarize_matrix(
+    result: dict,
+    target_recall: float,
+    sources: list[dict],
+    measurement_coverage: dict,
+) -> dict:
     points = result["matrix"]["points"]
     top_k_values = sorted({int(point["top_k"]) for point in points})
     curves = {}
     for top_k in top_k_values:
         curve = [point for point in points if int(point["top_k"]) == top_k]
+        natural_knees = {
+            metric: natural_knee_profile(curve, metric) for metric in KNEE_COST_METRICS
+        }
         curves[str(top_k)] = {
-            "curve_bend": curve_bend(curve),
-            "quality_floor": quality_floor(curve, target_recall),
+            "natural_knees": natural_knees,
+            "economy_profile": {
+                "objective": "gets_per_query",
+                **natural_knees["gets_per_query"],
+            },
+            "quality_profile": quality_profile(curve, target_recall),
         }
     segment = result["settled_geometry"]["segments"][0]
     corpus_rows = int(result["dataset"]["corpus_rows"])
     dimension = int(result["dataset"]["dimension"])
     coarse_cells = int(segment["coarse_cells"])
     return {
-        "source": str(source.resolve()),
-        "source_sha256": _sha256(source),
+        "sources": sources,
+        "measurement_coverage": measurement_coverage,
         "corpus_rows": corpus_rows,
         "dimension": dimension,
         "coarse_cells": coarse_cells,
@@ -191,7 +333,10 @@ def summarize_matrix(result: dict, target_recall: float, source: Path) -> dict:
         "empty_cell_fraction": segment.get("empty_cell_fraction"),
         "radius_summary": segment.get("radius_summary"),
         "curves": curves,
-        "points": points,
+        "points": sorted(
+            points,
+            key=lambda point: (int(point["top_k"]), int(point["nprobe"])),
+        ),
     }
 
 
@@ -205,31 +350,85 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def build_analysis(matrices: list[Path], target_recall: float) -> dict:
-    scales = [
-        summarize_matrix(load_matrix(path), target_recall, path) for path in matrices
-    ]
-    scales.sort(key=lambda scale: scale["corpus_rows"])
-    if len({scale["corpus_rows"] for scale in scales}) != len(scales):
-        raise RuntimeError("duplicate corpus scale in input matrices")
-    top_k_values = sorted(
-        set.intersection(
-            *[{int(value) for value in scale["curves"]} for scale in scales]
+def _segment_provenance(segment: dict) -> dict:
+    return {
+        key: segment.get(key)
+        for key in (
+            "path",
+            "blob_etag",
+            "bytes",
+            "layout_version",
+            "coarse_cells",
+            "coarse_seed",
         )
-    )
-    fits = {}
-    for top_k in top_k_values:
-        samples = [
-            {
-                "corpus_rows": scale["corpus_rows"],
-                "coarse_cells": scale["coarse_cells"],
-                "nprobe": scale["curves"][str(top_k)]["quality_floor"]["nprobe"],
-            }
-            for scale in scales
-        ]
-        fit = fit_power_law(samples)
-        fit["samples"] = samples
-        fit["comparison"] = [
+    }
+
+
+def matrix_provenance(result: dict) -> dict:
+    """Return immutable identity; intentionally exclude snapshot timestamps."""
+    dataset = result.get("dataset", {})
+    filesystem = result.get("filesystem_profile", {})
+    geometry = result.get("settled_geometry", {})
+    return {
+        "git_revision": result.get("git_revision"),
+        "collection_id": result.get("collection_id"),
+        "binary": {
+            "sha256": result.get("binary", {}).get("sha256"),
+            "source_revision": result.get("binary", {}).get("source_revision"),
+        },
+        "bed_config_sha256": result.get("bed_config", {}).get("sha256"),
+        "dataset": {
+            key: dataset.get(key)
+            for key in (
+                "base",
+                "base_format",
+                "corpus_rows",
+                "dimension",
+                "queries_path",
+                "query_format",
+                "groundtruth",
+                "groundtruth_format",
+                "groundtruth_scope_rows",
+                "groundtruth_width",
+                "query_range",
+            )
+        },
+        "filesystem": {
+            "storage_url": filesystem.get("storage_url"),
+            "azurite": filesystem.get("azurite"),
+            "persistent_local_tier": filesystem.get("persistent_local_tier"),
+        },
+        "compute_profile": result.get("compute_profile"),
+        "settled_geometry": {
+            "segment_count": geometry.get("segment_count"),
+            "row_count": geometry.get("row_count"),
+            "segments": [
+                _segment_provenance(segment) for segment in geometry.get("segments", [])
+            ],
+        },
+    }
+
+
+def _fit_series(samples: list[dict]) -> dict:
+    ordered = sorted(samples, key=lambda sample: int(sample["corpus_rows"]))
+    if len(ordered) < 3:
+        return {
+            "status": "insufficient_samples",
+            "sample_count": len(ordered),
+            "samples": ordered,
+        }
+    fit = fit_power_law(ordered)
+    return {
+        "status": "fit",
+        "evidence_status": (
+            "complete"
+            if all(sample["measurement_coverage"] == "complete" for sample in ordered)
+            else "provisional_partial_input"
+        ),
+        **fit,
+        "sample_count": len(ordered),
+        "samples": ordered,
+        "comparison": [
             {
                 **sample,
                 "fitted_nprobe": fit["coefficient"]
@@ -238,11 +437,114 @@ def build_analysis(matrices: list[Path], target_recall: float) -> dict:
                     2.0 * math.sqrt(sample["coarse_cells"])
                 ),
             }
-            for sample in samples
-        ]
-        fits[str(top_k)] = fit
+            for sample in ordered
+        ],
+    }
+
+
+def build_analysis(matrices: list[Path], target_recall: float) -> dict:
+    if not matrices:
+        raise RuntimeError("analysis requires at least one matrix")
+    grouped: dict[int, list[tuple[Path, dict]]] = {}
+    for path in matrices:
+        result = load_matrix(path)
+        corpus_rows = int(result["dataset"]["corpus_rows"])
+        grouped.setdefault(corpus_rows, []).append((path, result))
+
+    scales = []
+    for corpus_rows, entries in grouped.items():
+        expected_provenance = matrix_provenance(entries[0][1])
+        if any(
+            matrix_provenance(result) != expected_provenance
+            for _, result in entries[1:]
+        ):
+            raise RuntimeError(
+                f"corpus scale {corpus_rows}: checkpoint provenance differs"
+            )
+        merged_points = []
+        identities: set[tuple[int, int]] = set()
+        expected_identities: set[tuple[int, int]] = set()
+        sources = []
+        statuses = []
+        for path, result in entries:
+            statuses.append(str(result["status"]))
+            sources.append(
+                {
+                    "path": str(path.resolve()),
+                    "sha256": _sha256(path),
+                    "status": result["status"],
+                    "checkpoint": result.get("checkpoint"),
+                }
+            )
+            expected_identities.update(
+                (int(nprobe), int(top_k))
+                for nprobe in result["matrix"].get("nprobes", [])
+                for top_k in result["matrix"].get("top_k_values", [])
+            )
+            for point in result["matrix"]["points"]:
+                identity = (int(point["nprobe"]), int(point["top_k"]))
+                if identity in identities:
+                    raise RuntimeError(
+                        f"corpus scale {corpus_rows}: duplicate measured point "
+                        f"nprobe={identity[0]} top_k={identity[1]}"
+                    )
+                identities.add(identity)
+                merged_points.append(point)
+        merged = dict(entries[0][1])
+        merged["matrix"] = dict(merged["matrix"])
+        merged["matrix"]["points"] = merged_points
+        coverage_status = (
+            "complete"
+            if all(status in {"pass", "fail"} for status in statuses)
+            else "partial"
+        )
+        expected_point_count = len(expected_identities)
+        if expected_point_count == 0:
+            raise RuntimeError(f"corpus scale {corpus_rows}: empty measurement plan")
+        coverage = {
+            "status": coverage_status,
+            "source_count": len(entries),
+            "source_statuses": statuses,
+            "measured_point_count": len(merged_points),
+            "expected_point_count": expected_point_count,
+            "completion_fraction": len(merged_points) / expected_point_count,
+        }
+        scales.append(summarize_matrix(merged, target_recall, sources, coverage))
+
+    scales.sort(key=lambda scale: scale["corpus_rows"])
+    top_k_values = sorted({int(value) for scale in scales for value in scale["curves"]})
+    fits = {"natural_knee": {}, "quality_floor": {}}
+    for top_k in top_k_values:
+        natural_samples = []
+        quality_samples = []
+        for scale in scales:
+            curve = scale["curves"].get(str(top_k))
+            if curve is None:
+                continue
+            economy = curve["economy_profile"]
+            if economy["status"] == "measured":
+                natural_samples.append(
+                    {
+                        "corpus_rows": scale["corpus_rows"],
+                        "coarse_cells": scale["coarse_cells"],
+                        "nprobe": int(economy["point"]["nprobe"]),
+                        "measurement_coverage": scale["measurement_coverage"]["status"],
+                    }
+                )
+            quality = curve["quality_profile"]
+            if quality["status"] == "attained":
+                quality_samples.append(
+                    {
+                        "corpus_rows": scale["corpus_rows"],
+                        "coarse_cells": scale["coarse_cells"],
+                        "nprobe": int(quality["point"]["nprobe"]),
+                        "measurement_coverage": scale["measurement_coverage"]["status"],
+                    }
+                )
+        fits["natural_knee"][str(top_k)] = _fit_series(natural_samples)
+        fits["quality_floor"][str(top_k)] = _fit_series(quality_samples)
     return {
-        "protocol": "pax_five_point_nprobe_geometry_analysis",
+        "protocol": "pax_nprobe_geometry_analysis_v2",
         "target_recall": target_recall,
         "scale_count": len(scales),
         "scales": scales,
@@ -253,12 +555,13 @@ def build_analysis(matrices: list[Path], target_recall: float) -> dict:
                 "therefore the fitted deployment form is coefficient * "
                 "(corpus_rows * dimension / 4MiB) ^ exponent"
             ),
-            "recommendation_rule": (
-                "minimum measured nprobe whose recall meets the target"
+            "economy_rule": (
+                "maximum normalized Kneedle distance on log(GET/query) versus "
+                "recall after removing cost-dominated points"
             ),
-            "curve_bend_rule": (
-                "maximum Kneedle distance on log(nprobe) versus the monotone "
-                "recall envelope"
+            "quality_rule": (
+                "minimum measured nprobe whose recall meets the explicit target; "
+                "report unattained rather than lowering the target"
             ),
             "extrapolation": (
                 "descriptive only within measured_cell_range; clamp to "
@@ -316,14 +619,17 @@ def write_svg(analysis: dict, destination: Path) -> None:
         "<style>",
         "text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#18212b}",
         ".grid{stroke:#d9e1e8;stroke-width:1}.axis{stroke:#536272;stroke-width:1.5}",
-        ".knee{stroke:#111827;stroke-width:2.5;fill:none}",
+        ".natural-knee{stroke:#111827;stroke-width:2.5;fill:none}",
+        ".quality-floor{stroke:#111827;stroke-width:2.5;fill:none;"
+        "stroke-dasharray:5 4}",
         "</style>",
         '<rect width="100%" height="100%" fill="#fbfdff"/>',
         '<text x="95" y="34" font-size="22" font-weight="700">'
         "PAX nprobe scale geometry — release/Azurite evidence</text>",
         f'<text x="95" y="56" font-size="13">Bubble area scales with nprobe; '
-        f"color scales with physical GET/query; ring = minimum nprobe at recall ≥ "
-        f"{analysis['target_recall']:.3f}; x jitter only separates bubbles.</text>",
+        f"color scales with physical GET/query; solid ring = GET knee; dashed "
+        f"ring = first recall ≥ {analysis['target_recall']:.3f} when attained; "
+        "x jitter only separates bubbles.</text>",
     ]
     for tick in range(6):
         recall = y_min + (1.0 - y_min) * tick / 5
@@ -384,13 +690,23 @@ def write_svg(analysis: dict, destination: Path) -> None:
                 f"{dash}><title>{tooltip}</title></circle>"
             )
         for top_k_text, curve in scale["curves"].items():
-            knee = curve["quality_floor"]
-            cx = x_position(scale["corpus_rows"], int(knee["nprobe"]), int(top_k_text))
-            cy = y_position(float(knee["recall_at_k"]))
-            radius = 6.0 + 13.0 * math.sqrt(int(knee["nprobe"]) / max_probe)
-            svg.append(
-                f'<circle class="knee" cx="{cx:.2f}" cy="{cy:.2f}" r="{radius:.2f}"/>'
+            marker_profiles = (
+                ("natural-knee", curve["economy_profile"]),
+                ("quality-floor", curve["quality_profile"]),
             )
+            for marker_class, profile in marker_profiles:
+                knee = profile.get("point")
+                if knee is None:
+                    continue
+                cx = x_position(
+                    scale["corpus_rows"], int(knee["nprobe"]), int(top_k_text)
+                )
+                cy = y_position(float(knee["recall_at_k"]))
+                radius = 6.0 + 13.0 * math.sqrt(int(knee["nprobe"]) / max_probe)
+                svg.append(
+                    f'<circle class="{marker_class}" cx="{cx:.2f}" '
+                    f'cy="{cy:.2f}" r="{radius:.2f}"/>'
+                )
     svg.extend(
         [
             f'<line class="axis" x1="{left}" y1="{top}" x2="{left}" '
@@ -494,7 +810,7 @@ def write_dual_axis_svg(analysis: dict, destination: Path) -> None:
     svg.append(
         f'<line x1="{left}" y1="{target_y:.2f}" x2="{width - right}" '
         f'y2="{target_y:.2f}" stroke="#111827" stroke-dasharray="9 5">'
-        f'<title>recall target {analysis["target_recall"]:.3f}</title></line>'
+        f"<title>recall target {analysis['target_recall']:.3f}</title></line>"
     )
     if max_gets >= 10.0:
         budget_y = gets_y(10.0)
@@ -512,13 +828,13 @@ def write_dual_axis_svg(analysis: dict, destination: Path) -> None:
                 key=lambda point: int(point["nprobe"]),
             )
             recall_path = " ".join(
-                f'{x_position(int(point["nprobe"]) / coarse_cells):.2f},'
-                f'{recall_y(float(point["recall_at_k"])):.2f}'
+                f"{x_position(int(point['nprobe']) / coarse_cells):.2f},"
+                f"{recall_y(float(point['recall_at_k'])):.2f}"
                 for point in points
             )
             gets_path = " ".join(
-                f'{x_position(int(point["nprobe"]) / coarse_cells):.2f},'
-                f'{gets_y(float(point["gets_per_query"])):.2f}'
+                f"{x_position(int(point['nprobe']) / coarse_cells):.2f},"
+                f"{gets_y(float(point['gets_per_query'])):.2f}"
                 for point in points
             )
             opacity = 1.0 if top_k == 10 else 0.55
@@ -563,8 +879,8 @@ def write_dual_axis_svg(analysis: dict, destination: Path) -> None:
                 f'x2="{legend_x + 30}" y2="{legend_y}" stroke="{color}" '
                 'stroke-width="3"/>',
                 f'<text x="{legend_x + 39}" y="{legend_y + 4}" font-size="12">'
-                f'{scale_label(int(scale["corpus_rows"]))} '
-                f'(k_c={coarse_cells})</text>',
+                f"{scale_label(int(scale['corpus_rows']))} "
+                f"(k_c={coarse_cells})</text>",
             ]
         )
     svg.extend(
@@ -577,7 +893,7 @@ def write_dual_axis_svg(analysis: dict, destination: Path) -> None:
             f'x2="{width - right}" y2="{height - bottom}"/>',
             f'<text x="{left + plot_width / 2:.2f}" y="{height - 28}" '
             'text-anchor="middle" font-size="14">Normalized probe fraction '
-            '(nprobe / k_c)</text>',
+            "(nprobe / k_c)</text>",
             f'<text x="24" y="{top + plot_height / 2:.2f}" text-anchor="middle" '
             f'font-size="14" transform="rotate(-90 24 {top + plot_height / 2:.2f})">'
             "Recall</text>",
@@ -606,9 +922,7 @@ def write_pareto_svg(analysis: dict, destination: Path) -> None:
     recall_max = 1.005
 
     def x_position(recall: float) -> float:
-        return left + plot_width * (recall - x_min) / max(
-            recall_max - x_min, 1e-12
-        )
+        return left + plot_width * (recall - x_min) / max(recall_max - x_min, 1e-12)
 
     def y_position(gets: float) -> float:
         return top + plot_height * (1.0 - gets / max(max_gets, 1e-12))
@@ -619,14 +933,18 @@ def write_pareto_svg(analysis: dict, destination: Path) -> None:
         "<style>",
         "text{font-family:ui-sans-serif,system-ui,sans-serif;fill:#18212b}",
         ".grid{stroke:#d9e1e8;stroke-width:1}.axis{stroke:#536272;stroke-width:1.5}",
-        ".knee{stroke:#111827;stroke-width:2.5;fill:none}",
+        ".natural-knee{stroke:#111827;stroke-width:2.5;fill:none}",
+        ".quality-floor{stroke:#111827;stroke-width:2.5;fill:none;"
+        "stroke-dasharray:5 4}",
         "</style>",
         '<rect width="100%" height="100%" fill="#fbfdff"/>',
         f'<text x="{left}" y="34" font-size="22" font-weight="700">'
         "Recall → GET/query Pareto frontier</text>",
         f'<text x="{left}" y="57" font-size="13">'
-        "Bubble area scales with actual rows probed / corpus rows; ring = first point at "
-        f'recall ≥ {analysis["target_recall"]:.3f}; circle = top-10; square = top-20.</text>',
+        "Bubble area scales with actual rows probed / corpus rows; solid ring = GET "
+        "knee; dashed ring = first point at "
+        f"recall ≥ {analysis['target_recall']:.3f} when attained; circle = top-10; "
+        "square = top-20.</text>",
     ]
     for tick in range(6):
         fraction = tick / 5
@@ -667,8 +985,8 @@ def write_pareto_svg(analysis: dict, destination: Path) -> None:
                 key=lambda point: int(point["nprobe"]),
             )
             path = " ".join(
-                f'{x_position(float(point["recall_at_k"])):.2f},'
-                f'{y_position(float(point["gets_per_query"])):.2f}'
+                f"{x_position(float(point['recall_at_k'])):.2f},"
+                f"{y_position(float(point['gets_per_query'])):.2f}"
                 for point in points
             )
             opacity = 1.0 if top_k == 10 else 0.55
@@ -703,19 +1021,27 @@ def write_pareto_svg(analysis: dict, destination: Path) -> None:
                         f'fill="{color}" fill-opacity=".38" stroke="{color}">'
                         f"<title>{tooltip}</title></rect>"
                     )
-            knee = curve_summary["quality_floor"]
-            knee_x = x_position(float(knee["recall_at_k"]))
-            knee_y = y_position(float(knee["gets_per_query"]))
-            svg.append(
-                f'<circle class="knee" cx="{knee_x:.2f}" cy="{knee_y:.2f}" r="17"/>'
+            marker_profiles = (
+                ("natural-knee", curve_summary["economy_profile"]),
+                ("quality-floor", curve_summary["quality_profile"]),
             )
+            for marker_class, profile in marker_profiles:
+                knee = profile.get("point")
+                if knee is None:
+                    continue
+                knee_x = x_position(float(knee["recall_at_k"]))
+                knee_y = y_position(float(knee["gets_per_query"]))
+                svg.append(
+                    f'<circle class="{marker_class}" cx="{knee_x:.2f}" '
+                    f'cy="{knee_y:.2f}" r="17"/>'
+                )
         legend_x = left + scale_index * 185
         legend_y = 82
         svg.extend(
             [
                 f'<circle cx="{legend_x}" cy="{legend_y}" r="5" fill="{color}"/>',
                 f'<text x="{legend_x + 12}" y="{legend_y + 4}" font-size="12">'
-                f'{scale_label(corpus_rows)} (k_c={scale["coarse_cells"]})</text>',
+                f"{scale_label(corpus_rows)} (k_c={scale['coarse_cells']})</text>",
             ]
         )
     svg.extend(

--- a/scripts/bench/nprobe_sweep.py
+++ b/scripts/bench/nprobe_sweep.py
@@ -173,7 +173,8 @@ def checkpoint_identity(result: dict) -> dict:
         "matrix_config": {
             "nprobes": matrix["nprobes"],
             "top_k_values": matrix["top_k_values"],
-            "min_recall": matrix["min_recall"],
+            "target_recall": matrix["target_recall"],
+            "quality_policy": matrix["quality_policy"],
         },
     }
 
@@ -226,6 +227,50 @@ def write_checkpoint(
     temporary.replace(output)
 
 
+def evaluate_quality(
+    points: list[dict],
+    top_k_values: list[int],
+    target_recall: float,
+) -> list[dict]:
+    """Report target attainment independently of measurement validity."""
+    outcomes = []
+    for top_k in top_k_values:
+        recalls = [
+            float(point["recall_at_k"])
+            for point in points
+            if int(point["top_k"]) == top_k
+        ]
+        maximum = max(recalls) if recalls else None
+        outcomes.append(
+            {
+                "top_k": top_k,
+                "target_recall": target_recall,
+                "status": (
+                    "attained"
+                    if maximum is not None and maximum >= target_recall
+                    else "unattained"
+                ),
+                "max_measured_recall": maximum,
+            }
+        )
+    return outcomes
+
+
+def final_status(
+    measurement_failures: list[str],
+    quality_outcomes: list[dict],
+    quality_policy: str,
+) -> str:
+    """Keep measurement failures fatal; make SLA gating an explicit policy."""
+    if measurement_failures:
+        return "fail"
+    if quality_policy == "require" and any(
+        outcome["status"] != "attained" for outcome in quality_outcomes
+    ):
+        return "fail"
+    return "pass"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binary", type=Path, required=True)
@@ -263,7 +308,16 @@ def main() -> int:
     parser.add_argument("--port", type=int, default=5690)
     parser.add_argument("--max-segments", type=int, default=1)
     parser.add_argument("--required-layout-version", type=int, default=3)
-    parser.add_argument("--min-recall", type=float, default=0.98)
+    parser.add_argument("--target-recall", type=float, default=0.98)
+    parser.add_argument(
+        "--quality-policy",
+        choices=("require", "report"),
+        default="require",
+        help=(
+            "require fails when the target is unattained; report preserves the "
+            "valid measurement and records target attainment separately"
+        ),
+    )
     parser.add_argument("--azurite", action="store_true")
     parser.add_argument(
         "--resume",
@@ -294,8 +348,8 @@ def main() -> int:
         raise RuntimeError("ground-truth scope must equal the measured corpus rows")
     if args.queries <= 0 or args.query_start < 0:
         raise RuntimeError("query count must be positive and start non-negative")
-    if not 0.0 < args.min_recall <= 1.0:
-        raise RuntimeError("--min-recall must be in (0, 1]")
+    if not 0.0 < args.target_recall <= 1.0:
+        raise RuntimeError("--target-recall must be in (0, 1]")
     if not args.collection_id.isdecimal():
         raise RuntimeError("--collection-id must be a decimal catalog object id")
 
@@ -408,10 +462,12 @@ def main() -> int:
         "matrix": {
             "nprobes": nprobes,
             "top_k_values": top_k_values,
-            "min_recall": args.min_recall,
+            "target_recall": args.target_recall,
+            "quality_policy": args.quality_policy,
             "points": [],
         },
-        "failures": [],
+        "measurement_failures": [],
+        "quality_outcomes": [],
     }
 
     if args.resume:
@@ -478,34 +534,40 @@ def main() -> int:
             point["expected_cells_probed_per_query"] = expected_cells
             actual_cells = point["ivf"]["cells_probed_per_query"]
             if abs(actual_cells - expected_cells) > 0.01:
-                result["failures"].append(
+                result["measurement_failures"].append(
                     f"{label}: measured cells/query {actual_cells:.3f} "
                     f"!= expected {expected_cells}"
                 )
             if attribution_failure := ACCEPTANCE.ivf_byte_attribution_failure(
                 label, point
             ):
-                result["failures"].append(attribution_failure)
+                result["measurement_failures"].append(attribution_failure)
             result["matrix"]["points"].append(point)
             completed.add((nprobe, top_k))
             write_checkpoint(output, result, "running")
 
-    for top_k in top_k_values:
-        recalls = [
-            point["recall_at_k"]
-            for point in result["matrix"]["points"]
-            if point["top_k"] == top_k
-        ]
-        if not recalls or max(recalls) < args.min_recall:
-            result["failures"].append(
-                f"top_k={top_k}: no nprobe reaches recall {args.min_recall:.4f}"
-            )
-    final_status = "pass" if not result["failures"] else "fail"
-    write_checkpoint(output, result, final_status)
+    result["quality_outcomes"] = evaluate_quality(
+        result["matrix"]["points"], top_k_values, args.target_recall
+    )
+    status = final_status(
+        result["measurement_failures"],
+        result["quality_outcomes"],
+        args.quality_policy,
+    )
+    write_checkpoint(output, result, status)
     print(f"matrix result: {output}", flush=True)
-    if result["failures"]:
-        for failure in result["failures"]:
+    if result["measurement_failures"]:
+        for failure in result["measurement_failures"]:
             print(f"FAIL: {failure}", flush=True)
+    if args.quality_policy == "require":
+        for outcome in result["quality_outcomes"]:
+            if outcome["status"] != "attained":
+                print(
+                    f"FAIL: top_k={outcome['top_k']}: no nprobe reaches recall "
+                    f"{args.target_recall:.4f}",
+                    flush=True,
+                )
+    if status == "fail":
         return 1
     return 0
 

--- a/tests/python/test_nprobe_geometry_analysis.py
+++ b/tests/python/test_nprobe_geometry_analysis.py
@@ -1,6 +1,9 @@
 import importlib.util
+import json
 import math
 from pathlib import Path
+
+import pytest
 
 SCRIPT = (
     Path(__file__).resolve().parents[2]
@@ -15,7 +18,7 @@ ANALYSIS = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(ANALYSIS)
 
 
-def test_quality_floor_prefers_first_probe_that_meets_recall():
+def test_quality_profile_prefers_first_probe_that_meets_recall():
     points = [
         {"nprobe": 1, "recall_at_k": 0.90, "gets_per_query": 1.0},
         {"nprobe": 2, "recall_at_k": 0.979, "gets_per_query": 2.0},
@@ -23,10 +26,29 @@ def test_quality_floor_prefers_first_probe_that_meets_recall():
         {"nprobe": 8, "recall_at_k": 0.990, "gets_per_query": 8.0},
     ]
 
-    knee = ANALYSIS.quality_floor(points, 0.98)
+    profile = ANALYSIS.quality_profile(points, 0.98)
 
-    assert knee["nprobe"] == 4
-    assert knee["recall_at_k"] == 0.981
+    assert profile["status"] == "attained"
+    assert profile["point"]["nprobe"] == 4
+    assert profile["point"]["recall_at_k"] == 0.981
+
+
+def test_quality_profile_reports_unattained_without_rejecting_curve():
+    points = [
+        {"nprobe": 2, "recall_at_k": 0.95, "gets_per_query": 2.0},
+        {"nprobe": 4, "recall_at_k": 0.97, "gets_per_query": 4.0},
+        {"nprobe": 8, "recall_at_k": 0.975, "gets_per_query": 8.0},
+    ]
+
+    profile = ANALYSIS.quality_profile(points, 0.98)
+
+    assert profile == {
+        "status": "unattained",
+        "target_recall": 0.98,
+        "point": None,
+        "max_measured_recall": 0.975,
+        "max_measured_nprobe": 8,
+    }
 
 
 def test_curve_bend_detects_diminishing_return_before_saturation():
@@ -38,8 +60,24 @@ def test_curve_bend_detects_diminishing_return_before_saturation():
         {"nprobe": 16, "recall_at_k": 0.981, "gets_per_query": 16.0},
     ]
 
-    bend = ANALYSIS.curve_bend(points)
+    bend = ANALYSIS.curve_bend(points, "nprobe")
 
+    assert bend["nprobe"] == 4
+
+
+def test_curve_bend_uses_cost_frontier_and_drops_dominated_points():
+    points = [
+        {"nprobe": 1, "recall_at_k": 0.70, "gets_per_query": 3.0},
+        {"nprobe": 2, "recall_at_k": 0.85, "gets_per_query": 2.0},
+        {"nprobe": 4, "recall_at_k": 0.97, "gets_per_query": 4.0},
+        {"nprobe": 8, "recall_at_k": 0.98, "gets_per_query": 8.0},
+        {"nprobe": 16, "recall_at_k": 0.981, "gets_per_query": 16.0},
+    ]
+
+    frontier = ANALYSIS.pareto_frontier(points, "gets_per_query")
+    bend = ANALYSIS.curve_bend(points, "gets_per_query")
+
+    assert [point["nprobe"] for point in frontier] == [2, 4, 8, 16]
     assert bend["nprobe"] == 4
 
 
@@ -70,6 +108,213 @@ def test_fit_rejects_fewer_than_three_independent_scales():
         raise AssertionError("fit unexpectedly accepted two points")
 
 
+def matrix_result(
+    points: list[dict],
+    *,
+    status: str = "pass",
+    corpus_rows: int = 100_000,
+    source_revision: str = "source-revision",
+    expected_nprobes: list[int] | None = None,
+) -> dict:
+    nprobes = expected_nprobes or sorted({point["nprobe"] for point in points})
+    top_k_values = sorted({point["top_k"] for point in points})
+    return {
+        "protocol": "pax_nprobe_topk_matrix",
+        "status": status,
+        "git_revision": source_revision,
+        "binary": {
+            "sha256": "binary-sha",
+            "source_revision": source_revision,
+        },
+        "bed_config": {"sha256": "config-sha"},
+        "dataset": {
+            "corpus_rows": corpus_rows,
+            "dimension": 128,
+            "groundtruth_scope_rows": corpus_rows,
+            "query_range": [0, 1000],
+        },
+        "filesystem_profile": {"storage_url": "az://benchmarks/run-1"},
+        "compute_profile": {"architecture": "arm64"},
+        "settled_geometry": {
+            "segment_count": 1,
+            "row_count": corpus_rows,
+            "segments": [
+                {
+                    "path": "run-1/1/data/segment.pax",
+                    "blob_etag": "etag-1",
+                    "bytes": 10_000,
+                    "layout_version": 3,
+                    "coarse_cells": 4,
+                    "coarse_seed": 17,
+                }
+            ],
+        },
+        "matrix": {
+            "nprobes": nprobes,
+            "top_k_values": top_k_values,
+            "target_recall": 0.98,
+            "quality_policy": "report",
+            "points": points,
+        },
+        "measurement_failures": [],
+        "quality_outcomes": [],
+        "checkpoint": {
+            "state": status,
+            "completed_points": len(points),
+            "expected_points": len(nprobes) * len(top_k_values),
+            "incomplete_reason": None if status == "pass" else "interrupted",
+        },
+    }
+
+
+def measured_point(nprobe: int, recall: float, gets: float) -> dict:
+    return {
+        "nprobe": nprobe,
+        "top_k": 10,
+        "recall_at_k": recall,
+        "gets_per_query": gets,
+        "bytes_per_query": gets * 1_000_000,
+        "latency_ms": {"p50": gets * 3.0, "p95": gets * 5.0},
+        "ivf": {"probed_rows_per_query": nprobe * 25_000.0},
+    }
+
+
+def write_matrix(path: Path, result: dict) -> None:
+    path.write_text(json.dumps(result))
+
+
+def test_build_analysis_merges_provenance_identical_partial_checkpoints(tmp_path: Path):
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    write_matrix(
+        first,
+        matrix_result(
+            [measured_point(1, 0.90, 2.0), measured_point(2, 0.96, 4.0)],
+            status="incomplete",
+            expected_nprobes=[1, 2, 5],
+        ),
+    )
+    write_matrix(
+        second,
+        matrix_result(
+            [measured_point(3, 0.974, 6.0), measured_point(4, 0.975, 8.0)],
+            status="incomplete",
+            expected_nprobes=[3, 4, 6],
+        ),
+    )
+
+    analysis = ANALYSIS.build_analysis([first, second], 0.98)
+
+    scale = analysis["scales"][0]
+    curve = scale["curves"]["10"]
+    assert scale["measurement_coverage"]["status"] == "partial"
+    assert scale["measurement_coverage"]["measured_point_count"] == 4
+    assert scale["measurement_coverage"]["expected_point_count"] == 6
+    assert scale["measurement_coverage"]["completion_fraction"] == pytest.approx(2 / 3)
+    assert len(scale["sources"]) == 2
+    assert [point["nprobe"] for point in scale["points"]] == [1, 2, 3, 4]
+    assert curve["natural_knees"]["gets_per_query"]["status"] == "measured"
+    assert curve["quality_profile"]["status"] == "unattained"
+    assert analysis["fits"]["natural_knee"]["10"]["status"] == ("insufficient_samples")
+    assert analysis["fits"]["quality_floor"]["10"]["status"] == ("insufficient_samples")
+
+
+def test_build_analysis_rejects_same_scale_with_different_provenance(tmp_path: Path):
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    write_matrix(first, matrix_result([measured_point(1, 0.90, 2.0)]))
+    write_matrix(
+        second,
+        matrix_result(
+            [measured_point(2, 0.96, 4.0)],
+            source_revision="different-source",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="provenance"):
+        ANALYSIS.build_analysis([first, second], 0.98)
+
+
+def test_quality_gated_failure_is_complete_measurement_evidence(tmp_path: Path):
+    path = tmp_path / "quality-fail.json"
+    result = matrix_result(
+        [
+            measured_point(1, 0.90, 2.0),
+            measured_point(2, 0.96, 4.0),
+            measured_point(3, 0.975, 6.0),
+        ],
+        status="fail",
+    )
+    result["matrix"]["quality_policy"] = "require"
+    result["quality_outcomes"] = [
+        {
+            "top_k": 10,
+            "target_recall": 0.98,
+            "status": "unattained",
+            "max_measured_recall": 0.975,
+        }
+    ]
+    write_matrix(path, result)
+
+    analysis = ANALYSIS.build_analysis([path], 0.98)
+
+    assert analysis["scales"][0]["measurement_coverage"]["status"] == "complete"
+    assert analysis["scales"][0]["curves"]["10"]["quality_profile"]["status"] == (
+        "unattained"
+    )
+
+
+def test_load_matrix_rejects_active_checkpoint(tmp_path: Path):
+    path = tmp_path / "running.json"
+    write_matrix(
+        path,
+        matrix_result([measured_point(1, 0.90, 2.0)], status="running"),
+    )
+
+    with pytest.raises(RuntimeError, match="still running"):
+        ANALYSIS.load_matrix(path)
+
+
+def test_load_matrix_rejects_terminal_checkpoint_missing_points(tmp_path: Path):
+    path = tmp_path / "truncated.json"
+    result = matrix_result([measured_point(1, 0.90, 2.0)])
+    result["checkpoint"]["expected_points"] = 2
+    write_matrix(path, result)
+
+    with pytest.raises(RuntimeError, match="missing measured points"):
+        ANALYSIS.load_matrix(path)
+
+
+def test_load_matrix_accepts_complete_pre_checkpoint_evidence(tmp_path: Path):
+    path = tmp_path / "legacy-complete.json"
+    result = matrix_result([measured_point(1, 0.90, 2.0)])
+    result.pop("checkpoint")
+    write_matrix(path, result)
+
+    assert ANALYSIS.load_matrix(path)["status"] == "pass"
+
+
+def test_fit_marks_partial_evidence_as_provisional():
+    samples = [
+        {
+            "corpus_rows": rows,
+            "coarse_cells": cells,
+            "nprobe": probe,
+            "measurement_coverage": coverage,
+        }
+        for rows, cells, probe, coverage in (
+            (100_000, 3, 2, "complete"),
+            (1_000_000, 30, 7, "complete"),
+            (10_000_000, 305, 30, "partial"),
+        )
+    ]
+
+    fit = ANALYSIS._fit_series(samples)
+
+    assert fit["status"] == "fit"
+    assert fit["evidence_status"] == "provisional_partial_input"
+
+
 def test_dual_axis_and_pareto_svgs_encode_decision_axes(tmp_path: Path):
     point_low = {
         "nprobe": 1,
@@ -78,12 +323,19 @@ def test_dual_axis_and_pareto_svgs_encode_decision_axes(tmp_path: Path):
         "gets_per_query": 2.0,
         "ivf": {"probed_rows_per_query": 25_000.0},
     }
-    point_knee = {
+    point_middle = {
         "nprobe": 2,
         "top_k": 10,
-        "recall_at_k": 0.985,
+        "recall_at_k": 0.970,
         "gets_per_query": 6.0,
         "ivf": {"probed_rows_per_query": 50_000.0},
+    }
+    point_quality = {
+        "nprobe": 4,
+        "top_k": 10,
+        "recall_at_k": 0.985,
+        "gets_per_query": 12.0,
+        "ivf": {"probed_rows_per_query": 75_000.0},
     }
     analysis = {
         "target_recall": 0.98,
@@ -91,11 +343,19 @@ def test_dual_axis_and_pareto_svgs_encode_decision_axes(tmp_path: Path):
             {
                 "corpus_rows": 100_000,
                 "coarse_cells": 4,
-                "points": [point_low, point_knee],
+                "points": [point_low, point_middle, point_quality],
                 "curves": {
                     "10": {
-                        "quality_floor": point_knee,
-                        "curve_bend": point_low,
+                        "economy_profile": {
+                            "objective": "gets_per_query",
+                            "status": "measured",
+                            "point": point_middle,
+                        },
+                        "quality_profile": {
+                            "status": "attained",
+                            "target_recall": 0.98,
+                            "point": point_quality,
+                        },
                     }
                 },
             }
@@ -115,5 +375,6 @@ def test_dual_axis_and_pareto_svgs_encode_decision_axes(tmp_path: Path):
     assert "N=100,000; k_c=4; top_k=10; nprobe=2" in dual_text
     assert "Recall → GET/query Pareto frontier" in pareto_text
     assert "Bubble area scales with actual rows probed / corpus rows" in pareto_text
-    assert "rows probed=50000" in pareto_text
-    assert 'class="knee"' in pareto_text
+    assert "rows probed=75000" in pareto_text
+    assert 'class="natural-knee"' in pareto_text
+    assert 'class="quality-floor"' in pareto_text

--- a/tests/python/test_nprobe_sweep.py
+++ b/tests/python/test_nprobe_sweep.py
@@ -27,19 +27,19 @@ def expected_result() -> dict:
         "matrix": {
             "nprobes": [1, 2],
             "top_k_values": [10, 20],
-            "min_recall": 0.98,
+            "target_recall": 0.98,
+            "quality_policy": "require",
             "points": [],
         },
-        "failures": [],
+        "measurement_failures": [],
+        "quality_outcomes": [],
     }
 
 
 def test_atomic_checkpoint_records_completed_and_expected_points(tmp_path: Path):
     output = tmp_path / "matrix.json"
     result = expected_result()
-    result["matrix"]["points"].append(
-        {"nprobe": 1, "top_k": 10, "recall_at_k": 0.9}
-    )
+    result["matrix"]["points"].append({"nprobe": 1, "top_k": 10, "recall_at_k": 0.9})
 
     SWEEP.write_checkpoint(output, result, "running")
 
@@ -58,9 +58,7 @@ def test_resume_accepts_only_matching_unique_completed_points():
     expected = expected_result()
     existing = copy.deepcopy(expected)
     existing["status"] = "incomplete"
-    existing["matrix"]["points"] = [
-        {"nprobe": 1, "top_k": 10, "recall_at_k": 0.9}
-    ]
+    existing["matrix"]["points"] = [{"nprobe": 1, "top_k": 10, "recall_at_k": 0.9}]
 
     assert SWEEP.validate_resume(existing, expected) == {(1, 10)}
 
@@ -75,9 +73,7 @@ def test_resume_accepts_only_matching_unique_completed_points():
         SWEEP.validate_resume(wrong_config, expected)
 
     duplicate = copy.deepcopy(existing)
-    duplicate["matrix"]["points"].append(
-        copy.deepcopy(existing["matrix"]["points"][0])
-    )
+    duplicate["matrix"]["points"].append(copy.deepcopy(existing["matrix"]["points"][0]))
     with pytest.raises(RuntimeError, match="duplicate point"):
         SWEEP.validate_resume(duplicate, expected)
 
@@ -89,3 +85,44 @@ def test_resume_rejects_terminal_checkpoint():
 
     with pytest.raises(RuntimeError, match="terminal"):
         SWEEP.validate_resume(existing, expected)
+
+
+def test_quality_policy_reports_unattained_without_invalidating_measurement():
+    points = [
+        {"top_k": 10, "recall_at_k": 0.975},
+        {"top_k": 20, "recall_at_k": 0.981},
+    ]
+
+    outcomes = SWEEP.evaluate_quality(points, [10, 20], 0.98)
+
+    assert outcomes == [
+        {
+            "top_k": 10,
+            "target_recall": 0.98,
+            "status": "unattained",
+            "max_measured_recall": 0.975,
+        },
+        {
+            "top_k": 20,
+            "target_recall": 0.98,
+            "status": "attained",
+            "max_measured_recall": 0.981,
+        },
+    ]
+    assert SWEEP.final_status([], outcomes, "report") == "pass"
+    assert SWEEP.final_status([], outcomes, "require") == "fail"
+
+
+def test_measurement_failure_always_fails_regardless_of_quality_policy():
+    outcomes = [
+        {
+            "top_k": 10,
+            "target_recall": 0.98,
+            "status": "attained",
+            "max_measured_recall": 0.99,
+        }
+    ]
+
+    assert SWEEP.final_status(["cell attribution mismatch"], outcomes, "report") == (
+        "fail"
+    )


### PR DESCRIPTION
## Summary

- separate measured natural economy knees from explicit recall-SLA attainment
- keep the sweep default at `target_recall=0.98` with `quality_policy=require`; add report-only discovery without turning an unattained SLA into a measurement failure
- merge non-empty partial same-scale checkpoints only under immutable provenance equality, with unique planned-point coverage and provisional-fit labeling
- publish five-scale BIGANN/Azurite evidence and reviewable bubble, dual-axis, and Pareto SVGs

## Evidence

- 100K/330K/1M/3.3M matrices are complete
- 10M is explicitly partial: 7/20 unique planned points across five provenance-identical checkpoints
- 10M top-10 GET/byte/p50/p95 knees agree at nprobe 30: recall 0.9744, 66.119 GET/query, 163.04 MB/query, 558.37 ms local-Azurite p50
- best measured 10M recall is 0.9782 at nprobe 64; the 0.98 target is reported unattained, not lowered
- 10M top-20 has one point and reports no knee

## Validation

- `19 passed`: focused analyzer/sweep tests
- Ruff lint and format clean
- benchmark evidence ledger validation green
- TD/ADR uniqueness green
- commit attribution guard green
- `make work-commit-check` green after rebasing onto latest `origin/develop`
