### PR TITLE
docs(adr): ADR-089 filter-aware PAX cascade + TD-FPRUNE-1 arc

### DIFF
--- a/docs/10-quality/td/TD-FPRUNE-1-filter-aware-cascade-arc.adoc
+++ b/docs/10-quality/td/TD-FPRUNE-1-filter-aware-cascade-arc.adoc
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FPRUNE-1: filter-aware PAX cascade — phased arc (ADR-089)
+:status: Open
+:dim: D3/D5 (compute-per-modality, object storage)
+:pillar: PERF
+
+Problem: filtered vector search on the PAX path is a whole-object brute-force
+scan — the coalesced cascade declines any query with a filter
+(`src/storage/engines/sst/search/mod.rs:420`) and falls to
+`search_pax_file_exact` (whole-object read, decode-all, per-record post-filter,
+`mod.rs:2448-2553`). Measured vs Qdrant on identical data (TD-CTXCORR-1
+harness): filtered p50 8.0→52.3 ms from 20k→80k rows (O(N)) vs 1.2→1.4 ms
+(flat); **38x at 80k and widening**. Recall parity — the brute force buys
+nothing. ADR-089 decides the fix: metadata-first cell/block pruning (Region-D
+columnar stats) composed with the geometric A0 probe, one pipeline, residual
+filter as the correctness backstop. This TD tracks the phases.
+
+== Phases (each evidence-gated; mixed-read-safe; default-OFF until baked)
+
+* **P1 — wire what exists (no format change).** At the `mod.rs:420` gate,
+  instead of declining: ranged-read footer + per-block `ColumnMeta`, prune via
+  the existing `evaluate_block`/`evaluate_row_groups` kernel
+  (`crates/storage/proximadb-block-format/src/prune.rs:60-160`; live precedent
+  `read_records_pruned` on the record-store path), map surviving blocks →
+  global-row ranges (footer cumulative row counts), run the cascade restricted
+  to those rows (the coalesced planners already take row lists:
+  `plan_coalesced_row_ranges` `segment_format.rs:853`), residual per-record
+  check at D-resolve (decode props beside OID). Requires **arming P-Shred**
+  (ADR-055) for schema columns marked `filterable` — per-collection opt-in —
+  since user tags live in opaque PROPS msgpack without it. Canonical columns
+  (tenant, timestamps, valid_from/to) prune without shredding.
+* **P2 — footer-resident block stats (zero-GET pruning).** Populate the
+  reserved `StatsKind::MinMax`/`BloomOid` slots in the segment footer block
+  table (`segment_layout.rs:222-262`; today always `StatsKind::None`,
+  `pax_block.rs:2104` — the ADR-062 D5 deferral, now lifted) for filterable
+  columns. Pruning then costs nothing beyond the footer the cascade already
+  reads. Mixed-read-safe by the stats_kind marker.
+* **P3 — per-cell stats (prune before any Region-A byte).** Optional
+  footer/A0 section with per-cell dictionary/zone summaries for filterable
+  columns; intersect with the geometric nprobe cut
+  (`coarse_probe_survivors`, `segment_format.rs:2130-2204`) so metadata-dead
+  cells are never fetched. Strongest when metadata correlates with clustering
+  (tenant/lang); measure the uncorrelated case honestly — P2 block stats carry
+  it. Budget-check against A0's ~120-300 KB envelope.
+* **P4 — stats-driven selectivity policy.** Distinct-hint HLL + null counts +
+  dictionary domains → per-segment selectivity estimate → route: ultra-selective
+  ⇒ direct row fetch + exact rank (no ANN); moderate ⇒ pruned cascade;
+  unselective ⇒ cascade + residual only. This is the real auto
+  `AnnFilteringMode` (closes the TD-073 deferral) and subsumes the AXIS
+  PreFilter/Inline/PostFilter modes as policy over capability.
+
+== Gates (per phase)
+
+* `filtered_recall_at_10` vs exact ground truth (TD-CTXCORR-1 harness) —
+  pruning is conservative; recall must match the unpruned path.
+* Filtered p50/p99 at 20k/80k/1M vs the recorded Qdrant baseline
+  (8.0/52.3 ms → target flat-ish scaling), synthetic partition (uncorrelated)
+  AND Wikipedia lang filter (correlated).
+* `io_trace` `object_gets`/`bytes_read` per filtered query — the pruning win
+  must be visible in the physical-cost counters (feeds TD-CTXCORR-1 Slice 4
+  economics).
+* Mixed-read: new-stats segments and legacy segments coexist in one
+  collection; recovery/readers default to legacy when markers absent.
+
+== Related (non-goals here)
+
+* AXIS REST `ann_filtering_mode` override (WIP branch
+  `feat/axis-rest-filter-mode`; compiles, unit-tested): a diagnostic/benchmark
+  lever for AXIS-indexed collections — NOT this fix. Landing it requires the
+  OpenAPI spec regen + all SDK regens in the same PR (mandate #15) since
+  `TypedSearchRequest` is utoipa-emitted.
+* WAL/unflushed side already filters at scan time
+  (`search_unflushed_vectors`: bloom pre-filter + per-record eval before
+  scoring) — no work needed there.
+* In-memory per-tag payload indexes (Qdrant-style): possible future cache
+  layer above this design; not the foundation (ADR-089 Alternatives).
+
+Refs: ADR-089 (decision + full file:line evidence), ADR-026/-055/-062/-065,
+TD-RDSTRAT-8, TD-CTXCORR-1, TD-073, TD-064, TD-FILT-1.

--- a/docs/12-design/adr/ADR-089-filter-aware-pax-cascade.adoc
+++ b/docs/12-design/adr/ADR-089-filter-aware-pax-cascade.adoc
@@ -1,0 +1,224 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= ADR-089: Filter-aware PAX cascade — metadata-first cell/block pruning composed with the geometric probe
+:toc: left
+:toclevels: 3
+:icons: font
+:last-updated: 2026-08-06
+
+== Status
+
+Proposed (2026-08-06). Phases are individually evidence-gated (see TD-FPRUNE-1);
+acceptance follows the P1 measurement, not this filing.
+
+== Context
+
+=== The measured problem
+
+Head-to-head pressure testing with the context-corridor harness (TD-CTXCORR-1,
+ground-truth recall, identical synthetic dataset, cosine + 1-of-8 partition
+filter) against Qdrant v1.18.2:
+
+|===
+| | filtered p50 @20k | filtered p50 @80k | scaling | filtered QPS @80k
+
+| ProximaDB (default path)
+| 8.0 ms
+| 52.3 ms
+| O(N) — superlinear growth
+| 19
+
+| Qdrant
+| 1.2 ms
+| 1.4 ms
+| flat (indexed)
+| 725
+|===
+
+A 6.6x gap at 20k widens to **38x at 80k** and extrapolates to hundreds-x at the
+1M publication floor. Accuracy is at parity (recall\@10 0.998 unfiltered / 1.0
+filtered on both) — the brute force buys no recall on this workload. Filtered
+search is the dominant RAG/agentic query shape (tenant, ACL, lang, recency
+predicates), so this is the #1 competitive weakness of the vector modality.
+
+=== Root cause — two layers, same disease
+
+1. **AXIS layer**: the plain REST filtered search routes to PreFilter-exact — a
+   full in-memory scan applying the predicate per record before scoring
+   (`src/index/axis/management/manager.rs:1439-1480`, exact scan `:4345-4434`).
+   The accelerated Inline/ACORN traversal exists (`hnsw_index.rs:465-547`) but is
+   unreachable from the public request (no mode field on `TypedSearchRequest`,
+   `src/network/rest/v2/records.rs:1400`) and the selectivity routing that would
+   pick it is deferred (TD-073).
+2. **Storage layer (the decisive one)**: for co-design collections (no
+   `index_configs`) AXIS is skipped entirely — "the segment IS the index"
+   (`src/services/operations/vectors/legacy.rs:4164-4177`) — and the PAX cascade
+   is the product's filtered path. There, one gate declines any filtered query:
+   `src/storage/engines/sst/search/mod.rs:420` ("UNFILTERED only"). Filtered
+   queries fall to `search_pax_file_exact` (`mod.rs:2448-2553`): read the
+   **whole object** (`:2462`), decode **every record**, filter per record
+   post-decode (`:2512-2519`), exact-f32-score all survivors. No predicate ever
+   restricts bytes read or rows scored on the PAX path.
+
+=== What the format already provides (write side)
+
+The PAX segment format is already "parquet for vectors" on the write side —
+ADR-026 folded VIPER's columnar ideas into the writer, but the filtered reader
+was never completed:
+
+* Region layout (ADR-065): A = RaBitQ codes, A0 = IVF probe directory (per-cell
+  byte extents), B = SQ8 codes, D = row blocks holding **all** scalar/tag
+  metadata as columnar stripes. Region C (exact fp32) never shipped; fp32 lives
+  in D.
+* Per-block stats exist today: `ColumnMeta` min/max + null_count +
+  distinct-hint HLL + dictionary/RunLength string encodings + 32-byte
+  footer-resident string blooms (`crates/storage/proximadb-block-format/src/stripe.rs:64-114`,
+  `writer.rs:1565-1620`) and an 8192-row row-group `[min,max]` sub-index
+  (`rowgroup.rs:14-31`).
+* The segment footer (`SegmentFooterIndex`,
+  `crates/storage/proximadb-storage-common/src/segment_layout.rs:400-450`)
+  carries a per-block table `{offset, size, row_count, stats_kind}` — with a
+  **reserved but unpopulated stats slot** (`StatsKind::None` always;
+  `MinMax`/`BloomOid` defined, deferred by ADR-062 D5).
+* **Cross-region addressing is an invariant** (ADR-065 §"row-ordinal identity"):
+  the global row ordinal maps by arithmetic to RaBitQ/SQ8 code offsets, by
+  cumulative footer row-counts to D blocks, and by contiguous ranges to A0
+  cells; v3 cells carry exact `a_off/a_len`, `b_off/b_len`,
+  `d_block_begin..d_block_end`, and block boundaries never straddle cells
+  (`pax_block.rs:849-851, 2050-2074`). A pruned D-block/cell set therefore maps
+  exactly onto reduced Region A/B byte ranges.
+* A sound conservative pruning kernel is **already live** — just not for
+  vectors: `evaluate_block`/`evaluate_row_groups` over And/Or/Not trees
+  (`crates/storage/proximadb-block-format/src/prune.rs:60-160`), used by
+  `RangedSegmentReader::read_records_pruned` on the record-store scan path
+  (`src/services/record_store.rs:4898`).
+* P-Shred (ADR-055) already writes props keys as typed stripes with
+  min/max + bloom, explicitly "for future zone-map/bloom pruning + projection
+  pushdown" (`writer.rs:349, 672-679`) — dormant opt-in.
+* The unfiltered cascade already does physical ranged, coalesced, cached GETs
+  (prefix → A0 probe (default-ON, TD-RDSTRAT-8) → per-cell Region-A extents →
+  footer → survivor SQ8 row-ranges → top-k D blocks;
+  `segment_format.rs:2388-2847`) — the I/O style this decision needs is the
+  house style.
+* Precedent for position-keyed row exclusion exists on both cascade and exact
+  paths: the deletion-vector store filters by `CascadeHit::position`
+  (`search/mod.rs:432-455`, cfg `cold-deletion-vectors`).
+* VIPER (Beta, opt-in, never auto-selected, AXIS-dark) had exactly this design
+  intent (metadata-columns-first candidate reduction, "60-90% I/O savings",
+  `src/storage/engines/viper/column_filter.rs:47-53`) but its engine-local
+  pushdown is dead code; ADR-026 froze VIPER in favor of folding these ideas
+  into AXIS+PAX. This ADR completes that fold on the read side.
+
+== Decision
+
+Make the metadata predicate a **first-class pre-stage of the PAX cascade**,
+composing with (not replacing) the geometric A0 probe. One pipeline; the
+unfiltered path is unchanged.
+
+----
+                  no filter ────────────────► Stage F = no-op ("all cells")
+Query ─► Stage F: metadata prune ─► A0 geometric probe ─► ∩ (cell intersection)
+         (footer/cell stats first;
+          per-block ColumnMeta only when needed)
+              └─► surviving cells/blocks → global-row set (bitmap)
+                              │
+        Stage 1  RaBitQ rank over surviving rows only    (reduced Region-A bytes)
+        Stage 2  SQ8 rerank of survivors ∩ bitmap        (reduced Region-B bytes)
+        Stage 3  top-k D-block resolve + residual per-record filter
+                 (conservative-pruning correctness backstop)
+----
+
+Principles:
+
+1. **Prune where the metadata lives (Region D stats), spend where the vectors
+   live (Regions A/B)** — the dominant filtered-search cost term is bytes
+   fetched + candidates scored in A/B that the predicate would have excluded;
+   only stats-first pruning moves that term, and its cost falls again on object
+   storage (fewer ranged GETs — the D5 dimension). Footer/cell-resident stats
+   make the pruning decision at zero incremental GETs (the cascade already
+   reads prefix + A0 + footer).
+2. **Geometric and metadata pruning compose at cell granularity** — cells are
+   contiguous row ranges, so the A0 nprobe cut and the metadata cut intersect;
+   they are not competing routers.
+3. **Graceful degradation, no cliff** — an unselective predicate prunes
+   nothing, costs only cached stats reads, and proceeds ≈unfiltered plus a
+   cheap residual check; an ultra-selective predicate skips ANN entirely and
+   exact-ranks the few surviving rows ("PreFilter-exact done right": over
+   pruned rows, not all rows).
+4. **Conservative pruning + residual filter = correctness** — stats may only
+   ever produce false positives (blocks that survive but contain no match),
+   never false negatives; the residual per-record check at D-resolve is the
+   backstop. `filtered_recall_at_10` vs exact ground truth must stay 1.0-safe
+   relative to the unpruned path.
+5. **Selectivity policy from measured stats, not guesses** — distinct-hint HLL
+   + null counts + dictionary domains give a per-segment selectivity estimate;
+   this becomes the real auto `AnnFilteringMode` policy (what TD-073 deferred),
+   and subsumes the AXIS PreFilter/Inline/PostFilter debate as policy over a
+   storage capability.
+6. **Mixed-read-safe, default-OFF** (mandate #8): footer stats ride the
+   reserved `StatsKind` marker (absent ⇒ legacy behavior); per-cell stats ride
+   a new optional footer/A0 section tag; shred arming is per-collection
+   opt-in until baked. No flag-day; old and new segments coexist.
+
+== What must be built (the honest gap list)
+
+1. The composition itself: change the `search/mod.rs:420` gate to feed a
+   row/cell set into the cascade; restricted variants of the rank/fetch
+   planners (the coalesced-range planners already take row lists).
+2. Stats for user metadata: arm P-Shred for schema columns marked
+   `filterable` (the collection schema already carries the signal). PROPS is
+   an opaque msgpack blob without it — nothing to prune on for user tags.
+3. Footer-resident block stats: populate `StatsKind::MinMax`/`BloomOid` for
+   filterable columns so block pruning needs no per-block metadata GETs.
+4. Residual filter on the cascade path: decode props alongside OID at the
+   D-resolve stage.
+5. Selectivity estimation + routing policy (P4).
+
+== Alternatives considered
+
+* **AXIS Inline/ACORN only** (expose `ann_filtering_mode` on the request; WIP
+  branch `feat/axis-rest-filter-mode`): necessary as a diagnostic/benchmark
+  lever and for AXIS-indexed collections, but it never touches the storage
+  cost term, and co-design collections skip AXIS entirely. Kept as a lever,
+  rejected as the fix.
+* **Revive VIPER for filtered search**: duplicates the investment on a frozen
+  engine (ADR-026), still whole-file reads, and abandons the cascade's
+  quantized tiers. Rejected; VIPER's idea lands here instead.
+* **In-memory inverted index / bitmap index per tag (Qdrant-style payload
+  index)**: fastest for hot data but pays memory per tag per segment,
+  duplicates state the columnar stats already encode, and does nothing for the
+  object-store cost term. May be revisited later as a cache layer *above* this
+  design; rejected as the foundation.
+* **Do nothing / post-filter with oversampling**: measured 38x and widening;
+  under-return risk (TD-064). Rejected.
+
+== Consequences
+
+* Filtered vector search stops being a whole-object scan; bytes and GETs per
+  filtered query drop with selectivity — directly observable in the
+  `io_trace` counters (`object_gets`, `bytes_read`) and the context-corridor
+  physical-cost metrics (TD-CTXCORR-1 Slice 4).
+* The Wikipedia lang-filtered corridor benchmark (TD-CTXCORR-1 Slice 2b-ii-B)
+  becomes the primary eval: correlated metadata (lang/tenant) is the favorable
+  case for cell-level pruning and must be measured against the uncorrelated
+  synthetic-partition case (measure, don't assert — per-cell pruning is
+  honestly weaker on uncorrelated tags; per-block/row-group stats carry that
+  case).
+* Write path grows optional stats emission (footer StatsKind, per-cell
+  summaries, shred stripes) — mixed-read-safe, size-bounded (per-cell summary
+  budget must be validated against A0's ~120-300 KB envelope).
+* The exact fallback (`search_pax_file_exact`) remains as the correctness
+  oracle and the TD-165 exact-mode path.
+
+== References
+
+* Evidence: TD-CTXCORR-1 (benchmark + 38x measurement), the 2026-08-05/06
+  investigation (this ADR's Context file:line citations).
+* Format/write side: ADR-065 (tier regions), ADR-062 (stacked quantization;
+  D5 deferral now lifted by this ADR), ADR-055 (P-Shred), TD-RDSTRAT-8 (A0
+  probe directory).
+* Lineage: ADR-026 (fold VIPER ideas into AXIS+PAX — this completes the read
+  side), ADR-002 (normalized filter/candidate contract), ADR-011 (ANN
+  filtering modes — subsumed as policy), TD-073 (selectivity policy),
+  TD-064 (post-filter shortfall), TD-FILT-1 (fail-loud filter evaluation).
+* Tracker: TD-FPRUNE-1 (phased arc P1-P4).

--- a/docs/12-design/adr/README.adoc
+++ b/docs/12-design/adr/README.adoc
@@ -423,6 +423,11 @@ This directory contains Architecture Decision Records (ADRs) governing ProximaDB
 | Deterministic local-spill compaction under independent RAM and scratch admission
 | Proposed (2026-08-02)
 | Adds a default-OFF alternate construction plan for compactions that cannot fit ADR-086's RAM envelope: block-ranged input, external MVCC and IVF orderings, and disk-backed PAX A/B/D/resolver construction under independent process-wide RAM and local-scratch reservations. The PAX format is unchanged; only the final segment is uploaded and published atomically. OSS owns the correctness mechanism and neutral meters, while Anvaiops owns tenant/economic placement policy. Tracked: TD-COMPACT-11.
+
+| link:ADR-089-filter-aware-pax-cascade.adoc[ADR-089]
+| Filter-aware PAX cascade — metadata-first cell/block pruning composed with the geometric probe
+| Proposed (2026-08-06)
+| Filtered vector search on the PAX path is a whole-object brute-force scan (the coalesced cascade is UNFILTERED-only, `search/mod.rs:420`) — measured 38x slower than Qdrant at 80k rows and O(N)-widening, with zero recall benefit. The format already carries parquet-grade pruning metadata (ColumnMeta min/max + dictionaries + string blooms + row-group index in Region-D blocks; reserved footer StatsKind; exact row-ordinal↔cell↔block addressing per ADR-065) and a live pruning kernel (`prune.rs`, record-store path). Decision: make the metadata predicate a pre-stage of the cascade — footer/cell stats prune cells/blocks, intersect with the A0 geometric probe, RaBitQ/SQ8 run only over surviving rows, residual per-record filter at D-resolve as the conservative-pruning backstop; selectivity policy from measured stats (HLL/null counts) subsumes the AXIS PreFilter/Inline/PostFilter modes. Completes ADR-026's VIPER-ideas fold on the read side; lifts the ADR-062 D5 zone-map deferral. Unfiltered path unchanged. Tracked: TD-FPRUNE-1 (P1 wire-existing → P2 footer stats → P3 per-cell stats → P4 selectivity policy), evidence-gated by the TD-CTXCORR-1 harness + io_trace byte/GET counters.
 | link:ADR-0083-consolidated-catalog-identity-model.adoc[ADR-0083]
 | Consolidated catalog identity model — the composite is the SOLE canonical identity; retire the global u64
 | Accepted — Revision 2 (2026-07-30)


### PR DESCRIPTION
Files the strategic decision from the filtered-search pressure test + three-way code investigation (PAX format / cascade read path / VIPER status).

## The measured problem
Context-corridor head-to-head vs Qdrant v1.18.2 (identical dataset, ground-truth recall): ProximaDB filtered p50 **8.0→52.3 ms** from 20k→80k rows (O(N)) vs Qdrant **1.2→1.4 ms** (flat) — **38x at 80k and widening**, recall at parity. Root cause: the coalesced PAX cascade is UNFILTERED-only (`search/mod.rs:420`); any filtered query falls to `search_pax_file_exact` = whole-object read + decode-all + per-record post-filter. For co-design collections AXIS is skipped entirely, so this IS the product's filtered path.

## The decision (ADR-089)
Metadata predicate becomes a **pre-stage of the cascade**: Region-D columnar stats (ColumnMeta min/max + dictionaries + string blooms + row-group index — all written today) prune cells/blocks via the **already-live** `prune.rs` kernel; the pruned set intersects the A0 geometric probe at cell granularity; RaBitQ/SQ8 run only over surviving rows (exact row-ordinal↔cell↔block addressing is an ADR-065 invariant); residual per-record filter at D-resolve is the conservative-pruning correctness backstop. Selectivity policy from measured stats (HLL/null counts) subsumes the AXIS PreFilter/Inline/PostFilter modes as policy-over-capability. **Unfiltered path unchanged** — Stage F is a no-op without a predicate.

This completes ADR-026's stated fold of VIPER's columnar ideas into AXIS+PAX on the *read* side, and lifts the ADR-062 D5 zone-map deferral.

## The arc (TD-FPRUNE-1, each phase evidence-gated, mixed-read-safe, default-OFF)
- **P1** wire what exists (no format change; arm P-Shred for `filterable` columns — user tags are opaque PROPS msgpack without it)
- **P2** populate the reserved footer `StatsKind` → zero-GET block pruning
- **P3** per-cell stats intersected with the geometric nprobe cut
- **P4** stats-driven selectivity routing (closes the TD-073 deferral)

Gates: filtered_recall vs exact ground truth (conservative pruning must not lose recall), filtered p50/p99 at 20k/80k/1M vs the recorded Qdrant baseline on both correlated (Wikipedia lang) and uncorrelated (synthetic partition) filters, and io_trace object_gets/bytes_read (feeds TD-CTXCORR-1 Slice-4 economics).

Docs-only; guards green (td-adr-unique 89 ADRs/348 TDs, work-commit-check). ADR indexed in README.