### PR TITLE
refactor(bench): DatasetProvider seam for context-corridor (TD-CTXCORR-1 Slice 2a)

### DIFF
--- a/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
+++ b/docs/10-quality/benchmarks/CONTEXT_CORRIDOR_BENCHMARK.adoc
@@ -29,6 +29,21 @@ Every report must include recall, filtered recall, ingest rate, p50/p95/p99, pea
 GET/PUT counts, bytes moved, cache hit ratio, and estimated cost per million queries. A performance
 claim that omits accuracy or physical-cost signals is not a ProximaDB co-design result.
 
+== Datasets (the `DatasetProvider` seam)
+
+The dataset is injected through a `DatasetProvider` seam: a provider owns its corpus, its held-out
+queries, and their ground truth as one cohesive unit, and exposes a `DatasetDescriptor` (name,
+dimension, `distance`, `filter_field`, record count, checksum). `ingest_stream` depends only on
+`provider.corpus()`; `run_queries` depends only on `provider.queries()` (ground truth travels with
+the query). This is the correct integration boundary: real datasets plug in without touching the
+ingest/measurement machinery, and the *dataset* — not each adapter — owns distance and filter field.
+
+`--dataset synthetic` (default) is the deterministic CI/smoke path. `--dataset sift1m` (canonical
+unfiltered recall reference, L2, precomputed 100-NN ground truth) and `--dataset wikipedia`
+(filtered-corridor driver: real passage embeddings + `lang`/`category` metadata, cosine) load local,
+checksummed, memory-mapped vectors + precomputed ground truth and drive the adapters' distance and
+filter field from the descriptor — TD-CTXCORR-1 Slice 2b.
+
 == Runnable slices
 
 The runner streams deterministic batches instead of retaining the corpus in Python memory, so the

--- a/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
+++ b/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
@@ -104,9 +104,17 @@ metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
 * **Slice 1 — ground-truth recall (this PR, DONE).** Held-out queries + streaming
   exact-kNN; unfiltered and filtered recall vs truth; honest `metric_scope` and a
   `recall_methodology` block in the report. Unit-tested (TDD).
-* **Slice 2 — real local corpora + scale-safe ground truth.** Drive ALL six
-  adapters from one locally-held, checksummed corpus via a pluggable dataset
-  provider (`synthetic` stays as the deterministic CI/smoke path):
+* **Slice 2a — the `DatasetProvider` seam (DONE).** A provider owns its corpus,
+  held-out queries, and ground truth as one unit, exposing a `DatasetDescriptor`
+  (name, dimension, `distance`, `filter_field`, record count, checksum);
+  `ingest_stream` depends only on `corpus()`, `run_queries` only on `queries()`.
+  `SyntheticDatasetProvider` is the behaviour-preserving default; `sift1m` /
+  `wikipedia` reject clearly until 2b. The correct boundary: real datasets plug in
+  without touching the ingest/measurement machinery, and the dataset (not each
+  adapter) owns distance + filter field.
+* **Slice 2b — real local corpora + scale-safe ground truth.** Drive ALL six
+  adapters from one locally-held, checksummed corpus through the Slice-2a seam
+  (`synthetic` stays as the deterministic CI/smoke path):
   ** **Wikipedia passage embeddings WITH metadata** (DECIDED: e.g. Cohere
      `wikipedia-22-12`) as the primary *filtered-corridor* driver — each vector
      carries a real categorical field (`lang`, article `category`/`title`) so the

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -23,6 +23,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -247,9 +248,108 @@ class QueryGroundTruth:
 
 
 @dataclass(frozen=True)
