### PR TITLE
feat(bench): Wikipedia filtered-corridor provider (TD-CTXCORR-1 Slice 2b-ii-B)

### DIFF
--- a/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
+++ b/docs/10-quality/td/TD-CTXCORR-1-context-corridor-evidence-arc.adoc
@@ -132,20 +132,23 @@ metadata) are what stress ANN recall and filtered pre/post-filter behaviour.
   a dataset whose distance an adapter does not yet support. Live-validated
   end-to-end on Qdrant: SIFT fixture (L2, no filter) recall@10 = 1.0 vs exact-L2
   ground truth; synthetic path byte-identical (cosine/partition, recall 1.0).
-* **Slice 2b-ii-B — Wikipedia + the remaining five adapters.** Build the concrete
-  providers on the Slice-2a seam and 2b-i IO, and drive the rest of the fleet:
-  ** **Wikipedia passage embeddings WITH metadata** (DECIDED: e.g. Cohere
-     `wikipedia-22-12`) as the primary *filtered-corridor* driver — each vector
-     carries a real categorical field (`lang`, article `category`/`title`) so the
-     filter is correlated with content, which is what actually stresses
-     pre/post-filter behaviour. This is the differentiating measurement.
-  ** **Precompute filtered ground truth once**, offline, cached keyed by
-     `(corpus_hash, query_hash, k, filter_field)` — the pure-Python
-     `GroundTruthAccumulator` is `O(N*Q*dim)`, fine for validation, not for 1M.
-  ** **Make pgvector / Milvus / Elasticsearch / SurrealDB / ProximaDB
-     descriptor-driven** (distance + filter_field from the `DatasetDescriptor`,
-     as Qdrant now is) so SIFT (L2) and Wikipedia (cosine, `lang`) flow through
-     the whole fleet unchanged. Live-validate each against its container.
+* **Slice 2b-ii-B — Wikipedia filtered-corridor driver (DONE).**
+  `WikipediaDatasetProvider` reads local `.fvecs` base vectors + a parallel
+  metadata `.jsonl` (per-vector `lang`/`category`) + a `queries.jsonl` cache
+  (each query: vector, filter value, precomputed unfiltered AND within-filter
+  ground truth) → descriptor `distance=cosine`, `filter_field="lang"`. Ground
+  truth is precomputed offline (the cache file); the `dataset_hash` is the base
+  `.fvecs` checksum. `build_provider` wires `wikipedia`. Live-validated
+  end-to-end on the (already descriptor-driven) Qdrant with a cosine + `lang`
+  fixture: recall@10 = 1.0 AND filtered_recall@10 = 1.0 vs exact cosine ground
+  truth — the differentiating *filtered* measurement, and proof the seam needed
+  zero further adapter change for a content-correlated filter.
+* **Slice 2b-ii-C — the remaining five adapters, descriptor-driven.** Make
+  pgvector / Milvus / Elasticsearch / SurrealDB / ProximaDB take distance +
+  filter_field from the `DatasetDescriptor` (as Qdrant now does) so SIFT (L2) and
+  Wikipedia (cosine, `lang`) flow through the whole fleet, not just Qdrant.
+  Live-validate each against its container. (A distance guard already blocks a
+  mismatched run until each adapter is converted.)
 * **Slice 3 — Inline-mode filtered runs.** Expose an
   `--proximadb-filter-mode {auto,inline,prefilter}` knob on `ProximaAdapter` that
   sets the AXIS `ann_filtering_mode` (+ selectivity) on the REST `search` request

--- a/scripts/bench/context_corridor.py
+++ b/scripts/bench/context_corridor.py
@@ -443,6 +443,100 @@ class SiftDatasetProvider:
         return self._queries
 
 
