### PR TITLE
docs(td): file TD-DEPS-1 — bincode 2.x is maintenance, not perf (measured)

### DIFF
--- a/docs/10-quality/td/TD-DEPS-1-bincode-2x-maintenance-upgrade.adoc
+++ b/docs/10-quality/td/TD-DEPS-1-bincode-2x-maintenance-upgrade.adoc
@@ -1,0 +1,115 @@
+= TD-DEPS-1: bincode 1.3.3 → 2.x is a MAINTENANCE upgrade, not a performance one (measured)
+:status: Open
+:dim: D3
+:pillar: SUS
+
+== Problem
+
+`bincode` 1.3.3 is used at **257 call sites across 80 files**, concentrated in
+durable paths: `src/index/axis/storage` (47), the WAL serialization path,
+`src/storage/engines/sst`, `proximadb-bloom` strategies, and
+`proximadb-records`. 1.3.3 predates the upstream 2.0 rewrite and is effectively
+in maintenance mode.
+
+**`bincode 3.0.0` is NOT the upgrade target — it is a deliberate non-functional
+release.** Its entire `src/lib.rs` is:
+
+[source,rust]
+----
+compile_error!("https://xkcd.com/2347/");
+----
+
+4,323 bytes, zero dependencies, zero features (2.0.1 is 70,469 bytes). Verified
+by extracting the published `.crate` from static.crates.io. Any PR bumping to
+3.0.0 breaks the whole build and must be closed on sight (dependabot proposed
+exactly this in #1502).
+
+== Measurement — the perf/compression case does NOT hold (2026-08-06)
+
+Benchmarked against payloads matching our real shapes, both raw and after
+**zstd level 3** — the level the live path actually uses
+(`src/index/axis/storage/format_strategy.rs:111` does
+`bincode::serialize` → `zstd::encode_all(.., 3)`). Release build, mean of 20
+iterations.
+
+.A. Warm-cluster chunk — `Vec<(u64, Vec<f32>)>`, 1000×128 (the dominant on-disk payload, `serialization.rs:550`)
+[cols="3,2,2,2", options="header"]
+|===
+| encoder | raw bytes | after zstd(3) | encode
+
+| bincode 1.3.3 (baseline) | 528,008 | 458,507 | 0.068 ms
+| bincode 2.0.1 serde + `standard()` (varint) | 515,501 (**−2.37%**) | 459,473 (**+0.21%**) | 0.077 ms
+| bincode 2.0.1 serde + `legacy()` (fixed) | 528,008 (+0.00%) | 458,507 (+0.00%) | 0.069 ms
+|===
+
+.B. Int-heavy header — 20k ids/offsets/lens/flags (varint's BEST case, included so the test is not rigged)
+[cols="3,2,2,2", options="header"]
+|===
+| encoder | raw bytes | after zstd(3) | encode
+
+| bincode 1.3.3 (baseline) | 420,032 | 8,860 | 0.066 ms
+| bincode 2.0.1 serde + `standard()` (varint) | 138,694 (**−66.98%**) | 9,142 (**+3.18%**) | 0.148 ms
+| bincode 2.0.1 serde + `legacy()` (fixed) | 420,032 (+0.00%) | 8,860 (+0.00%) | 0.067 ms
+|===
+
+Decode (same payloads): **A** 0.132 ms → 0.322 ms (**+143%**); **B** 0.054 ms →
+0.197 ms (**+262%**).
+
+=== What the numbers say
+
+. **Varint buys nothing on our dominant payload.** It applies to integers;
+  `f32`/`f64` are fixed-width in both versions. A 128-dim vector is 512 bytes of
+  float against one id, so >99% of those bytes encode identically — hence the
+  −2.37%.
+. **Varint's 67% raw win becomes a 3% LOSS after zstd.** Even in its best case,
+  zstd already removes the zero-padding in fixed-width integers, and removes it
+  *better* than varint does. Since the live path compresses, the raw-size column
+  is the wrong one to optimise — this is the co-design point that a codec win is
+  irrelevant if a later stage already captured it.
+. **Decode regresses 2.4–3.6×** through the serde compatibility path.
+
+=== Limitation of this measurement (read before citing it)
+
+These figures use bincode 2's **serde compatibility layer**
+(`bincode2::serde::encode_to_vec`), which is the migration path that does *not*
+require touching the types at all 257 sites. bincode 2's **native
+`Encode`/`Decode` derives** avoid serde's data-model indirection and would very
+likely decode faster — possibly faster than 1.3.3. That path was NOT measured,
+because it requires deriving the new traits on every persisted type, which is
+the expensive migration this TD is trying to size. **Do not cite the decode
+regression as an argument against native-derive bincode 2.**
+
+== Why the migration is nonetheless CHEAP right now
+
+The usual blocker would be mandate #8: bincode 2's default `standard()` config
+is not byte-compatible with 1.x, so persisted data written by 1.3.3 would be
+unreadable — normally forcing a mixed-read-safe, version-marked, default-OFF
+migration.
+
+**Pre-release status removes that burden.** There is no production data to
+preserve, so the format may simply change. (bincode 2 also ships a `legacy()`
+config that reproduces 1.x fixed-int framing, if a compatibility bridge is ever
+wanted.)
+
+== Next action
+
+Treat as **maintenance, low priority** — not a perf or compression win:
+
+. Take it when there is a reason to touch these paths anyway, or when 1.3.3
+  becomes a security or ecosystem liability.
+. If taken, migrate to the **native `Encode`/`Decode` derives**, not the serde
+  shim — the shim is measurably slower on decode and delivers none of the
+  upside.
+. Re-measure with native derives before and after; per mandate #6 the perf claim
+  must come from a measured trace, and this TD's numbers only cover the serde
+  path.
+. Keep `bincode 3.0.0` permanently out. Consider an `ignore` entry in
+  `.github/dependabot.yml` if it is proposed again — noting that config only
+  takes effect once it reaches the default branch `main` (see TD-SDK-2's
+  sibling finding about dependabot config living on `main`).
+
+== Deps
+
+* Related: mandate #8 (storage-format migration), mandate #6 (measure, don't
+  assert), `BENCHMARK_EVIDENCE.toml`.
+* Closed as harmful: dependabot #1502 (bincode 3.0.0).


### PR DESCRIPTION
Answers "what do we actually gain from bincode 2.x" with a measurement instead of reasoning, so it's settled rather than re-argued. **Docs only.**

## The measurement

Payloads matching our real shapes, measured raw **and after zstd level 3** — the level the live path uses (`format_strategy.rs:111` does `bincode::serialize` → `zstd::encode_all(.., 3)`). Release build, mean of 20 iterations.

**A. Warm-cluster chunk** — `Vec<(u64, Vec<f32>)>` 1000×128, the dominant on-disk payload (`serialization.rs:550`)

| encoder | raw | after zstd(3) | encode |
|---|---|---|---|
| bincode 1.3.3 (baseline) | 528,008 | 458,507 | 0.068 ms |
| 2.0.1 serde + `standard()` varint | 515,501 (**−2.37%**) | 459,473 (**+0.21%**) | 0.077 ms |
| 2.0.1 serde + `legacy()` fixed | 528,008 (+0.00%) | 458,507 (+0.00%) | 0.069 ms |

**B. Int-heavy header** — 20k ids/offsets/lens/flags, varint's *best* case (included so the test isn't rigged)

