### PR TITLE
refactor(ts): migrate the SDK off moduleResolution node10 + file TD-SDK-2

### DIFF
--- a/clients/nodejs-embedded/tsconfig.esm.json
+++ b/clients/nodejs-embedded/tsconfig.esm.json
@@ -4,6 +4,7 @@
     "module": "ES2022",
     "outDir": "./dist/esm",
     "declaration": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "moduleResolution": "bundler"
   }
 }

--- a/clients/nodejs-embedded/tsconfig.json
+++ b/clients/nodejs-embedded/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
-    "lib": ["ES2022"],
+    "module": "node16",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -30,10 +33,18 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/docs/10-quality/td/TD-SDK-2-typescript-7-blocked-on-openapi-typescript.adoc
+++ b/docs/10-quality/td/TD-SDK-2-typescript-7-blocked-on-openapi-typescript.adoc
@@ -1,0 +1,92 @@
+= TD-SDK-2: TypeScript 7 for the Node SDK is blocked on openapi-typescript
+:status: Open
+:dim: D5
+:pillar: OE
+
+== Problem
+
+`clients/nodejs-embedded` cannot move to TypeScript 7. **Our code is not the
+blocker** — with the `moduleResolution` migration landed (see below), TS 7.0.2
+type-checks the SDK clean, builds both the CJS and ESM outputs (16 files), and
+passes all 18 vitest tests.
+
+The blocker is `openapi-typescript`, the generator behind the spec-driven REST
+transport that the merge-blocking `TS SDK Codegen Drift (TD-126)` gate enforces:
+
+----
+node_modules/openapi-typescript/dist/lib/ts.mjs:11
+const BOOLEAN = ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+                           ^
+TypeError: Cannot read properties of undefined (reading 'createKeywordTypeNode')
+----
+
+TypeScript 7 is the native (Go) port and no longer exposes `ts.factory` on its
+JS API. Bumping TypeScript today therefore turns the codegen-drift gate red —
+the gate that exists specifically to stop server↔SDK drift (mandate #15).
+
+== Why it cannot be worked around today (measured 2026-08-06)
+
+There is no `openapi-typescript` release that supports TS 7:
+
+[cols="2,3", options="header"]
+|===
+| dist-tag / version | typescript peer
+
+| `latest` = **7.13.0** | `^5.x`
+| `next` = 7.0.0-rc.1 | *older than latest* — stale tag
+| every published version | `^5.x`; none drops the constraint
+|===
+
+Three workarounds were tried and all failed:
+
+. **npm `overrides`** scoped to the generator
+  (`"overrides": { "openapi-typescript": { "typescript": "5.9.3" } }`) — npm
+  hoists peer dependencies, so no nested TS 5 is created and the generator still
+  loads the top-level TS 7.
+. **Isolated npx toolchain** —
+  `npx --yes --package typescript@5.9.3 --package openapi-typescript@7.13.0 …`
+  in `codegen/gen.sh`. Module resolution still reaches the project's hoisted
+  TypeScript. Same crash.
+. **Straight bump** — same crash.
+
+== What HAS landed (the prerequisite, done)
+
+The `moduleResolution` half is complete and independent of the version bump:
+
+* `tsconfig.json`: `module` `commonjs` → `node16`, `moduleResolution` `node`
+  ("node10", *removed* in TS 7) → `node16`, plus `types: ["node"]` and
+  `lib: ["ES2022","DOM"]` — TS 7 otherwise resolves no ambient globals here
+  (`setTimeout`, `AbortController`, `Request`/`Response`/`RequestInit` all
+  reported missing).
+* `tsconfig.esm.json`: `moduleResolution` → `bundler`.
+
+`node16` was chosen over `bundler` for the base config because `bundler` is only
+valid with an ESM `module` setting while the primary build emits CommonJS;
+`node16` keeps CJS emit (package.json declares no `"type"`) and CJS resolution
+still tolerates this source's extensionless relative imports (`from "./client"`),
+avoiding a rewrite of every import to carry `.js`.
+
+Verified on the unchanged TypeScript 5.9.3: lint clean, dual build emits, 18
+tests pass, `gen-sdk` succeeds with no `src/generated` drift.
+
+== Next action
+
+. **Watch for an `openapi-typescript` release that supports TS 7** (peer moves
+  off `^5.x`, or `ts.factory` usage is replaced). When it ships, the bump is a
+  one-line `devDependencies` change — the tsconfig work is already done.
+  Re-check with `npm view openapi-typescript peerDependencies`.
+. **If TS 7 is wanted sooner, the only real path is replacing the generator.**
+  That is its own project, not a dependency bump: a different OpenAPI→TS tool
+  emits different `src/generated` output, which cascades into the hand-written
+  facade (`src/client.ts`, `src/transport.ts`) and must keep the TD-126 drift
+  gate meaningful. Scope it deliberately, with the generated output regenerated
+  and reviewed in the same PR.
+. **Do not** unpin or bypass the drift gate to force the bump — mandate #15
+  requires the REST surface to stay generated from the canonical spec.
+
+== Deps
+
+* Blocks: TypeScript 7 adoption in `clients/nodejs-embedded`.
+* Blocked by: upstream `openapi-typescript` TS 7 support.
+* Related: TD-126 (spec-driven SDK transports), dependabot #1460 (closed with
+  this finding recorded).


