### PR TITLE
build: warn about merge skew when refreshing a whole-tree baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,41 @@ panic-policy-baseline:
 	@echo "🧯 Refreshing WS-2 panic policy baseline..."
 	bash scripts/count_panic_patterns.sh --mode report --format json --write $(PANIC_POLICY_BASELINE)
 	@echo "Updated baseline: $(PANIC_POLICY_BASELINE)"
+	@$(MAKE) --no-print-directory baseline-merge-skew-warning ARTIFACT="$(PANIC_POLICY_BASELINE)" REVERIFY="make panic-policy-no-regression"
+
+# Shared post-refresh warning for every COMPUTED WHOLE-TREE SNAPSHOT baseline
+# (v1-proto usage, panic policy, coverage). Not a gate — a reminder printed at the
+# one moment it is actionable.
+#
+# WHY (real incident, 2026-08-05, PR #1431 -> #1436): #1431 refreshed the v1-proto
+# floor 2913 -> 2770, a number computed on the tree at that moment. While it sat in
+# review, #1424 merged and added one v1 reference. #1431 then merged carrying the
+# now-stale 2770 while develop's truth was 2771, so every later src/-touching PR
+# failed `2771 > 2770` — a false-positive red that blocked the queue until #1436
+# regenerated the number. Both PRs were individually GREEN: CI validates a PR's own
+# tree, and `required_status_checks.strict` is false on develop, so a green tick is
+# a claim about the branch, not about the merge result.
+#
+# The trap is that these artifacts are snapshots of a GLOBAL property, so they are
+# coupled to EVERY file. The usual rebase test — "does develop conflict with the
+# files I touched?" — always answers "no" for a one-line JSON edit and is the wrong
+# question. The right one: "did anything land under me that changes the number I
+# froze?" Regenerate immediately before merge; do not trust a number computed hours
+# earlier.
+.PHONY: baseline-merge-skew-warning
+baseline-merge-skew-warning:
+	@echo ""
+	@echo "⚠️  $(ARTIFACT) is a snapshot of a GLOBAL property of the whole tree."
+	@echo "    It goes stale the moment ANY other PR lands a change to what it counts,"
+	@echo "    and CI will NOT catch that: it validates your branch, not the merge result"
+	@echo "    (develop does not require branches to be up to date)."
+	@echo ""
+	@echo "    Before merging, rebase on the latest develop, re-run this refresh, and verify:"
+	@echo "        git fetch origin && git rebase origin/develop"
+	@echo "        $(REVERIFY)"
+	@echo ""
+	@echo "    A floor left one below reality turns EVERY subsequent PR red (see #1431 -> #1436)."
+	@echo ""
 
 # TD-123: ratchet proximadb.v1 proto usage downward as the v1->v2 message-type
 # migration proceeds. v1 proto is the legacy internal domain model; this gate
@@ -256,6 +291,7 @@ v1-proto-usage-baseline:
 	@echo "🧹 Refreshing TD-123 v1 proto usage baseline..."
 	python3 scripts/check_v1_proto_usage.py --mode report --format json --write $(V1_PROTO_USAGE_BASELINE)
 	@echo "Updated baseline: $(V1_PROTO_USAGE_BASELINE)"
+	@$(MAKE) --no-print-directory baseline-merge-skew-warning ARTIFACT="$(V1_PROTO_USAGE_BASELINE)" REVERIFY="make v1-proto-usage-no-regression"
 
 # Release targets
 release: clean build-server test benchmark


### PR DESCRIPTION
Adds a `baseline-merge-skew-warning` target, invoked by `v1-proto-usage-baseline` and `panic-policy-baseline`, printing the rebase + re-verify sequence at the one moment it's actionable.

**Makefile only. No gate, no CI change, no behaviour change.**

## Why — a real incident (#1431 → #1436)

#1431 refreshed the v1-proto floor 2913 → **2770**, computed on the tree at that moment. While it sat in review, **#1424 merged and added one v1 reference** to `tests/hmgi_integration_test.rs`. #1431 then merged carrying the stale 2770 while develop's truth was **2771** — so every later `src/`-touching PR failed `2771 > 2770`. A false-positive red that blocked the queue (incl. #1434) until #1436 regenerated the number.

Proof it was already stale at merge:

```
$ git show ead2cd170:tests/hmgi_integration_test.rs | grep -c 'proximadb_v1\|proximadb\.v1'
4          # the merge commit contains the ref its own baseline doesn't count
```

**Both PRs were individually green, and that's the point.** CI validates a PR's own tree, and `required_status_checks.strict` is `false` on develop, so a green tick is a claim about the *branch*, not the *merge result*.

## The trap worth naming

These artifacts snapshot a **global property**, so they're coupled to every file in the tree. The habitual rebase test — *"does develop conflict with the files I touched?"* — always answers "no" for a one-line JSON edit, which is exactly why this slipped past. The right question is *"did anything land under me that changes the number I froze?"*

## Why a reminder and not enforcement

Enforcing it means one of two things, both worse right now:

- **Require up-to-date branches (`strict`)** — develop takes **~17 merges/day** (122/7d) against **~37 min** CI. Every merge would invalidate every open PR; at 3–5 concurrent PRs that multiplies runner load ~4–6× on the shared, finite resource mandate #7 calls out.
- **Merge queue** — the right instrument if this recurs, but there's no `merge_group` trigger today.

And the failure is self-healing: TD-149 already runs the drift jobs unconditionally on push to a protected branch, which is what surfaced this one inside ~90 minutes. Paying a permanent CI tax to prevent an occasional short-lived false red is the wrong trade. The reasoning is recorded in the Makefile comment so nobody "upgrades" this to a gate without re-deriving the cost.

## Verification

- `make v1-proto-usage-baseline` prints the warning **and** still writes a correct baseline — `total: 2771` unchanged, only `generated_at` moved. That doubles as an independent confirmation that #1436's corrected floor is right.
- Reverted that timestamp so this PR carries **no baseline churn** — committing a freshly-computed baseline here would risk reintroducing the very skew being documented.
- `make -n panic-policy-baseline` expands correctly.
- `make work-commit-check` green.

Ref #1431, #1436, #1424, TD-123, TD-149.