### PR TITLE
feat(bench): SIFT vertical for context-corridor (TD-CTXCORR-1 Slice 2b-ii-A)

### DIFF
--- a/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
+++ b/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
@@ -119,25 +119,33 @@ metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
   the operator CLI. `benches/context-corridor/data/.gitignore` keeps the corpus
   dir but ignores the (large) vectors — never committed; the checksum is the
   report `dataset_hash`. All TDD'd on byte fixtures (no download in tests).
-* **Slice 2b-ii — real corpora + descriptor-driven adapters.** Build the concrete
-  providers on the Slice-2a seam and 2b-i IO, and drive ALL six adapters from one
-  locally-held, checksummed corpus (`synthetic` stays as the CI/smoke path):
+* **Slice 2b-ii-A — SIFT vertical (DONE).** `SiftDatasetProvider` reads local
+  `.fvecs`/`.ivecs` (via 2b-i `corpus_io`) → descriptor `distance=l2`,
+  `filter_field=None`, with unfiltered ground truth from the precomputed
+  neighbours. The harness is now **filter-optional**: `descriptor.filter_field`
+  may be None → `run_queries` runs unfiltered-only and reports
+  `filtered_recall_at_10` as unavailable (None). The **Qdrant** adapter is
+  descriptor-driven (distance cosine→Cosine / l2→Euclid; filter field from the
+  descriptor; no payload index when there is no filter field) with
+  backward-compatible cosine/`partition` defaults, and declares
+  `supported_distances`. `build_provider` wires `sift1m`; a distance guard rejects
+  a dataset whose distance an adapter does not yet support. Live-validated
+  end-to-end on Qdrant: SIFT fixture (L2, no filter) recall@10 = 1.0 vs exact-L2
+  ground truth; synthetic path byte-identical (cosine/partition, recall 1.0).
+* **Slice 2b-ii-B — Wikipedia + the remaining five adapters.** Build the concrete
+  providers on the Slice-2a seam and 2b-i IO, and drive the rest of the fleet:
   ** **Wikipedia passage embeddings WITH metadata** (DECIDED: e.g. Cohere
      `wikipedia-22-12`) as the primary *filtered-corridor* driver — each vector
      carries a real categorical field (`lang`, article `category`/`title`) so the
      filter is correlated with content, which is what actually stresses
      pre/post-filter behaviour. This is the differentiating measurement.
-  ** **SIFT1M** as the standard *unfiltered* recall reference (1M x 128, 10k
-     queries, canonical precomputed 100-NN ground truth, L2 distance) — credibility
-     and comparability with published ANN results. It has no metadata, so it
-     cannot exercise the filtered corridor — it is a reference, not the driver.
   ** **Precompute filtered ground truth once**, offline, cached keyed by
      `(corpus_hash, query_hash, k, filter_field)` — the pure-Python
      `GroundTruthAccumulator` is `O(N*Q*dim)`, fine for validation, not for 1M.
-  ** **Wire each adapter's distance + filter_field FROM the `DatasetDescriptor`**
-     (the 2a seam exposes both) instead of the hardcoded cosine/`partition`, so
-     SIFT (L2, no metadata → filter optional) and Wikipedia (cosine, `lang`) flow
-     through unchanged. Live-validate against the containers.
+  ** **Make pgvector / Milvus / Elasticsearch / SurrealDB / ProximaDB
+     descriptor-driven** (distance + filter_field from the `DatasetDescriptor`,
+     as Qdrant now is) so SIFT (L2) and Wikipedia (cosine, `lang`) flow through
+     the whole fleet unchanged. Live-validate each against its container.
 * **Slice 3 — Inline-mode filtered runs.** Expose an
   `--proximadb-filter-mode {auto,inline,prefilter}` knob on `ProximaAdapter` that
   sets the AXIS `ann_filtering_mode` (+ selectivity) on the REST `search` request

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -33,6 +33,14 @@ try:
 except ImportError:  # pragma: no cover - exercised on Windows runners.
     resource = None  # type: ignore[assignment]
 
