### PR TITLE
fix(sdk): repair stale Python SDK unit tests + gate them at develop->qa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2059,7 +2059,10 @@ jobs:
       matrix:
         # 3.9 dropped: the package declares requires-python ">=3.10".
         python-version: ["3.10", "3.11", "3.12"]
-    if: ${{ !inputs.skip_tests && needs.changes.outputs.extensive == 'true' }}
+    # medium_tier (base qa OR main), not extensive (base main only): the ~5min
+    # Python SDK suite runs at develop->qa too, so SDK regressions block one
+    # stage earlier instead of only surfacing at the qa->main boundary.
+    if: ${{ !inputs.skip_tests && needs.changes.outputs.medium_tier == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/clients/python/tests/unit/test_models_coverage.py
+++ b/clients/python/tests/unit/test_models_coverage.py
@@ -11,14 +11,18 @@ class TestCollectionConfigEdgeCases:
     """Test edge cases in CollectionConfig"""
 
     def test_collection_name_validation_edge_case(self):
-        """Test collection name validation at boundary"""
-        # Test exactly 8 characters (should pass)
-        config = CollectionConfig(name="testcoll", dimension=128)  # exactly 8 chars
+        """Test collection name validation at boundary (8-char minimum relaxed, #1113)."""
+        # 8-character names work
+        config = CollectionConfig(name="testcoll", dimension=128)
         assert config.name == "testcoll"
 
-        # Test 7 characters (should fail)
-        with pytest.raises(Exception, match="String should have at least 8 characters"):
-            CollectionConfig(name="test123", dimension=128)  # only 7 chars
+        # Short (7-char) names are now accepted — the 8-char minimum was relaxed
+        # for relational-DDL tables; the SDK must not be stricter than the server.
+        assert CollectionConfig(name="test123", dimension=128).name == "test123"
+
+        # Empty names are still rejected (Pydantic min_length=1)
+        with pytest.raises(Exception):
+            CollectionConfig(name="", dimension=128)
 
     def test_index_config_property_none(self):
         """Test index_config property when no configs exist"""

--- a/clients/python/tests/unit/test_relaxed_validation.py
+++ b/clients/python/tests/unit/test_relaxed_validation.py
@@ -101,35 +101,35 @@ class TestRelaxedValidation:
         assert DistanceMetric.BRAY_CURTIS == "bray_curtis"
         assert DistanceMetric.HELLINGER == "hellinger"
 
-    def test_strict_name_validation(self):
-        """Test that collection name validation enforces 8+ character minimum"""
-        # Valid names (8+ characters) should work
-        config = CollectionConfig(name="valid_collection_name", dimension=128)
-        assert config.name == "valid_collection_name"
+    def test_relaxed_name_validation(self):
+        """Collection names are no longer required to be 8+ characters.
 
-        # Exactly 8 characters should work
-        config = CollectionConfig(name="exactly8", dimension=128)
-        assert config.name == "exactly8"
+        The former 8-char minimum was a vector-collection-era constraint the
+        server relaxed for relational-DDL tables (part / orders / region); the
+        SDK must not be stricter than the server (#1113, TD-SDK-1). Only
+        empty / whitespace-only names are rejected.
+        """
+        # 8+ character names still work
+        assert (
+            CollectionConfig(name="valid_collection_name", dimension=128).name
+            == "valid_collection_name"
+        )
+        assert CollectionConfig(name="exactly8", dimension=128).name == "exactly8"
 
-        # Short names should fail (< 8 characters)
-        with pytest.raises(ValueError, match="at least 8 characters"):
-            CollectionConfig(name="short", dimension=128)
+        # Short names are now ACCEPTED (relational tables)
+        assert CollectionConfig(name="short", dimension=128).name == "short"
+        assert CollectionConfig(name="a", dimension=128).name == "a"
 
-        # Very short names should fail
-        with pytest.raises(ValueError, match="at least 8 characters"):
-            CollectionConfig(name="a", dimension=128)
+        # Surrounding whitespace is stripped; the short result is still accepted
+        assert CollectionConfig(name="  short  ", dimension=128).name == "short"
 
-        # Empty names should fail (Pydantic catches this)
+        # Empty names still fail (Pydantic min_length=1)
         with pytest.raises(ValidationError):
             CollectionConfig(name="", dimension=128)
 
-        # Whitespace-only names should fail (Pydantic min_length catches this too)
+        # Whitespace-only names still fail (validator rejects empty-after-strip)
         with pytest.raises(ValidationError):
             CollectionConfig(name="   ", dimension=128)
-
-        # Names with whitespace that become < 8 chars after strip should fail
-        with pytest.raises(ValueError, match="at least 8 characters"):
-            CollectionConfig(name="  short  ", dimension=128)
 
     def test_relaxed_dimension_validation(self):
         """Test that dimension validation is relaxed"""

--- a/clients/python/tests/unit/test_rest_adapter_cov.py
+++ b/clients/python/tests/unit/test_rest_adapter_cov.py
@@ -589,7 +589,9 @@ def test_search_numpy_query(adapter):
     adapter._client._search_ret = [SearchResult(id="a", score=0.1)]
     results = adapter.search("c1", np.array([0.1, 0.2]))
     assert results[0].id == "a"
-    assert isinstance(adapter._client.last_search["query_vector"], list)
+    # The REST search payload uses the `vector` key (not `query_vector`); a numpy
+    # array is normalized to a plain list on the wire.
+    assert isinstance(adapter._client.last_search["vector"], list)
 
 
 def test_search_object_results(adapter):

--- a/clients/python/tests/unit/test_sdk_imports_moved.py
+++ b/clients/python/tests/unit/test_sdk_imports_moved.py
@@ -80,7 +80,12 @@ class TestImports:
         assert issubclass(CollectionNotFoundError, ProximaDBError)
 
     def test_chunking_imports(self):
-        """Test text chunking imports"""
+        """Test text chunking imports (opt-in `[chunking]` extra)."""
+        # Chunking public names are exported only when the `[chunking]` extra
+        # (tree-sitter) is installed; skip when it isn't, matching the SDK's
+        # opt-in design (see proximadb_sdk.__init__._chunking_concern_available).
+        pytest.importorskip("tree_sitter")
+
         from proximadb_sdk import (
             ChunkingStrategy,
             chunk_by_sentences,


### PR DESCRIPTION
The v0.3.0 release-commit CI on main surfaced 4 red Python SDK unit tests that had been skipped in the qa gate (they only run at the extensive/base-main tier). All 4 are **stale tests** lagging intentional SDK changes (validated locally, now pass):
- name validation: 8-char minimum relaxed (#1113) -> short names accepted
- REST search payload key renamed `query_vector` -> `vector`
- `ChunkingStrategy` is behind the opt-in `[chunking]` extra -> `importorskip('tree_sitter')`

Plus: move the Python SDK test job to **medium_tier** so it runs (and blocks, via `CI Success` which already `needs: python-test`) at **develop->qa**, not only qa->main — so this can't silently recur.

Part of the v0.3.0 release train (fix -> develop -> qa -> main).