### PR TITLE
docs(v1): tighten the v1-proto ratchet floor and correct TD-V1SUNSET-1's stale state

### DIFF
--- a/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
+++ b/docs/10-quality/td/TD-V1SUNSET-1-rest-grpc-sunset-cutover.adoc
@@ -3,7 +3,7 @@
 = TD-V1SUNSET-1: v1 REST/gRPC sunset cutover — execution plan
 :toc: macro
 :icons: font
-:last-updated: 2026-07-09
+:last-updated: 2026-08-05
 
 [cols="1,3", options="header"]
 |===
@@ -24,16 +24,29 @@ the live-vs-deprecated boundary, or the one prerequisite that is easy to miss (t
 deprecation-header utility imported by *live* handlers). This TD captures that
 execution detail so the cutover is mechanical once the sunset window closes.
 
-== Current state (verified 2026-07-09)
+== Current state (re-verified 2026-08-05)
 
 === Kill-switches
 
 * **REST v1** — `src/network/middleware/v1_sunset.rs`. `rest_v1_compat_enabled()`
-  reads `PROXIMADB_REST_V1_COMPAT`; `parse_compat_flag` at line 65 maps
-  `None => true` (**default ON**). The middleware (`v1_sunset_middleware`, line 72)
+  reads `PROXIMADB_REST_V1_COMPAT`; `parse_compat_flag` maps
+  `None => false` (**default OFF**). The middleware (`v1_sunset_middleware`)
   returns `410 Gone` + RFC 8594 headers for any `/api/v1/` path when compat is off.
   Mounted at `src/network/rest/server.rs:494-498` (multi-port) and `:820-824`
-  (unified). **Flip = change line 65 `None => true,` → `None => false,`.**
+  (unified).
++
+[NOTE]
+====
+**The flip is DONE — this bullet used to say the opposite.** Until 2026-08-05
+this section read `None => true` (**default ON**) and instructed
+"*Flip = change line 65 `None => true,` → `None => false,`*". That instruction
+was already stale when written down here: `9c9b04669` (#814,
+"flip REST v1 sunset default OFF — /api/v1 now returns 410") had landed the
+change, and the Status field above recorded it, but this body section was never
+updated to match. Anyone reading "Current state" alone would have concluded the
+cutover was still pending. `/api/v1/*` has returned `410 Gone` by default since
+#814; opting back in requires explicitly setting `PROXIMADB_REST_V1_COMPAT`.
+====
 
 * **gRPC v1** — `enable_grpc_v1_compat` / `PROXIMADB_GRPC_V1_COMPAT`,
   **default OFF** (`src/core/config/bootstrap_config.rs:454-458`,

--- a/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
+++ b/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
@@ -9,8 +9,8 @@
     "/v1_pb2/",
     "check_v1_proto_usage.py"
   ],
-  "file_count": 481,
-  "generated_at": "2026-07-08T04:19:03Z",
+  "file_count": 488,
+  "generated_at": "2026-08-05T01:39:21Z",
   "mode": "report",
   "patterns": [
     "proximadb_v1",
@@ -19,9 +19,9 @@
   ],
   "per_root": {
     "clients": 41,
-    "crates": 99,
-    "src": 2399,
-    "tests": 374
+    "crates": 294,
+    "src": 2058,
+    "tests": 377
   },
   "roots": [
     "src",
@@ -30,5 +30,5 @@
     "tests"
   ],
   "schema_version": 1,
-  "total": 2913
+  "total": 2770
 }


### PR DESCRIPTION
Two v1-sunset housekeeping items. Both are cases where the tracking artifact disagreed with the code.

## 1. Tighten the v1-proto ratchet floor (TD-123)

Baseline total references **2913 → 2770 (−143)**.

It's a *no-regression* gate, so leaving the floor at the stale number silently banked 143 references of headroom that future work could re-consume without ever failing CI. Re-running against the new floor reports `delta +0`.

Worth reading carefully, because the diff looks like a regression and isn't:

| | before | after |
|---|---|---|
| total references | 2913 | **2770** ↓ |
| file_count | 481 | 488 ↑ |
| `src` | 2399 | 2058 ↓ |
| `crates` | 99 | 294 ↑ |

Files went *up* while references went *down* — that's the root-monolith decomposition redistributing code out of `src/` into `crates/`. The ratchet gates on **references**, not file count.

## 2. Correct `Current state` in TD-V1SUNSET-1

The section claimed `parse_compat_flag` maps `None => true` (**default ON**) and instructed:

> **Flip = change line 65 `None => true,` → `None => false,`**

The code has read `None => false` since **`9c9b04669` (#814**, "flip REST v1 sunset default OFF — /api/v1 now returns 410"), confirmed with `git log -L` on the function. The TD's Status field already recorded #814 as landed — only this body section was left behind. So anyone reading "Current state" on its own would conclude the cutover was still pending, when `/api/v1/*` has actually returned `410 Gone` by default for weeks (opting back in needs an explicit `PROXIMADB_REST_V1_COMPAT`).

Fixed the bullet, added a NOTE recording what it used to say and why it was wrong — so the correction is auditable rather than a silent rewrite — and moved `:last-updated:` to the re-verification date.

## Verification

No behaviour change; a ratchet floor and a doc.

- v1 ratchet passes at the new floor (`delta +0`).
- `check_td_adr_unique.py` clean (341 TD ids).
- `make work-commit-check` green.

Ref TD-V1SUNSET-1, TD-123, #814.