### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to ProximaDB will be documented in this file.
 
+## [0.3.0] - 2026-08-05
+
+Major feature release (802 commits since 0.2.2). Headlines: a Postgres-wire query surface for
+vector search, DuckDB-backed OLAP routing, relational ABAC enforcement, and delete-vector-aware
+SST compaction across the storage engine.
+
+### SQL / pgwire
+- `vector_search` UDTF and the `<->` distance operator resolve over the Postgres wire protocol,
+  returning `id + score + payload`, unified behind a single `unified_search_native` v2 kernel
+  (TD-XMODAL-4).
+
+### OLAP & analytics
+- DuckDB-Local production routing for join/aggregate Parquet OLAP (ADR-059, default-OFF).
+- Per-column HLL NDV populated at materialize for cost-based planning (TD-OLAP-2).
+
+### Storage engine (SST / PAX / WAL / delete-vectors)
+- Delete-vector-aware compaction: drops DV-deleted rows and retires input `.dv` files; merge-on-read
+  on the RaBitQ cascade path (TD-DELVEC-1).
+- Continued always-PAX flush/compaction and WAL hardening.
+
+### Search & routing
+- `CompiledGlobalFilter` unifies the AXIS filtered-ANN predicate path (F7).
+
+### Security & multi-tenancy (ABAC)
+- Live relational policy enforcement with canonical identity carried through relational reads.
+
+### Observability
+- Persistent-L2 cache probes plumbed into the io-trace envelope + warehouse; real operational
+  counters and score-scale contract tests (TD-METRICS / TD-IOTRACE).
+
+### Dependencies
+- Bump `sandhi-core` to 0.1.6 (usage metering; one-way ProximaDB → Sandhi, ADR-060).
+
+_See the git history (`v0.2.2..v0.3.0`) for the full 802-commit detail across the sst, storage,
+abac, decomp, olap, search, catalog, observability, wal, tenant, and pgwire areas._
+
 ## [0.2.2] - 2026-07-04
 
 ### Storage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9641,9 +9641,9 @@ dependencies = [
 
 [[package]]
 name = "sandhi-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd8167e137bcbdbf7c96f56a9e7cba4dcb16b6eeba53dc96efb0666d5f6e9bd"
+checksum = "fd53a6bbdfc8c7f8d82cb7d65ce4a18deedb1e90d5d016eae6360a09ab9096ad"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proximadb"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 autobenches = false
 authors = ["Vijaykumar Singh <vijay@anvaiops.com>"]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proximadb-sdk"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["ProximaDB Contributors"]
 description = "Rust SDK for ProximaDB - Native client for agent development"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "proximadb_embedded"
-version = "0.2.2"
+version = "0.3.0"
 description = "ProximaDB - High-performance vector database with embedded mode"
 authors = [
     {name = "Vijaykumar Singh", email = "vijay@anvaiops.com"}


### PR DESCRIPTION
Release-prep for **v0.3.0** (802 commits since 0.2.2):
- Bump version `0.2.2 -> 0.3.0` (root crate, rust client, pyproject)
- Lock `sandhi-core` to the newly published **0.1.6** (one-way ProximaDB → Sandhi, ADR-060)
- Curated `[0.3.0]` CHANGELOG (pgwire vector search, DuckDB OLAP routing, delete-vector SST compaction, relational ABAC, observability)

Next: promote develop → qa → main, then tag `v0.3.0` + `python-v0.3.0`.