+class WikipediaDatasetProvider:
+    """Wikipedia passage-embedding provider: the filtered-corridor driver.
+
+    Reads local `.fvecs` base vectors, a parallel `.jsonl` metadata file (one JSON
+    object per base vector carrying the categorical filter field), and a
+    `queries.jsonl` cache (each query: vector, filter value, and precomputed
+    unfiltered + filtered ground-truth ids). Distance is cosine; the filter is a
+    real content-correlated field (`lang`/`category`) — the differentiating
+    filtered-corridor measurement (TD-CTXCORR-1 Slice 2b-ii-B).
+    """
+
+    system_distance = "cosine"
+
+    def __init__(
+        self,
+        *,
+        base_path: Path | str,
+        meta_path: Path | str,
+        queries_path: Path | str,
+        top_k: int,
+        filter_field: str = "lang",
+    ) -> None:
+        self._base_path = Path(base_path)
+        self._meta_path = Path(meta_path)
+        self._queries_path = Path(queries_path)
+        self._top_k = top_k
+        self._filter_field = filter_field
+        self._descriptor: DatasetDescriptor | None = None
+        self._queries: list[QueryGroundTruth] | None = None
+
+    def _build(self) -> None:
+        queries: list[QueryGroundTruth] = []
+        with open(self._queries_path, encoding="utf-8") as handle:
+            for index, line in enumerate(handle):
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                queries.append(
+                    QueryGroundTruth(
+                        query={
+                            "id": f"query-{index}",
+                            "vector": record["vector"],
+                            "props": {
+                                self._filter_field: record["filter_value"],
+                                "ordinal": -1,
+                            },
+                        },
+                        unfiltered_truth=frozenset(record["unfiltered_truth"]),
+                        filtered_truth=frozenset(record["filtered_truth"]),
+                    )
+                )
+        self._queries = queries
+        first = next(corpus_io.read_fvecs(self._base_path), None)
+        dimension = len(first) if first is not None else 0
+        record_count = (
+            self._base_path.stat().st_size // (4 + 4 * dimension)
+            if dimension
+            else 0
+        )
+        self._descriptor = DatasetDescriptor(
+            name="wikipedia",
+            dimension=dimension,
+            distance=self.system_distance,
+            record_count=record_count,
+            dataset_hash=corpus_io.sha256_file(self._base_path),
+            filter_field=self._filter_field,
+            query_count=len(queries),
+        )
+
+    def descriptor(self) -> DatasetDescriptor:
+        if self._descriptor is None:
+            self._build()
+        assert self._descriptor is not None
+        return self._descriptor
+
+    def corpus(self) -> Iterator[dict[str, Any]]:
+        with open(self._meta_path, encoding="utf-8") as meta_handle:
+            for index, (vector, meta_line) in enumerate(
+                zip(corpus_io.read_fvecs(self._base_path), meta_handle)
+            ):
+                metadata = json.loads(meta_line)
+                yield {
+                    "id": f"wiki-{index}",
+                    "vector": vector,
+                    "props": {**metadata, "ordinal": index},
+                }
+
+    def queries(self) -> list[QueryGroundTruth]:
+        if self._queries is None:
+            self._build()
+        assert self._queries is not None
+        return self._queries
+
+
 class Adapter(Protocol):
     system_id: str
 
@@ -1762,13 +1856,15 @@ def build_provider(args: argparse.Namespace) -> DatasetProvider:
             groundtruth_path=args.sift_groundtruth,
             top_k=TOP_K,
         )
-    # Wikipedia (filtered driver: local passage embeddings + lang/category
-    # metadata, cosine, precomputed filtered ground truth) is TD-CTXCORR-1 Slice
-    # 2b-ii-B.
-    raise NotImplementedError(
-        f"dataset {args.dataset!r} is not wired yet: the Wikipedia filtered-corridor "
-        "driver is TD-CTXCORR-1 Slice 2b-ii-B"
-    )
+    if args.dataset == "wikipedia":
+        return WikipediaDatasetProvider(
+            base_path=args.wiki_base,
+            meta_path=args.wiki_meta,
+            queries_path=args.wiki_queries,
+            top_k=TOP_K,
+            filter_field=args.wiki_filter_field,
+        )
+    raise ValueError(f"unknown dataset {args.dataset!r}")
 
 
 def main() -> int:
@@ -1839,6 +1935,14 @@ def main() -> int:
     parser.add_argument("--sift-base", type=Path, help="SIFT base .fvecs (local, gitignored)")
     parser.add_argument("--sift-query", type=Path, help="SIFT query .fvecs")
     parser.add_argument("--sift-groundtruth", type=Path, help="SIFT ground-truth .ivecs")
+    parser.add_argument("--wiki-base", type=Path, help="Wikipedia base .fvecs (local, gitignored)")
+    parser.add_argument("--wiki-meta", type=Path, help="Wikipedia per-vector metadata .jsonl")
+    parser.add_argument(
+        "--wiki-queries",
+        type=Path,
+        help="Wikipedia queries .jsonl (vector + filter_value + precomputed truth)",
+    )
+    parser.add_argument("--wiki-filter-field", default="lang", help="Wikipedia filter field")
     parser.add_argument("--records", type=int, default=1000)
     parser.add_argument("--dimension", type=int, default=32)
     parser.add_argument("--queries", type=int, default=200)

--- a/tests/scripts/test_context_corridor.py
+++ b/tests/scripts/test_context_corridor.py
@@ -125,18 +125,73 @@ class ContextCorridorTest(unittest.TestCase):
         self.assertEqual(adapter.max_batch, 3)
         self.assertGreater(ingest_seconds, 0)
 
