### PR TITLE
fix(sdk): read the flat v2 collection shape in list/get accessors

### DIFF
--- a/clients/python/src/proximadb_sdk/embedded.py
+++ b/clients/python/src/proximadb_sdk/embedded.py
@@ -463,6 +463,32 @@ def create_embedding_model(
         )
 
 
+def _collection_field(entry: Any, field: str) -> Any:
+    """Read a collection descriptor field across both payload shapes.
+
+    The v2 REST API returns collection descriptors **flat**::
+
+        {"collection_id": "1", "name": "docs", "dimension": 384, ...}
+
+    Older payloads nested the same fields under ``config``::
+
+        {"config": {"name": "docs", "dimension": 384}}
+
+    This SDK previously assumed the nested form unconditionally, so
+    ``list_collections()`` raised ``KeyError('config')`` and ``get_collection()``
+    returned ``None`` even on a 200 against a live v2 server. Reading either
+    shape keeps both server versions working.
+    """
+    if not isinstance(entry, dict):
+        return None
+    if field in entry:
+        return entry[field]
+    config = entry.get("config")
+    if isinstance(config, dict):
+        return config.get(field)
+    return None
+
+
 # =============================================================================
 # Configuration
 # =============================================================================
@@ -1100,19 +1126,21 @@ prefetch_budget = 4
         if name in self._collections:
             return self._collections[name]
 
-        async with self._http_client() as client:
-            response = await client.get(
-                f"{self.rest_url}/api/v2/collections/{name}",
-                timeout=10.0,
-            )
-
-            if response.status_code == 200:
-                data = response.json()
-                if data.get("collection"):
-                    dim = data["collection"]["config"]["dimension"]
-                    collection = EmbeddedCollection(name, dim, self)
-                    self._collections[name] = collection
-                    return collection
+        # Resolved from the LIST endpoint rather than GET /collections/{name},
+        # for two reasons:
+        #
+        # 1. GET returns 200 for a collection that does not exist, with
+        #    dimension 0 and a created_at equal to the request instant. Trusting
+        #    it hands back a phantom handle that silently writes nowhere.
+        #    LIST reports only collections that actually exist.
+        # 2. LIST already carries the dimension, so this needs one request, not
+        #    two (GET to fetch + LIST to verify).
+        for entry in await self._collection_entries():
+            if _collection_field(entry, "name") == name:
+                dim = _collection_field(entry, "dimension") or 0
+                collection = EmbeddedCollection(name, int(dim), self)
+                self._collections[name] = collection
+                return collection
 
         return None
 
@@ -1139,12 +1167,8 @@ prefetch_budget = 4
 
             return response.status_code in (200, 204, 404)
 
-    async def list_collections(self) -> list[str]:
-        """List all collections.
-
-        Returns:
-            List of collection names
-        """
+    async def _collection_entries(self) -> list[dict[str, Any]]:
+        """Return the raw collection descriptors from the LIST endpoint."""
         if not self._started:
             await self.start()
 
@@ -1153,13 +1177,16 @@ prefetch_budget = 4
                 f"{self.rest_url}/api/v2/collections",
                 timeout=10.0,
             )
+            if response.status_code != 200:
+                return []
+            data = response.json()
+            entries = data.get("collections", [])
+            return [e for e in entries if isinstance(e, dict)]
 
-            if response.status_code == 200:
-                data = response.json()
-                collections = data.get("collections", [])
-                return [c["config"]["name"] for c in collections]
-
-        return []
+    async def list_collections(self) -> list[str]:
+        """List all collection names."""
+        names = [_collection_field(e, "name") for e in await self._collection_entries()]
+        return [n for n in names if n]
 
     def _to_sql_value(self, value: Any) -> dict[str, Any]:
         """Convert Python value to SqlValue format."""

