### PR TITLE
feat(bench): add runnable Milvus context-corridor adapter

### DIFF
--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -72,8 +72,18 @@ query_endpoint = "/points/query"
 [[system]]
 id = "milvus"
 role = "competitor"
-adapter_status = "planned"
+adapter_status = "runnable"
 comparison_surface = "collection scalar fields + filtered ANN"
+
+[system.adapter]
+runner_system = "milvus"
+distance = "cosine"
+vector_index = "hnsw(M=16,efConstruction=100)"
+metadata_index = "bitmap(partition)"
+hnsw_ef_search = 40
+consistency_level = "Strong"
+readiness_fence = "flush + loaded + vector/scalar indexes finished"
+query_endpoint = "/v2/vectordb/entities/search"
 
 [[system]]
 id = "elasticsearch"

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -112,11 +112,42 @@ signals, while unsupported object-store economics remain explicit `null` publica
 All three runnable adapters issue an unfiltered and metadata-filtered query for each deterministic
 target record.
 
+The Milvus baseline uses an explicit schema rather than dynamic fields: a VARCHAR primary key,
+FLOAT_VECTOR embedding, VARCHAR partition, and INT64 ordinal. It builds HNSW
+(`M = 16`, `efConstruction = 100`) plus a BITMAP index suited to the eight-value partition field,
+uses strong collection consistency, and searches with `ef = 40`. After ingest, the runner flushes
+streaming data and waits for 100% collection load plus `Finished` state with zero pending rows on
+both indexes. Use the release-provided standalone manifest and retain its exact image digest with
+published evidence; this example pins the current stable Milvus v3.0.0 release:
+
+[source,bash]
+----
+curl -fsSL \
+  https://github.com/milvus-io/milvus/releases/download/v3.0.0/milvus-standalone-docker-compose.yml \
+  -o /tmp/milvus-standalone-v3.0.0.yml
+docker compose -f /tmp/milvus-standalone-v3.0.0.yml up -d
+
+python3 scripts/bench/context_corridor.py \
+  --system milvus \
+  --milvus-url http://127.0.0.1:19530 \
+  --milvus-token root:Milvus \
+  --milvus-server-version 3.0.0 \
+  --records 1000 \
+  --dimension 32 \
+  --queries 200 \
+  --output artifacts/context-corridor/milvus-local.json
+----
+
+The token is used only as a bearer credential and is redacted from failed-run artifacts and console
+errors. Milvus v2 REST does not expose the server version, so `--milvus-server-version` is an
+operator declaration that must be checked against the retained container digest before publication.
+Collection, load-state, HNSW, and scalar-index descriptions are captured as server signals.
+
 == Publication gate
 
 No cross-system winner, price/performance, or TAM-facing benchmark claim may be published until:
 
-* all six adapters are runnable (ProximaDB, pgvector, and Qdrant are currently complete);
+* all six adapters are runnable (ProximaDB, pgvector, Qdrant, and Milvus are currently complete);
 * each system runs at least five trials over at least one million records;
 * local, S3, Azure, and GCS configurations are represented where supported;
 * raw results, failed runs, commit/version, configuration, hardware, and dataset hash are retained;

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -634,6 +634,239 @@ class QdrantAdapter:
             self._request("DELETE", f"/collections/{self.collection}", None)
 
 
