### PR TITLE
fix(ci): make the touched-crate fast lane actually touched-crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,12 @@ jobs:
         run: python3 scripts/check_mvp_trust_corridor.py
       - name: Test canonical MVP smoke client
         run: python3 -m unittest discover -s tests/scripts -p 'test_mvp_smoke.py'
+      # Guards the touched-crate fast lane's cost invariant (see the
+      # rust-affected-fast job header): the monolith-dependent closure must keep
+      # excluding crates whose graph pulls in the root crate. Pure-python, no
+      # toolchain needed.
+      - name: Test affected-crate selection
+        run: python3 -m unittest discover -s tests/scripts -p 'test_affected_crates.py'
       - name: Validate context-corridor benchmark contract
         run: make context-benchmark-check
 
@@ -1565,6 +1571,27 @@ jobs:
   # where it pays off — more so as TD-DECOMP-1 follow-ups move logic DOWN into
   # leaf crates. rust-cache only (no sccache): leaf crates are small, and sccache
   # adds the #920 OOM risk for no gain at this scale.
+  #
+  # SKIPPING THE ROOT CRATE BY NAME IS NOT ENOUGH (fixed here). `-p <crate>`
+  # compiles that crate's WHOLE dependency graph, and 8 workspace members
+  # path-depend on the root monolith (the 3 crates/binding/* bindings, the 4
+  # apps/*, and clients/rust `proximadb-sdk` via a non-optional
+  # `proximadb-embedded`). So a diff touching e.g. proximadb-embedded selected
+  # `-p proximadb-embedded` and dragged the entire monolith back in — the exact
+  # cost this lane exists to avoid. Measured: such runs compiled 600+ third-party
+  # crates from cold and were still on tantivy/tokenizers/lalrpop when the
+  # timeout killed them, burning a full runner slot for ZERO signal (~39% of the
+  # runs that actually ran, all at the timeout wall). The cache could never
+  # amortize it either: rust-cache saves only on success, and the ONLY cache a
+  # PR can inherit — the develop-branch one — is written by develop pushes where
+  # `git diff origin/develop...HEAD` is empty by construction, so that cache
+  # holds a cargo registry and no compiled artifacts. Every real run therefore
+  # started at "No cache found."
+  # The fix is to make the selection honor the lane's own name: exclude the root
+  # monolith AND its transitive workspace dependents (9 of 124 crates; 115 stay
+  # eligible), so this lane only ever compiles genuinely cheap graphs. The 9
+  # excluded crates remain covered by the required rust-test job; they become
+  # eligible again as TD-DECOMP-1 moves logic out of the monolith.
   # ============================================================================
   rust-affected-fast:
     name: Rust touched-crate fast check (advisory)
@@ -1572,7 +1599,11 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true        # advisory — never a merge gate (also not in ci-success.needs)
-    timeout-minutes: 15
+    # 10m is a CANARY, not a budget: with the selection fixed this lane is a
+    # cheap leaf compile (observed 58-165s from cold), so ~4x headroom. If a
+    # future dependency edge makes a "leaf" crate heavy again, we want to find
+    # out after 10 wasted minutes, not 15.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1586,6 +1617,10 @@ jobs:
         with:
           prefix-key: "v1-rust-affected-fast"
           shared-key: "build"
+          # A genuine test/compile FAILURE here is the signal this lane exists to
+          # give; saving its (small, leaf-only) target/ means the fix push on the
+          # same PR rebuilds warm instead of repeating the cold compile.
+          cache-on-failure: true
 
       - name: Install Dependencies
         run: |
@@ -1598,26 +1633,22 @@ jobs:
       - name: Affected-only fast unit check
         run: |
           set -euo pipefail