+# corpus_io is a sibling module in scripts/bench/. Inject that directory so the
+# import works both when run as a script and when loaded via importlib in tests.
+_BENCH_DIR = str(Path(__file__).resolve().parent)
+if _BENCH_DIR not in sys.path:
+    sys.path.insert(0, _BENCH_DIR)
+
+import corpus_io  # noqa: E402  — path-injected sibling bench module
+
 SCENARIO_ID = "context-corridor-v1"
 TOP_K = 10
 REQUIRED_METRICS = (
@@ -254,7 +262,7 @@ class DatasetDescriptor:
     distance: str  # "cosine" | "l2" — the contract that drives adapter config
     record_count: int
     dataset_hash: str
-    filter_field: str  # the metadata field the filtered corridor filters on
+    filter_field: str | None  # the filter field, or None if the dataset has none
     query_count: int
 
 
@@ -344,6 +352,89 @@ class SyntheticDatasetProvider:
         rng = random.Random(self._seed)
         for index in range(self._record_count):
             yield make_record(index, self._dimension, rng)
+
+    def queries(self) -> list[QueryGroundTruth]:
+        if self._queries is None:
+            self._build()
+        assert self._queries is not None
+        return self._queries
+
+
+class SiftDatasetProvider:
+    """SIFT1M-family provider: the canonical *unfiltered* recall reference.
+
+    Reads local `.fvecs` base/query vectors and `.ivecs` precomputed neighbours
+    (TD-CTXCORR-1 Slice 2b). SIFT has no metadata, so `filter_field` is None and
+    the harness runs unfiltered-only. Distance is L2, per the SIFT convention.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_path: Path | str,
+        query_path: Path | str,
+        groundtruth_path: Path | str,
+        top_k: int,
+    ) -> None:
+        self._base_path = Path(base_path)
+        self._query_path = Path(query_path)
+        self._groundtruth_path = Path(groundtruth_path)
+        self._top_k = top_k
+        self._descriptor: DatasetDescriptor | None = None
+        self._queries: list[QueryGroundTruth] | None = None
+
+    def _dimension_and_count(self) -> tuple[int, int]:
+        first = next(corpus_io.read_fvecs(self._base_path), None)
+        if first is None:
+            return 0, 0
+        dimension = len(first)
+        # int32 header + dimension * float32 per record.
+        record_size = 4 + 4 * dimension
+        return dimension, self._base_path.stat().st_size // record_size
+
+    def _build(self) -> None:
+        query_vectors = list(corpus_io.read_fvecs(self._query_path))
+        groundtruth = list(corpus_io.read_ivecs(self._groundtruth_path))
+        if len(groundtruth) != len(query_vectors):
+            raise ValueError(
+                "SIFT ground-truth row count does not match the query count"
+            )
+        self._queries = [
+            QueryGroundTruth(
+                query={
+                    "id": f"query-{index}",
+                    "vector": vector,
+                    "props": {"ordinal": -1},
+                },
+                unfiltered_truth=frozenset(
+                    f"sift-{neighbour}" for neighbour in neighbours[: self._top_k]
+                ),
+                filtered_truth=frozenset(),
+            )
+            for index, (vector, neighbours) in enumerate(
+                zip(query_vectors, groundtruth)
+            )
+        ]
+        dimension, record_count = self._dimension_and_count()
+        self._descriptor = DatasetDescriptor(
+            name="sift1m",
+            dimension=dimension,
+            distance="l2",
+            record_count=record_count,
+            dataset_hash=corpus_io.sha256_file(self._base_path),
+            filter_field=None,
+            query_count=len(self._queries),
+        )
+
+    def descriptor(self) -> DatasetDescriptor:
+        if self._descriptor is None:
+            self._build()
+        assert self._descriptor is not None
+        return self._descriptor
+
+    def corpus(self) -> Iterator[dict[str, Any]]:
+        for index, vector in enumerate(corpus_io.read_fvecs(self._base_path)):
+            yield {"id": f"sift-{index}", "vector": vector, "props": {"ordinal": index}}
 
     def queries(self) -> list[QueryGroundTruth]:
         if self._queries is None:
@@ -648,8 +739,12 @@ class PgvectorAdapter:
             self.connection.close()
 
 
+_QDRANT_DISTANCE = {"cosine": "Cosine", "l2": "Euclid"}
+
+
 class QdrantAdapter:
     system_id = "qdrant"
+    supported_distances = ("cosine", "l2")
 
     def __init__(
         self,
@@ -657,12 +752,19 @@ class QdrantAdapter:
         api_key: str,
         timeout: float,
         collection: str,
+        distance: str = "cosine",
+        filter_field: str | None = "partition",
     ) -> None:
         if not re.fullmatch(r"[A-Za-z0-9_-]+", collection):
             raise ValueError("generated Qdrant collection name is not safe")
+        if distance not in _QDRANT_DISTANCE:
+            raise ValueError(f"unsupported Qdrant distance: {distance}")
         self.base_url = base_url
         self.timeout = timeout
         self.collection = collection
+        self.distance = distance
+        self.filter_field = filter_field
+        self._qdrant_distance = _QDRANT_DISTANCE[distance]
         self.headers = {"api-key": api_key} if api_key else {}
         self.version = "unknown"
         self.query_usage: dict[str, float] = {}
@@ -688,17 +790,19 @@ class QdrantAdapter:
             "PUT",
             f"/collections/{self.collection}",
             {
-                "vectors": {"size": dimension, "distance": "Cosine"},
+                "vectors": {"size": dimension, "distance": self._qdrant_distance},
                 "hnsw_config": {"m": 16, "ef_construct": 100},
             },
         )
         # Qdrant recommends creating payload indexes before ingest so filtered
-        # queries never measure an unindexed payload scan.
-        self._request(
-            "PUT",
-            f"/collections/{self.collection}/index?wait=true",
-            {"field_name": "partition", "field_schema": "keyword"},
-        )
+        # queries never measure an unindexed payload scan. Datasets without a
+        # filter field (e.g. SIFT) skip this.
+        if self.filter_field is not None:
+            self._request(
+                "PUT",
+                f"/collections/{self.collection}/index?wait=true",
+                {"field_name": self.filter_field, "field_schema": "keyword"},
+            )
 
     def insert_batch(self, records: list[dict[str, Any]]) -> None:
         points = [
@@ -769,12 +873,12 @@ class QdrantAdapter:
             "with_payload": ["record_id"],
             "params": {"hnsw_ef": 40, "exact": False},
         }
-        if filtered:
+        if filtered and self.filter_field is not None:
             body["filter"] = {
                 "must": [
                     {
-                        "key": "partition",
-                        "match": {"value": record["props"]["partition"]},
+                        "key": self.filter_field,
+                        "match": {"value": record["props"][self.filter_field]},
                     }
                 ]
             }
@@ -813,10 +917,14 @@ class QdrantAdapter:
         return {
             "base_url": self.base_url,
             "server_version": self.version,
-            "distance": "cosine",
+            "distance": self.distance,
             "index": "hnsw(m=16,ef_construct=100)",
             "hnsw_ef_search": 40,
-            "filter_index": "keyword(partition)",
+            "filter_index": (
+                f"keyword({self.filter_field})"
+                if self.filter_field is not None
+                else "none"
+            ),
             "query_endpoint": "/points/query",
             "write_visibility": "wait=true per batch",
             "readiness_fence": "green status and empty update queue",
@@ -1461,34 +1569,46 @@ def run_queries(
     queries: list[QueryGroundTruth],
     *,
     warmup_count: int,
-) -> tuple[dict[str, float], list[float]]:
+    supports_filter: bool = True,
+) -> tuple[dict[str, float | None], list[float]]:
+    # When the dataset has no filter field (descriptor.filter_field is None), the
+    # filtered corridor does not apply: run unfiltered-only and report
+    # filtered_recall_at_10 as unavailable (None).
     unfiltered_recall = 0.0
     filtered_recall = 0.0
     measured = 0
-    filtered_latencies: list[float] = []
+    latencies: list[float] = []
     for ordinal, ground_truth in enumerate(queries):
-        unfiltered_ids, _ = adapter.search(ground_truth.query, filtered=False)
-        filtered_ids, filtered_latency = adapter.search(
-            ground_truth.query, filtered=True
+        unfiltered_ids, unfiltered_latency = adapter.search(
+            ground_truth.query, filtered=False
         )
+        if supports_filter:
+            filtered_ids, filtered_latency = adapter.search(
+                ground_truth.query, filtered=True
+            )
+        else:
+            filtered_ids, filtered_latency = [], unfiltered_latency
         if ordinal < warmup_count:
             continue
         measured += 1
-        filtered_latencies.append(filtered_latency)
+        latencies.append(filtered_latency)
         unfiltered_recall += recall_at_k(
             unfiltered_ids[:TOP_K], ground_truth.unfiltered_truth
         )
-        filtered_recall += recall_at_k(
-            filtered_ids[:TOP_K], ground_truth.filtered_truth
-        )
+        if supports_filter:
+            filtered_recall += recall_at_k(
+                filtered_ids[:TOP_K], ground_truth.filtered_truth
+            )
     if measured == 0:
         raise RuntimeError("benchmark produced no measured queries")
     return (
         {
             "recall_at_10": round(unfiltered_recall / measured, 6),
-            "filtered_recall_at_10": round(filtered_recall / measured, 6),
+            "filtered_recall_at_10": (
+                round(filtered_recall / measured, 6) if supports_filter else None
+            ),
         },
-        filtered_latencies,
+        latencies,
     )
 
 
@@ -1580,17 +1700,24 @@ def write_report(path: Path, report: dict[str, Any]) -> None:
     )
 
 
-def make_adapter(args: argparse.Namespace, run_name: str) -> Adapter:
+def make_adapter(
+    args: argparse.Namespace, run_name: str, descriptor: DatasetDescriptor
+) -> Adapter:
     if args.system == "proximadb":
         return ProximaAdapter(args.base_url, args.timeout, run_name)
     if args.system == "pgvector":
         return PgvectorAdapter(args.pg_dsn, run_name)
     if args.system == "qdrant":
+        # Qdrant is descriptor-driven (distance + filter field from the dataset);
+        # other adapters gain this in TD-CTXCORR-1 Slice 2b-ii and stay cosine +
+        # "partition" for now (guarded below).
         return QdrantAdapter(
             args.qdrant_url,
             args.qdrant_api_key,
             args.timeout,
             run_name,
+            distance=descriptor.distance,
+            filter_field=descriptor.filter_field,
         )
     if args.system == "milvus":
         return MilvusAdapter(
@@ -1628,14 +1755,19 @@ def build_provider(args: argparse.Namespace) -> DatasetProvider:
             query_count=args.warmup + args.queries,
             top_k=TOP_K,
         )
-    # SIFT1M (unfiltered reference) and Wikipedia (filtered driver) load local,
-    # checksummed, memory-mapped vectors + precomputed ground truth, and drive the
-    # adapters' distance/filter-field from the descriptor. That IO and the
-    # adapter re-parameterization are TD-CTXCORR-1 Slice 2b.
+    if args.dataset == "sift1m":
+        return SiftDatasetProvider(
+            base_path=args.sift_base,
+            query_path=args.sift_query,
+            groundtruth_path=args.sift_groundtruth,
+            top_k=TOP_K,
+        )
+    # Wikipedia (filtered driver: local passage embeddings + lang/category
+    # metadata, cosine, precomputed filtered ground truth) is TD-CTXCORR-1 Slice
+    # 2b-ii-B.
     raise NotImplementedError(
-        f"dataset {args.dataset!r} is not wired yet: it needs the fetch + "
-        "precomputed ground-truth loaders and descriptor-driven adapter config "
-        "(TD-CTXCORR-1 Slice 2b)"
+        f"dataset {args.dataset!r} is not wired yet: the Wikipedia filtered-corridor "
+        "driver is TD-CTXCORR-1 Slice 2b-ii-B"
     )
 
 
@@ -1702,8 +1834,11 @@ def main() -> int:
         "--dataset",
         choices=("synthetic", "sift1m", "wikipedia"),
         default="synthetic",
-        help="synthetic (deterministic CI/smoke); sift1m/wikipedia = TD-CTXCORR-1 Slice 2b",
+        help="synthetic (deterministic CI/smoke); sift1m (unfiltered reference); wikipedia = Slice 2b-ii-B",
     )
+    parser.add_argument("--sift-base", type=Path, help="SIFT base .fvecs (local, gitignored)")
+    parser.add_argument("--sift-query", type=Path, help="SIFT query .fvecs")
+    parser.add_argument("--sift-groundtruth", type=Path, help="SIFT ground-truth .ivecs")
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
     parser.add_argument("--queries", type=int, default=200)
@@ -1732,7 +1867,15 @@ def main() -> int:
     provider = build_provider(args)
     descriptor = provider.descriptor()
     run_name = f"context_bench_{int(time.time())}_{run_rng.randrange(100000):05d}"
-    adapter = make_adapter(args, run_name)
+    adapter = make_adapter(args, run_name, descriptor)
+    supported = getattr(type(adapter), "supported_distances", ("cosine",))
+    if descriptor.distance not in supported:
+        parser.error(
+            f"the {args.system} adapter does not support distance "
+            f"'{descriptor.distance}' required by dataset '{descriptor.name}' yet "
+            "(TD-CTXCORR-1 Slice 2b-ii)"
+        )
+    supports_filter = descriptor.filter_field is not None
     try:
         ingest_seconds = ingest_stream(
             adapter,
@@ -1743,6 +1886,7 @@ def main() -> int:
             adapter,
             provider.queries(),
             warmup_count=args.warmup,
+            supports_filter=supports_filter,
         )
         report = build_report(
             adapter,

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib.util
 import json
 import random
+import struct
 import sys
 import tempfile
 import unittest
@@ -126,7 +127,7 @@ class ContextCorridorTest(unittest.TestCase):
 
     def test_build_provider_rejects_unfetched_datasets(self) -> None:
         args = argparse.Namespace(
-            dataset="sift1m",
+            dataset="wikipedia",
             records=10,
             dimension=4,
             queries=1,
@@ -136,6 +137,117 @@ class ContextCorridorTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError) as caught:
             CONTEXT.build_provider(args)
         self.assertIn("TD-CTXCORR-1", str(caught.exception))
+
+    def _write_vecs(self, path: Path, vectors: list[list[float]], fmt: str) -> None:
+        with open(path, "wb") as handle:
+            for vector in vectors:
+                handle.write(struct.pack("<i", len(vector)))
+                handle.write(struct.pack(f"<{len(vector)}{fmt}", *vector))
+
+    def test_sift_provider_reads_fvecs_ivecs_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory) / "base.fvecs"
+            query = Path(directory) / "query.fvecs"
+            gt = Path(directory) / "gt.ivecs"
+            self._write_vecs(
+                base, [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], "f"
+            )
+            self._write_vecs(query, [[0.9, 0.1]], "f")
+            # Nearest base vectors to the query, by index: 1 then 3.
+            self._write_vecs(gt, [[1, 3]], "i")
+            provider = CONTEXT.SiftDatasetProvider(
+                base_path=base, query_path=query, groundtruth_path=gt, top_k=2
+            )
+            descriptor = provider.descriptor()
+            self.assertEqual(descriptor.name, "sift1m")
+            self.assertEqual(descriptor.distance, "l2")
+            self.assertEqual(descriptor.dimension, 2)
+            self.assertEqual(descriptor.record_count, 4)
+            self.assertIsNone(descriptor.filter_field)
+            corpus = list(provider.corpus())
+            self.assertEqual([r["id"] for r in corpus], ["sift-0", "sift-1", "sift-2", "sift-3"])
+            (ground_truth,) = provider.queries()
+            self.assertEqual(ground_truth.unfiltered_truth, frozenset({"sift-1", "sift-3"}))
+            self.assertEqual(ground_truth.filtered_truth, frozenset())
+
+    def test_run_queries_is_filter_optional(self) -> None:
+        class UnfilteredStub:
+            system_id = "stub"
+
+            def __init__(self) -> None:
+                self.filtered_calls = 0
+
+            def search(self, record, *, filtered):
+                if filtered:
+                    self.filtered_calls += 1
+                    return ["z"], 9.0
+                return ["a", "b"], 1.0
+
+        adapter = UnfilteredStub()
+        queries = [
+            CONTEXT.QueryGroundTruth(
+                query={"id": "query-0", "vector": [0.0], "props": {}},
+                unfiltered_truth=frozenset({"a", "b"}),
+                filtered_truth=frozenset(),
+            )
+        ]
+        accuracy, latencies = CONTEXT.run_queries(
+            adapter, queries, warmup_count=0, supports_filter=False
+        )
+        self.assertEqual(accuracy["recall_at_10"], 1.0)
+        self.assertIsNone(accuracy["filtered_recall_at_10"])
+        self.assertEqual(adapter.filtered_calls, 0)  # never runs a filtered search
+        self.assertEqual(latencies, [1.0])  # unfiltered latency stands in
+
+    def test_qdrant_adapter_is_descriptor_driven(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return {"result": {}}, 0.5
+
+        # L2 + no filter field: Euclid distance, and NO payload index is created.
+        adapter = CONTEXT.QdrantAdapter(
+            "http://qdrant.example",
+            "",
+            12.0,
+            "context_bench_1",
+            distance="l2",
+            filter_field=None,
+        )
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+        # calls[0] is the GET "/" version probe; calls[1] is the collection create.
+        create = calls[1][0][3]
+        self.assertEqual(create["vectors"]["distance"], "Euclid")
+        self.assertFalse(any("/index" in c[0][2] for c in calls))
+        self.assertEqual(adapter.environment()["distance"], "l2")
+        self.assertIn("cosine", CONTEXT.QdrantAdapter.supported_distances)
+        self.assertIn("l2", CONTEXT.QdrantAdapter.supported_distances)
+
+    def test_qdrant_adapter_defaults_preserve_cosine_partition(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_request(*args, **kwargs):
+            calls.append((args, kwargs))
+            return {"result": {}}, 0.5
+
+        adapter = CONTEXT.QdrantAdapter("http://qdrant.example", "", 12.0, "c1")
+        with patch.object(CONTEXT, "request", side_effect=fake_request):
+            adapter.prepare(2)
+        self.assertEqual(calls[1][0][3]["vectors"]["distance"], "Cosine")
+        self.assertTrue(any("/index" in c[0][2] for c in calls))  # partition index created
+        self.assertEqual(adapter.environment()["filter_index"], "keyword(partition)")
+
+    def test_build_provider_constructs_sift(self) -> None:
+        args = argparse.Namespace(
+            dataset="sift1m",
+            sift_base="/data/base.fvecs",
+            sift_query="/data/query.fvecs",
+            sift_groundtruth="/data/gt.ivecs",
+        )
+        provider = CONTEXT.build_provider(args)
+        self.assertIsInstance(provider, CONTEXT.SiftDatasetProvider)
 
     def test_queries_measure_recall_against_ground_truth(self) -> None:
         class StubAdapter:


### PR DESCRIPTION
Stacked on #1441 (dataset-IO) → #1440 → #1439 → #1438 → develop. Auto-merge OFF until the base PRs merge in order.

The first RUNNABLE real-dataset vertical: real `.fvecs/.ivecs` → provider → descriptor → descriptor-driven adapter → recall vs precomputed ground truth. Proves the 2a seam + 2b-i IO end-to-end.

## What lands (TDD)
- **`SiftDatasetProvider`** — reads local `.fvecs` base/query + `.ivecs` neighbours (via 2b-i `corpus_io`); descriptor `distance=l2`, `filter_field=None`; unfiltered ground truth from the precomputed neighbours.
- **Filter-optional harness** — `descriptor.filter_field` may be None → `run_queries` runs unfiltered-only and reports `filtered_recall_at_10` as unavailable (None). SIFT has no metadata, so this is the honest shape.
- **Descriptor-driven Qdrant** — distance cosine→Cosine / l2→Euclid; filter field from the descriptor; no payload index when there's no filter field. **Backward-compatible** cosine/`partition` defaults, so the synthetic path is byte-identical. Declares `supported_distances`.
- **`build_provider` wires `sift1m`**; a distance guard cleanly rejects a dataset whose distance an adapter doesn't support yet (the other 5 adapters → Slice 2b-ii-B).

## Validation
- RED→GREEN; **50/50 tests** (SIFT fvecs/ivecs fixture read, filter-optional recall, Qdrant descriptor-driven + defaults-preserved, build_provider sift). Validator, TD-uniqueness, work-commit-check all green.
- **Live end-to-end on Qdrant** with a generated SIFT fixture (exact-L2 ground truth): SIFT (L2, no filter) recall@10 = 1.0; synthetic (cosine, partition) unchanged at recall 1.0 / filtered 1.0.

## Deferred (Slice 2b-ii-B)
Wikipedia filtered-corridor driver + making the other five adapters (pgvector/Milvus/ES/SurrealDB/ProximaDB) descriptor-driven — a fleet-wide change I want to live-validate per-container, so it's staged next rather than shipped unvalidated.