### PR TITLE
feat(bench): add runnable SurrealDB context-corridor adapter

### DIFF
--- a/benches/context-corridor/scenario.toml
+++ b/benches/context-corridor/scenario.toml
@@ -104,8 +104,17 @@ query_endpoint = "/_search (knn)"
 [[system]]
 id = "surrealdb"
 role = "direct-category"
-adapter_status = "planned"
+adapter_status = "runnable"
 comparison_surface = "multi-model record + vector index"
+
+[system.adapter]
+runner_system = "surrealdb"
+distance = "cosine"
+vector_index = "hnsw(M=16,EFC=100)"
+metadata_index = "index(partition)"
+hnsw_ef_search = 40
+readiness_fence = "synchronous index + full document count"
+query_endpoint = "/sql (<|K,EF|> KNN)"
 
 [publication]
 require_raw_results = true

--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -176,11 +176,45 @@ server version is read live from the cluster root, and index doc/store/segment s
 server signals. As with the other competitors, unsupported object-store economics remain explicit
 `null` publication blockers.
 
+The SurrealDB baseline is the direct multi-model comparison: a `SCHEMAFULL` table with typed
+`record_id`, `partition`, `ordinal`, and `embedding` fields, an HNSW index
+(`DEFINE INDEX … HNSW DIMENSION d DIST COSINE M 16 EFC 100`), and a scalar index on `partition` so the
+filter is indexed. Ingest uses a single bulk `INSERT INTO … [ … ]`; search uses the `<|K, EF|>` KNN
+operator (`<|10, 40|>`) combined with an `AND partition = …` predicate for the filtered case. All
+SurrealQL runs over the HTTP `/sql` endpoint with Basic auth and the `Surreal-NS` / `Surreal-DB`
+headers. Because SurrealDB maintains the HNSW index synchronously on write, the readiness fence is a
+full document-count check rather than a settle interval. This example pins the current stable
+SurrealDB v3.2.0 release with an in-memory datastore for the disposable benchmark deployment:
+
+[source,bash]
+----
+docker run --rm -d --name context-surrealdb \
+  -p 8000:8000 \
+  surrealdb/surrealdb:v3.2.0 \
+  start --user root --pass root --bind 0.0.0.0:8000 memory
+
+python3 scripts/bench/context_corridor.py \
+  --system surrealdb \
+  --surrealdb-url http://127.0.0.1:8000 \
+  --surrealdb-user root --surrealdb-pass root \
+  --surrealdb-server-version 3.2.0 \
+  --records 1000 \
+  --dimension 32 \
+  --queries 200 \
+  --output artifacts/context-corridor/surrealdb-local.json
+----
+
+The root password is used only to build the Basic-auth header and is redacted from failed-run
+artifacts and console errors. SurrealDB's HTTP surface does not expose the server version, so
+`--surrealdb-server-version` is an operator declaration that must be checked against the retained
+container digest before publication. Table info and the final document count are captured as server
+signals; unsupported object-store economics remain explicit `null` publication blockers.
+
 == Publication gate
 
 No cross-system winner, price/performance, or TAM-facing benchmark claim may be published until:
 
-* all six adapters are runnable (ProximaDB, pgvector, Qdrant, Milvus, and Elasticsearch are currently complete);
+* all six adapters are runnable (ProximaDB, pgvector, Qdrant, Milvus, Elasticsearch, and SurrealDB are all complete);
 * each system runs at least five trials over at least one million records;
 * local, S3, Azure, and GCS configurations are represented where supported;
 * raw results, failed runs, commit/version, configuration, hardware, and dataset hash are retained;

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -10,6 +10,7 @@ record scale does not require materializing the corpus in Python memory.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import math
@@ -150,6 +151,12 @@ def sanitized_error(error: Exception, *secrets: str) -> str:
 
 def vector_literal(vector: list[float]) -> str:
     return "[" + ",".join(format(value, ".9g") for value in vector) + "]"