-          pkgs="$(python3 scripts/affected_crates.py origin/develop)"
-          [ -n "$pkgs" ] || { echo 'No crate source changed — skipping.'; exit 0; }
-          # Bare positionals to cargo/nextest are TEST-NAME FILTERS, not package
-          # selectors — turn the space-separated list into -p args. Skip the root
-          # crate (proximadb): a src/** edit maps to it, but compiling its lib is
-          # redundant with rust-test and OOM-prone here (see job header).
-          root_seen=no
-          pkg_args=""
-          for p in $pkgs; do
-            if [ "$p" = "proximadb" ]; then
-              root_seen=yes
-            else
-              pkg_args="$pkg_args -p $p"
-            fi
-          done
-          [ "$root_seen" = "yes" ] && echo "Root crate 'proximadb' changed — covered by the required rust-test job; not re-run in this fast lane."
-          if [ -z "$pkg_args" ]; then
-            echo 'Only the root crate (or nothing leaf) changed — nothing fast to check here.'
+          # --exclude-dependents-of proximadb drops the root monolith AND every
+          # workspace member that transitively depends on it (see job header):
+          # `-p X` compiles X's whole dependency graph, so those crates are never
+          # cheap here. They stay covered by the required rust-test job. The
+          # script names the dropped crates on stderr, so the log still says why.
+          pkgs="$(python3 scripts/affected_crates.py --exclude-dependents-of proximadb origin/develop)"
+          if [ -z "$pkgs" ]; then
+            echo 'No eligible leaf crate changed — nothing fast to check here.'
             exit 0
           fi
+          # Bare positionals to cargo/nextest are TEST-NAME FILTERS, not package
+          # selectors — turn the space-separated list into -p args.
+          pkg_args=""
+          for p in $pkgs; do
+            pkg_args="$pkg_args -p $p"
+          done
           echo "Affected leaf crates:$pkg_args"
           cargo nextest run --lib --profile unit $pkg_args
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -39,6 +39,10 @@ url = "2.4"
 
 # Reference to main proximadb crate for embedded mode
 proximadb = { path = "../..", optional = true }
+# NOTE: non-optional, and it path-depends on the root monolith — so `-p
+# proximadb-sdk` compiles the whole monolith even with the `proximadb` feature
+# off. That is why this crate is excluded from the advisory touched-crate fast
+# lane (`rust-affected-fast` in ci.yml); the required `rust-test` job covers it.
 proximadb-embedded = { path = "../../crates/binding/proximadb-embedded" }
 
 [features]

--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -28,6 +28,12 @@ crate-type = ["cdylib", "rlib"]
 # apps — the PAX-exact-scan direction (TD-AXIS-4, ADR-082). Because embedded's `axis`
 # feature forwards `proximadb/axis`, embedded's axis cfg is always in sync with the
 # root's, so the flush→AXIS reap's cross-crate type stays consistent in every build.
+#
+# CI cost note: this edge makes `-p proximadb-embedded` compile the whole root
+# monolith, so this crate is excluded from the advisory touched-crate fast lane
+# (`rust-affected-fast` in ci.yml, via `affected_crates.py
+# --exclude-dependents-of proximadb`). It stays covered by the required
+# `rust-test` job. It becomes fast-lane-eligible again if this edge ever goes.
 proximadb = { path = "../../..", default-features = false }
 # FA-b: optional, behind the `abac-policy` feature. Embedded mode is abac-OFF by
 # design (in-process; the host app owns authorization) — this dep exists only so

--- a/docs/12-design/BUILD_CI_ACCELERATION_2026_07_31.adoc
+++ b/docs/12-design/BUILD_CI_ACCELERATION_2026_07_31.adoc
@@ -91,6 +91,37 @@ leaf-crate edits (more hits as L1/L1-follow-up move logic down). Companion:
 derive `CARGO_BUILD_JOBS` from runner RAM per lane (leaf lanes can raise it above
 the monolith's jobs=1 — small crates don't OOM).
 