+class MilvusAdapter:
+    system_id = "milvus"
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        timeout: float,
+        collection: str,
+        declared_server_version: str,
+    ) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_]+", collection):
+            raise ValueError("generated Milvus collection name is not safe")
+        self.base_url = base_url
+        self.timeout = timeout
+        self.collection = collection
+        self.declared_server_version = declared_server_version
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Request-Timeout": str(max(1, math.ceil(timeout))),
+        }
+        self.readiness_wait_seconds = 0.0
+
+    def _request(self, path: str, body: dict) -> tuple[dict[str, Any], float]:
+        payload, latency = request(
+            self.base_url,
+            "POST",
+            path,
+            body,
+            self.timeout,
+            self.headers,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Milvus {path} returned a non-object response")
+        if payload.get("code") != 0:
+            raise RuntimeError(
+                f"Milvus {path} failed with code {payload.get('code')}: "
+                f"{payload.get('message', 'unknown error')}"
+            )
+        return payload, latency
+
+    def prepare(self, dimension: int) -> None:
+        self._request(
+            "/v2/vectordb/collections/create",
+            {
+                "collectionName": self.collection,
+                "schema": {
+                    "autoID": False,
+                    "enableDynamicField": False,
+                    "fields": [
+                        {
+                            "fieldName": "id",
+                            "dataType": "VarChar",
+                            "isPrimary": True,
+                            "elementTypeParams": {"max_length": 64},
+                        },
+                        {
+                            "fieldName": "embedding",
+                            "dataType": "FloatVector",
+                            "elementTypeParams": {"dim": dimension},
+                        },
+                        {
+                            "fieldName": "partition",
+                            "dataType": "VarChar",
+                            "elementTypeParams": {"max_length": 16},
+                        },
+                        {"fieldName": "ordinal", "dataType": "Int64"},
+                    ],
+                },
+                "indexParams": [
+                    {
+                        "fieldName": "embedding",
+                        "indexName": "embedding_hnsw_idx",
+                        "metricType": "COSINE",
+                        "params": {
+                            "index_type": "HNSW",
+                            "M": 16,
+                            "efConstruction": 100,
+                        },
+                    },
+                    {
+                        "fieldName": "partition",
+                        "indexName": "partition_bitmap_idx",
+                        "params": {"index_type": "BITMAP"},
+                    },
+                ],
+                "consistencyLevel": "Strong",
+            },
+        )
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        entities = [
+            {
+                "id": record["id"],
+                "embedding": record["vector"],
+                "partition": record["props"]["partition"],
+                "ordinal": record["props"]["ordinal"],
+            }
+            for record in records
+        ]
+        payload, _ = self._request(
+            "/v2/vectordb/entities/insert",
+            {"collectionName": self.collection, "data": entities},
+        )
+        data = payload.get("data")
+        inserted = data.get("insertCount") if isinstance(data, dict) else None
+        if inserted != len(records):
+            raise RuntimeError(
+                f"Milvus acknowledged {inserted!r} of {len(records)} inserted records"
+            )
+
+    def _index_ready(self, name: str) -> bool:
+        payload, _ = self._request(
+            "/v2/vectordb/indexes/describe",
+            {"collectionName": self.collection, "indexName": name},
+        )
+        indexes = payload.get("data")
+        if not isinstance(indexes, list) or len(indexes) != 1:
+            return False
+        index = indexes[0]
+        if not isinstance(index, dict):
+            return False
+        if index.get("indexState") == "Failed":
+            raise RuntimeError(
+                f"Milvus index {name} failed: {index.get('failReason', 'unknown')}"
+            )
+        return index.get("indexState") == "Finished" and index.get("pendingRows", 0) == 0
+
+    def finish_ingest(self) -> None:
+        self._request(
+            "/v2/vectordb/collections/flush",
+            {"collectionName": self.collection},
+        )
+        started = time.monotonic()
+        deadline = started + self.timeout
+        while True:
+            load, _ = self._request(
+                "/v2/vectordb/collections/get_load_state",
+                {"collectionName": self.collection},
+            )
+            load_data = load.get("data")
+            loaded = (
+                isinstance(load_data, dict)
+                and load_data.get("loadState") == "LoadStateLoaded"
+                and load_data.get("loadProgress") == 100
+            )
+            vector_ready = self._index_ready("embedding_hnsw_idx")
+            scalar_ready = self._index_ready("partition_bitmap_idx")
+            if loaded and vector_ready and scalar_ready:
+                self.readiness_wait_seconds = time.monotonic() - started
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    "Milvus collection and indexes did not become fully loaded "
+                    f"within {self.timeout:g}s"
+                )
+            time.sleep(min(0.25, remaining))
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        body: dict[str, Any] = {
+            "collectionName": self.collection,
+            "data": [record["vector"]],
+            "annsField": "embedding",
+            "limit": TOP_K,
+            "outputFields": ["id"],
+            "searchParams": {
+                "metricType": "COSINE",
+                "params": {"ef": 40},
+            },
+        }
+        if filtered:
+            partition = json.dumps(record["props"]["partition"])
+            body["filter"] = f"partition == {partition}"
+        payload, latency = self._request(
+            "/v2/vectordb/entities/search",
+            body,
+        )
+        values = payload.get("data")
+        found = [
+            value["id"]
+            for value in (values if isinstance(values, list) else [])
+            if isinstance(value, dict) and isinstance(value.get("id"), str)
+        ]
+        return found[:TOP_K], latency
+
+    def signals(self) -> dict[str, Any]:
+        common = {"collectionName": self.collection}
+        collection, _ = self._request(
+            "/v2/vectordb/collections/describe", common
+        )
+        load, _ = self._request(
+            "/v2/vectordb/collections/get_load_state", common
+        )
+        vector_index, _ = self._request(
+            "/v2/vectordb/indexes/describe",
+            {**common, "indexName": "embedding_hnsw_idx"},
+        )
+        scalar_index, _ = self._request(
+            "/v2/vectordb/indexes/describe",
+            {**common, "indexName": "partition_bitmap_idx"},
+        )
+        return {
+            "collection": collection,
+            "load_state": load,
+            "vector_index": vector_index,
+            "scalar_index": scalar_index,
+        }
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "server_version": self.declared_server_version,
+            "server_version_source": "operator-declared (v2 REST does not expose it)",
+            "consistency_level": "Strong",
+            "distance": "cosine",
+            "index": "hnsw(M=16,efConstruction=100)",
+            "hnsw_ef_search": 40,
+            "filter_index": "bitmap(partition)",
+            "readiness_fence": "flush + loaded + vector/scalar indexes finished",
+            "readiness_wait_seconds": round(self.readiness_wait_seconds, 6),
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if not keep_data:
+            self._request(
+                "/v2/vectordb/collections/drop",
+                {"collectionName": self.collection},
+            )
+
+
 def ingest_stream(
     adapter: Adapter,
     *,
@@ -794,11 +1027,19 @@ def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
         return ProximaAdapter(args.base_url, args.timeout, run_name)
     if args.system == "pgvector":
         return PgvectorAdapter(args.pg_dsn, run_name)
-    return QdrantAdapter(
-        args.qdrant_url,
-        args.qdrant_api_key,
+    if args.system == "qdrant":
+        return QdrantAdapter(
+            args.qdrant_url,
+            args.qdrant_api_key,
+            args.timeout,
+            run_name,
+        )
+    return MilvusAdapter(
+        args.milvus_url,
+        args.milvus_token,
         args.timeout,
         run_name,
+        args.milvus_server_version,
     )
 
 
@@ -806,7 +1047,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--system",
-        choices=("proximadb", "pgvector", "qdrant"),
+        choices=("proximadb", "pgvector", "qdrant", "milvus"),
         default="proximadb",
     )
     parser.add_argument("--base-url", default="http://127.0.0.1:5678")
@@ -820,6 +1061,17 @@ def main() -> int:
         "--qdrant-api-key",
         default="",
         help="optional Qdrant API key; never written to the report",
+    )
+    parser.add_argument("--milvus-url", default="http://127.0.0.1:19530")
+    parser.add_argument(
+        "--milvus-token",
+        default="root:Milvus",
+        help="Milvus bearer token; never written to the report",
+    )
+    parser.add_argument(
+        "--milvus-server-version",
+        default="unknown",
+        help="deployed Milvus version recorded in the report",
     )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
