### PR TITLE
feat(bench): add runnable Elasticsearch context-corridor adapter

### DIFF
--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -88,8 +88,18 @@ query_endpoint = "/v2/vectordb/entities/search"
 [[system]]
 id = "elasticsearch"
 role = "competitor"
-adapter_status = "planned"
+adapter_status = "runnable"
 comparison_surface = "document fields + kNN/hybrid search"
+
+[system.adapter]
+runner_system = "elasticsearch"
+distance = "cosine"
+vector_index = "dense_vector hnsw(m=16,ef_construction=100)"
+metadata_index = "keyword(partition)"
+hnsw_num_candidates = 40
+write_visibility = "forced _refresh per ingest"
+readiness_fence = "green status and matching document count"
+query_endpoint = "/_search (knn)"
 
 [[system]]
 id = "surrealdb"

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -109,7 +109,7 @@ For Qdrant Cloud or an authenticated deployment, pass `--qdrant-api-key`; the ke
 the `api-key` header and is redacted from failed-run artifacts and console errors. The adapter
 retains Qdrant's per-query hardware usage counters and final collection telemetry as server
 signals, while unsupported object-store economics remain explicit `null` publication blockers.
-All three runnable adapters issue an unfiltered and metadata-filtered query for each deterministic
+Every runnable adapter issues an unfiltered and metadata-filtered query for each deterministic
 target record.
 
 The Milvus baseline uses an explicit schema rather than dynamic fields: a VARCHAR primary key,