-class DatasetManifest:
-    sha256: str
-    queries: list[QueryGroundTruth]
+class DatasetDescriptor:
+    name: str
+    dimension: int
+    distance: str  # "cosine" | "l2" — the contract that drives adapter config
+    record_count: int
+    dataset_hash: str
+    filter_field: str  # the metadata field the filtered corridor filters on
+    query_count: int
+
+
+class DatasetProvider(Protocol):
+    """The seam between a dataset and the ingest/measurement machinery.
+
+    A provider owns its corpus, its held-out queries, and their ground truth as
+    one cohesive unit. `ingest_stream` depends only on `corpus()`; `run_queries`
+    depends only on `queries()`. Synthetic computes ground truth; real datasets
+    (SIFT1M, Wikipedia — TD-CTXCORR-1 Slice 2b) load precomputed ground truth and
+    memory-map local, checksummed vectors behind this same interface.
+    """
+
+    def descriptor(self) -> DatasetDescriptor: ...
+
+    def corpus(self) -> Iterator[dict[str, Any]]: ...
+
+    def queries(self) -> list[QueryGroundTruth]: ...
+
+
+class SyntheticDatasetProvider:
+    system_distance = "cosine"
+
+    def __init__(
+        self,
+        *,
+        record_count: int,
+        dimension: int,
+        seed: int,
+        query_count: int,
+        top_k: int,
+    ) -> None:
+        self._record_count = record_count
+        self._dimension = dimension
+        self._seed = seed
+        self._query_count = query_count
+        self._top_k = top_k
+        self._descriptor: DatasetDescriptor | None = None
+        self._queries: list[QueryGroundTruth] | None = None
+
+    def _build(self) -> None:
+        # One corpus pass computes both the dataset hash and the exact-kNN ground
+        # truth for the held-out queries. Held-out queries use a separate RNG
+        # stream (see make_query) so they are never inserted records.
+        query_rng = random.Random(self._seed ^ 0x0DDBA11)
+        raw_queries = [
+            make_query(index, self._dimension, query_rng)
+            for index in range(self._query_count)
+        ]
+        accumulator = GroundTruthAccumulator(raw_queries, self._top_k)
+        hasher = hashlib.sha256()
+        hasher.update(b"[")
+        rng = random.Random(self._seed)
+        for index in range(self._record_count):
+            record = make_record(index, self._dimension, rng)
+            if index:
+                hasher.update(b",")
+            hasher.update(
+                json.dumps(record, sort_keys=True, separators=(",", ":")).encode()
+            )
+            accumulator.observe(record)
+        hasher.update(b"]")
+        truths = accumulator.finalize()
+        self._queries = [
+            QueryGroundTruth(
+                query=query, unfiltered_truth=unfiltered, filtered_truth=filtered
+            )
+            for query, (unfiltered, filtered) in zip(raw_queries, truths)
+        ]
+        self._descriptor = DatasetDescriptor(
+            name="synthetic",
+            dimension=self._dimension,
+            distance=self.system_distance,
+            record_count=self._record_count,
+            dataset_hash=hasher.hexdigest(),
+            filter_field="partition",
+            query_count=self._query_count,
+        )
+
+    def descriptor(self) -> DatasetDescriptor:
+        if self._descriptor is None:
+            self._build()
+        assert self._descriptor is not None
+        return self._descriptor
+
+    def corpus(self) -> Iterator[dict[str, Any]]:
+        rng = random.Random(self._seed)
+        for index in range(self._record_count):
+            yield make_record(index, self._dimension, rng)
+
+    def queries(self) -> list[QueryGroundTruth]:
+        if self._queries is None:
+            self._build()
+        assert self._queries is not None
+        return self._queries
 
 
 class Adapter(Protocol):
@@ -1335,30 +1435,17 @@ class SurrealDBAdapter:
 
 def ingest_stream(
     adapter: Adapter,
+    provider: DatasetProvider,
     *,
-    record_count: int,
-    dimension: int,
     batch_size: int,
-    seed: int,
-    queries: list[dict[str, Any]],
-) -> tuple[DatasetManifest, float]:
-    accumulator = GroundTruthAccumulator(queries, TOP_K)
-    hasher = hashlib.sha256()
-    hasher.update(b"[")
-    rng = random.Random(seed)
-    adapter.prepare(dimension)
+) -> float:
+    # Pure ingest: stream the provider's corpus into the adapter. Ground truth
+    # and the dataset hash belong to the provider (see the DatasetProvider seam),
+    # so this function has no knowledge of how the dataset was produced.
+    adapter.prepare(provider.descriptor().dimension)
     started = time.perf_counter()
     batch: list[dict[str, Any]] = []
-    for index in range(record_count):
-        record = make_record(index, dimension, rng)
-        if index:
-            hasher.update(b",")
-        hasher.update(
-            json.dumps(record, sort_keys=True, separators=(",", ":")).encode()
-        )
-        # Exact-kNN ground truth is accumulated in this same streaming pass, so
-        # the corpus is never materialized in memory.
-        accumulator.observe(record)
+    for record in provider.corpus():
         batch.append(record)
         if len(batch) == batch_size:
             adapter.insert_batch(batch)