### PR DESCRIPTION
Migrates `clients/nodejs-embedded` off `moduleResolution: node10` — the mode **TypeScript 7 removed outright** — and files **TD-SDK-2** recording why the TS 7 bump itself is still blocked.

Config + docs only. No source changes. TypeScript stays at 5.9.3.

## The migration

| file | change |
|---|---|
| `tsconfig.json` | `module` `commonjs` → `node16`; `moduleResolution` `node` (node10) → `node16`; `types: ["node"]`; `lib` `["ES2022"]` → `["ES2022","DOM"]` |
| `tsconfig.esm.json` | `moduleResolution` → `bundler` |

**Why `node16` and not `bundler` for the base:** `bundler` is only valid with an ESM `module` setting, but the primary build emits CommonJS. `node16` keeps CJS emit (package.json declares no `"type"`), and CJS resolution still tolerates this source's extensionless relative imports (`from "./client"`) — avoiding a rewrite of every import to carry `.js`, which `node16` would demand in ESM mode. The ESM config overrides to `bundler`, valid alongside its `module: ES2022` and likewise extension-tolerant.

`types: ["node"]` + the `DOM` lib are needed under TS 7, which otherwise resolves **no ambient globals at all** here — `setTimeout`, `AbortController`, `Request`/`Response`/`RequestInit` were all reported missing. Both are harmless under 5.9, which picked these up implicitly.

## TS 7 is blocked — by the generator, not by us

With this config applied, **TypeScript 7.0.2 type-checks the SDK clean, builds both CJS and ESM (16 files), and passes all 18 tests.** The blocker is `openapi-typescript`:

```
openapi-typescript/dist/lib/ts.mjs:11
const BOOLEAN = ts.factory.createKeywordTypeNode(...)
TypeError: Cannot read properties of undefined (reading 'createKeywordTypeNode')
```

TS 7's native port no longer exposes `ts.factory`. **No published release supports TS 7** — `latest` 7.13.0 declares peer `^5.x`, the `next` tag points at 7.0.0-rc.1 (*older* than latest), and no version drops the constraint.

Three workarounds were tried, all failed — recorded in TD-SDK-2 so nobody re-derives them:

1. **npm `overrides`** scoped to the generator — npm hoists peer deps, so no nested TS 5 is created.
2. **Isolated `npx --package typescript@5.9.3 --package openapi-typescript@7.13.0`** in `gen.sh` — module resolution still reaches the project's hoisted TypeScript.
3. **Straight bump** — same crash.

Bumping today would turn `TS SDK Codegen Drift (TD-126)` red, which mandate #15 exists to prevent. Landing the migration separately means the eventual bump is a one-line change.

## Verification

On the unchanged TypeScript 5.9.3: `npm run lint` clean · `npm run build` emits CJS + ESM (16 files) · `npm test` 18 passed · `npm run gen-sdk` succeeds with **no** `src/generated` drift.

`check_td_adr_unique.py` clean (348 TD ids) · `make work-commit-check` green.

Ref TD-SDK-2, TD-126, #1460 (closed with this finding).