@@ -143,11 +143,44 @@ errors. Milvus v2 REST does not expose the server version, so `--milvus-server-v
 operator declaration that must be checked against the retained container digest before publication.
 Collection, load-state, HNSW, and scalar-index descriptions are captured as server signals.
 
+The Elasticsearch baseline maps an explicit document schema: a `keyword` `record_id`, a `keyword`
+`partition` (so the filter is an indexed term rather than a scan), an `long` ordinal, and a
+`dense_vector` embedding indexed with cosine HNSW (`m = 16`, `ef_construction = 100`). Ingest uses
+the native `_bulk` NDJSON API; search uses the kNN query with `num_candidates = 40` (the ANN breadth
+knob) and a `term` filter. After ingest the runner forces a `_refresh` and waits for `green` shard
+status with a document count matching what `_bulk` acknowledged, so queries never race ingest. This
+example pins the current stable Elasticsearch v9.5.0 release and disables security for the disposable
+single-node benchmark deployment (retain the exact image digest with published evidence):
+
+[source,bash]
+----
+docker run --rm -d --name context-elasticsearch \
+  -p 9200:9200 \
+  -e discovery.type=single-node \
+  -e xpack.security.enabled=false \
+  -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+  docker.elastic.co/elasticsearch/elasticsearch:9.5.0
+
+python3 scripts/bench/context_corridor.py \
+  --system elasticsearch \
+  --elasticsearch-url http://127.0.0.1:9200 \
+  --records 1000 \
+  --dimension 32 \
+  --queries 200 \
+  --output artifacts/context-corridor/elasticsearch-local.json
+----
+
+For a secured or Elastic Cloud deployment, pass `--elasticsearch-api-key`; the key is sent only in
+the `Authorization: ApiKey` header and is redacted from failed-run artifacts and console errors. The
+server version is read live from the cluster root, and index doc/store/segment stats are captured as
+server signals. As with the other competitors, unsupported object-store economics remain explicit
+`null` publication blockers.
+
 == Publication gate
 
 No cross-system winner, price/performance, or TAM-facing benchmark claim may be published until:
 
-* all six adapters are runnable (ProximaDB, pgvector, Qdrant, and Milvus are currently complete);
+* all six adapters are runnable (ProximaDB, pgvector, Qdrant, Milvus, and Elasticsearch are currently complete);
 * each system runs at least five trials over at least one million records;
 * local, S3, Azure, and GCS configurations are represented where supported;
 * raw results, failed runs, commit/version, configuration, hardware, and dataset hash are retained;

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -56,12 +56,20 @@ def request(
     body: dict | None,
     timeout: float,
     extra_headers: dict[str, str] | None = None,
+    *,
+    raw_body: bytes | None = None,
+    content_type: str | None = None,
 ) -> tuple[Any, float]:
     headers = {"Accept": "application/json"}
     if extra_headers:
         headers.update(extra_headers)
     payload = None
-    if body is not None:
+    if raw_body is not None:
+        # Pre-encoded payloads (e.g. Elasticsearch bulk NDJSON) carry their own
+        # content type and must not be re-serialized as JSON.
+        headers["Content-Type"] = content_type or "application/octet-stream"
+        payload = raw_body
+    elif body is not None:
         headers["Content-Type"] = "application/json"
         payload = json.dumps(body, separators=(",", ":")).encode()
     req = urllib.request.Request(
@@ -867,6 +875,223 @@ class MilvusAdapter:
             )
 
 
+class ElasticsearchAdapter:
+    system_id = "elasticsearch"
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        timeout: float,
+        index: str,
+    ) -> None:
+        # Elasticsearch index names must be lowercase and cannot contain most
+        # punctuation; the generated run name already satisfies this.
+        if not re.fullmatch(r"[a-z0-9_-]+", index):
+            raise ValueError("generated Elasticsearch index name is not safe")
+        self.base_url = base_url
+        self.timeout = timeout
+        self.index = index
+        self.headers = {"Authorization": f"ApiKey {api_key}"} if api_key else {}
+        self.version = "unknown"
+        self.expected_docs = 0
+        self.readiness_wait_seconds = 0.0
+
+    def _request(
+        self, method: str, path: str, body: dict | None
+    ) -> tuple[Any, float]:
+        return request(
+            self.base_url,
+            method,
+            path,
+            body,
+            self.timeout,
+            self.headers,
+        )
+
+    def prepare(self, dimension: int) -> None:
+        service, _ = self._request("GET", "/", None)
+        version = service.get("version") if isinstance(service, dict) else None
+        if isinstance(version, dict) and isinstance(version.get("number"), str):
+            self.version = version["number"]
+        self._request(
+            "PUT",
+            f"/{self.index}",
+            {
+                "settings": {
+                    "number_of_shards": 1,
+                    "number_of_replicas": 0,
+                    "refresh_interval": "1s",
+                },
+                "mappings": {
+                    "properties": {
+                        "record_id": {"type": "keyword"},
+                        "partition": {"type": "keyword"},
+                        "ordinal": {"type": "long"},
+                        "embedding": {
+                            "type": "dense_vector",
+                            "dims": dimension,
+                            "index": True,
+                            "similarity": "cosine",
+                            "index_options": {
+                                "type": "hnsw",
+                                "m": 16,
+                                "ef_construction": 100,
+                            },
+                        },
+                    }
+                },
+            },
+        )
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        lines: list[str] = []
+        for record in records:
+            lines.append(
+                json.dumps(
+                    {"index": {"_id": record["id"]}}, separators=(",", ":")
+                )
+            )
+            lines.append(
+                json.dumps(
+                    {
+                        "record_id": record["id"],
+                        "embedding": record["vector"],
+                        "partition": record["props"]["partition"],
+                        "ordinal": record["props"]["ordinal"],
+                    },
+                    separators=(",", ":"),
+                )
+            )
+        payload = ("\n".join(lines) + "\n").encode()
+        response, _ = request(
+            self.base_url,
+            "POST",
+            f"/{self.index}/_bulk",
+            None,
+            self.timeout,
+            self.headers,
+            raw_body=payload,
+            content_type="application/x-ndjson",
+        )
+        if isinstance(response, dict) and response.get("errors"):
+            items = response.get("items")
+            first = items[0] if isinstance(items, list) and items else {}
+            action = first.get("index", {}) if isinstance(first, dict) else {}
+            raise RuntimeError(
+                "Elasticsearch bulk insert reported errors: "
+                f"{action.get('error', 'unknown')}"
+            )
+        self.expected_docs += len(records)
+
+    def finish_ingest(self) -> None:
+        # A forced _refresh is the explicit write-visibility fence. dense_vector
+        # HNSW graphs are built as part of segment construction, so a green
+        # shard plus a document count matching what was acknowledged means
+        # queries never race ingest.
+        started = time.monotonic()
+        deadline = started + self.timeout
+        while True:
+            self._request("POST", f"/{self.index}/_refresh", None)
+            health, _ = self._request(
+                "GET",
+                f"/_cluster/health/{self.index}"
+                "?wait_for_status=green&timeout=1s",
+                None,
+            )
+            status = health.get("status") if isinstance(health, dict) else None
+            count_payload, _ = self._request(
+                "GET", f"/{self.index}/_count", None
+            )
+            count = (
+                count_payload.get("count")
+                if isinstance(count_payload, dict)
+                else None
+            )
+            if status == "green" and count == self.expected_docs:
+                self.readiness_wait_seconds = time.monotonic() - started
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    "Elasticsearch index did not reach green status with "
+                    f"{self.expected_docs} visible documents within "
+                    f"{self.timeout:g}s"
+                )
+            time.sleep(min(0.25, remaining))
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        knn: dict[str, Any] = {
+            "field": "embedding",
+            "query_vector": record["vector"],
+            "k": TOP_K,
+            "num_candidates": 40,
+        }
+        if filtered:
+            knn["filter"] = {
+                "term": {"partition": record["props"]["partition"]}
+            }
+        body = {
+            "knn": knn,
+            "size": TOP_K,
+            "_source": False,
+            "fields": ["record_id"],
+        }
+        payload, latency = self._request(
+            "POST", f"/{self.index}/_search", body
+        )
+        outer = payload.get("hits") if isinstance(payload, dict) else None
+        hits = outer.get("hits") if isinstance(outer, dict) else None
+        found: list[str] = []
+        for hit in hits if isinstance(hits, list) else []:
+            if not isinstance(hit, dict):
+                continue
+            record_id = None
+            fields = hit.get("fields")
+            if isinstance(fields, dict):
+                values = fields.get("record_id")
+                if (
+                    isinstance(values, list)
+                    and values
+                    and isinstance(values[0], str)
+                ):
+                    record_id = values[0]
+            if record_id is None and isinstance(hit.get("_id"), str):
+                record_id = hit["_id"]
+            if isinstance(record_id, str):
+                found.append(record_id)
+        return found[:TOP_K], latency
+
+    def signals(self) -> dict[str, Any]:
+        stats, _ = self._request(
+            "GET", f"/{self.index}/_stats/docs,store,segments", None
+        )
+        count, _ = self._request("GET", f"/{self.index}/_count", None)
+        return {"index_stats": stats, "count": count}
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "server_version": self.version,
+            "distance": "cosine",
+            "index": "dense_vector hnsw(m=16,ef_construction=100)",
+            "hnsw_num_candidates": 40,
+            "filter_index": "keyword(partition)",
+            "query_endpoint": "/_search (knn)",
+            "write_visibility": "forced _refresh per ingest",
+            "readiness_fence": "green status and matching document count",
+            "readiness_wait_seconds": round(self.readiness_wait_seconds, 6),
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if not keep_data:
+            self._request(
+                "DELETE", f"/{self.index}?ignore_unavailable=true", None
+            )
+
+
 def ingest_stream(
     adapter: Adapter,
     *,
@@ -1034,12 +1259,19 @@ def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
             args.timeout,
             run_name,
         )
-    return MilvusAdapter(
-        args.milvus_url,
-        args.milvus_token,
+    if args.system == "milvus":
+        return MilvusAdapter(
+            args.milvus_url,
+            args.milvus_token,
+            args.timeout,
+            run_name,
+            args.milvus_server_version,
+        )
+    return ElasticsearchAdapter(
+        args.elasticsearch_url,
+        args.elasticsearch_api_key,
         args.timeout,
         run_name,
-        args.milvus_server_version,
     )
 
 
@@ -1047,7 +1279,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--system",
-        choices=("proximadb", "pgvector", "qdrant", "milvus"),
+        choices=("proximadb", "pgvector", "qdrant", "milvus", "elasticsearch"),
         default="proximadb",
     )
     parser.add_argument("--base-url", default="http://127.0.0.1:5678")
@@ -1072,6 +1304,14 @@ def main() -> int:
         "--milvus-server-version",
         default="unknown",
         help="deployed Milvus version recorded in the report",
+    )
+    parser.add_argument(
+        "--elasticsearch-url", default="http://127.0.0.1:9200"
+    )
+    parser.add_argument(
+        "--elasticsearch-api-key",
+        default="",
+        help="optional Elasticsearch API key; never written to the report",
     )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
@@ -1135,7 +1375,11 @@ def main() -> int:
         return 0
     except Exception as exc:  # Failed runs are evidence and must be retained.
         safe_error = sanitized_error(
-            exc, args.pg_dsn, args.qdrant_api_key, args.milvus_token
+            exc,
+            args.pg_dsn,
+            args.qdrant_api_key,
+            args.milvus_token,
+            args.elasticsearch_api_key,
         )
         failure = {
             "schema_version": 1,
@@ -1159,6 +1403,7 @@ def main() -> int:
                 args.pg_dsn,
                 args.qdrant_api_key,
                 args.milvus_token,
+                args.elasticsearch_api_key,
             )
             print(
                 f"context corridor cleanup warning: {safe_cleanup_error}",

--- a/scripts/validate_context_benchmark.py
+++ b/scripts/validate_context_benchmark.py
@@ -46,10 +46,10 @@ def main() -> int:
     runnable = {
         item.get("id") for item in data.get("system", []) if item.get("adapter_status") == "runnable"
     }
-    if runnable != {"milvus", "pgvector", "proximadb", "qdrant"}:
+    if runnable != {"elasticsearch", "milvus", "pgvector", "proximadb", "qdrant"}:
         errors.append(
-            "the implemented ProximaDB, pgvector, Qdrant, and Milvus adapters "
-            "must be marked runnable"
+            "the implemented ProximaDB, pgvector, Qdrant, Milvus, and "
+            "Elasticsearch adapters must be marked runnable"
         )
     qdrant = next(
         (item for item in data.get("system", []) if item.get("id") == "qdrant"),
@@ -90,6 +90,25 @@ def main() -> int:
             "Milvus adapter contract must disclose the pinned scalar/vector "
             "indexes, consistency, and readiness settings"
         )
+    elasticsearch = next(
+        (item for item in data.get("system", []) if item.get("id") == "elasticsearch"),
+        {},
+    )
+    expected_elasticsearch_adapter = {
+        "runner_system": "elasticsearch",
+        "distance": "cosine",
+        "vector_index": "dense_vector hnsw(m=16,ef_construction=100)",
+        "metadata_index": "keyword(partition)",
+        "hnsw_num_candidates": 40,
+        "write_visibility": "forced _refresh per ingest",
+        "readiness_fence": "green status and matching document count",
+        "query_endpoint": "/_search (knn)",
+    }
+    if elasticsearch.get("adapter", {}) != expected_elasticsearch_adapter:
+        errors.append(
+            "Elasticsearch adapter contract must disclose the pinned "
+            "dense_vector ANN, keyword filter, visibility, and readiness settings"
+        )
     protocol = data.get("protocol", {})
     metrics = set(protocol.get("required_metrics", []))
     missing_metrics = REQUIRED_METRICS - metrics
@@ -123,8 +142,8 @@ def main() -> int:
         return 1
     print(
         "Context benchmark contract OK: 6 systems, 13 metrics, 4 backends, "
-        "five-trial/1M publication floor; ProximaDB, pgvector, Qdrant, and "
-        "Milvus adapters are runnable."
+        "five-trial/1M publication floor; ProximaDB, pgvector, Qdrant, "
+        "Milvus, and Elasticsearch adapters are runnable."
     )
     return 0
 

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -463,18 +463,164 @@ class ContextCorridorTest(unittest.TestCase):
         self.assertEqual(environment["hnsw_ef_search"], 40)
         self.assertEqual(environment["server_version"], "3.0.0")
 
+    def test_elasticsearch_index_name_is_path_safe(self) -> None:
+        with self.assertRaises(ValueError):
+            CONTEXT.ElasticsearchAdapter(
+                "http://es.example", "", 30.0, "Bad-Index"
+            )
+
+    def test_elasticsearch_prepare_and_bulk_insert_contract(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            if args[1:4] == ("GET", "/", None):
+                return {"version": {"number": "9.5.0"}}, 0.5
+            if args[2].endswith("/_bulk"):
+                return {"errors": False, "items": []}, 0.5
+            return {"acknowledged": True}, 0.5
+
+        adapter = CONTEXT.ElasticsearchAdapter(
+            "http://es.example", "private-key", 12.0, "context_bench_1"
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+            adapter.insert_batch([record])
+
+        self.assertEqual(adapter.version, "9.5.0")
+        put_args, _ = calls[1]
+        self.assertEqual(put_args[1:3], ("PUT", "/context_bench_1"))
+        embedding = put_args[3]["mappings"]["properties"]["embedding"]
+        self.assertEqual(embedding["type"], "dense_vector")
+        self.assertEqual(embedding["dims"], 2)
+        self.assertEqual(embedding["similarity"], "cosine")
+        self.assertEqual(
+            embedding["index_options"],
+            {"type": "hnsw", "m": 16, "ef_construction": 100},
+        )
+        self.assertEqual(
+            put_args[3]["mappings"]["properties"]["partition"]["type"],
+            "keyword",
+        )
+        bulk_args, bulk_kwargs = calls[2]
+        self.assertEqual(bulk_args[2], "/context_bench_1/_bulk")
+        self.assertEqual(bulk_kwargs["content_type"], "application/x-ndjson")
+        lines = bulk_kwargs["raw_body"].decode().splitlines()
+        self.assertEqual(json.loads(lines[0]), {"index": {"_id": "rec-7"}})
+        self.assertEqual(
+            json.loads(lines[1]),
+            {
+                "record_id": "rec-7",
+                "embedding": [0.25, -0.5],
+                "partition": "p7",
+                "ordinal": 7,
+            },
+        )
+        self.assertEqual(adapter.expected_docs, 1)
+        self.assertEqual(bulk_args[5], {"Authorization": "ApiKey private-key"})
+
+    def test_elasticsearch_bulk_errors_are_surfaced(self) -> None:
+        adapter = CONTEXT.ElasticsearchAdapter(
+            "http://es.example", "", 12.0, "context_bench_1"
+        )
+        error_response = {
+            "errors": True,
+            "items": [{"index": {"error": {"reason": "mapper_parsing"}}}],
+        }
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", return_value=(error_response, 0.5)):
+            with self.assertRaises(RuntimeError):
+                adapter.insert_batch([record])
+
+    def test_elasticsearch_filtered_knn_contract_and_result_mapping(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return (
+                {"hits": {"hits": [{"_id": "rec-7", "fields": {"record_id": ["rec-7"]}}]}},
+                1.25,
+            )
+
+        adapter = CONTEXT.ElasticsearchAdapter(
+            "http://es.example", "", 12.0, "context_bench_1"
+        )
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            found, latency = adapter.search(record, filtered=True)
+
+        self.assertEqual(found, ["rec-7"])
+        self.assertEqual(latency, 1.25)
+        args, _ = calls[0]
+        self.assertEqual(args[2], "/context_bench_1/_search")
+        knn = args[3]["knn"]
+        self.assertEqual(knn["field"], "embedding")
+        self.assertEqual(knn["k"], 10)
+        self.assertEqual(knn["num_candidates"], 40)
+        self.assertEqual(knn["filter"], {"term": {"partition": "p7"}})
+        self.assertFalse(args[3]["_source"])
+
+    def test_elasticsearch_ingest_waits_for_green_and_matching_count(self) -> None:
+        adapter = CONTEXT.ElasticsearchAdapter(
+            "http://es.example", "", 12.0, "context_bench_1"
+        )
+        adapter.expected_docs = 1
+        responses = [
+            ({}, 0.5),  # refresh
+            ({"status": "yellow"}, 0.5),  # health (not green)
+            ({"count": 0}, 0.5),  # count (mismatch)
+            ({}, 0.5),  # refresh
+            ({"status": "green"}, 0.5),  # health
+            ({"count": 1}, 0.5),  # count (match)
+        ]
+        with (
+            patch.object(CONTEXT, "request", side_effect=responses) as mocked,
+            patch.object(CONTEXT.time, "sleep") as mocked_sleep,
+        ):
+            adapter.finish_ingest()
+
+        self.assertEqual(mocked.call_count, 6)
+        mocked_sleep.assert_called_once_with(0.25)
+        self.assertGreaterEqual(adapter.readiness_wait_seconds, 0.0)
+
+    def test_elasticsearch_environment_does_not_disclose_api_key(self) -> None:
+        adapter = CONTEXT.ElasticsearchAdapter(
+            "http://es.example", "private-key", 12.0, "context_bench_1"
+        )
+        environment = adapter.environment()
+        self.assertNotIn("private-key", json.dumps(environment))
+        self.assertEqual(environment["hnsw_num_candidates"], 40)
+        self.assertEqual(environment["query_endpoint"], "/_search (knn)")
+
     def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
         dsn = "postgresql://alice:secret@db.example/test"
         api_key = "qdrant-private-key"
         milvus_token = "milvus-private-token"
+        es_api_key = "elasticsearch-private-key"
         error = RuntimeError(
             f"could not use {dsn}; password=second-secret; api-key={api_key}; "
-            f"token={milvus_token}"
+            f"token={milvus_token}; es={es_api_key}"
         )
-        sanitized = CONTEXT.sanitized_error(error, dsn, api_key, milvus_token)
+        sanitized = CONTEXT.sanitized_error(
+            error, dsn, api_key, milvus_token, es_api_key
+        )
         self.assertNotIn("secret", sanitized)
         self.assertNotIn(api_key, sanitized)
         self.assertNotIn(milvus_token, sanitized)
+        self.assertNotIn(es_api_key, sanitized)
         self.assertIn("<redacted>", sanitized)
 
 


### PR DESCRIPTION
Stacked after #1433 (Milvus), which is stacked toward develop. Keep auto-merge disabled until the base PR merges in order.

Adds a dependency-free Elasticsearch REST adapter to context-corridor-v1, taking the runnable competitor set to five (ProximaDB, pgvector, Qdrant, Milvus, Elasticsearch).

Product-native surface:
- Explicit document mapping: `keyword` record_id + partition (indexed term filter, not a scan), `long` ordinal, `dense_vector` embedding with cosine HNSW (`m=16`, `ef_construction=100`).
- Ingest via the native `_bulk` NDJSON API; kNN search with `num_candidates=40` and a `term` filter.
- Write-visibility/readiness fence: forced `_refresh` + `green` shard status + document count matching what `_bulk` acknowledged, so queries never race ingest.
- Optional `--elasticsearch-api-key` sent only in the `Authorization: ApiKey` header; redacted from failed-run artifacts and console errors.
- Server version read live from the cluster root; index doc/store/segment stats captured as server signals. Object-store economics remain explicit `null` publication blockers.

Verification:
- 23/23 adapter unit tests pass; `validate_context_benchmark.py` contract green; `make work-commit-check` passes.
- Live proof on pinned `docker.elastic.co/elasticsearch/elasticsearch:9.5.0`, 1000 records / dim 32: recall@10 = 1.0 and filtered_recall@10 = 1.0, 1000 docs indexed, readiness fence ~0.09s.

Contract, scenario, tests, and docs are updated together; the shared `request()` helper gained an optional pre-encoded (NDJSON) body path used only by the bulk ingest.