+==== D4 post-implementation correction (2026-08-06)
+
+The lane as shipped skipped the root `proximadb` crate *by name*, which is not
+sufficient: `-p <crate>` compiles that crate's whole dependency graph, and nine
+workspace members (`proximadb` + the three `crates/binding/*`, the four
+`apps/*`, and `clients/rust`'s `proximadb-sdk` via a non-optional
+`proximadb-embedded`) transitively pull the monolith back in. A diff touching
+any of them selected e.g. `-p proximadb-sdk -p proximadb-embedded` and compiled
+600+ third-party crates from cold until the 15-minute timeout killed the job.
+
+Measured over 80 consecutive `ci.yml` runs: 40 skipped, 18 green (58–165s), one
+genuine failure (354s — real signal), and **12 cancelled, 8 of them at exactly
+915–917s — the timeout wall**. So ~39% of the runs that actually ran burned a
+full runner slot for zero signal.
+
+The cache could not amortize it, and structurally never will: `rust-cache` saves
+only on success, so timed-out runs never save; and the only cache a PR can
+inherit — the `develop`-branch one — is written by `develop` pushes, where
+`git diff origin/develop...HEAD` is empty by construction, so the job exits
+having compiled *nothing* and stores a cargo registry with no `target/`
+artifacts. Both the timed-out PR runs and the `develop` push runs log
+`No cache found.`
+
+Fix: `affected_crates.py --exclude-dependents-of proximadb` excludes the
+monolith *and its transitive workspace dependents* (9 of 124 crates; 115 stay
+eligible), so the lane only ever compiles genuinely cheap graphs. Timeout
+tightened 15m → 10m as a canary (~4x headroom over the observed 165s worst
+case). Closure regressions are guarded by `tests/scripts/test_affected_crates.py`.
+The nine excluded crates stay covered by the required `rust-test` job and become
+eligible again as TD-DECOMP-1 moves logic out of the monolith.
+
 === L4 / D5 — deployment shapes  (additive feature bundles — document + validate)
 
 The shapes already exist as Cargo feature bundles (no cfg-divergent impls). This

--- a/scripts/affected_crates.py
+++ b/scripts/affected_crates.py
@@ -10,9 +10,20 @@ This is DIRECT crates only — reverse-dependents are not expanded. For a change
 to a low-level foundation crate, also run the full suite (`make test`); a
 v2 can walk `cargo metadata`'s resolve graph for dependents.
 
