### PR TITLE
feat(bench): add runnable Qdrant context-corridor adapter

### DIFF
--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -56,8 +56,18 @@ hnsw_iterative_scan = "strict_order"
 [[system]]
 id = "qdrant"
 role = "competitor"
-adapter_status = "planned"
+adapter_status = "runnable"
 comparison_surface = "point payload + filtered vector search"
+
+[system.adapter]
+runner_system = "qdrant"
+distance = "cosine"
+vector_index = "hnsw(m=16,ef_construct=100)"
+metadata_index = "keyword(partition)"
+hnsw_ef_search = 40
+write_visibility = "wait=true per batch"
+readiness_fence = "green status and empty update queue"
+query_endpoint = "/points/query"
 
 [[system]]
 id = "milvus"

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -82,11 +82,41 @@ unfiltered and metadata-filtered query for each deterministic target record. The
 metric is explicitly scoped as target-record presence in the top ten, not full-neighbour
 ground-truth recall.
 
+The Qdrant baseline uses point payload for the canonical record ID and typed filter fields, a
+keyword payload index created before ingest, and the universal Query Points API with cosine HNSW
+(`hnsw_ef = 40`). Every upsert uses `wait=true`, making write visibility explicit instead of adding
+an arbitrary settle interval. Before measuring queries, the runner also waits for collection status
+`green` and an empty update queue so publication-scale HNSW construction cannot overlap latency.
+Qdrant may intentionally use a full scan below its configured optimizer/query-planner thresholds;
+the captured collection telemetry discloses the actual indexed-vector count. Pin the server image
+recorded with published evidence; this example uses Qdrant v1.18.2:
+
+[source,bash]
+----
+docker run --rm -d --name context-qdrant \
+  -p 6333:6333 qdrant/qdrant:v1.18.2
+
+python3 scripts/bench/context_corridor.py \
+  --system qdrant \
+  --qdrant-url http://127.0.0.1:6333 \
+  --records 1000 \
+  --dimension 32 \
+  --queries 200 \
+  --output artifacts/context-corridor/qdrant-local.json
+----
+
+For Qdrant Cloud or an authenticated deployment, pass `--qdrant-api-key`; the key is sent only in
+the `api-key` header and is redacted from failed-run artifacts and console errors. The adapter
+retains Qdrant's per-query hardware usage counters and final collection telemetry as server
+signals, while unsupported object-store economics remain explicit `null` publication blockers.
+All three runnable adapters issue an unfiltered and metadata-filtered query for each deterministic
+target record.
+
 == Publication gate
 
 No cross-system winner, price/performance, or TAM-facing benchmark claim may be published until:
 
