### PR TITLE
feat(bench): dataset-IO foundation for context-corridor (TD-CTXCORR-1 Slice 2b-i)

### DIFF
--- a/benches/context-corridor/data/.gitignore
+++ b/benches/context-corridor/data/.gitignore
@@ -1,0 +1,6 @@
+# Local, gitignored benchmark corpora (TD-CTXCORR-1 Slice 2b). Benchmark vectors
+# (SIFT1M, Wikipedia embeddings, precomputed ground truth) are large and MUST NOT
+# be committed — fetch + SHA256-verify them with scripts/bench/fetch_corpus.py.
+# The checksum becomes the report dataset_hash.
+*
+!.gitignore

--- a/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
+++ b/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
@@ -112,9 +112,16 @@ metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
   `wikipedia` reject clearly until 2b. The correct boundary: real datasets plug in
   without touching the ingest/measurement machinery, and the dataset (not each
   adapter) owns distance + filter field.
-* **Slice 2b — real local corpora + scale-safe ground truth.** Drive ALL six
-  adapters from one locally-held, checksummed corpus through the Slice-2a seam
-  (`synthetic` stays as the deterministic CI/smoke path):
+* **Slice 2b-i — dataset-IO foundation (DONE).** `scripts/bench/corpus_io.py`:
+  SIFT-family `.fvecs`/`.ivecs` streaming readers, `sha256_file`/`verify_checksum`,
+  and an idempotent injectable-downloader `fetch_corpus` (downloads to a `.part`
+  sidecar, promotes only on checksum match). `scripts/bench/fetch_corpus.py` is
+  the operator CLI. `benches/context-corridor/data/.gitignore` keeps the corpus
+  dir but ignores the (large) vectors — never committed; the checksum is the
+  report `dataset_hash`. All TDD'd on byte fixtures (no download in tests).
+* **Slice 2b-ii — real corpora + descriptor-driven adapters.** Build the concrete
+  providers on the Slice-2a seam and 2b-i IO, and drive ALL six adapters from one
+  locally-held, checksummed corpus (`synthetic` stays as the CI/smoke path):
   ** **Wikipedia passage embeddings WITH metadata** (DECIDED: e.g. Cohere
      `wikipedia-22-12`) as the primary *filtered-corridor* driver — each vector
      carries a real categorical field (`lang`, article `category`/`title`) so the
@@ -124,15 +131,13 @@ metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
      queries, canonical precomputed 100-NN ground truth, L2 distance) — credibility
      and comparability with published ANN results. It has no metadata, so it
      cannot exercise the filtered corridor — it is a reference, not the driver.
-  ** Vectors kept **local + gitignored** (1M x 768 f32 ~ 3 GB) via a
-     `fetch_corpus.py` that downloads and verifies a SHA256; that checksum is the
-     report `dataset_hash` (satisfies `require_dataset_hash`). Never commit the
-     vectors.
   ** **Precompute filtered ground truth once**, offline, cached keyed by
      `(corpus_hash, query_hash, k, filter_field)` — the pure-Python
      `GroundTruthAccumulator` is `O(N*Q*dim)`, fine for validation, not for 1M.
-  ** **Distance per dataset** (SIFT = L2, text embeddings = cosine) — a small
-     adapter/index knob; the adapters currently hardcode cosine.
+  ** **Wire each adapter's distance + filter_field FROM the `DatasetDescriptor`**
+     (the 2a seam exposes both) instead of the hardcoded cosine/`partition`, so
+     SIFT (L2, no metadata → filter optional) and Wikipedia (cosine, `lang`) flow
+     through unchanged. Live-validate against the containers.
 * **Slice 3 — Inline-mode filtered runs.** Expose an
   `--proximadb-filter-mode {auto,inline,prefilter}` knob on `ProximaAdapter` that
   sets the AXIS `ann_filtering_mode` (+ selectivity) on the REST `search` request

