### PR TITLE
fix(sdk): let the REST client connect through a Unix-domain socket

### DIFF
--- a/clients/python/src/proximadb_sdk/config.py
+++ b/clients/python/src/proximadb_sdk/config.py
@@ -101,6 +101,15 @@ class ClientConfig(BaseModel):
     port_mode: PortMode = Field(
         default=PortMode.UNIFIED, description="Server port mode (unified or multi)"
     )
+    uds_path: str | None = Field(
+        default=None,
+        description=(
+            "Path to a Unix-domain socket to connect through instead of TCP. "
+            "Set this to talk to an embedded server started with "
+            "transport='uds' (the embedded default since #264), whose rest_url "
+            "is the host-header sentinel 'http://localhost' and carries no port."
+        ),
+    )
 
     # Timeouts
     timeout: float = Field(

--- a/clients/python/src/proximadb_sdk/protocols/rest_sync.py
+++ b/clients/python/src/proximadb_sdk/protocols/rest_sync.py
@@ -332,6 +332,20 @@ class ProximaDBClient:
             keepalive_expiry=self.config.connection.keepalive_timeout,
         )
 
+        uds_path = getattr(self.config, "uds_path", None)
+        if uds_path:
+            # Portless embedded mode: the server binds a Unix-domain socket and
+            # no TCP port at all, so `config.url` is only a host header and the
+            # connection has to be made through a UDS transport. TLS and HTTP/2
+            # are deliberately not forwarded — neither applies to a local socket,
+            # and httpx ignores those Client kwargs once `transport` is given.
+            return httpx.Client(
+                base_url=self.config.url,
+                headers=self.config.get_base_headers(),
+                timeout=timeout,
+                transport=httpx.HTTPTransport(uds=uds_path, limits=limits),
+            )
+
         return httpx.Client(
             base_url=self.config.url,
             headers=self.config.get_base_headers(),

--- a/clients/python/src/proximadb_sdk/unified_client.py
+++ b/clients/python/src/proximadb_sdk/unified_client.py
@@ -127,6 +127,7 @@ class ProximaDBClient:
         api_key: str | None = None,
         protocol: Protocol | str = Protocol.AUTO,
         port_mode: PortMode | str = PortMode.UNIFIED,
+        uds_path: str | None = None,
         config: ClientConfig | None = None,
         auth_config: AuthConfig | None = None,
         auth_method: AuthMethod | None = None,
@@ -210,6 +211,11 @@ class ProximaDBClient:
         elif port_mode != PortMode.UNIFIED:
             # Override port_mode if explicitly specified
             config.port_mode = port_mode
+
+        # Portless embedded servers expose a Unix-domain socket rather than a
+        # TCP port; an explicit uds_path wins over whatever load_config resolved.
+        if uds_path is not None:
+            config.uds_path = uds_path
 
         # Setup authentication
         self._setup_authentication(

--- a/clients/python/tests/unit/test_rest_sync_uds_transport.py
+++ b/clients/python/tests/unit/test_rest_sync_uds_transport.py
@@ -1,0 +1,56 @@
+"""UDS transport for the sync REST client.
+
+An embedded server started with ``transport="uds"`` (the default) binds a
+Unix-domain socket and no TCP port, and its ``rest_url`` degrades to the host
+header sentinel ``http://localhost``. A client built from that URL alone
+silently targets port 80, so the socket has to be plumbed through explicitly.
+"""
+
+import httpx
+
+from proximadb_sdk.config import ClientConfig
+from proximadb_sdk.protocols.rest_sync import ProximaDBClient as RestClient
+from proximadb_sdk.unified_client import ProximaDBClient
+
+
+def _uds_transport(client: httpx.Client):
+    """Return the httpx transport's configured UDS path, or None."""
+    transport = client._transport
+    pool = getattr(transport, "_pool", None)
+    return getattr(pool, "_uds", None)
+
+
+def test_uds_path_produces_a_unix_socket_transport(tmp_path):
+    socket = tmp_path / "proximadb.rest.sock"
+    client = RestClient(config=ClientConfig(url="http://localhost", uds_path=str(socket)))
+
+    http_client = client._create_http_client()
+    try:
+        assert _uds_transport(http_client) == str(socket)
+        # base_url is still needed — it supplies the Host header on every request.
+        assert str(http_client.base_url) == "http://localhost"
+    finally:
+        http_client.close()
+
+
+def test_without_uds_path_the_tcp_client_is_unchanged():
+    client = RestClient(config=ClientConfig(url="http://localhost:15678"))
+
+    http_client = client._create_http_client()
+    try:
+        assert _uds_transport(http_client) is None
+        assert str(http_client.base_url) == "http://localhost:15678"
+    finally:
+        http_client.close()
+
+
+def test_unified_client_forwards_uds_path_to_config(tmp_path):
+    socket = tmp_path / "proximadb.rest.sock"
+
+    client = ProximaDBClient(url="http://localhost", protocol="rest", uds_path=str(socket))
+
+    assert client.config.uds_path == str(socket)
+
+
+def test_uds_path_defaults_to_none():
+    assert ClientConfig(url="http://localhost:15678").uds_path is None

--- a/clients/python/tests/unit/test_rest_sync_uds_transport.py
+++ b/clients/python/tests/unit/test_rest_sync_uds_transport.py
@@ -22,7 +22,9 @@ def _uds_transport(client: httpx.Client):
 
 def test_uds_path_produces_a_unix_socket_transport(tmp_path):
     socket = tmp_path / "proximadb.rest.sock"
-    client = RestClient(config=ClientConfig(url="http://localhost", uds_path=str(socket)))
+    client = RestClient(
+        config=ClientConfig(url="http://localhost", uds_path=str(socket))
+    )
 
     http_client = client._create_http_client()
     try:
@@ -47,7 +49,9 @@ def test_without_uds_path_the_tcp_client_is_unchanged():
 def test_unified_client_forwards_uds_path_to_config(tmp_path):
     socket = tmp_path / "proximadb.rest.sock"
 
-    client = ProximaDBClient(url="http://localhost", protocol="rest", uds_path=str(socket))
+    client = ProximaDBClient(
+        url="http://localhost", protocol="rest", uds_path=str(socket)
+    )
 
     assert client.config.uds_path == str(socket)
 


### PR DESCRIPTION
## Problem

Embedded mode has been portless since **#264**: the server binds UDS sockets and no TCP port, so `EmbeddedProximaDB.rest_url` degrades to the host-header sentinel `"http://localhost"` — no port.

`ProximaDBClient` has **no UDS support at all** — `uds=` exists only inside `embedded.py`. Any client built from that `rest_url` therefore silently targets **port 80** and every request fails:

```
Network error: [Errno 61] Connection refused | Error Code: NETWORK_ERROR
```

This is worse than a clean failure for callers that mix both paths. Operations issued through `EmbeddedProximaDB`'s own UDS-aware httpx client succeed, while anything routed through `ProximaDBClient` cannot connect — a **split transport**. Victor hit exactly this: its ProximaRecord writes committed while the ORION graph projection of those same records never landed.

## Fix

- `uds_path` on `ClientConfig` and `ProximaDBClient`.
- `rest_sync._create_http_client` injects `httpx.HTTPTransport(uds=...)` when set.
- `base_url` is still required — it supplies the Host header.

TLS and HTTP/2 are deliberately not forwarded on the UDS branch: neither applies to a local socket, and httpx ignores those `Client` kwargs once `transport` is given, so forwarding them would be misleading rather than harmless.

The TCP path is untouched.

## Tests

`tests/unit/test_rest_sync_uds_transport.py` — 4 tests: UDS transport is configured and `base_url` preserved; the TCP client is unchanged (regression guard); `ProximaDBClient` forwards `uds_path` to config; the field defaults to `None`.

Verified end to end against a live embedded server via Victor's integration suite — the previously-failing ORION projection now succeeds, and its impact_analysis / hybrid parity assertions pass.