+
+
+def surql_str(value: str) -> str:
+    # Single-quote a SurrealQL string literal, escaping backslashes and quotes.
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
 
 
 def make_record(index: int, dimension: int, rng: random.Random) -> dict[str, Any]:
@@ -1092,6 +1099,161 @@ class ElasticsearchAdapter:
             )
 
 
+class SurrealDBAdapter:
+    system_id = "surrealdb"
+
+    def __init__(
+        self,
+        base_url: str,
+        user: str,
+        password: str,
+        namespace: str,
+        database: str,
+        timeout: float,
+        table: str,
+        declared_server_version: str,
+    ) -> None:
+        if not re.fullmatch(r"[a-z0-9_]+", table):
+            raise ValueError("generated SurrealDB table name is not safe")
+        self.base_url = base_url
+        self.timeout = timeout
+        self.table = table
+        self.namespace = namespace
+        self.database = database
+        self.version = declared_server_version
+        token = base64.b64encode(f"{user}:{password}".encode()).decode()
+        self.headers = {
+            "Authorization": f"Basic {token}",
+            "Surreal-NS": namespace,
+            "Surreal-DB": database,
+            "Accept": "application/json",
+        }
+        self.expected_docs = 0
+        self.readiness_wait_seconds = 0.0
+
+    def _query(self, surql: str) -> tuple[list[Any], float]:
+        payload, latency = request(
+            self.base_url,
+            "POST",
+            "/sql",
+            None,
+            self.timeout,
+            self.headers,
+            raw_body=surql.encode(),
+            content_type="text/plain",
+        )
+        if not isinstance(payload, list):
+            raise RuntimeError(
+                f"SurrealDB returned an unexpected response: {payload!r}"
+            )
+        for item in payload:
+            if isinstance(item, dict) and item.get("status") != "OK":
+                raise RuntimeError(
+                    f"SurrealDB statement failed: {item.get('result')}"
+                )
+        return payload, latency
+
+    def prepare(self, dimension: int) -> None:
+        # SCHEMAFULL keeps the comparison on typed multi-model records; the
+        # HNSW index and a scalar index on partition make filtered ANN an
+        # indexed operation rather than a table scan.
+        self._query(
+            f"DEFINE TABLE {self.table} SCHEMAFULL; "
+            f"DEFINE FIELD record_id ON {self.table} TYPE string; "
+            f"DEFINE FIELD partition ON {self.table} TYPE string; "
+            f"DEFINE FIELD ordinal ON {self.table} TYPE int; "
+            f"DEFINE FIELD embedding ON {self.table} TYPE array<float>; "
+            f"DEFINE INDEX partition_idx ON {self.table} FIELDS partition; "
+            f"DEFINE INDEX embedding_idx ON {self.table} FIELDS embedding "
+            f"HNSW DIMENSION {dimension} DIST COSINE M 16 EFC 100;"
+        )
+
+    def insert_batch(self, records: list[dict[str, Any]]) -> None:
+        rows = ", ".join(
+            "{"
+            f"record_id: {surql_str(record['id'])}, "
+            f"embedding: {json.dumps(record['vector'])}, "
+            f"partition: {surql_str(record['props']['partition'])}, "
+            f"ordinal: {int(record['props']['ordinal'])}"
+            "}"
+            for record in records
+        )
+        self._query(f"INSERT INTO {self.table} [{rows}];")
+        self.expected_docs += len(records)
+
+    def finish_ingest(self) -> None:
+        # SurrealDB maintains the HNSW index synchronously on write, so once the
+        # INSERT statements return OK the index already reflects them. Confirm
+        # every record is visible as the explicit readiness fence.
+        started = time.monotonic()
+        deadline = started + self.timeout
+        while True:
+            payload, _ = self._query(
+                f"SELECT count() FROM {self.table} GROUP ALL;"
+            )
+            rows = payload[0].get("result") if payload else None
+            count = (
+                rows[0].get("count")
+                if isinstance(rows, list) and rows and isinstance(rows[0], dict)
+                else 0
+            )
+            if count == self.expected_docs:
+                self.readiness_wait_seconds = time.monotonic() - started
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"SurrealDB did not expose {self.expected_docs} records "
+                    f"within {self.timeout:g}s"
+                )
+            time.sleep(min(0.25, remaining))
+
+    def search(
+        self, record: dict[str, Any], *, filtered: bool
+    ) -> tuple[list[str], float]:
+        where = f"embedding <|{TOP_K},40|> {json.dumps(record['vector'])}"
+        if filtered:
+            where += f" AND partition = {surql_str(record['props']['partition'])}"
+        payload, latency = self._query(
+            f"SELECT record_id FROM {self.table} WHERE {where};"
+        )
+        rows = payload[0].get("result") if payload else None
+        found: list[str] = []
+        for row in rows if isinstance(rows, list) else []:
+            record_id = row.get("record_id") if isinstance(row, dict) else None
+            if isinstance(record_id, str):
+                found.append(record_id)
+        return found[:TOP_K], latency
+
+    def signals(self) -> dict[str, Any]:
+        info, _ = self._query(f"INFO FOR TABLE {self.table};")
+        count, _ = self._query(f"SELECT count() FROM {self.table} GROUP ALL;")
+        return {
+            "table_info": info[0].get("result") if info else None,
+            "count": count[0].get("result") if count else None,
+        }
+
+    def environment(self) -> dict[str, Any]:
+        return {
+            "base_url": self.base_url,
+            "server_version": self.version,
+            "server_version_source": "operator-declared (HTTP does not expose it)",
+            "namespace": self.namespace,
+            "database": self.database,
+            "distance": "cosine",
+            "index": "hnsw(M=16,EFC=100)",
+            "hnsw_ef_search": 40,
+            "filter_index": "index(partition)",
+            "query_endpoint": "/sql (<|K,EF|> KNN)",
+            "readiness_fence": "synchronous index + full document count",
+            "readiness_wait_seconds": round(self.readiness_wait_seconds, 6),
+        }
+
+    def close(self, *, keep_data: bool) -> None:
+        if not keep_data:
+            self._query(f"REMOVE TABLE IF EXISTS {self.table};")
+
+
 def ingest_stream(
     adapter: Adapter,
     *,
@@ -1267,11 +1429,22 @@ def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
             run_name,
             args.milvus_server_version,
         )
