### PR TITLE
docs(rules): note RUSTC_WRAPPER=sccache for direct cargo calls (CLAUDE.md.seed)

### DIFF
--- a/docs/agent-rules/CLAUDE.md.seed
+++ b/docs/agent-rules/CLAUDE.md.seed
@@ -65,6 +65,9 @@ jobs at 3 for OOM safety — don't override upward.
 cargo check-fast                      # alias: cargo check --all-targets — tightest inner loop
 cargo build                           # dev build
 cargo build --profile release-server  # optimized server binary (make build-server)
+# sccache: `scripts/worktree.sh new` wires it for ITS OWN launches, but DIRECT cargo calls
+# (cargo check/build/clippy invoked here) do NOT inherit it — prefix or `export RUSTC_WRAPPER=sccache`
+# to reuse the shared cache (cold rebuild ~30min -> ~4min):  RUSTC_WRAPPER=sccache cargo check -p <crate>
 ```
 
 ### Test (nextest preferred — process-per-test isolation; install: make install-fast-tools)


### PR DESCRIPTION
## What

Adds a one-line note to the **Build / check** section of `docs/agent-rules/CLAUDE.md.seed` (the
canonical shared source for the local-only root `CLAUDE.md`, per #443):

```
# sccache: `scripts/worktree.sh new` wires it for ITS OWN launches, but DIRECT cargo calls
# (cargo check/build/clippy invoked here) do NOT inherit it — prefix or `export RUSTC_WRAPPER=sccache`
# to reuse the shared cache (cold rebuild ~30min -> ~4min):  RUSTC_WRAPPER=sccache cargo check -p <crate>
```

## Why

The seed's Core Directive #1 already says `scripts/worktree.sh new … "wires sccache when present"` —
but that wiring only covers `worktree.sh`'s **own** launches. **Direct** `cargo` invocations (the
`cargo check`/`build`/`clippy` an agent runs in a shell) do **not** inherit `RUSTC_WRAPPER`, so they
silently fall back to a cold local compile — measured ~30 min for a root-crate cold rebuild vs ~4 min
reusing sccache's shared cache (47+ cached Rust dep hits). This gap wasted ~30 min per cold-worktree
decomposition slice this session. The note makes the direct-call fix explicit.

Docs-only change to a tracked seed file (root `CLAUDE.md` is gitignored/local per #443, so this seed
is the only way to propagate the guidance to other machines/agents). `GEMINI.md.seed` has no parallel
Build/check section, so no mirror needed there.