--- a/scripts/bench/corpus_io.py
+++ b/scripts/bench/corpus_io.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Local dataset IO for the context-corridor benchmark (TD-CTXCORR-1 Slice 2b).
+
+SIFT-family ``.fvecs`` / ``.ivecs`` readers and checksum helpers. Benchmark
+vectors are kept **local and gitignored** and verified by SHA256 — the checksum
+becomes the report ``dataset_hash`` (satisfies ``require_dataset_hash``). These
+are the file-format + fetch foundation the SIFT1M / Wikipedia providers
+(Slice 2b-ii) build on; nothing here downloads by itself except the injectable
+``fetch_corpus`` helper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+import urllib.request
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+_HEADER = struct.Struct("<i")
+
+
+def _read_vecs(path: Path | str, code: str) -> Iterator[list[float]]:
+    # .fvecs/.ivecs layout: for each vector, an int32 dimension followed by
+    # `dimension` little-endian values of the given struct code ('f' or 'i').
+    with open(path, "rb") as handle:
+        while True:
+            header = handle.read(4)
+            if not header:
+                return
+            if len(header) != 4:
+                raise ValueError(f"truncated .{code}vecs header in {path}")
+            (dimension,) = _HEADER.unpack(header)
+            if dimension < 0:
+                raise ValueError(f"invalid .{code}vecs dimension {dimension} in {path}")
+            body = handle.read(4 * dimension)
+            if len(body) != 4 * dimension:
+                raise ValueError(f"truncated .{code}vecs vector body in {path}")
+            yield list(struct.unpack(f"<{dimension}{code}", body))
+
+
+def read_fvecs(path: Path | str) -> Iterator[list[float]]:
+    """Stream float32 vectors from a ``.fvecs`` file (SIFT base/query vectors)."""
+    return _read_vecs(path, "f")
+
+
+def read_ivecs(path: Path | str) -> Iterator[list[int]]:
+    """Stream int32 vectors from an ``.ivecs`` file (SIFT ground-truth neighbours)."""
+    return (
+        [int(value) for value in vector] for vector in _read_vecs(path, "i")
+    )
+
+
+def sha256_file(path: Path | str, *, chunk_size: int = 1 << 20) -> str:
+    hasher = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def verify_checksum(path: Path | str, expected: str) -> str:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise ValueError(
+            f"checksum mismatch for {path}: expected {expected}, got {actual}"
+        )
+    return actual
+
+
+def fetch_corpus(
+    url: str,
+    dest: Path | str,
+    expected_sha256: str,
+    *,
+    download: Callable[[str, str], object] | None = None,
+) -> str:
+    """Fetch ``url`` to ``dest`` and verify its SHA256; return the checksum.
+
+    Idempotent: an existing ``dest`` with the right checksum is reused (no
+    download). Downloads to a ``.part`` sidecar and only promotes it on a
+    checksum match, so a mismatch never leaves a corrupt corpus in place. The
+    downloader is injectable for testing.
+    """
+    download = download or urllib.request.urlretrieve
+    dest = Path(dest)
+    if dest.exists():
+        actual = sha256_file(dest)
+        if actual == expected_sha256:
+            return actual
+        raise ValueError(
+            f"{dest} exists but its checksum {actual} != expected "
+            f"{expected_sha256}; delete it to re-fetch"
+        )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    partial = dest.with_name(dest.name + ".part")
+    try:
+        download(url, str(partial))
+        actual = sha256_file(partial)
+        if actual != expected_sha256:
+            raise ValueError(
+                f"checksum mismatch for {url}: expected {expected_sha256}, "
+                f"got {actual}"
+            )
+        partial.replace(dest)
+    finally:
+        if partial.exists():
+            partial.unlink()
+    return actual