--- a/clients/python/tests/unit/test_embedded_collection_accessors.py
+++ b/clients/python/tests/unit/test_embedded_collection_accessors.py
@@ -1,0 +1,94 @@
+"""Collection accessors must read the v2 payload shape the server actually sends.
+
+`list_collections()` assumed every descriptor nested its fields under `config`.
+The v2 REST API returns them flat, so it raised `KeyError('config')` and
+`get_collection()` returned None even on a 200 — which in turn made
+`create_collection` -> COLLECTION_EXISTS unrecoverable for callers, since the
+natural fallback (fetch the existing one) could never succeed.
+"""
+
+import pytest
+
+from proximadb_sdk.embedded import EmbeddedConfig, EmbeddedProximaDB, _collection_field
+
+V2_FLAT = {
+    "collection_id": "1",
+    "name": "proxima_codegraph_records",
+    "dimension": 384,
+    "engine": "helix",
+    "record_count": None,
+}
+LEGACY_NESTED = {"config": {"name": "legacy_docs", "dimension": 128}}
+
+
+def test_collection_field_reads_flat_v2_shape():
+    assert _collection_field(V2_FLAT, "name") == "proxima_codegraph_records"
+    assert _collection_field(V2_FLAT, "dimension") == 384
+
+
+def test_collection_field_still_reads_legacy_nested_shape():
+    assert _collection_field(LEGACY_NESTED, "name") == "legacy_docs"
+    assert _collection_field(LEGACY_NESTED, "dimension") == 128
+
+
+def test_collection_field_returns_none_for_unknown_or_malformed():
+    assert _collection_field(V2_FLAT, "nope") is None
+    assert _collection_field({}, "name") is None
+    assert _collection_field(None, "name") is None
+    assert _collection_field("not-a-dict", "name") is None
+
+
+def _db(monkeypatch, entries):
+    db = EmbeddedProximaDB(config=EmbeddedConfig(data_dir="/tmp/does-not-matter"))
+    db._started = True
+
+    async def fake_entries():
+        return entries
+
+    monkeypatch.setattr(db, "_collection_entries", fake_entries)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_list_collections_parses_flat_entries(monkeypatch):
+    db = _db(monkeypatch, [V2_FLAT, LEGACY_NESTED])
+    assert await db.list_collections() == ["proxima_codegraph_records", "legacy_docs"]
+
+
+@pytest.mark.asyncio
+async def test_list_collections_skips_entries_without_a_name(monkeypatch):
+    db = _db(monkeypatch, [V2_FLAT, {"collection_id": "2"}])
+    assert await db.list_collections() == ["proxima_codegraph_records"]
+
+
+@pytest.mark.asyncio
+async def test_get_collection_resolves_an_existing_collection(monkeypatch):
+    db = _db(monkeypatch, [V2_FLAT])
+    coll = await db.get_collection("proxima_codegraph_records")
+    assert coll is not None
+    assert coll.dimension == 384
+
+
+@pytest.mark.asyncio
+async def test_get_collection_returns_none_for_a_missing_collection(monkeypatch):
+    """Must not hand back a phantom handle.
+
+    GET /api/v2/collections/{name} answers 200 for a name that does not exist,
+    with dimension 0 and a created_at equal to the request instant. Resolving
+    through LIST — which reports only real collections — avoids adopting a
+    collection that silently writes nowhere.
+    """
+    db = _db(monkeypatch, [V2_FLAT])
+    assert await db.get_collection("never_created") is None
+
+
+@pytest.mark.asyncio
+async def test_get_collection_prefers_the_process_cache(monkeypatch):
+    db = _db(monkeypatch, [V2_FLAT])
+    first = await db.get_collection("proxima_codegraph_records")
+    monkeypatch.setattr(db, "_collection_entries", None)  # would raise if consulted
+    assert await db.get_collection("proxima_codegraph_records") is first
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes items 1 and 2 of #1486.

## Problem

`GET /api/v2/collections` returns descriptors **flat**:

```json
{"collections": [{"collection_id": "1", "name": "proxima_codegraph_records",
                  "dimension": 384, "engine": "helix", "record_count": null}]}
```

The SDK assumed a nested `config`:

```python
# list_collections()
return [c["config"]["name"] for c in collections]        # KeyError: 'config'

# get_collection()
if data.get("collection"):                               # never true — payload is flat
    dim = data["collection"]["config"]["dimension"]
return None                                              # so this returns None on a 200
```

**Why it matters beyond the two methods:** `create_collection` on an existing collection fails with `COLLECTION_EXISTS`, and the natural recovery — fetch the existing one — could never succeed, because `get_collection` always returned `None`. Any record-backed workflow therefore worked exactly once, on a fresh data directory; reopening an indexed store raised `RuntimeError` before a record could be read or written. That is how this surfaced in Victor.

## Fix

- `_collection_field()` reads either shape, so older servers keep working.
- `_collection_entries()` shares the LIST fetch between both accessors.
- `get_collection()` resolves through **LIST** rather than `GET /collections/{name}`.

That last choice is deliberate and is item 2 of #1486: `GET` answers **200** for a collection that does not exist, with `dimension: 0` and a `created_at` equal to the request instant. Trusting it hands back a phantom handle that silently writes nowhere. LIST reports only collections that exist and already carries the dimension, so this is one request instead of two.

**The server-side GET behaviour is still worth fixing** — this only stops the SDK from being fooled by it. A read appearing to materialise state remains surprising for any other client.

## Tests

`tests/unit/test_embedded_collection_accessors.py` — 8 tests: both payload shapes, malformed/missing entries, existing vs missing collection, and that the process cache is preferred. The missing-collection test is the regression guard for the phantom handle.

Verified end to end: reopening a populated embedded store now adopts its collection instead of raising, and the graph reads back intact across a restart (1,328 nodes / 1,258 edges).