| encoder | raw | after zstd(3) | encode |
|---|---|---|---|
| bincode 1.3.3 (baseline) | 420,032 | 8,860 | 0.066 ms |
| 2.0.1 serde + `standard()` varint | 138,694 (**−66.98%**) | 9,142 (**+3.18%**) | 0.148 ms |
| 2.0.1 serde + `legacy()` fixed | 420,032 (+0.00%) | 8,860 (+0.00%) | 0.067 ms |

Decode: **A** 0.132 → 0.322 ms (**+143%**) · **B** 0.054 → 0.197 ms (**+262%**).

## What it means

**Varint's 67% raw win becomes a 3% loss after zstd.** Two reasons the raw column is the wrong one to read:

1. **Varint applies to integers; our bulk payload is `f32`.** A 128-dim vector is 512 bytes of float against one id, so >99% of those bytes encode identically in both versions — hence −2.37%.
2. **The live path already compresses.** zstd removes fixed-width zero-padding *better* than varint does. This is the co-design point in miniature: a codec win is irrelevant if a later stage already captured it.

So bincode 2.x is a **maintenance** upgrade (active upstream, `no_std`, native derives, configurable encoding), **not** a perf or compression one.

## Limitation, stated in the TD

These figures use bincode 2's **serde compatibility layer** — the path that avoids touching all 257 call sites. Native `Encode`/`Decode` derives avoid serde's indirection and would likely decode *faster*, possibly beating 1.3.3. That path was **not** measured, because it requires deriving new traits on every persisted type — the expensive migration this TD is sizing. The decode regression must not be cited against native-derive bincode 2.

## Also recorded: bincode 3.0.0 must stay out permanently

Its entire `src/lib.rs` is `compile_error!("https://xkcd.com/2347/")` — 4,323 bytes, zero deps (2.0.1 is 70,469). Verified by extracting the published `.crate`. Dependabot proposed it in #1502; closed.

## Why the migration is cheap when we want it

Normally mandate #8 would apply — bincode 2's `standard()` isn't byte-compatible with 1.x, so persisted data would be unreadable. **Pre-release status removes that**: no production data to preserve. (A `legacy()` config reproducing 1.x framing exists if a bridge is ever wanted.)

`check_td_adr_unique.py` clean (352 TD ids) · `make work-commit-check` green.

Ref TD-DEPS-1, #1502, mandate #6, mandate #8.