--- a/scripts/bench/fetch_corpus.py
+++ b/scripts/bench/fetch_corpus.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fetch + SHA256-verify a context-corridor benchmark corpus (TD-CTXCORR-1 Slice 2b).
+
+Vectors are kept local and gitignored under benches/context-corridor/data/; the
+printed checksum is the report ``dataset_hash``. Idempotent — an existing file
+with the right checksum is reused.
+
+Example (SIFT1M base vectors)::
+
+    python3 scripts/bench/fetch_corpus.py \\
+      --url http://<mirror>/sift/sift_base.fvecs \\
+      --dest benches/context-corridor/data/sift/sift_base.fvecs \\
+      --sha256 <expected-sha256>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import corpus_io  # noqa: E402  (path-injected sibling module)
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "benches/context-corridor/data"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--dest", type=Path, required=True)
+    parser.add_argument("--sha256", required=True, help="expected SHA256 of the file")
+    args = parser.parse_args()
+    try:
+        checksum = corpus_io.fetch_corpus(args.url, args.dest, args.sha256)
+    except (OSError, ValueError) as error:
+        print(f"fetch_corpus failed: {error}", file=sys.stderr)
+        return 1
+    print(checksum)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_corpus_io.py
+++ b/tests/scripts/test_corpus_io.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "corpus_io", ROOT / "scripts/bench/corpus_io.py"
+)
+assert SPEC and SPEC.loader
+CORPUS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CORPUS)
+
+
+def _write_vecs(path: Path, vectors: list[list[float]], fmt: str) -> None:
+    with open(path, "wb") as handle:
+        for vector in vectors:
+            handle.write(struct.pack("<i", len(vector)))
+            handle.write(struct.pack(f"<{len(vector)}{fmt}", *vector))
+
+
+class CorpusIoTest(unittest.TestCase):
+    def test_read_fvecs_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "base.fvecs"
+            _write_vecs(path, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], "f")
+            self.assertEqual(
+                list(CORPUS.read_fvecs(path)),
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            )
+
+    def test_read_ivecs_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "gt.ivecs"
+            _write_vecs(path, [[7, 8], [9, 10]], "i")
+            self.assertEqual(list(CORPUS.read_ivecs(path)), [[7, 8], [9, 10]])
+
+    def test_read_fvecs_truncated_body_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.fvecs"
+            with open(path, "wb") as handle:
+                handle.write(struct.pack("<i", 3))  # claims dim 3 …
+                handle.write(b"\x00\x00\x00\x00")  # … but only one float follows
+            with self.assertRaises(ValueError):
+                list(CORPUS.read_fvecs(path))
+
+    def test_sha256_file_and_verify_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "blob.bin"
+            path.write_bytes(b"hello")
+            expected = hashlib.sha256(b"hello").hexdigest()
+            self.assertEqual(CORPUS.sha256_file(path), expected)
+            self.assertEqual(CORPUS.verify_checksum(path, expected), expected)
+            with self.assertRaises(ValueError):
+                CORPUS.verify_checksum(path, "0" * 64)
+
+    def test_fetch_corpus_downloads_verifies_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dest = Path(directory) / "nested" / "corpus.fvecs"
+            payload = b"vectors-payload"
+            checksum = hashlib.sha256(payload).hexdigest()
+            calls: list[str] = []
+
+            def fake_download(url: str, tmp: str) -> None:
+                calls.append(url)
+                Path(tmp).write_bytes(payload)
+
+            got = CORPUS.fetch_corpus(
+                "http://example/corpus", dest, checksum, download=fake_download
+            )
+            self.assertEqual(got, checksum)
+            self.assertTrue(dest.exists())
+            self.assertEqual(len(calls), 1)
+
+            # An existing file with the right checksum is reused, not re-downloaded.
+            again = CORPUS.fetch_corpus(
+                "http://example/corpus", dest, checksum, download=fake_download
+            )
+            self.assertEqual(again, checksum)
+            self.assertEqual(len(calls), 1)
+
+    def test_fetch_corpus_checksum_mismatch_raises_and_cleans_up(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dest = Path(directory) / "corpus.fvecs"
+
+            def fake_download(url: str, tmp: str) -> None:
+                Path(tmp).write_bytes(b"corrupted")
+
+            with self.assertRaises(ValueError):
+                CORPUS.fetch_corpus(
+                    "http://example", dest, "0" * 64, download=fake_download
+                )
+            self.assertFalse(dest.exists())
+            self.assertFalse(dest.with_name(dest.name + ".part").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #1440 (DatasetProvider seam) → #1439 → #1438 → develop. Auto-merge OFF until the base PRs merge in order.

The file-format + fetch foundation the real data providers (Slice 2b-ii) build on. Pure, self-contained, TDD'd — no downloads, no adapter changes.

## What lands
- `scripts/bench/corpus_io.py`: SIFT-family `.fvecs`/`.ivecs` streaming readers (with truncation validation), `sha256_file`/`verify_checksum`, and an idempotent `fetch_corpus` — downloads to a `.part` sidecar and promotes only on a checksum match, so a mismatch never leaves a corrupt corpus in place; downloader is injectable for testing.
- `scripts/bench/fetch_corpus.py`: the operator CLI (`--url --dest --sha256`), prints the checksum (→ report `dataset_hash`).
- `benches/context-corridor/data/.gitignore`: keeps the corpus dir, ignores the (multi-GB) vectors — never committed.

## TDD
Tests written first (RED) → implementation (GREEN). **6 corpus-IO tests** (fvecs/ivecs round-trip, truncated-body rejection, sha256 + verify, fetch download+verify+idempotent-reuse, mismatch-raises-and-cleans-up) on tiny byte fixtures — no network. Full suite **45/45**; validator, TD-uniqueness, and work-commit-check all green. Verified the data-dir gitignore actually ignores `*.fvecs`.

## Why foundation-only (autonomous scope)
Slice 2b-ii — the `SiftDatasetProvider`/`WikipediaDatasetProvider` classes and wiring each of the six adapters' distance + filter_field FROM the `DatasetDescriptor` — is a behavioral change to the now-merging benchmark that deserves live validation against the containers, so it is staged next rather than shipped unvalidated. This PR is the safe, tested substrate it needs (readers + fetch + checksum + local-corpus discipline).