### PR TITLE
fix(v1): correct v1-proto ratchet baseline 2770→2771 (TD-123)

### DIFF
--- a/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
+++ b/docs/_internal/roadmap/V1_PROTO_USAGE_BASELINE.json
@@ -10,7 +10,7 @@
     "check_v1_proto_usage.py"
   ],
   "file_count": 488,
-  "generated_at": "2026-08-05T01:39:21Z",
+  "generated_at": "2026-08-05T03:38:09Z",
   "mode": "report",
   "patterns": [
     "proximadb_v1",
@@ -21,7 +21,7 @@
     "clients": 41,
     "crates": 294,
     "src": 2058,
-    "tests": 377
+    "tests": 378
   },
   "roots": [
     "src",
@@ -30,5 +30,5 @@
     "tests"
   ],
   "schema_version": 1,
-  "total": 2770
+  "total": 2771
 }


### PR DESCRIPTION
## What

Regenerates `V1_PROTO_USAGE_BASELINE.json` from `2770` → **`2771`** (the true v1-proto reference
count). One-file docs change; no code touched.

## Why

#1431 (`ead2cd170`, "tighten the v1-proto ratchet floor") lowered the baseline from the stale 2913 to
**2770**, but the actual count was already **2771** at that commit. Verified by running the checker at
each checkpoint:

| checkpoint | actual count |
|---|---|
| `#1431~1` (parent) | 2771 |
| `ead2cd170` (#1431) | 2771 |
| `origin/develop` (HEAD) | 2771 |
| baseline file | 2770 ← 1 too low |

The floor landed 1 below reality and slipped through CI because #1431 touched only `docs/` and the v1
no-regression check is **path-filtered** (a docs-only change doesn't trigger it — the #1430 issue).

**Effect:** every `src/`-touching PR since fails `v1 Proto Usage No Regression (TD-123)` with
`2771 > baseline 2770` — a false positive blocking the merge queue (e.g. #1434, and any other
src-touching PR).

## Fix

Regenerate the baseline to the true count via `scripts/check_v1_proto_usage.py --write`. No ratchet
progress is lost — the count has genuinely been 2771 since before #1431; `2770` was simply wrong. The
TD-123 downward ratchet resumes from 2771 on the next real v1→v2 migration.

## Verification

- `check_v1_proto_usage.py --mode no-regression` → **references 2771 == baseline 2771, delta +0 (passes)**
- Regenerated via the script's `--write` (per_root/file_count consistent, not a hand-edit)

> Note: this PR is docs-only, so it may not re-trigger the v1 check itself (path-filtered) — but the
> local verification above confirms count == baseline, and once it lands, `src/`-touching PRs will run
> the check against the corrected 2771 floor and pass.

**Must merge before #1434** (and any other src-touching PR) to unblock them.