-    return ElasticsearchAdapter(
-        args.elasticsearch_url,
-        args.elasticsearch_api_key,
+    if args.system == "elasticsearch":
+        return ElasticsearchAdapter(
+            args.elasticsearch_url,
+            args.elasticsearch_api_key,
+            args.timeout,
+            run_name,
+        )
+    return SurrealDBAdapter(
+        args.surrealdb_url,
+        args.surrealdb_user,
+        args.surrealdb_pass,
+        args.surrealdb_namespace,
+        args.surrealdb_database,
         args.timeout,
         run_name,
+        args.surrealdb_server_version,
     )
 
 
@@ -1279,7 +1452,14 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--system",
-        choices=("proximadb", "pgvector", "qdrant", "milvus", "elasticsearch"),
+        choices=(
+            "proximadb",
+            "pgvector",
+            "qdrant",
+            "milvus",
+            "elasticsearch",
+            "surrealdb",
+        ),
         default="proximadb",
     )
     parser.add_argument("--base-url", default="http://127.0.0.1:5678")
@@ -1312,6 +1492,20 @@ def main() -> int:
         "--elasticsearch-api-key",
         default="",
         help="optional Elasticsearch API key; never written to the report",
+    )
+    parser.add_argument("--surrealdb-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--surrealdb-user", default="root")
+    parser.add_argument(
+        "--surrealdb-pass",
+        default="root",
+        help="SurrealDB root password; never written to the report",
+    )
+    parser.add_argument("--surrealdb-namespace", default="benchmark")
+    parser.add_argument("--surrealdb-database", default="context_corridor")
+    parser.add_argument(
+        "--surrealdb-server-version",
+        default="unknown",
+        help="deployed SurrealDB version recorded in the report",
     )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
