### PR TITLE
fix(build): build the embedded wheel from the crate that has the bindings

### DIFF
--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -12,6 +12,12 @@ description = "Embedded mode for ProximaDB — in-process database with language
 [lib]
 name = "proximadb_embedded"
 path = "src/lib.rs"
+# `cdylib` is what maturin packages as the Python extension module
+# (`proximadb_embedded._proximadb_embedded`); the PyO3 entry point lives in
+# `src/python.rs` behind the `python` feature. `rlib` must stay: this crate is a
+# normal Rust dependency of `proximadb-spark-jni` and a dev-dependency of the
+# root crate's integration tests. Dropping either breaks one of those consumers.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Depends on the root proximadb library (one-directional: embedded -> root, no cycle).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,18 @@ Repository = "https://github.com/anvai-labs/proximaDB"
 Issues = "https://github.com/anvai-labs/proximaDB/issues"
 
 [tool.maturin]
-# Canonical embedded wheel configuration.
-# This pyproject is the authoritative one when building against the repo-root
-# Cargo manifest, including `maturin build -m Cargo.toml ...`.
-features = ["python", "pylib"]
+# Canonical embedded wheel configuration. `release-python.yml` builds from this
+# file at the repo root (`maturin build --release --features python`).
+#
+# The PyO3 bindings no longer live in the root crate: #1021 extracted them into
+# `crates/binding/proximadb-embedded`, so the wheel must be built from THAT
+# manifest. The root crate keeps only a `python = []` stub (for the Windows CI
+# cfg) and is `crate-type = ["rlib"]`, so building the wheel against the root
+# manifest yields no extension module at all.
+manifest-path = "crates/binding/proximadb-embedded/Cargo.toml"
+# `pylib` was removed with the same extraction — the cdylib is now declared by
+# the binding crate's `[lib] crate-type`, not gated behind a root feature.
+features = ["python"]
 python-source = "clients/python-embedded/src"
 module-name = "proximadb_embedded._proximadb_embedded"
 bindings = "pyo3"


### PR DESCRIPTION
## Problem

**#1021** extracted the 16.8K-LOC embedded engine — PyO3 entry point included — into `crates/binding/proximadb-embedded`. The Python build config never followed, so the `proximadb_embedded` wheel has been unbuildable since.

Three separate defects, all from that one move:

1. **Wrong manifest.** maturin still built against the **root** manifest. Root's `python` feature is now an empty stub (`python = []`, kept only for the Windows CI cfg) and its lib is `crate-type = ["rlib"]` — no extension module can come out of it.
2. **Removed feature.** Both pyprojects requested `features = ["python", "pylib"]`. `pylib` was removed by the same extraction and exists nowhere in the tree.
3. **No cdylib.** Neither crate declared one for maturin to package — the binding crate had no `crate-type` at all.

`release-python.yml` builds the wheel from the root package (`maturin build --release --features python`), so this is the shipped path, not a local-only problem.

## Fix

- `manifest-path` → `crates/binding/proximadb-embedded/Cargo.toml`
- `features = ["python"]` (drop the removed `pylib`)
- binding crate → `crate-type = ["cdylib", "rlib"]`

**`rlib` is deliberate and load-bearing:** `proximadb-spark-jni` depends on this crate normally and the root crate dev-depends on it for integration tests. A cdylib-only lib would break both.

## Verification

maturin previously produced no extension module at all. It now resolves the bindings:

```
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support
📡 Using build options bindings, compatibility from pyproject.toml
```

That also settles empirically that `python-source` resolves relative to the **pyproject**, not the manifest — the stale comment claiming otherwise is removed. A full wheel build is running; I'll post the artifact name when it lands.

## Follow-up (not in this PR)

`pyproject.toml` and `clients/python-embedded/pyproject.toml` both declare `name = "proximadb_embedded"` at `0.2.2` with duplicate `[tool.maturin]` blocks, and each comment claims to be the authoritative one. Nothing invokes the `clients/python-embedded` copy. That duplication is what let the config drift out of sync with the crate move in the first place — worth collapsing to one.