-    def test_build_provider_rejects_unfetched_datasets(self) -> None:
+    def test_build_provider_rejects_unknown_dataset(self) -> None:
+        args = argparse.Namespace(dataset="mystery")
+        with self.assertRaises(ValueError):
+            CONTEXT.build_provider(args)
+
+    def test_wikipedia_provider_reads_local_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory) / "base.fvecs"
+            meta = Path(directory) / "meta.jsonl"
+            queries = Path(directory) / "queries.jsonl"
+            self._write_vecs(
+                base, [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [-1.0, 0.0]], "f"
+            )
+            meta.write_text(
+                "\n".join(
+                    json.dumps({"lang": lang})
+                    for lang in ("en", "de", "en", "de")
+                )
+                + "\n"
+            )
+            queries.write_text(
+                json.dumps(
+                    {
+                        "vector": [0.9, 0.1],
+                        "filter_value": "en",
+                        "unfiltered_truth": ["wiki-0", "wiki-2"],
+                        "filtered_truth": ["wiki-0", "wiki-2"],
+                    }
+                )
+                + "\n"
+            )
+            provider = CONTEXT.WikipediaDatasetProvider(
+                base_path=base,
+                meta_path=meta,
+                queries_path=queries,
+                top_k=2,
+                filter_field="lang",
+            )
+            descriptor = provider.descriptor()
+            self.assertEqual(descriptor.name, "wikipedia")
+            self.assertEqual(descriptor.distance, "cosine")
+            self.assertEqual(descriptor.filter_field, "lang")
+            self.assertEqual(descriptor.dimension, 2)
+            self.assertEqual(descriptor.record_count, 4)
+            corpus = list(provider.corpus())
+            self.assertEqual(corpus[0]["id"], "wiki-0")
+            self.assertEqual(corpus[0]["props"]["lang"], "en")
+            self.assertEqual(corpus[0]["props"]["ordinal"], 0)
+            (ground_truth,) = provider.queries()
+            self.assertEqual(ground_truth.query["props"]["lang"], "en")
+            self.assertEqual(
+                ground_truth.unfiltered_truth, frozenset({"wiki-0", "wiki-2"})
+            )
+            self.assertEqual(
+                ground_truth.filtered_truth, frozenset({"wiki-0", "wiki-2"})
+            )
+
+    def test_build_provider_constructs_wikipedia(self) -> None:
         args = argparse.Namespace(
             dataset="wikipedia",
-            records=10,
-            dimension=4,
-            queries=1,
-            warmup=0,
-            seed=7,
+            wiki_base="/data/base.fvecs",
+            wiki_meta="/data/meta.jsonl",
+            wiki_queries="/data/queries.jsonl",
+            wiki_filter_field="lang",
         )
-        with self.assertRaises(NotImplementedError) as caught:
-            CONTEXT.build_provider(args)
-        self.assertIn("TD-CTXCORR-1", str(caught.exception))
+        provider = CONTEXT.build_provider(args)
+        self.assertIsInstance(provider, CONTEXT.WikipediaDatasetProvider)
 
     def _write_vecs(self, path: Path, vectors: list[list[float]], fmt: str) -> None:
         with open(path, "wb") as handle:


### PR DESCRIPTION
Stacked on #1442 (SIFT vertical) → #1441 → #1440 → #1439 → develop. Auto-merge OFF until the base PRs merge in order.

The **filtered-corridor driver** — the differentiating measurement — and the last data provider. Completes 'all providers'.

## What lands (TDD)
- **`WikipediaDatasetProvider`** — reads local `.fvecs` base vectors + a parallel metadata `.jsonl` (per-vector `lang`/`category`) + a `queries.jsonl` cache (each query: vector, filter value, precomputed **unfiltered AND within-filter** ground truth) → descriptor `distance=cosine`, `filter_field=lang`. dataset_hash = base `.fvecs` checksum.
- **`build_provider` wires `wikipedia`**; the fallthrough is now a clean `ValueError` for unknown datasets.

## Validation
- RED→GREEN; **52/52 tests** (Wikipedia fixture read: descriptor cosine/lang, corpus props carry lang+ordinal, queries carry both truths; build_provider wikipedia; unknown-dataset rejected). Validator, TD-uniqueness, work-commit-check all green.
- **Live end-to-end on Qdrant** with a cosine + `lang` fixture (exact cosine GT): **recall@10 = 1.0 AND filtered_recall@10 = 1.0**. The already-descriptor-driven Qdrant (from 2b-ii-A) handled cosine + `lang` filter with **zero further adapter change** — proof the seam is right.

## Remaining (Slice 2b-ii-C)
Make the other five adapters (pgvector/Milvus/ES/SurrealDB/ProximaDB) descriptor-driven so SIFT (L2) + Wikipedia (cosine, `lang`) flow through the whole fleet, not just Qdrant. A distance guard already blocks a mismatched run until each is converted.