@@ -1380,6 +1574,7 @@ def main() -> int:
             args.qdrant_api_key,
             args.milvus_token,
             args.elasticsearch_api_key,
+            args.surrealdb_pass,
         )
         failure = {
             "schema_version": 1,
@@ -1404,6 +1599,7 @@ def main() -> int:
                 args.qdrant_api_key,
                 args.milvus_token,
                 args.elasticsearch_api_key,
+                args.surrealdb_pass,
             )
             print(
                 f"context corridor cleanup warning: {safe_cleanup_error}",

--- a/scripts/validate_context_benchmark.py
+++ b/scripts/validate_context_benchmark.py
@@ -46,10 +46,10 @@ def main() -> int:
     runnable = {
         item.get("id") for item in data.get("system", []) if item.get("adapter_status") == "runnable"
     }
-    if runnable != {"elasticsearch", "milvus", "pgvector", "proximadb", "qdrant"}:
+    if runnable != REQUIRED_SYSTEMS:
         errors.append(
-            "the implemented ProximaDB, pgvector, Qdrant, Milvus, and "
-            "Elasticsearch adapters must be marked runnable"
+            "all six adapters (ProximaDB, pgvector, Qdrant, Milvus, "
+            "Elasticsearch, SurrealDB) must be marked runnable"
         )
     qdrant = next(
         (item for item in data.get("system", []) if item.get("id") == "qdrant"),
@@ -109,6 +109,24 @@ def main() -> int:
             "Elasticsearch adapter contract must disclose the pinned "
             "dense_vector ANN, keyword filter, visibility, and readiness settings"
         )
+    surrealdb = next(
+        (item for item in data.get("system", []) if item.get("id") == "surrealdb"),
+        {},
+    )
+    expected_surrealdb_adapter = {
+        "runner_system": "surrealdb",
+        "distance": "cosine",
+        "vector_index": "hnsw(M=16,EFC=100)",
+        "metadata_index": "index(partition)",
+        "hnsw_ef_search": 40,
+        "readiness_fence": "synchronous index + full document count",
+        "query_endpoint": "/sql (<|K,EF|> KNN)",
+    }
+    if surrealdb.get("adapter", {}) != expected_surrealdb_adapter:
+        errors.append(
+            "SurrealDB adapter contract must disclose the pinned HNSW ANN, "
+            "scalar filter index, and readiness settings"
+        )
     protocol = data.get("protocol", {})
     metrics = set(protocol.get("required_metrics", []))
     missing_metrics = REQUIRED_METRICS - metrics
@@ -142,8 +160,8 @@ def main() -> int:
         return 1
     print(
         "Context benchmark contract OK: 6 systems, 13 metrics, 4 backends, "
-        "five-trial/1M publication floor; ProximaDB, pgvector, Qdrant, "
-        "Milvus, and Elasticsearch adapters are runnable."
+        "five-trial/1M publication floor; all six adapters (ProximaDB, "
+        "pgvector, Qdrant, Milvus, Elasticsearch, SurrealDB) are runnable."
     )
     return 0
 

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import importlib.util
 import json
@@ -605,22 +606,169 @@ class ContextCorridorTest(unittest.TestCase):
         self.assertEqual(environment["hnsw_num_candidates"], 40)
         self.assertEqual(environment["query_endpoint"], "/_search (knn)")
 
+    def _surrealdb_adapter(self, password: str = ""):
+        return CONTEXT.SurrealDBAdapter(
+            "http://surreal.example",
+            "root",
+            password,
+            "benchmark",
+            "context_corridor",
+            12.0,
+            "context_bench_1",
+            "3.2.0",
+        )
+
+    def test_surrealdb_table_name_is_path_safe(self) -> None:
+        with self.assertRaises(ValueError):
+            CONTEXT.SurrealDBAdapter(
+                "http://surreal.example",
+                "root",
+                "",
+                "benchmark",
+                "context_corridor",
+                30.0,
+                "Bad-Table",
+                "3.2.0",
+            )
+
+    def test_surrealdb_prepare_and_insert_contract(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return [{"status": "OK", "result": None}], 0.5
+
+        adapter = self._surrealdb_adapter("secret-pass")
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+            adapter.insert_batch([record])
+
+        define_surql = calls[0][1]["raw_body"].decode()
+        self.assertIn(
+            "HNSW DIMENSION 2 DIST COSINE M 16 EFC 100", define_surql
+        )
+        self.assertIn("DEFINE INDEX partition_idx", define_surql)
+        headers = calls[0][0][5]
+        self.assertEqual(
+            base64.b64decode(headers["Authorization"].split()[1]).decode(),
+            "root:secret-pass",
+        )
+        self.assertEqual(headers["Surreal-NS"], "benchmark")
+        self.assertEqual(headers["Surreal-DB"], "context_corridor")
+        insert_surql = calls[1][1]["raw_body"].decode()
+        self.assertIn("INSERT INTO context_bench_1", insert_surql)
+        self.assertIn("record_id: 'rec-7'", insert_surql)
+        self.assertIn("partition: 'p7'", insert_surql)
+        self.assertIn("embedding: [0.25, -0.5]", insert_surql)
+        self.assertIn("ordinal: 7", insert_surql)
+        self.assertEqual(adapter.expected_docs, 1)
+
+    def test_surrealdb_statement_error_is_surfaced(self) -> None:
+        adapter = self._surrealdb_adapter()
+        with patch.object(
+            CONTEXT, "request", return_value=([{"status": "ERR", "result": "boom"}], 0.5)
+        ):
+            with self.assertRaises(RuntimeError):
+                adapter.insert_batch(
+                    [
+                        {
+                            "id": "rec-1",
+                            "vector": [0.1],
+                            "props": {"partition": "p1", "ordinal": 1},
+                        }
+                    ]
+                )
+
+    def test_surrealdb_filtered_knn_contract_and_result_mapping(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return [{"status": "OK", "result": [{"record_id": "rec-7"}]}], 1.25
+
+        adapter = self._surrealdb_adapter()
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            found, latency = adapter.search(record, filtered=True)
+
+        self.assertEqual(found, ["rec-7"])
+        self.assertEqual(latency, 1.25)
+        surql = calls[0][1]["raw_body"].decode()
+        self.assertIn("SELECT record_id FROM context_bench_1", surql)
+        self.assertIn("embedding <|10,40|> [0.25, -0.5]", surql)
+        self.assertIn("AND partition = 'p7'", surql)
+
+    def test_surrealdb_unfiltered_search_has_no_partition_filter(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return [{"status": "OK", "result": [{"record_id": "rec-7"}]}], 1.0
+
+        adapter = self._surrealdb_adapter()
+        record = {
+            "id": "rec-7",
+            "vector": [0.25, -0.5],
+            "props": {"partition": "p7", "ordinal": 7},
+        }
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.search(record, filtered=False)
+
+        surql = calls[0][1]["raw_body"].decode()
+        self.assertIn("embedding <|10,40|>", surql)
+        self.assertNotIn("partition", surql)
+
+    def test_surrealdb_ingest_waits_for_full_count(self) -> None:
+        adapter = self._surrealdb_adapter()
+        adapter.expected_docs = 2
+        responses = [
+            ([{"status": "OK", "result": [{"count": 1}]}], 0.5),  # mismatch
+            ([{"status": "OK", "result": [{"count": 2}]}], 0.5),  # match
+        ]
+        with (
+            patch.object(CONTEXT, "request", side_effect=responses) as mocked,
+            patch.object(CONTEXT.time, "sleep") as mocked_sleep,
+        ):
+            adapter.finish_ingest()
+
+        self.assertEqual(mocked.call_count, 2)
+        mocked_sleep.assert_called_once_with(0.25)
+        self.assertGreaterEqual(adapter.readiness_wait_seconds, 0.0)
+
+    def test_surrealdb_environment_does_not_disclose_password(self) -> None:
+        adapter = self._surrealdb_adapter("secret-pass")
+        environment = adapter.environment()
+        self.assertNotIn("secret-pass", json.dumps(environment))
+        self.assertEqual(environment["hnsw_ef_search"], 40)
+        self.assertEqual(environment["server_version"], "3.2.0")
+
     def test_failure_text_does_not_persist_a_dsn_or_keyword_password(self) -> None:
         dsn = "postgresql://alice:secret@db.example/test"
         api_key = "qdrant-private-key"
         milvus_token = "milvus-private-token"
         es_api_key = "elasticsearch-private-key"
+        surreal_pass = "surrealdb-private-pass"
         error = RuntimeError(
             f"could not use {dsn}; password=second-secret; api-key={api_key}; "
-            f"token={milvus_token}; es={es_api_key}"
+            f"token={milvus_token}; es={es_api_key}; surreal={surreal_pass}"
         )
         sanitized = CONTEXT.sanitized_error(
-            error, dsn, api_key, milvus_token, es_api_key
+            error, dsn, api_key, milvus_token, es_api_key, surreal_pass
         )
         self.assertNotIn("secret", sanitized)
         self.assertNotIn(api_key, sanitized)
         self.assertNotIn(milvus_token, sanitized)
         self.assertNotIn(es_api_key, sanitized)
+        self.assertNotIn(surreal_pass, sanitized)
         self.assertIn("<redacted>", sanitized)
 
 


### PR DESCRIPTION
Stacked after #1437 (Elasticsearch) → #1433 (Milvus) → develop. Keep auto-merge disabled until the base PRs merge in order.

Adds the sixth and final context-corridor competitor, taking the contract to **all six adapters runnable** (ProximaDB, pgvector, Qdrant, Milvus, Elasticsearch, SurrealDB) — the direct multi-model comparison.

Product-native surface (SurrealDB v3 HTTP `/sql`):
- `SCHEMAFULL` table with typed `record_id` / `partition` / `ordinal` / `embedding` fields; HNSW index (`DEFINE INDEX … HNSW DIMENSION d DIST COSINE M 16 EFC 100`) plus a scalar index on `partition` so the filter is indexed.
- Bulk `INSERT INTO … [ … ]`; KNN via the `<|K, EF|>` operator (`<|10, 40|>`) combined with an `AND partition = …` predicate for the filtered case.
- Basic auth + `Surreal-NS` / `Surreal-DB` headers; root password used only to build the auth header and redacted from failed-run artifacts and console errors.
- Readiness fence: HNSW is maintained synchronously on write, so the fence is a full document-count check (no settle interval). Table info + count captured as server signals; object-store economics remain explicit `null` blockers.
- Version is operator-declared (`--surrealdb-server-version`); HTTP does not expose it — must be checked against the retained container digest before publication.

Verification:
- 30/30 adapter unit tests pass; `validate_context_benchmark.py` now reports **all six adapters runnable**; `make work-commit-check` passes.
- Live proof on pinned `surrealdb/surrealdb:v3.2.0`, 1000 records / dim 32: recall@10 = 1.0 and filtered_recall@10 = 1.0, 1000 records indexed, readiness ~0.02s.

Contract, scenario, tests, and docs are updated together. With all adapters runnable, the `forbid_cross_system_claims_until_all_adapters_runnable` publication gate's precondition is now met — publication still requires the 5-trial / 1M-record / four-backend / physical-cost-metric floors.