### PR TITLE
feat(bench): ground-truth recall for context-corridor + TD-CTXCORR-1

### DIFF
--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -77,10 +77,18 @@ python3 -m venv /tmp/proximadb-context-bench
 ----
 
 The DSN is consumed only by the adapter and is never written to the result. The default cleanup
-drops the per-run table; pass `--keep-data` only for local diagnosis. Both adapters issue an
-unfiltered and metadata-filtered query for each deterministic target record. The current accuracy
-metric is explicitly scoped as target-record presence in the top ten, not full-neighbour
-ground-truth recall.
+drops the per-run table; pass `--keep-data` only for local diagnosis.
+
+**Recall methodology (ground truth).** Accuracy is measured against exact cosine-kNN ground truth,
+not a self-match. Queries are **held-out** (drawn from a separate deterministic RNG stream, never
+inserted). During the single ingest pass the harness computes each query's true top-k over the full
+corpus — unfiltered and within the query's partition — in bounded per-query heaps (memory
+`O(queries x top_k)`, so the corpus is never materialized). `recall_at_10` /
+`filtered_recall_at_10` report the mean over measured queries of
+`|returned_topk intersect truth_topk| / |truth_topk|`, so an engine that misses true neighbours
+scores below 1.0. NOTE: uniform-random synthetic vectors are near-equidistant in high dimensions and
+are recovered exactly by HNSW until very large N, so this synthetic path does not separate systems
+on recall — real/clustered embeddings at scale do (see TD-CTXCORR-1, Slice 2: Wikipedia + SIFT1M).
 
 The Qdrant baseline uses point payload for the canonical record ID and typed filter fields, a
 keyword payload index created before ingest, and the universal Query Points API with cosine HNSW
@@ -109,8 +117,8 @@ For Qdrant Cloud or an authenticated deployment, pass `--qdrant-api-key`; the ke
 the `api-key` header and is redacted from failed-run artifacts and console errors. The adapter
 retains Qdrant's per-query hardware usage counters and final collection telemetry as server
 signals, while unsupported object-store economics remain explicit `null` publication blockers.
-Every runnable adapter issues an unfiltered and metadata-filtered query for each deterministic
-target record.
+Every runnable adapter issues an unfiltered and a metadata-filtered query for each held-out query
+vector, scored against exact-kNN ground truth (see Recall methodology above).
 
 The Milvus baseline uses an explicit schema rather than dynamic fields: a VARCHAR primary key,
 FLOAT_VECTOR embedding, VARCHAR partition, and INT64 ordinal. It builds HNSW