@@ -1366,23 +1453,7 @@ def ingest_stream(
     if batch:
         adapter.insert_batch(batch)
     adapter.finish_ingest()
-    ingest_seconds = time.perf_counter() - started
-    hasher.update(b"]")
-    truths = accumulator.finalize()
-    return (
-        DatasetManifest(
-            sha256=hasher.hexdigest(),
-            queries=[
-                QueryGroundTruth(
-                    query=query,
-                    unfiltered_truth=unfiltered,
-                    filtered_truth=filtered,
-                )
-                for query, (unfiltered, filtered) in zip(queries, truths)
-            ],
-        ),
-        ingest_seconds,
-    )
+    return time.perf_counter() - started
 
 
 def run_queries(
@@ -1436,11 +1507,8 @@ def build_report(
     adapter: Adapter,
     *,
     root: Path,
-    manifest: DatasetManifest,
-    record_count: int,
-    dimension: int,
+    descriptor: DatasetDescriptor,
     seed: int,
-    query_count: int,
     warmup_count: int,
     ingest_seconds: float,
     accuracy: dict[str, float],
@@ -1448,7 +1516,9 @@ def build_report(
 ) -> dict[str, Any]:
     metrics: dict[str, Any] = {
         **accuracy,
-        "ingest_records_per_second": round(record_count / ingest_seconds, 3),
+        "ingest_records_per_second": round(
+            descriptor.record_count / ingest_seconds, 3
+        ),
         "latency_p50_ms": round(percentile(latencies, 50), 3),
         "latency_p95_ms": round(percentile(latencies, 95), 3),
         "latency_p99_ms": round(percentile(latencies, 99), 3),
@@ -1463,10 +1533,13 @@ def build_report(
         "status": "measured-local-baseline",
         "commit_sha": git_sha(root),
         "dataset": {
-            "records": record_count,
-            "dimension": dimension,
+            "name": descriptor.name,
+            "records": descriptor.record_count,
+            "dimension": descriptor.dimension,
+            "distance": descriptor.distance,
+            "filter_field": descriptor.filter_field,
             "seed": seed,
-            "sha256": manifest.sha256,
+            "sha256": descriptor.dataset_hash,
         },
         "environment": {
             "platform": platform.platform(),
@@ -1489,7 +1562,7 @@ def build_report(
                 "|returned_topk intersect truth_topk| / |truth_topk|"
             ),
         },
-        "query_count": query_count,
+        "query_count": descriptor.query_count,
         "warmup_count": warmup_count,
         "server_signals": adapter.signals(),
         "publication_eligible": False,
@@ -1543,6 +1616,26 @@ def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
         args.timeout,
         run_name,
         args.surrealdb_server_version,
+    )
+
+
+def build_provider(args: argparse.Namespace) -> DatasetProvider:
+    if args.dataset == "synthetic":
+        return SyntheticDatasetProvider(
+            record_count=args.records,
+            dimension=args.dimension,
+            seed=args.seed,
+            query_count=args.warmup + args.queries,
+            top_k=TOP_K,
+        )
+    # SIFT1M (unfiltered reference) and Wikipedia (filtered driver) load local,
+    # checksummed, memory-mapped vectors + precomputed ground truth, and drive the
+    # adapters' distance/filter-field from the descriptor. That IO and the
+    # adapter re-parameterization are TD-CTXCORR-1 Slice 2b.
+    raise NotImplementedError(
+        f"dataset {args.dataset!r} is not wired yet: it needs the fetch + "
+        "precomputed ground-truth loaders and descriptor-driven adapter config "
+        "(TD-CTXCORR-1 Slice 2b)"
     )
 
 
@@ -1605,6 +1698,12 @@ def main() -> int:
         default="unknown",
         help="deployed SurrealDB version recorded in the report",
     )
+    parser.add_argument(
+        "--dataset",
+        choices=("synthetic", "sift1m", "wikipedia"),
+        default="synthetic",
+        help="synthetic (deterministic CI/smoke); sift1m/wikipedia = TD-CTXCORR-1 Slice 2b",
+    )
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
     parser.add_argument("--queries", type=int, default=200)
@@ -1630,38 +1729,26 @@ def main() -> int:
 
     root = Path(__file__).resolve().parents[2]
     run_rng = random.Random(args.seed ^ 0xC0DEC0DE)
-    # Held-out queries: a distinct RNG stream from the corpus (seeded by args.seed
-    # in ingest_stream) so queries are never inserted records — recall is measured
-    # against the true nearest neighbours, not a self-match.
-    query_rng = random.Random(args.seed ^ 0x0DDBA11)
-    queries = [
-        make_query(index, args.dimension, query_rng)
-        for index in range(args.warmup + args.queries)
-    ]
+    provider = build_provider(args)
+    descriptor = provider.descriptor()
     run_name = f"context_bench_{int(time.time())}_{run_rng.randrange(100000):05d}"
     adapter = make_adapter(args, run_name)
     try:
-        manifest, ingest_seconds = ingest_stream(
+        ingest_seconds = ingest_stream(
             adapter,
-            record_count=args.records,
-            dimension=args.dimension,
+            provider,
             batch_size=args.batch_size,
-            seed=args.seed,
-            queries=queries,
         )
         accuracy, latencies = run_queries(
             adapter,
-            manifest.queries,
+            provider.queries(),
             warmup_count=args.warmup,
         )
         report = build_report(
             adapter,
             root=root,
-            manifest=manifest,
-            record_count=args.records,
-            dimension=args.dimension,
+            descriptor=descriptor,
             seed=args.seed,
-            query_count=args.queries,
             warmup_count=args.warmup,
             ingest_seconds=ingest_seconds,
             accuracy=accuracy,

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import base64
 import hashlib
 import importlib.util
@@ -59,42 +60,82 @@ class FakeAdapter:
 
 
 class ContextCorridorTest(unittest.TestCase):
-    def test_streamed_dataset_builds_hash_and_ground_truth(self) -> None:
-        adapter = FakeAdapter()
-        queries = [CONTEXT.make_query(i, 4, random.Random(100 + i)) for i in range(2)]
-        manifest, ingest_seconds = CONTEXT.ingest_stream(
-            adapter,
-            record_count=11,
-            dimension=4,
-            batch_size=3,
-            seed=7,
-            queries=queries,
+    def test_synthetic_provider_descriptor_is_deterministic(self) -> None:
+        provider = CONTEXT.SyntheticDatasetProvider(
+            record_count=11, dimension=4, seed=7, query_count=2, top_k=10
         )
+        descriptor = provider.descriptor()
+        self.assertEqual(descriptor.name, "synthetic")
+        self.assertEqual(descriptor.dimension, 4)
+        self.assertEqual(descriptor.distance, "cosine")
+        self.assertEqual(descriptor.record_count, 11)
+        self.assertEqual(descriptor.filter_field, "partition")
+        self.assertEqual(descriptor.query_count, 2)
 
         rng = random.Random(7)
         records = [CONTEXT.make_record(index, 4, rng) for index in range(11)]
         expected_hash = hashlib.sha256(
             json.dumps(records, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest()
+        # The descriptor hash matches an independent stream of the same corpus
+        # (compatible with the pre-seam hash) and is stable across instances.
+        self.assertEqual(descriptor.dataset_hash, expected_hash)
+        twin = CONTEXT.SyntheticDatasetProvider(
+            record_count=11, dimension=4, seed=7, query_count=2, top_k=10
+        )
+        self.assertEqual(twin.descriptor().dataset_hash, expected_hash)
 
-        self.assertEqual(manifest.sha256, expected_hash)
-        self.assertEqual(len(manifest.queries), 2)
-        # Ground-truth ids are real corpus ids, and the filtered truth stays
-        # within the query's own partition.
-        corpus_by_id = {record["id"]: record for record in records}
-        for ground_truth in manifest.queries:
-            self.assertTrue(
-                ground_truth.unfiltered_truth.issubset(corpus_by_id.keys())
-            )
+    def test_synthetic_provider_corpus_is_streamed_and_deterministic(self) -> None:
+        provider = CONTEXT.SyntheticDatasetProvider(
+            record_count=5, dimension=3, seed=7, query_count=1, top_k=10
+        )
+        first = list(provider.corpus())
+        second = list(provider.corpus())
+        rng = random.Random(7)
+        expected = [CONTEXT.make_record(index, 3, rng) for index in range(5)]
+        self.assertEqual(first, expected)
+        self.assertEqual(first, second)
+
+    def test_synthetic_provider_queries_carry_ground_truth(self) -> None:
+        provider = CONTEXT.SyntheticDatasetProvider(
+            record_count=32, dimension=4, seed=7, query_count=3, top_k=5
+        )
+        corpus_by_id = {record["id"]: record for record in provider.corpus()}
+        queries = provider.queries()
+        self.assertEqual(len(queries), 3)
+        for ground_truth in queries:
+            self.assertTrue(ground_truth.unfiltered_truth)
+            self.assertTrue(ground_truth.unfiltered_truth.issubset(corpus_by_id))
             partition = ground_truth.query["props"]["partition"]
             for record_id in ground_truth.filtered_truth:
                 self.assertEqual(
                     corpus_by_id[record_id]["props"]["partition"], partition
                 )
+
+    def test_ingest_stream_drives_adapter_from_provider(self) -> None:
+        adapter = FakeAdapter()
+        provider = CONTEXT.SyntheticDatasetProvider(
+            record_count=11, dimension=4, seed=7, query_count=2, top_k=10
+        )
+        ingest_seconds = CONTEXT.ingest_stream(adapter, provider, batch_size=3)
+
         self.assertEqual(adapter.prepared_dimension, 4)
         self.assertEqual(adapter.inserted, 11)
         self.assertEqual(adapter.max_batch, 3)
         self.assertGreater(ingest_seconds, 0)
+
+    def test_build_provider_rejects_unfetched_datasets(self) -> None:
+        args = argparse.Namespace(
+            dataset="sift1m",
+            records=10,
+            dimension=4,
+            queries=1,
+            warmup=0,
+            seed=7,
+        )
+        with self.assertRaises(NotImplementedError) as caught:
+            CONTEXT.build_provider(args)
+        self.assertIn("TD-CTXCORR-1", str(caught.exception))
 
     def test_queries_measure_recall_against_ground_truth(self) -> None:
         class StubAdapter:
@@ -162,14 +203,20 @@ class ContextCorridorTest(unittest.TestCase):
 
     def test_report_has_the_complete_metric_contract(self) -> None:
         adapter = FakeAdapter()
+        descriptor = CONTEXT.DatasetDescriptor(
+            name="synthetic",
+            dimension=8,
+            distance="cosine",
+            record_count=100,
+            dataset_hash="abc",
+            filter_field="partition",
+            query_count=3,
+        )
         report = CONTEXT.build_report(
             adapter,
             root=ROOT,
-            manifest=CONTEXT.DatasetManifest("abc", []),
-            record_count=100,
-            dimension=8,
+            descriptor=descriptor,
             seed=9,
-            query_count=3,
             warmup_count=1,
             ingest_seconds=2.0,
             accuracy={"recall_at_10": 1.0, "filtered_recall_at_10": 1.0},
@@ -178,6 +225,9 @@ class ContextCorridorTest(unittest.TestCase):
 
         self.assertEqual(set(report["metrics"]), set(CONTEXT.REQUIRED_METRICS))
         self.assertEqual(report["metrics"]["ingest_records_per_second"], 50.0)
+        self.assertEqual(report["dataset"]["sha256"], "abc")
+        self.assertEqual(report["dataset"]["distance"], "cosine")
+        self.assertEqual(report["dataset"]["name"], "synthetic")
         self.assertFalse(report["publication_eligible"])
         self.assertIn("object_gets", report["metric_scope"]["unavailable"])
 


### PR DESCRIPTION
Stacked on #1439 (ground-truth recall) → #1438 → #1437 → develop. Auto-merge OFF until the base PRs merge in order.

First-principles boundary work, not micro-optimization: puts the dataset behind the **correct seam** so real corpora plug in without touching the ingest/measurement machinery.

## The boundary
Introduces a `DatasetProvider` seam: a provider owns its **corpus, held-out queries, and ground truth** as one cohesive unit, and exposes a `DatasetDescriptor` carrying `distance` and `filter_field`.
- `ingest_stream` now depends only on `provider.corpus()` — pure ingest, no GT/hash logic.
- `run_queries` depends only on `provider.queries()` — ground truth travels with the query.
- `build_report` takes the `DatasetDescriptor`; the report `dataset` block now discloses `name`/`distance`/`filter_field`.
- **The dataset — not each adapter — owns distance and filter field.** That's how SIFT (L2, no metadata) and Wikipedia (cosine, `lang`) will flow through unchanged in Slice 2b.

`SyntheticDatasetProvider` is the behavior-preserving default (identical corpus, hash, and recall as #1439); `--dataset sift1m|wikipedia` reject with a clear pointer to TD-CTXCORR-1 Slice 2b.

## TDD
Tests written first (RED, 6 failing), then implementation (GREEN). **37/37 pass**, incl. provider descriptor determinism + hash compatibility with the pre-seam stream, streamed/deterministic corpus, queries-carry-ground-truth, ingest-from-provider, and the unfetched-dataset rejection. Live-validated end-to-end against Qdrant: synthetic path unchanged (recall 1.0, deterministic hash), `dataset` block now carries the descriptor contract, `sift1m` rejects cleanly.

No metric names change; scenario contract + validator untouched. Slice 2b (SIFT1M + Wikipedia loaders: fetch+checksum+mmap, precomputed filtered GT, descriptor-driven adapter distance/filter-field) builds on this seam.