-* all six adapters are runnable (ProximaDB and pgvector are currently complete);
+* all six adapters are runnable (ProximaDB, pgvector, and Qdrant are currently complete);
 * each system runs at least five trials over at least one million records;
 * local, S3, Azure, and GCS configurations are represented where supported;
 * raw results, failed runs, commit/version, configuration, hardware, and dataset hash are retained;

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -50,9 +50,16 @@ REQUIRED_METRICS = (
 
 
 def request(
-    base: str, method: str, path: str, body: dict | None, timeout: float
+    base: str,
+    method: str,
+    path: str,
+    body: dict | None,
+    timeout: float,
+    extra_headers: dict[str, str] | None = None,
 ) -> tuple[Any, float]:
     headers = {"Accept": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
     payload = None
     if body is not None:
         headers["Content-Type"] = "application/json"
@@ -121,9 +128,16 @@ def peak_rss_bytes() -> int | None:
     return int(peak if sys.platform == "darwin" else peak * 1024)
 
 
-def sanitized_error(error: Exception, dsn: str) -> str:
-    message = str(error).replace(dsn, "<redacted-dsn>")
-    return re.sub(r"(?i)(password\s*=\s*)\S+", r"\1<redacted>", message)
+def sanitized_error(error: Exception, *secrets: str) -> str:
+    message = str(error)
+    for secret in secrets:
+        if secret:
+            message = message.replace(secret, "<redacted>")
+    return re.sub(
+        r"(?i)((?:password|api[-_ ]?key|token)\s*=\s*)\S+",
+        r"\1<redacted>",
+        message,
+    )
 
 
 def vector_literal(vector: list[float]) -> str:
@@ -440,6 +454,186 @@ class PgvectorAdapter:
             self.connection.close()
 
 
+class QdrantAdapter:
+    system_id = "qdrant"
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        timeout: float,
+        collection: str,
+    ) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", collection):
+            raise ValueError("generated Qdrant collection name is not safe")
+        self.base_url = base_url
+        self.timeout = timeout
+        self.collection = collection
+        self.headers = {"api-key": api_key} if api_key else {}
+        self.version = "unknown"
+        self.query_usage: dict[str, float] = {}
+        self.readiness_wait_seconds = 0.0
+
+    def _request(
+        self, method: str, path: str, body: dict | None
+    ) -> tuple[Any, float]:
+        return request(
+            self.base_url,
+            method,
+            path,
+            body,
+            self.timeout,
+            self.headers,
+        )
+
+    def prepare(self, dimension: int) -> None:
+        service, _ = self._request("GET", "/", None)
+        if isinstance(service, dict) and isinstance(service.get("version"), str):
+            self.version = service["version"]
+        self._request(
+            "PUT",
+            f"/collections/{self.collection}",
+            {
+                "vectors": {"size": dimension, "distance": "Cosine"},
+                "hnsw_config": {"m": 16, "ef_construct": 100},
+            },
+        )
+        # Qdrant recommends creating payload indexes before ingest so filtered
+        # queries never measure an unindexed payload scan.
+        self._request(
+            "PUT",
+            f"/collections/{self.collection}/index?wait=true",
+            {"field_name": "partition", "field_schema": "keyword"},
+        )
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        points = [
+            {
+                # Qdrant point IDs are unsigned integers or UUIDs. Retain the
+                # canonical cross-system ID in payload for result comparison.
+                "id": record["props"]["ordinal"],
+                "vector": record["vector"],
+                "payload": {"record_id": record["id"], **record["props"]},
+            }
+            for record in records
+        ]
+        self._request(
+            "PUT",
+            f"/collections/{self.collection}/points?wait=true",
+            {"points": points},
+        )
+
+    def finish_ingest(self) -> None:
+        # wait=true makes each batch visible, but HNSW segment construction is
+        # asynchronous once the optimizer threshold is crossed. Do not begin
+        # latency measurement while that background work is still active.
+        started = time.monotonic()
+        deadline = started + self.timeout
+        while True:
+            payload, _ = self._request(
+                "GET", f"/collections/{self.collection}", None
+            )
+            result = payload.get("result") if isinstance(payload, dict) else None
+            status = result.get("status") if isinstance(result, dict) else None
+            queue = result.get("update_queue") if isinstance(result, dict) else None
+            queue_length = queue.get("length", 0) if isinstance(queue, dict) else 0
+            if status == "green" and queue_length == 0:
+                self.readiness_wait_seconds = time.monotonic() - started
+                return
+            if status == "red":
+                optimizer = (
+                    result.get("optimizer_status")
+                    if isinstance(result, dict)
+                    else "unknown"
+                )
+                raise RuntimeError(f"Qdrant collection optimizer failed: {optimizer}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    "Qdrant collection did not reach green status with an empty "
+                    f"update queue within {self.timeout:g}s"
+                )
+            time.sleep(min(0.25, remaining))
+
+    def _accumulate_usage(self, payload: dict[str, Any]) -> None:
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            return
+        hardware = usage.get("hardware", usage)
+        if not isinstance(hardware, dict):
+            return
+        for name, value in hardware.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                self.query_usage[name] = self.query_usage.get(name, 0.0) + value
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        body: dict[str, Any] = {
+            "query": record["vector"],
+            "limit": TOP_K,
+            "with_payload": ["record_id"],
+            "params": {"hnsw_ef": 40, "exact": False},
+        }
+        if filtered:
+            body["filter"] = {
+                "must": [
+                    {
+                        "key": "partition",
+                        "match": {"value": record["props"]["partition"]},
+                    }
+                ]
+            }
+        payload, latency = self._request(
+            "POST",
+            f"/collections/{self.collection}/points/query",
+            body,
+        )
+        if not isinstance(payload, dict):
+            return [], latency
+        self._accumulate_usage(payload)
+        result = payload.get("result")
+        points = result.get("points") if isinstance(result, dict) else None
+        found: list[str] = []
+        for point in points if isinstance(points, list) else []:
+            point_payload = point.get("payload") if isinstance(point, dict) else None
+            record_id = (
+                point_payload.get("record_id")
+                if isinstance(point_payload, dict)
+                else None
+            )
+            if isinstance(record_id, str):
+                found.append(record_id)
+        return found[:TOP_K], latency
+
+    def signals(self) -> dict[str, Any]:
+        collection_info, _ = self._request(
+            "GET", f"/collections/{self.collection}", None
+        )
+        return {
+            "collection_info": collection_info,
+            "query_usage_totals": self.query_usage,
+        }
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "server_version": self.version,
+            "distance": "cosine",
+            "index": "hnsw(m=16,ef_construct=100)",
+            "hnsw_ef_search": 40,
+            "filter_index": "keyword(partition)",
+            "query_endpoint": "/points/query",
+            "write_visibility": "wait=true per batch",
+            "readiness_fence": "green status and empty update queue",
+            "readiness_wait_seconds": round(self.readiness_wait_seconds, 6),
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if not keep_data:
+            self._request("DELETE", f"/collections/{self.collection}", None)
+
+
 def ingest_stream(
     adapter: Adapter,
     *,
@@ -598,19 +792,34 @@ def write_report(path: Path, report: dict[str, Any]) -> None:
 def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
     if args.system == "proximadb":
         return ProximaAdapter(args.base_url, args.timeout, run_name)
-    return PgvectorAdapter(args.pg_dsn, run_name)
+    if args.system == "pgvector":
+        return PgvectorAdapter(args.pg_dsn, run_name)
+    return QdrantAdapter(
+        args.qdrant_url,
+        args.qdrant_api_key,
+        args.timeout,
+        run_name,
+    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--system", choices=("proximadb", "pgvector"), default="proximadb"
+        "--system",
+        choices=("proximadb", "pgvector", "qdrant"),
+        default="proximadb",
     )
     parser.add_argument("--base-url", default="http://127.0.0.1:5678")
     parser.add_argument(
         "--pg-dsn",
         default="postgresql://postgres:postgres@127.0.0.1:5432/postgres",
         help="pgvector PostgreSQL DSN; never written to the report",
+    )
+    parser.add_argument("--qdrant-url", default="http://127.0.0.1:6333")
+    parser.add_argument(
+        "--qdrant-api-key",
+        default="",
+        help="optional Qdrant API key; never written to the report",
     )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
@@ -622,8 +831,16 @@ def main() -> int:
     parser.add_argument("--keep-data", action="store_true")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    if min(args.records, args.dimension, args.queries, args.batch_size) <= 0:
-        parser.error("records, dimension, queries, and batch-size must be positive")
+    if min(
+        args.records,
+        args.dimension,
+        args.queries,
+        args.batch_size,
+        args.timeout,
+    ) <= 0:
+        parser.error(
+            "records, dimension, queries, batch-size, and timeout must be positive"
+        )
     if args.warmup < 0:
         parser.error("warmup must be non-negative")
 
@@ -665,6 +882,7 @@ def main() -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0
     except Exception as exc:  # Failed runs are evidence and must be retained.
+        safe_error = sanitized_error(exc, args.pg_dsn, args.qdrant_api_key)
         failure = {
             "schema_version": 1,
             "scenario_id": SCENARIO_ID,
@@ -672,17 +890,23 @@ def main() -> int:
             "status": "failed",
             "commit_sha": git_sha(root),
             "error_type": type(exc).__name__,
-            "error": sanitized_error(exc, args.pg_dsn),
+            "error": safe_error,
             "publication_eligible": False,
         }
         write_report(args.output, failure)
-        print(f"context corridor FAILED: {exc}", file=sys.stderr)
+        print(f"context corridor FAILED: {safe_error}", file=sys.stderr)
         return 1
     finally:
         try:
             adapter.close(keep_data=args.keep_data)
         except Exception as cleanup_error:
-            print(f"context corridor cleanup warning: {cleanup_error}", file=sys.stderr)
+            safe_cleanup_error = sanitized_error(
+                cleanup_error, args.pg_dsn, args.qdrant_api_key
+            )
+            print(
+                f"context corridor cleanup warning: {safe_cleanup_error}",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/validate_context_benchmark.py
+++ b/scripts/validate_context_benchmark.py
@@ -46,8 +46,30 @@ def main() -> int:
     runnable = {
         item.get("id") for item in data.get("system", []) if item.get("adapter_status") == "runnable"
     }
-    if runnable != {"pgvector", "proximadb"}:
-        errors.append("the implemented ProximaDB and pgvector adapters must be marked runnable")
+    if runnable != {"pgvector", "proximadb", "qdrant"}:
+        errors.append(
+            "the implemented ProximaDB, pgvector, and Qdrant adapters must be marked runnable"
+        )
+    qdrant = next(
+        (item for item in data.get("system", []) if item.get("id") == "qdrant"),
+        {},
+    )
+    qdrant_adapter = qdrant.get("adapter", {})
+    expected_qdrant_adapter = {
+        "runner_system": "qdrant",
+        "distance": "cosine",
+        "vector_index": "hnsw(m=16,ef_construct=100)",
+        "metadata_index": "keyword(partition)",
+        "hnsw_ef_search": 40,
+        "write_visibility": "wait=true per batch",
+        "readiness_fence": "green status and empty update queue",
+        "query_endpoint": "/points/query",
+    }
+    if qdrant_adapter != expected_qdrant_adapter:
+        errors.append(
+            "Qdrant adapter contract must disclose the pinned filter, ANN, "
+            "visibility, and readiness settings"
+        )
     protocol = data.get("protocol", {})
     metrics = set(protocol.get("required_metrics", []))
     missing_metrics = REQUIRED_METRICS - metrics
@@ -81,7 +103,8 @@ def main() -> int:
         return 1
     print(
         "Context benchmark contract OK: 6 systems, 13 metrics, 4 backends, "
-        "five-trial/1M publication floor; ProximaDB and pgvector adapters are runnable."
+        "five-trial/1M publication floor; ProximaDB, pgvector, and Qdrant "
+        "adapters are runnable."
     )
     return 0
 

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -163,12 +163,163 @@ class ContextCorridorTest(unittest.TestCase):
         self.assertEqual(environment["hnsw_ef_search"], 40)
         self.assertEqual(environment["hnsw_iterative_scan"], "strict_order")
 
+    def test_qdrant_collection_name_is_path_safe(self) -> None:
+        with self.assertRaises(ValueError):
+            CONTEXT.QdrantAdapter(
+                "http://qdrant.example", "", 30.0, "bad/collection"
+            )
+
+    def test_qdrant_prepare_and_insert_contract(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args):
+            calls.append(args)
+            if args[1:4] == ("GET", "/", None):
+                return {"version": "1.18.2"}, 0.5
+            return {"status": "ok"}, 0.5
+
+        adapter = CONTEXT.QdrantAdapter(
+            "http://qdrant.example", "private-key", 12.0, "context_corridor"
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+            adapter.insert_batch([record])
+
+        self.assertEqual(adapter.version, "1.18.2")
+        self.assertEqual(
+            calls[1][1:4],
+            (
+                "PUT",
+                "/collections/context_corridor",
+                {
+                    "vectors": {"size": 2, "distance": "Cosine"},
+                    "hnsw_config": {"m": 16, "ef_construct": 100},
+                },
+            ),
+        )
+        self.assertEqual(
+            calls[2][1:4],
+            (
+                "PUT",
+                "/collections/context_corridor/index?wait=true",
+                {"field_name": "partition", "field_schema": "keyword"},
+            ),
+        )
+        self.assertEqual(calls[3][2], "/collections/context_corridor/points?wait=true")
+        self.assertEqual(
+            calls[3][3]["points"],
+            [
+                {
+                    "id": 7,
+                    "vector": [0.25, -0.5],
+                    "payload": {
+                        "record_id": "rec-7",
+                        "partition": "p7",
+                        "ordinal": 7,
+                    },
+                }
+            ],
+        )
+        self.assertEqual(calls[0][5], {"api-key": "private-key"})
+
+    def test_qdrant_filtered_query_contract_and_usage_signals(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args):
+            calls.append(args)
+            return (
+                {
+                    "usage": {
+                        "hardware": {"cpu": 2, "payload_index_io_read": 1}
+                    },
+                    "result": {
+                        "points": [
+                            {"id": 7, "payload": {"record_id": "rec-7"}}
+                        ]
+                    },
+                },
+                1.25,
+            )
+
+        adapter = CONTEXT.QdrantAdapter(
+            "http://qdrant.example", "", 12.0, "context_corridor"
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            found, latency = adapter.search(record, filtered=True)
+
+        self.assertEqual(found, ["rec-7"])
+        self.assertEqual(latency, 1.25)
+        self.assertEqual(calls[0][2], "/collections/context_corridor/points/query")
+        query = calls[0][3]
+        self.assertEqual(query["params"], {"hnsw_ef": 40, "exact": False})
+        self.assertEqual(query["with_payload"], ["record_id"])
+        self.assertEqual(
+            query["filter"],
+            {"must": [{"key": "partition", "match": {"value": "p7"}}]},
+        )
+        self.assertEqual(
+            adapter.query_usage, {"cpu": 2.0, "payload_index_io_read": 1.0}
+        )
+
+    def test_qdrant_ingest_waits_for_optimizer_readiness(self) -> None:
+        responses = [
+            {
+                "result": {
+                    "status": "yellow",
+                    "update_queue": {"length": 3},
+                }
+            },
+            {
+                "result": {
+                    "status": "green",
+                    "update_queue": {"length": 0},
+                }
+            },
+        ]
+        adapter = CONTEXT.QdrantAdapter(
+            "http://qdrant.example", "", 12.0, "context_corridor"
+        )
+        with (
+            patch.object(
+                CONTEXT,
+                "request",
+                side_effect=[(payload, 0.5) for payload in responses],
+            ) as mocked_request,
+            patch.object(CONTEXT.time, "sleep") as mocked_sleep,
+        ):
+            adapter.finish_ingest()
+
+        self.assertEqual(mocked_request.call_count, 2)
+        mocked_sleep.assert_called_once_with(0.25)
+        self.assertGreaterEqual(adapter.readiness_wait_seconds, 0.0)
+
+    def test_qdrant_environment_does_not_disclose_api_key(self) -> None:
+        adapter = CONTEXT.QdrantAdapter(
+            "http://qdrant.example", "private-key", 12.0, "context_corridor"
+        )
+        self.assertNotIn("private-key", json.dumps(adapter.environment()))
+        self.assertEqual(adapter.environment()["hnsw_ef_search"], 40)
+
     def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
         dsn = "postgresql://alice:secret@db.example/test"
-        error = RuntimeError(f"could not use {dsn}; password=second-secret")
-        sanitized = CONTEXT.sanitized_error(error, dsn)
+        api_key = "qdrant-private-key"
+        error = RuntimeError(
+            f"could not use {dsn}; password=second-secret; api-key={api_key}"
+        )
+        sanitized = CONTEXT.sanitized_error(error, dsn, api_key)
         self.assertNotIn("secret", sanitized)
-        self.assertIn("<redacted-dsn>", sanitized)
+        self.assertNotIn(api_key, sanitized)
+        self.assertIn("<redacted>", sanitized)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on #1427 for the agreed merge order. Auto-merge should remain disabled until #1427 lands.\n\nAdds a dependency-free Qdrant REST adapter to context-corridor-v1 with canonical ID mapping, indexed metadata filtering, explicit HNSW/query settings, synchronous write visibility, optimizer readiness fencing, server telemetry, and credential redaction. Marks Qdrant runnable in the machine contract and documents a pinned v1.18.2 invocation.\n\nVerified with 12 Python contract tests, make work-commit-check across 119 workspace crates, and a live Qdrant v1.18.2 run over 1,000 records (filtered and unfiltered target Recall@10 = 1.0). The smoke artifact remains publication-ineligible and discloses that Qdrant selected full scan below its HNSW thresholds.