-Usage: affected_crates.py [base-ref]   (default: origin/develop)
+`--exclude-dependents-of PKG` (repeatable) additionally drops PKG *and every
+workspace member that transitively depends on it* (any dependency kind —
+normal, dev, or build; optional deps count, conservatively). This exists for
+budget-capped fast lanes: selecting a crate with `-p` compiles its whole
+dependency graph, so a "leaf" crate that path-depends on the ~850K-LOC root
+`proximadb` monolith is not cheap at all — naming the root alone is not enough
+to keep such a lane fast. Excluded crates are reported on stderr; stdout stays
+the space-separated crate list.
+
+Usage: affected_crates.py [--exclude-dependents-of PKG]... [base-ref]
+                                                 (base-ref default: origin/develop)
 Prints space-separated crate names to stdout (empty if no crate source changed).
 """
+import argparse
 import json
 import os
 import subprocess
@@ -23,8 +34,34 @@ def git(args, cwd):
     return subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd).stdout
 
 
+def workspace_dependents_of(meta, roots):
+    """Return `roots` plus every workspace member transitively depending on them.
+
+    Uses the manifest-level dependency lists from `cargo metadata --no-deps`
+    (cheap: no registry resolve), restricted to workspace-internal edges.
+    """
+    names = {p["name"] for p in meta["packages"]}
+    rdeps = {}
+    for p in meta["packages"]:
+        for d in p["dependencies"]:
+            if d["name"] in names:
+                rdeps.setdefault(d["name"], set()).add(p["name"])
+    closure = {r for r in roots if r in names}
+    queue = list(closure)
+    while queue:
+        for dependent in rdeps.get(queue.pop(), ()):
+            if dependent not in closure:
+                closure.add(dependent)
+                queue.append(dependent)
+    return closure
+
+
 def main():
-    base = sys.argv[1] if len(sys.argv) > 1 else "origin/develop"
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("base", nargs="?", default="origin/develop")
+    ap.add_argument("--exclude-dependents-of", action="append", default=[], metavar="PKG")
+    args = ap.parse_args()
+    base = args.base
     root = git(["rev-parse", "--show-toplevel"], cwd=".").strip()
     if not root:
         sys.exit(0)
@@ -66,6 +103,18 @@ def main():
         c = crate_for(f)
         if c and c not in seen:
             seen.append(c)
+
+    if args.exclude_dependents_of:
+        excluded = workspace_dependents_of(meta, args.exclude_dependents_of)
+        dropped = [c for c in seen if c in excluded]
+        seen = [c for c in seen if c not in excluded]
+        if dropped:
+            print(
+                "affected_crates: excluded (depends on %s): %s"
+                % (", ".join(args.exclude_dependents_of), " ".join(dropped)),
+                file=sys.stderr,
+            )
+
     if seen:
         print(" ".join(seen))
 

--- a/tests/scripts/test_affected_crates.py
+++ b/tests/scripts/test_affected_crates.py
@@ -1,0 +1,113 @@
+"""Unit tests for scripts/affected_crates.py's workspace-dependent closure.
+
+Guards the touched-crate fast lane's cost invariant: `-p <crate>` compiles that
+crate's WHOLE dependency graph, so any workspace member that transitively
+depends on the ~850K-LOC root `proximadb` monolith must be excluded from the
+lane — naming the root package alone is not enough. Regressing this closure
+silently reintroduces the 15-minute-timeout class the lane was fixed for.
+
+Pure-synthetic (no `cargo metadata` invocation) so it runs in the toolchain-free
+capability-matrix CI job.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "affected_crates", ROOT / "scripts/affected_crates.py"
+)
+assert SPEC and SPEC.loader
+AFFECTED = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AFFECTED)
+
+
+def _meta(graph: dict[str, list[str]]) -> dict:
+    """Build a minimal `cargo metadata --no-deps`-shaped dict from name -> deps."""
+    return {
+        "packages": [
+            {"name": name, "dependencies": [{"name": d} for d in deps]}
+            for name, deps in graph.items()
+        ]
+    }
+
+
+class WorkspaceDependentsTest(unittest.TestCase):
+    def test_excludes_root_itself(self) -> None:
+        meta = _meta({"proximadb": [], "leaf": []})
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb"]), {"proximadb"}
+        )
+
+    def test_excludes_direct_dependent(self) -> None:
+        # The crates/binding/proximadb-embedded shape: a direct path dep on root.
+        meta = _meta({"proximadb": [], "embedded": ["proximadb"], "leaf": []})
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb"]),
+            {"proximadb", "embedded"},
+        )
+
+    def test_excludes_transitive_dependent(self) -> None:
+        # The clients/rust shape: sdk -> embedded -> proximadb. `sdk` never names
+        # the root, but `-p sdk` still drags the whole monolith in.
+        meta = _meta(
+            {
+                "proximadb": [],
+                "embedded": ["proximadb"],
+                "sdk": ["embedded"],
+                "leaf": ["some-third-party"],
+            }
+        )
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb"]),
+            {"proximadb", "embedded", "sdk"},
+        )
+
+    def test_keeps_unrelated_leaves(self) -> None:
+        meta = _meta(
+            {
+                "proximadb": ["foundation"],
+                "foundation": [],
+                "codec": ["foundation"],
+                "embedded": ["proximadb"],
+            }
+        )
+        excluded = AFFECTED.workspace_dependents_of(meta, ["proximadb"])
+        # Crates the monolith depends ON stay eligible — the edge is directional.
+        self.assertNotIn("foundation", excluded)
+        self.assertNotIn("codec", excluded)
+        self.assertEqual(excluded, {"proximadb", "embedded"})
+
+    def test_ignores_non_workspace_dependency_names(self) -> None:
+        # Third-party deps share the namespace in `dependencies`; only
+        # workspace-internal edges may drive the closure.
+        meta = _meta({"proximadb": [], "leaf": ["serde", "tokio"]})
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb"]), {"proximadb"}
+        )
+
+    def test_unknown_root_is_a_noop(self) -> None:
+        meta = _meta({"proximadb": [], "leaf": []})
+        self.assertEqual(AFFECTED.workspace_dependents_of(meta, ["does-not-exist"]), set())
+
+    def test_cycle_safe(self) -> None:
+        # Cargo forbids cycles, but the traversal must terminate regardless.
+        meta = _meta({"proximadb": ["a"], "a": ["b"], "b": ["proximadb"]})
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb"]),
+            {"proximadb", "a", "b"},
+        )
+
+    def test_multiple_roots(self) -> None:
+        meta = _meta({"proximadb": [], "other": [], "x": ["other"], "leaf": []})
+        self.assertEqual(
+            AFFECTED.workspace_dependents_of(meta, ["proximadb", "other"]),
+            {"proximadb", "other", "x"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The advisory `Rust touched-crate fast check (advisory)` (`rust-affected-fast`) job was being cancelled at its 15-minute timeout on a large fraction of PRs, each time consuming a full runner slot and producing **zero** signal — while still printing `Compiling datafusion-sql` / `Compiling tantivy` when it was killed.

Measured over **80 consecutive `ci.yml` runs**:

| outcome | count | duration |
|---|---|---|
| skipped (`rust == false`) | 40 | — |
| success | 18 | 58–165 s |
| **cancelled (timeout)** | **12** | **8 of them at exactly 915–917 s** |
| failure (genuine signal) | 1 | 354 s |

So of the 40 runs that actually ran, **~39% hit the timeout wall**. The byte-identical ~15m15s duration across unrelated PRs is just `timeout-minutes: 15`, not anything PR-specific.

## Root cause

The lane skipped the root `proximadb` crate **by name**. But `-p <crate>` compiles that crate's *whole dependency graph*, and **nine** workspace members transitively pull the ~850K-LOC monolith back in:

`proximadb`, the three `crates/binding/*` (`proximadb-embedded`, `proximadb-spark-jni`, `proximadb-catalog-introspection`), the four `apps/*` (`proximadb-server`, `-bench`, `-ann-bench`, `-migrate`), and `clients/rust`'s `proximadb-sdk` — which reaches the monolith via a **non-optional** `proximadb-embedded` dep, so the `optional = true` on its own `proximadb` dep buys nothing.

Evidence, from the timed-out run on the thiserror bump:

```
Affected leaf crates: -p proximadb-sdk -p proximadb-embedded
...
Compiling tantivy v0.22.1
Compiling lalrpop v0.20.2
Compiling tokenizers v0.20.4
##[error]The operation was canceled.
```

616 `Compiling` lines in 14 minutes and still deep in third-party deps — i.e. the lane was doing exactly the monolith compile its own header says it exists to avoid.

### Why the cache never rescued it (and structurally never would)

- `Swatinem/rust-cache` saves only on success, so a timed-out run never saves.
- The only cache a PR can inherit is the **base-branch (`develop`)** one. On a `develop` push, `affected_crates.py`'s `git diff origin/develop...HEAD` is empty *by construction*, so the job exits having compiled **zero** crates and saves a ~231 MB cargo-registry cache with **no `target/` artifacts**.
- Its `prefix-key: v1-rust-affected-fast` is isolated from `v1-rust-compile-*` (the lane that does warm a real build cache), so nothing cross-warms it.

Both the timed-out PR runs and the `develop` push runs log `No cache found.` — verified in the raw logs.

## Approach chosen, and what was rejected

**Chosen: fix the selection so the lane honours its own name.**

- `scripts/affected_crates.py` gains `--exclude-dependents-of PKG` (repeatable, **opt-in** — the default output and `worktree.sh check`'s contract are byte-identical), which drops PKG *and every workspace member transitively depending on it*, across normal/dev/build kinds, treating optional deps conservatively. Dropped crates are named on **stderr**, so the CI log still explains itself and stdout stays the crate list.
- The lane passes `--exclude-dependents-of proximadb`: **9 of 124** crates excluded, **115 stay eligible**. The now-redundant shell-side root-name skip is deleted.
- Timeout **15m → 10m** as a *canary*, not a budget (~4× headroom over the observed 165 s worst case): a future heavy edge should cost 10 wasted minutes, not 15.
- `cache-on-failure: true` — a genuine failure is the signal this lane exists for; saving its small leaf `target/` means the fix push on the same PR rebuilds warm.

Rejected:

- **Cache-only fix** — insufficient. Even perfectly warm, compiling the monolith's test binary is what the required `rust-test` job needs `CARGO_BUILD_JOBS=1` + 12 G swap for. And the base-branch cache is empty by construction, so there is nothing to warm *from*.
- **sccache** — doesn't address scoping (only makes a doomed monolith compile marginally less doomed), and the job header rejected it for the #920 OOM risk.
- **Retiring the lane** — it does deliver its promised signal: 18 green runs at ~1–3 min and one genuine catch (354 s) in the last 80 runs. Retiring would throw away the only sub-2-minute Rust feedback in CI to fix a defect that is a 3-line selection bug.
- **Just bumping the timeout** — would double the wasted runner spend and keep the signal at zero.
- **Leaving it advisory-and-red** — a permanently-red advisory check trains reviewers to ignore red. It is now green and fast, so `continue-on-error` is defensible again.

## Verification

- **The timeout is reproduced and fixed locally.** Replaying the exact failing diff shape produces the CI log string verbatim, then drops it:
  ```
  OLD: proximadb-sdk proximadb-embedded proximadb-records
  NEW: affected_crates: excluded (depends on proximadb): proximadb-sdk proximadb-embedded
       proximadb-records
  ```
- **This PR's own diff is the failure shape.** It touches `proximadb-embedded`, `proximadb-sdk` and `tests/**`, which is precisely what used to select `-p proximadb-sdk -p proximadb-embedded` and time out. `crates/**` matches the `rust` path filter, so the lane runs on this PR — a fast green run here is the proof.
- **The positive path is unchanged by construction.** The flag is a strict filter: for a diff containing no monolith-dependent crate the output is byte-identical to before (verified — `proximadb-records` alone in both), so the 18 historical green runs remain representative.
- **`tests/scripts/test_affected_crates.py`** guards the closure (transitivity, direction, workspace-internal-only edges, cycles, multiple roots), wired into the toolchain-free `capability-matrix` job. Teeth verified by removing only the transitive traversal from the implementation → 2 failures; restored → green.
- `make work-commit-check` and `cargo fmt --check` pass.

## Residual risk

- A workspace member that is *not* monolith-dependent but is still heavy (e.g. a future crate pulling the full DataFusion graph) could approach the 10-minute canary. That now surfaces as a bounded, visible signal rather than a silent 15-minute burn.
- The nine excluded crates get no fast-lane coverage; they remain fully covered by the required `rust-test` job, and become eligible again as TD-DECOMP-1 moves logic out of the monolith.
- The exclusion is conservative on optional deps — it may drop a crate that would have been cheap under default features. That trade is deliberate: a wrongly-included crate costs a full runner slot, a wrongly-excluded one costs nothing beyond a lost early signal.