--- a/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
+++ b/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
@@ -1,0 +1,157 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-CTXCORR-1: context-corridor — from runnable instrument to co-design evidence
+:status: Partial
+:dim: D3/D4/D5 (compute-per-modality, network/egress, object-storage)
+:pillar: PERF
+
+Problem: the `context-corridor-v1` benchmark
+(`benches/context-corridor/scenario.toml`, `scripts/bench/context_corridor.py`)
+now has six runnable, product-native adapters (ProximaDB, pgvector, Qdrant,
+Milvus, Elasticsearch, SurrealDB), pinned images, live proofs, and the integrity
+gates (failed runs retained, no cross-system claims until all adapters runnable,
+accuracy-before-latency-before-cost). That is the *instrument*. It does not yet
+produce a *measurement* that can rank systems or validate the co-design thesis.
+Four gaps, three of them latent until you read the code.
+
+== Finding 1 — recall was a liveness check, not a quality measure (Slice 1: FIXED)
+
+The original harness searched each query with *its own inserted vector*
+(self-query, distance 0), so the target was always rank 1 and both
+`recall_at_10` and `filtered_recall_at_10` were **structurally 1.0 for any
+working index** — a broken engine returning garbage still "passed" filtered
+recall because the target was guaranteed present. This measured nothing.
+
+**Slice 1 (this PR)** replaces it with **exact cosine-kNN ground truth over
+held-out queries**: `make_query` draws queries from a separate RNG stream (not
+inserted); `GroundTruthAccumulator` computes each query's true top-k over the
+full corpus (unfiltered *and* within the query's partition) in a single
+streaming pass (memory `O(queries * top_k)`, so the corpus is never
+materialized); `recall_at_k` reports
+`|returned_topk intersect truth_topk| / |truth_topk|`. Recall is now real: an
+engine that misses true neighbours scores `< 1.0`, and a broken engine scores
+near 0 (unit-tested at 0.5 / 0.0 / 1.0).
+
+== Finding 2 — the default filtered path is a brute-force scan, not accelerated ANN
+
+Traced from the REST handler into the AXIS/HNSW engine. ProximaDB supports three
+filtered-search strategies (ADR-011), selectivity-routed at
+`src/index/axis/management/manager.rs:1439-1480`:
+
+* **PreFilter exact** (`manager.rs:4345-4434`) — applies the metadata predicate
+  to every record *first*, scores only survivors, `truncate(top_k)`. A true
+  pre-filter (filter kicks in first), **cannot under-return**, but is
+  **O(N) brute force with no ANN traversal at all**.
+* **Inline / ACORN skip-through** (`src/index/axis/indexes/hnsw_index.rs:465-547`)
+  — predicate evaluated *during* graph traversal; non-matching nodes still route
+  the walk but do not consume the `ef` result budget. Accelerated *and*
+  recall-safe (bounded by graph connectivity, not oversample pool).
+* **PostFilter** (`manager.rs:1947-1974`) — ANN-first, 2x oversample, then
+  residual filter; genuine under-return risk (TD-064 flags legacy post-filter
+  returning `< k`), observable via the `PredicateShortfall` telemetry
+  (`manager.rs:2007-2033` -> `records.rs:1540-1548`).
+
+The enum `#[default]` is misleadingly named `PostFilter` (`manager.rs:4119`) but
+carries no policy, so a plain REST `search` with `filters` and no selectivity
+(exactly what `ProximaAdapter` sends) **falls through to PreFilter-exact**. The
+selectivity-driven routing that would pick Inline is Beta / deferred
+(TD-073; `RecallProbeGate` diagnostic-only). The AXIS filtered path also uses an
+**in-memory per-record metadata scan, no bitmap/inverted index**
+(`manager.rs:1905-1920`); only the SST engine does index-backed pre-filter
+pushdown (bloom + zone-map, `src/storage/engines/sst/multi_stage_filter.rs:298-301`).
+
+**Consequence for the benchmark:** at 1k records a full scan is invisible, but at
+the 1M publication floor the default filtered query is O(N) — a latency/cost
+liability — while Qdrant/Milvus/ES run index-constrained filtered ANN. Publishing
+the filtered comparison on the *default* adapter path races their accelerated
+search with our brute-force scan. The benchmark must exercise **Inline** so we
+measure accelerated filtered ANN, and it must run at scale where the difference
+is visible.
+
+== Finding 3 — the co-design cost axis is unmeasured
+
+The 13-metric contract includes `object_gets`, `object_puts`, `bytes_read`,
+`bytes_written`, `cache_hit_ratio`, `estimated_cost_per_million_queries` — the
+dimensional cost terms the whole co-design thesis rests on (I/O round-trips +
+egress dominate, not CPU). `build_report` hardcodes all of them to `null` via
+`unavailable_physical_metrics()` for **every** system including ProximaDB, and
+`ProximaAdapter.signals()` returns route-health, not cost. So the axis that would
+prove or disprove the thesis is not being measured. This also violates the
+co-design mandate's "trace before you tune": context-corridor is a new
+measurement surface that does not consume the query-scoped I/O trace that already
+exists (ADR-066 io_trace / consumption telemetry).
+
+== Finding 4 — random uniform vectors do not discriminate (validated)
+
+With the Slice 1 ground-truth metric in place, Qdrant scores recall@10 = 1.0 even
+at dim 768 / 6k records / `ef=40` — because uniform-random high-dimensional
+vectors have a flat neighbour structure that HNSW recovers exactly until very
+large N. The methodology fix is necessary but not sufficient: **data realism is
+the other half.** Real embeddings (clustered, anisotropic, correlated with
+metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
+
+== Co-design framing (which dimensional cost term each phase moves)
+
+* Recall quality (Findings 1, 4) — *compute-per-modality* (D3): is the ANN/filter
+  actually returning the right context.
+* Filtered acceleration (Finding 2) — *compute* (D3) + *local disk/cache*: Inline
+  vs brute-force is a scan-vs-graph cost, and the metadata index is a cache/IO term.
+* Physical cost (Finding 3) — *object storage* (D5, GB-month + request count) and
+  *network/egress* (KOU). This is the dominant at-rest and per-query cost term.
+
+== Phased plan
+
+* **Slice 1 — ground-truth recall (this PR, DONE).** Held-out queries + streaming
+  exact-kNN; unfiltered and filtered recall vs truth; honest `metric_scope` and a
+  `recall_methodology` block in the report. Unit-tested (TDD).
+* **Slice 2 — real local corpora + scale-safe ground truth.** Drive ALL six
+  adapters from one locally-held, checksummed corpus via a pluggable dataset
+  provider (`synthetic` stays as the deterministic CI/smoke path):
+  ** **Wikipedia passage embeddings WITH metadata** (DECIDED: e.g. Cohere
+     `wikipedia-22-12`) as the primary *filtered-corridor* driver — each vector
+     carries a real categorical field (`lang`, article `category`/`title`) so the
+     filter is correlated with content, which is what actually stresses
+     pre/post-filter behaviour. This is the differentiating measurement.
+  ** **SIFT1M** as the standard *unfiltered* recall reference (1M x 128, 10k
+     queries, canonical precomputed 100-NN ground truth, L2 distance) — credibility
+     and comparability with published ANN results. It has no metadata, so it
+     cannot exercise the filtered corridor — it is a reference, not the driver.
+  ** Vectors kept **local + gitignored** (1M x 768 f32 ~ 3 GB) via a
+     `fetch_corpus.py` that downloads and verifies a SHA256; that checksum is the
+     report `dataset_hash` (satisfies `require_dataset_hash`). Never commit the
+     vectors.
+  ** **Precompute filtered ground truth once**, offline, cached keyed by
+     `(corpus_hash, query_hash, k, filter_field)` — the pure-Python
+     `GroundTruthAccumulator` is `O(N*Q*dim)`, fine for validation, not for 1M.
+  ** **Distance per dataset** (SIFT = L2, text embeddings = cosine) — a small
+     adapter/index knob; the adapters currently hardcode cosine.
+* **Slice 3 — Inline-mode filtered runs.** Expose an
+  `--proximadb-filter-mode {auto,inline,prefilter}` knob on `ProximaAdapter` that
+  sets the AXIS `ann_filtering_mode` (+ selectivity) on the REST `search` request
+  (`src/network/rest/v2/records.rs:1583-1665`,
+  `src/services/operations/vectors/legacy.rs:4118-4142`), and record the mode in
+  the report `environment`. Measure accelerated filtered ANN vs the brute-force
+  default so the benchmark *pulls* toward the Inline path.
+* **Slice 4 — trace -> cost wiring.** Consume ProximaDB's per-query io_trace
+  (ADR-066) into `object_gets` / `bytes_read` / `estimated_cost_per_million_queries`
+  for the candidate; define infra-level request/byte/egress counting for the
+  competitors on object-store-backed deployments so the cost comparison is
+  apples-to-apples.
+* **Slice 5 — object-store backends + trials.** Run against S3 / Azure / GCS
+  (the required backends and the actual co-design test — access tier is the cost
+  lever, ADR-036) at >= 1M records, 5 trials, with variance / confidence
+  intervals. This is where a genuine win — or a surprise — shows up.
+
+== Acceptance / ratchet
+
+No cross-system winner, price/performance, or TAM-facing claim until Slices 2-5
+land and the publication floor in `scenario.toml` (>= 1M records, 5 trials, four
+backends, complete physical-cost metrics, dataset hash, hardware manifest, failed
+runs retained) is met. Slice 1 makes recall honest; it does not license a win
+claim. The whole point of the arc is that the benchmark should *drive ProximaDB*
+toward accelerated filtered retrieval and measured I/O cost — not reward a
+brute-force scan that happens to be recall-safe on an easy synthetic problem.
+
+Related: ADR-011 (ANN filtering modes), TD-064 (post-filter shortfall),
+TD-073 (per-collection selectivity policy), ADR-036 (object access tier),
+ADR-066 (io_trace ETL sink).

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import heapq
 import json
 import math
 import platform
@@ -167,10 +168,88 @@ def make_record(index: int, dimension: int, rng: random.Random) -> dict[str, Any
     }
 
 
+def make_query(index: int, dimension: int, rng: random.Random) -> dict[str, Any]:
+    # A HELD-OUT query: same distribution as the corpus but drawn from a
+    # separate RNG stream (see main()), so it is not an inserted record. Recall
+    # is measured against the true nearest neighbours, not a self-match.
+    return {
+        "id": f"query-{index}",
+        "vector": [rng.uniform(-1.0, 1.0) for _ in range(dimension)],
+        "props": {"partition": f"p{index % 8}", "ordinal": -1},
+    }
+
+
+def _cosine(vector: list[float], norm: float, other: list[float]) -> float:
+    other_norm = math.sqrt(sum(value * value for value in other)) or 1.0
+    dot = sum(a * b for a, b in zip(vector, other))
+    return dot / (norm * other_norm)
+
+
+class GroundTruthAccumulator:
+    """Exact cosine-kNN ground truth, accumulated in a single streaming pass.
+
+    Memory is O(queries * top_k) — bounded per-query min-heaps — so the corpus
+    never needs to be materialized, preserving the streaming/scale property of
+    the harness. Compute is O(records * queries * dim); at publication scale this
+    should be vectorized or precomputed (see TD-CTXCORR-1).
+    """
+
+    def __init__(self, queries: list[dict[str, Any]], top_k: int) -> None:
+        self._queries = queries
+        self._top_k = top_k
+        self._norms = [
+            math.sqrt(sum(v * v for v in q["vector"])) or 1.0 for q in queries
+        ]
+        self._unfiltered: list[list[tuple[float, str]]] = [[] for _ in queries]
+        self._filtered: list[list[tuple[float, str]]] = [[] for _ in queries]
+
+    def observe(self, record: dict[str, Any]) -> None:
+        record_id = record["id"]
+        record_vector = record["vector"]
+        record_partition = record["props"]["partition"]
+        for index, query in enumerate(self._queries):
+            similarity = _cosine(query["vector"], self._norms[index], record_vector)
+            self._push(self._unfiltered[index], similarity, record_id)
+            if record_partition == query["props"]["partition"]:
+                self._push(self._filtered[index], similarity, record_id)
+
+    def _push(self, heap: list[tuple[float, str]], similarity: float, rid: str) -> None:
+        if len(heap) < self._top_k:
+            heapq.heappush(heap, (similarity, rid))
+        elif similarity > heap[0][0]:
+            heapq.heapreplace(heap, (similarity, rid))
+
+    def finalize(self) -> list[tuple[frozenset[str], frozenset[str]]]:
+        return [
+            (
+                frozenset(rid for _, rid in self._unfiltered[index]),
+                frozenset(rid for _, rid in self._filtered[index]),
+            )
+            for index in range(len(self._queries))
+        ]
+
+
+def recall_at_k(returned: list[str], truth: frozenset[str]) -> float:
+    # Fraction of the true top-k neighbours that the engine actually returned.
+    # An empty truth set (e.g. an empty partition) is vacuously satisfied.
+    if not truth:
+        return 1.0
+    unique = set(returned)
+    hits = sum(1 for record_id in truth if record_id in unique)
+    return hits / len(truth)
+
+
+@dataclass(frozen=True)
+class QueryGroundTruth:
+    query: dict[str, Any]
+    unfiltered_truth: frozenset[str]
+    filtered_truth: frozenset[str]
+
+
 @dataclass(frozen=True)
 class DatasetManifest:
     sha256: str
-    query_records: list[dict[str, Any]]
+    queries: list[QueryGroundTruth]
 
 
 class Adapter(Protocol):
@@ -1261,10 +1340,9 @@ def ingest_stream(
     dimension: int,
     batch_size: int,
     seed: int,
-    query_indexes: list[int],
+    queries: list[dict[str, Any]],
 ) -> tuple[DatasetManifest, float]:
-    selected = set(query_indexes)
-    query_records: dict[int, dict[str, Any]] = {}
+    accumulator = GroundTruthAccumulator(queries, TOP_K)
     hasher = hashlib.sha256()
     hasher.update(b"[")
     rng = random.Random(seed)
@@ -1278,8 +1356,9 @@ def ingest_stream(
         hasher.update(
             json.dumps(record, sort_keys=True, separators=(",", ":")).encode()
         )
-        if index in selected:
-            query_records[index] = record
+        # Exact-kNN ground truth is accumulated in this same streaming pass, so
+        # the corpus is never materialized in memory.
+        accumulator.observe(record)
         batch.append(record)
         if len(batch) == batch_size:
             adapter.insert_batch(batch)
@@ -1289,13 +1368,18 @@ def ingest_stream(
     adapter.finish_ingest()
     ingest_seconds = time.perf_counter() - started
     hasher.update(b"]")
-    missing = selected - query_records.keys()
-    if missing:
-        raise RuntimeError(f"query records were not generated: {sorted(missing)[:10]}")
+    truths = accumulator.finalize()
     return (
         DatasetManifest(
             sha256=hasher.hexdigest(),
-            query_records=[query_records[index] for index in query_indexes],
+            queries=[
+                QueryGroundTruth(
+                    query=query,
+                    unfiltered_truth=unfiltered,
+                    filtered_truth=filtered,
+                )
+                for query, (unfiltered, filtered) in zip(queries, truths)
+            ],
         ),
         ingest_seconds,
     )
@@ -1303,29 +1387,35 @@ def ingest_stream(
 
 def run_queries(
     adapter: Adapter,
-    records: list[dict[str, Any]],
+    queries: list[QueryGroundTruth],
     *,
     warmup_count: int,
 ) -> tuple[dict[str, float], list[float]]:
-    unfiltered_hits = 0
-    filtered_hits = 0
+    unfiltered_recall = 0.0
+    filtered_recall = 0.0
     measured = 0
     filtered_latencies: list[float] = []
-    for ordinal, record in enumerate(records):
-        unfiltered_ids, _ = adapter.search(record, filtered=False)
-        filtered_ids, filtered_latency = adapter.search(record, filtered=True)
+    for ordinal, ground_truth in enumerate(queries):
+        unfiltered_ids, _ = adapter.search(ground_truth.query, filtered=False)
+        filtered_ids, filtered_latency = adapter.search(
+            ground_truth.query, filtered=True
+        )
         if ordinal < warmup_count:
             continue
         measured += 1
         filtered_latencies.append(filtered_latency)
-        unfiltered_hits += int(record["id"] in unfiltered_ids[:TOP_K])
-        filtered_hits += int(record["id"] in filtered_ids[:TOP_K])
+        unfiltered_recall += recall_at_k(
+            unfiltered_ids[:TOP_K], ground_truth.unfiltered_truth
+        )
+        filtered_recall += recall_at_k(
+            filtered_ids[:TOP_K], ground_truth.filtered_truth
+        )
     if measured == 0:
         raise RuntimeError("benchmark produced no measured queries")
     return (
         {
-            "recall_at_10": round(unfiltered_hits / measured, 6),
-            "filtered_recall_at_10": round(filtered_hits / measured, 6),
+            "recall_at_10": round(unfiltered_recall / measured, 6),
+            "filtered_recall_at_10": round(filtered_recall / measured, 6),
         },
         filtered_latencies,
     )
@@ -1385,11 +1475,19 @@ def build_report(
         },
         "metrics": metrics,
         "metric_scope": {
-            "recall_at_10": "inserted query-record target present in top 10",
-            "filtered_recall_at_10": "inserted query-record target present in filtered top 10",
+            "recall_at_10": "mean recall@10 vs exact cosine-kNN ground truth over held-out queries",
+            "filtered_recall_at_10": "mean recall@10 vs exact cosine-kNN ground truth within the query partition",
             "latency_percentiles": "filtered search client-observed latency",
             "peak_rss_bytes": "benchmark runner peak RSS; not server RSS",
             "unavailable": [key for key, value in metrics.items() if value is None],
+        },
+        "recall_methodology": {
+            "queries": "held-out (not inserted), same distribution as the corpus",
+            "ground_truth": "exact cosine kNN over the full corpus, computed streaming",
+            "metric": (
+                "mean over measured queries of "
+                "|returned_topk intersect truth_topk| / |truth_topk|"
+            ),
         },
         "query_count": query_count,
         "warmup_count": warmup_count,
@@ -1532,8 +1630,13 @@ def main() -> int:
 
     root = Path(__file__).resolve().parents[2]
     run_rng = random.Random(args.seed ^ 0xC0DEC0DE)
-    query_indexes = [
-        run_rng.randrange(args.records) for _ in range(args.warmup + args.queries)
+    # Held-out queries: a distinct RNG stream from the corpus (seeded by args.seed
+    # in ingest_stream) so queries are never inserted records — recall is measured
+    # against the true nearest neighbours, not a self-match.
+    query_rng = random.Random(args.seed ^ 0x0DDBA11)
+    queries = [
+        make_query(index, args.dimension, query_rng)
+        for index in range(args.warmup + args.queries)
     ]
     run_name = f"context_bench_{int(time.time())}_{run_rng.randrange(100000):05d}"
     adapter = make_adapter(args, run_name)
@@ -1544,11 +1647,11 @@ def main() -> int:
             dimension=args.dimension,
             batch_size=args.batch_size,
             seed=args.seed,
-            query_indexes=query_indexes,
+            queries=queries,
         )
         accuracy, latencies = run_queries(
             adapter,
-            manifest.query_records,
+            manifest.queries,
             warmup_count=args.warmup,
         )
         report = build_report(

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -59,15 +59,16 @@ class FakeAdapter:
 
 
 class ContextCorridorTest(unittest.TestCase):
-    def test_streamed_dataset_is_bounded_and_hash_compatible(self) -> None:
+    def test_streamed_dataset_builds_hash_and_ground_truth(self) -> None:
         adapter = FakeAdapter()
+        queries = [CONTEXT.make_query(i, 4, random.Random(100 + i)) for i in range(2)]
         manifest, ingest_seconds = CONTEXT.ingest_stream(
             adapter,
             record_count=11,
             dimension=4,
             batch_size=3,
             seed=7,
-            query_indexes=[0, 7, 7, 10],
+            queries=queries,
         )
 
         rng = random.Random(7)
@@ -77,31 +78,87 @@ class ContextCorridorTest(unittest.TestCase):
         ).hexdigest()
 
         self.assertEqual(manifest.sha256, expected_hash)
-        self.assertEqual(
-            [record["id"] for record in manifest.query_records],
-            ["rec-0", "rec-7", "rec-7", "rec-10"],
-        )
+        self.assertEqual(len(manifest.queries), 2)
+        # Ground-truth ids are real corpus ids, and the filtered truth stays
+        # within the query's own partition.
+        corpus_by_id = {record["id"]: record for record in records}
+        for ground_truth in manifest.queries:
+            self.assertTrue(
+                ground_truth.unfiltered_truth.issubset(corpus_by_id.keys())
+            )
+            partition = ground_truth.query["props"]["partition"]
+            for record_id in ground_truth.filtered_truth:
+                self.assertEqual(
+                    corpus_by_id[record_id]["props"]["partition"], partition
+                )
         self.assertEqual(adapter.prepared_dimension, 4)
         self.assertEqual(adapter.inserted, 11)
         self.assertEqual(adapter.max_batch, 3)
         self.assertGreater(ingest_seconds, 0)
 
-    def test_queries_measure_filtered_and_unfiltered_target_recall(self) -> None:
-        adapter = FakeAdapter()
-        records = [
-            {
-                "id": f"rec-{index}",
-                "vector": [float(index)],
-                "props": {"partition": "p0"},
-            }
-            for index in range(4)
-        ]
-        accuracy, latencies = CONTEXT.run_queries(adapter, records, warmup_count=1)
+    def test_queries_measure_recall_against_ground_truth(self) -> None:
+        class StubAdapter:
+            system_id = "stub"
 
-        self.assertEqual(accuracy["recall_at_10"], 1.0)
+            def search(self, record, *, filtered):
+                # Unfiltered returns 2 of the 4 true neighbours (0.5 recall);
+                # filtered returns exactly the true filtered set (1.0 recall).
+                if filtered:
+                    return ["a", "b"], 2.0
+                return ["a", "b", "x", "y"], 1.0
+
+        queries = [
+            CONTEXT.QueryGroundTruth(
+                query={
+                    "id": "query-0",
+                    "vector": [0.0],
+                    "props": {"partition": "p0"},
+                },
+                unfiltered_truth=frozenset({"a", "b", "c", "d"}),
+                filtered_truth=frozenset({"a", "b"}),
+            )
+        ]
+        accuracy, latencies = CONTEXT.run_queries(
+            StubAdapter(), queries, warmup_count=0
+        )
+
+        self.assertEqual(accuracy["recall_at_10"], 0.5)
         self.assertEqual(accuracy["filtered_recall_at_10"], 1.0)
-        self.assertEqual(latencies, [2.0, 2.0, 2.0])
-        self.assertEqual(adapter.search_calls, 8)
+        self.assertEqual(latencies, [2.0])
+
+    def test_ground_truth_accumulator_computes_exact_topk(self) -> None:
+        queries = [{"id": "q", "vector": [1.0, 0.0], "props": {"partition": "p0"}}]
+        accumulator = CONTEXT.GroundTruthAccumulator(queries, top_k=2)
+        records = [
+            {"id": "a", "vector": [1.0, 0.0], "props": {"partition": "p0"}},
+            {"id": "b", "vector": [0.9, 0.1], "props": {"partition": "p1"}},
+            {"id": "c", "vector": [0.5, 0.5], "props": {"partition": "p0"}},
+            {"id": "d", "vector": [-1.0, 0.0], "props": {"partition": "p0"}},
+        ]
+        for record in records:
+            accumulator.observe(record)
+        (unfiltered, filtered), = accumulator.finalize()
+
+        # Top-2 by cosine overall = a (1.0), b (0.994); within p0 = a, c.
+        self.assertEqual(unfiltered, frozenset({"a", "b"}))
+        self.assertEqual(filtered, frozenset({"a", "c"}))
+
+    def test_recall_at_k_measures_intersection(self) -> None:
+        truth = frozenset({"a", "b", "c", "d"})
+        self.assertEqual(CONTEXT.recall_at_k(["a", "b", "c", "d"], truth), 1.0)
+        self.assertEqual(CONTEXT.recall_at_k(["a", "b"], truth), 0.5)
+        self.assertEqual(CONTEXT.recall_at_k(["x", "y"], truth), 0.0)
+        # Empty truth (e.g. an empty partition) is vacuously satisfied.
+        self.assertEqual(CONTEXT.recall_at_k([], frozenset()), 1.0)
+
+    def test_make_query_structure_and_partition_cycle(self) -> None:
+        query = CONTEXT.make_query(3, 4, random.Random(7))
+        self.assertEqual(query["id"], "query-3")
+        self.assertEqual(query["props"]["partition"], "p3")
+        self.assertEqual(len(query["vector"]), 4)
+        self.assertEqual(
+            CONTEXT.make_query(8, 4, random.Random(7))["props"]["partition"], "p0"
+        )
 
     def test_report_has_the_complete_metric_contract(self) -> None:
         adapter = FakeAdapter()


### PR DESCRIPTION
Stacked on #1438 (SurrealDB) → #1437 (Elasticsearch) → develop. Auto-merge OFF until the base PRs merge in order.

Turns the context-corridor benchmark from a runnable *instrument* into an honest *measurement*, and files the evidence arc that keeps it driving ProximaDB in the right direction.

## Slice 1 (this PR): ground-truth recall (TDD)
The old harness searched each query with its **own inserted vector** (self-query, distance 0), so recall was **structurally 1.0 for any working index** — a broken engine still 'passed'. Replaced with **exact cosine-kNN ground truth over held-out queries**:
- `make_query` draws queries from a separate RNG stream (never inserted).
- `GroundTruthAccumulator` computes each query's true top-k over the full corpus — unfiltered **and** within the query's partition — in a single streaming pass, bounded heaps (memory `O(queries x top_k)`, corpus never materialized).
- `recall_at_k` = `|returned_topk ∩ truth_topk| / |truth_topk|`; report gains a `recall_methodology` block and honest `metric_scope`.
- **TDD**: tests written first (RED), then implementation (GREEN). 33/33 pass, incl. accumulator exact-top-k, recall 0.5/0.0/1.0/vacuous, held-out query structure. Live-validated end-to-end against Qdrant.

Key honest finding, documented: **uniform-random vectors don't discriminate** even with correct ground truth (HNSW recovers them exactly until very large N) — data realism is the other half.

## TD-CTXCORR-1: the evidence arc
Folds in the filtered-search investigation and the remaining gaps, co-design framed:
- **Finding 2 (filtered search):** the default REST filtered path routes to **PreFilter-exact — an O(N) brute-force scan** (recall-safe but not ANN-accelerated); Inline/ACORN is the accelerated path but is Beta/deferred (ADR-011, TD-064, TD-073). Cited file:line.
- **Finding 3:** physical-cost metrics (`object_gets`/`bytes`/`estimated_cost`) are hardcoded `null` — the co-design cost axis is unmeasured.
- **Phased plan:** Slice 2 = **Wikipedia embeddings (filtered driver, real metadata) + SIFT1M (unfiltered reference)** kept local + checksummed, precomputed filtered GT; Slice 3 = Inline-mode filtered runs; Slice 4 = trace→cost wiring (ADR-066); Slice 5 = object-store backends at 1M + 5 trials.

No metric names change; scenario contract and validator are untouched. No cross-system win may be claimed until Slices 2–5 land and the publication floor is met.