### PR TITLE
fix(ci): run the recall E2E when src/services changes (TD-RECALL-2 / #1406)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,16 @@ jobs:
               # integration job, which the storage-only filter would otherwise miss.
               - 'src/storage/persistence/write_ahead_log/**'
               - 'src/storage/memtable/**'
+              # TD-RECALL-2 / #1406: same lesson, one layer up. Identity/OID minting
+              # in src/services (system_catalog.rs) feeds OID resolution on the
+              # cross-segment search path, so it can regress ANN recall WITHOUT
+              # touching src/query or src/storage. #1406 changed only
+              # src/services/{system_catalog,system_catalog_state}.rs + src/network,
+              # matched no recall filter, and its PR SKIPPED this job — the cross-tier
+              # recall collapse (mean 1.000 → 0.000) surfaced only later on develop and
+              # cost a bisect + revert (#1425). Recall is a cross-cutting OUTCOME, so
+              # this filter tracks what can break it, not who owns the code.
+              - 'src/services/**'
             storage_changes:
               - 'src/storage/**'
               - 'tests/*storage*'


### PR DESCRIPTION
Adds `src/services/**` to the `query_changes` path filter so the query integration lane — which runs `tests/vector_ann_recall_e2e.rs` — fires on changes to identity/OID minting code.

## The gap, with evidence

#1406 regressed cross-tier ANN recall (Phase C `mean 1.000 → 0.000`) via `src/services/system_catalog.rs`. **CI never ran the test that catches it.** On #1406's own PR, every recall-capable lane was skipped:

```
SKIPPED   Rust Integration Tests (query)      ← runs vector_ann_recall_e2e
SKIPPED   Rust Integration Tests (storage)
SKIPPED   SIFT PAX recall ratchet (N=10k)
```

Because `src/services/**` matched **no** filter gating recall coverage:

| filter | paths | matches #1406? |
|---|---|---|
| `query_changes` | `src/query/**`, `tests/*query*`, `tests/*federated*`, WAL, memtable | ❌ |
| `core_changes` | `src/core/**`, `src/compute/**`, `src/lib.rs`, `Cargo.*` | ❌ |
| `storage_changes` | `src/storage/**`, `tests/*storage*`, `tests/*sst*`, `tests/*wal*` | ❌ |

So the collapse surfaced only after landing on `develop`, costing a bisect and a revert (#1425).

## Why this shape of fix

This is the **same lesson the filter already encodes one layer down** — WAL and memtable paths were added to `query_changes` with the comment that they'd otherwise be missed by "the storage-only filter." Recall is a cross-cutting *outcome*: identity/OID minting feeds OID resolution on the cross-segment search path, so it can regress recall without touching `src/query` or `src/storage`. The filter should track **what can break it, not who owns the code**.

Deliberately narrow — this widens one existing path filter rather than promoting heavy suites to every PR:

- SIFT ratchet (30 m timeout) and storage lane (45 m) keep their current triggers.
- Only the query lane (~21 m) gains `src/services/**`, which ~15% of recent commits touch (259/1707 over 60 days).

## Verification

- Workflow YAML parses; `query_changes` resolves to `['src/query/**', 'tests/*query*', 'tests/*federated*', 'src/storage/persistence/write_ahead_log/**', 'src/storage/memtable/**', 'src/services/**']`.
- **Glob form confirmed empirically**, not assumed: #1320 touched the direct child `src/query/table_write_executor.rs` and its `Rust Integration Tests (query)` lane ran `SUCCESS` — so `src/**`-style globstars do match direct children, meaning `src/services/**` will match `src/services/system_catalog.rs` (the actual #1406 culprit).
- `make work-commit-check` green.

Ref TD-RECALL-2, #1406, #1425.