@@ -882,7 +1134,9 @@ def main() -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0
     except Exception as exc:  # Failed runs are evidence and must be retained.
-        safe_error = sanitized_error(exc, args.pg_dsn, args.qdrant_api_key)
+        safe_error = sanitized_error(
+            exc, args.pg_dsn, args.qdrant_api_key, args.milvus_token
+        )
         failure = {
             "schema_version": 1,
             "scenario_id": SCENARIO_ID,
@@ -901,7 +1155,10 @@ def main() -> int:
             adapter.close(keep_data=args.keep_data)
         except Exception as cleanup_error:
             safe_cleanup_error = sanitized_error(
-                cleanup_error, args.pg_dsn, args.qdrant_api_key
+                cleanup_error,
+                args.pg_dsn,
+                args.qdrant_api_key,
+                args.milvus_token,
             )
             print(
                 f"context corridor cleanup warning: {safe_cleanup_error}",

--- a/scripts/validate_context_benchmark.py
+++ b/scripts/validate_context_benchmark.py
@@ -46,9 +46,10 @@ def main() -> int:
     runnable = {
         item.get("id") for item in data.get("system", []) if item.get("adapter_status") == "runnable"
     }
-    if runnable != {"pgvector", "proximadb", "qdrant"}:
+    if runnable != {"milvus", "pgvector", "proximadb", "qdrant"}:
         errors.append(
-            "the implemented ProximaDB, pgvector, and Qdrant adapters must be marked runnable"
+            "the implemented ProximaDB, pgvector, Qdrant, and Milvus adapters "
+            "must be marked runnable"
         )
     qdrant = next(
         (item for item in data.get("system", []) if item.get("id") == "qdrant"),
@@ -69,6 +70,25 @@ def main() -> int:
         errors.append(
             "Qdrant adapter contract must disclose the pinned filter, ANN, "
             "visibility, and readiness settings"
+        )
+    milvus = next(
+        (item for item in data.get("system", []) if item.get("id") == "milvus"),
+        {},
+    )
+    expected_milvus_adapter = {
+        "runner_system": "milvus",
+        "distance": "cosine",
+        "vector_index": "hnsw(M=16,efConstruction=100)",
+        "metadata_index": "bitmap(partition)",
+        "hnsw_ef_search": 40,
+        "consistency_level": "Strong",
+        "readiness_fence": "flush + loaded + vector/scalar indexes finished",
+        "query_endpoint": "/v2/vectordb/entities/search",
+    }
+    if milvus.get("adapter", {}) != expected_milvus_adapter:
+        errors.append(
+            "Milvus adapter contract must disclose the pinned scalar/vector "
+            "indexes, consistency, and readiness settings"
         )
     protocol = data.get("protocol", {})
     metrics = set(protocol.get("required_metrics", []))
@@ -103,8 +123,8 @@ def main() -> int:
         return 1
     print(
         "Context benchmark contract OK: 6 systems, 13 metrics, 4 backends, "
-        "five-trial/1M publication floor; ProximaDB, pgvector, and Qdrant "
-        "adapters are runnable."
+        "five-trial/1M publication floor; ProximaDB, pgvector, Qdrant, and "
+        "Milvus adapters are runnable."
     )
     return 0
 

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -310,15 +310,171 @@ class ContextCorridorTest(unittest.TestCase):
         self.assertNotIn("private-key", json.dumps(adapter.environment()))
         self.assertEqual(adapter.environment()["hnsw_ef_search"], 40)
 
+    def test_milvus_collection_name_is_path_safe(self) -> None:
+        with self.assertRaises(ValueError):
+            CONTEXT.MilvusAdapter(
+                "http://milvus.example",
+                "private-token",
+                30.0,
+                "bad-collection",
+                "3.0.0",
+            )
+
+    def test_milvus_prepare_and_insert_contract(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args):
+            calls.append(args)
+            if args[2] == "/v2/vectordb/entities/insert":
+                return {"code": 0, "data": {"insertCount": 1}}, 0.5
+            return {"code": 0, "data": {}}, 0.5
+
+        adapter = CONTEXT.MilvusAdapter(
+            "http://milvus.example",
+            "private-token",
+            12.0,
+            "context_corridor",
+            "3.0.0",
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+            adapter.insert_batch([record])
+
+        self.assertEqual(calls[0][2], "/v2/vectordb/collections/create")
+        create = calls[0][3]
+        self.assertEqual(create["consistencyLevel"], "Strong")
+        self.assertFalse(create["schema"]["enableDynamicField"])
+        self.assertEqual(
+            create["indexParams"],
+            [
+                {
+                    "fieldName": "embedding",
+                    "indexName": "embedding_hnsw_idx",
+                    "metricType": "COSINE",
+                    "params": {
+                        "index_type": "HNSW",
+                        "M": 16,
+                        "efConstruction": 100,
+                    },
+                },
+                {
+                    "fieldName": "partition",
+                    "indexName": "partition_bitmap_idx",
+                    "params": {"index_type": "BITMAP"},
+                },
+            ],
+        )
+        self.assertEqual(
+            calls[1][3]["data"],
+            [
+                {
+                    "id": "rec-7",
+                    "embedding": [0.25, -0.5],
+                    "partition": "p7",
+                    "ordinal": 7,
+                }
+            ],
+        )
+        self.assertEqual(calls[0][5]["Authorization"], "Bearer private-token")
+
+    def test_milvus_filtered_search_contract_and_result_mapping(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args):
+            calls.append(args)
+            return {"code": 0, "data": [{"id": "rec-7", "distance": 1.0}]}, 1.25
+
+        adapter = CONTEXT.MilvusAdapter(
+            "http://milvus.example",
+            "private-token",
+            12.0,
+            "context_corridor",
+            "3.0.0",
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            found, latency = adapter.search(record, filtered=True)
+
+        self.assertEqual(found, ["rec-7"])
+        self.assertEqual(latency, 1.25)
+        self.assertEqual(calls[0][2], "/v2/vectordb/entities/search")
+        search = calls[0][3]
+        self.assertEqual(search["filter"], 'partition == "p7"')
+        self.assertEqual(
+            search["searchParams"],
+            {"metricType": "COSINE", "params": {"ef": 40}},
+        )
+
+    def test_milvus_ingest_waits_for_load_and_both_indexes(self) -> None:
+        adapter = CONTEXT.MilvusAdapter(
+            "http://milvus.example",
+            "private-token",
+            12.0,
+            "context_corridor",
+            "3.0.0",
+        )
+        finished_index = {
+            "data": [
+                {
+                    "indexState": "Finished",
+                    "pendingRows": 0,
+                }
+            ]
+        }
+        responses = [
+            ({"data": {}}, 0.5),
+            (
+                {
+                    "data": {
+                        "loadState": "LoadStateLoaded",
+                        "loadProgress": 100,
+                    }
+                },
+                0.5,
+            ),
+            (finished_index, 0.5),
+            (finished_index, 0.5),
+        ]
+        with patch.object(adapter, "_request", side_effect=responses) as mocked:
+            adapter.finish_ingest()
+
+        self.assertEqual(mocked.call_count, 4)
+        self.assertGreaterEqual(adapter.readiness_wait_seconds, 0.0)
+
+    def test_milvus_environment_does_not_disclose_token(self) -> None:
+        adapter = CONTEXT.MilvusAdapter(
+            "http://milvus.example",
+            "private-token",
+            12.0,
+            "context_corridor",
+            "3.0.0",
+        )
+        environment = adapter.environment()
+        self.assertNotIn("private-token", json.dumps(environment))
+        self.assertEqual(environment["hnsw_ef_search"], 40)
+        self.assertEqual(environment["server_version"], "3.0.0")
+
     def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
         dsn = "postgresql://alice:secret@db.example/test"
         api_key = "qdrant-private-key"
+        milvus_token = "milvus-private-token"
         error = RuntimeError(
-            f"could not use {dsn}; password=second-secret; api-key={api_key}"
+            f"could not use {dsn}; password=second-secret; api-key={api_key}; "
+            f"token={milvus_token}"
         )
-        sanitized = CONTEXT.sanitized_error(error, dsn, api_key)
+        sanitized = CONTEXT.sanitized_error(error, dsn, api_key, milvus_token)
         self.assertNotIn("secret", sanitized)
         self.assertNotIn(api_key, sanitized)
+        self.assertNotIn(milvus_token, sanitized)
         self.assertIn("<redacted>", sanitized)
 
 


### PR DESCRIPTION
Stacked after #1432, which is held behind #1427. Keep auto-merge disabled until the base PR is retargeted/merged in order.\n\nAdds a dependency-free Milvus v2 REST adapter with an explicit typed schema, HNSW cosine index, low-cardinality BITMAP partition index, strong consistency, flush/load/index readiness fencing, strict response-code and insert-count validation, telemetry capture, declared-version provenance, and token redaction. Marks Milvus runnable in the machine contract and documents the pinned current stable v3.0.0 deployment.\n\nVerified with 17 Python contract tests, make work-commit-check across 119 workspace crates, and a live Milvus v3.0.0 run over 1,000 records. Live evidence showed both indexes Finished, 1,000 indexed rows, zero pending rows, full collection load, and filtered/unfiltered target Recall@10 = 1.0. The smoke artifact remains publication-ineligible.