### PR TITLE
fix(tenant): thread tenant through the v1 batch port; file TD-TENANT-2

### DIFF
--- a/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
+++ b/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
@@ -87,9 +87,38 @@ through the in-memory layer too, and the predicate becomes genuinely redundant.
   and as defense-in-depth; the point is that **reads must not depend on comparing it**.
 * Changing object-store path layout — that half is already correct.
 
+== Addendum (2026-08-06) — cross-tenant sharing sharpens, not weakens, this TD
+
+link:../../12-design/adr/ADR-090-identity-grants-and-byob-storage.adoc[ADR-090] (Proposed)
+adds a requirement this TD's original framing did not anticipate: **a tenant must be able
+to share a collection with another tenant/user** via a catalog-seam `Grant`, evaluated
+once at open/plan time.
+
+Two corrections to this TD's framing follow:
+
+. *"A collection belongs to exactly one tenant"* stands for **ownership** (path, billing,
+  residency) but was over-read as also bounding **access**. The corrected model:
+  **ownership is structural; access is granted.** Within-collection and cross-tenant
+  access are both ABAC decisions on catalog metadata (ADR-090 L1), with row-level
+  predicates at read time (L2).
+. The per-row predicate this TD retires is not merely redundant once ADR-0083 D2 lands —
+  **sharing requires its retirement.** A shared read is by definition a foreign-tenant
+  read; `record.tenant_id == ctx.tenant_id` would return zero rows for every legitimate
+  grantee. The predicate is therefore incompatible with the target model, not just
+  inferior to it.
+
+Sequencing is unchanged and still mandatory: ADR-0083 D2 re-keying **first** (the
+predicate is load-bearing in the string-keyed WAL/memtable layer until then), retirement
+second — now executed as part of ADR-090 L1/L2 (tracker: TD-AUTHZ-1) rather than as a
+standalone step. The regression test this TD calls for (two tenants, same-named
+collections, no cross-observation) remains required and gains a sibling: a granted read
+**must** observe the shared rows.
+
 == Deps
 
 * Blocked by: ADR-0083 D2 re-keying (WAL/memtable/admission on the composite).
+* Superseded-in-part by: ADR-090 L1/L2 (grants + predicate retirement); program tracker
+  TD-AUTHZ-1.
 * Related: CLAUDE.md mandate #3 (structural isolation); ADR-0083 (composite identity);
   TD-TENANT-1 (header trust policy); the ABAC push-down that owns row-level access.
 * Discovered while auditing OQ-4 of

--- a/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
+++ b/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
@@ -1,0 +1,96 @@
+= TD-TENANT-2: retire per-row tenant filtering — re-key WAL/memtable on CollectionIdentity, leave row-level to ABAC
+:status: Open
+:dim: D5
+:pillar: SEC
+
+== Problem
+
+Tenant isolation is currently enforced in the read path by a **per-row predicate**:
+
+[source,rust]
+----
+// src/services/operations/vectors/legacy.rs (4 sites)
+record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
+----
+
+This is wrong on three counts.
+
+**1. It contradicts mandate #3.** CLAUDE.md is explicit: *"Isolation is **structural**, never a
+per-query predicate."* This is the predicate the mandate forbids.
+
+**2. It has a bypass value.** An empty `tenant_id` matches **every** tenant. The v1 bridge
+(`From<&VectorRecord> for ProximaRecord`) sets `tenant_id: String::new()` because the v1 wire
+type has no tenant field — so any record reaching the filter untenanted is readable
+cross-tenant. (The specific v1 port that discarded its caller's tenant is fixed separately;
+the *sentinel-as-wildcard* weakness is what this TD is about.)
+
+**3. It is the wrong mechanism for the concern.** In the standard multi-tenant model — and in
+this system's own design — a collection belongs to exactly one tenant, and *within-collection*
+access control is ABAC's job, not the tenant field's. A collection should never hold rows for
+multiple tenants, so a per-row tenant comparison is answering a question that structural
+isolation already answers.
+
+== Why it cannot simply be deleted today
+
+Structural isolation is real, but **it stops at the object-store boundary**:
+
+* Object-store paths are tenant-scoped by construction —
+  `accounts/{account_id}/{tenant_id}/{namespace_id}/{collection_id}/`, or legacy
+  `data/{tenant_id}/{namespace_id}/{collection_id}/`
+  (`src/storage/trait_components/path_resolver.rs:359-362`).
+* ADR-0083 makes `CollectionIdentity { account_id, namespace_id, collection_id }` the sole
+  canonical identity, *"self-describing (the path is the identity's segments)"*.
+
+But the in-memory layer is **not** keyed that way:
+
+[source,rust]
+----
+// src/storage/persistence/write_ahead_log/mod.rs:3021
+pub async fn get_collection_vectors_raw(&self, collection_id: &str)
+    -> Result<Vec<ProximaRecord>>
+----
+
+A **bare string**, with no account/namespace resolution on that path. Given this codebase's
+known name-vs-id aliasing, two tenants owning a collection of the same name can therefore
+share a memtable — which means **the per-row predicate is currently load-bearing in the WAL /
+memtable layer**. Deleting it before the layer is re-keyed would remove the only thing
+separating those rows.
+
+That is the whole shape of the debt: the structural guarantee is genuine at rest and absent
+in memory, and a per-row predicate has been papering over the gap.
+
+== The fix is already decided — ADR-0083 D2, not yet implemented
+
+ADR-0083 §D2 ("admission / scheduling / flush / compaction key on the composite") already
+prescribes the migration: *"re-key flush plan / WAL / memtable / admission / compaction from
+`parse::<u64>()` to the composite triple."* Once that lands, tenant separation is structural
+through the in-memory layer too, and the predicate becomes genuinely redundant.
+
+== Next action (sequencing matters — do not reorder)
+
+. **Re-key WAL / memtable / admission on `CollectionIdentity`** per ADR-0083 D2. Start with
+  `get_collection_vectors_raw` and the memtable keying; the composite is already the catalog's
+  canonical identity, so this is a plumbing change, not a new concept. ADR-0083 notes the
+  perf objection is a non-issue (lock-striping uses a derived hash).
+. **Then retire the per-row predicate** at all four `legacy.rs` sites, including the
+  `is_empty()` wildcard. Not before — see above.
+. **Leave row-level access to ABAC.** The mechanism already exists: the security
+  `FilterExpression` is AND-ed with the user filter and pushed down through ACORN
+  (see the co-designed vector ABAC push-down work). Tenant answers *which collection you can
+  open*; ABAC answers *which rows within it you may see*.
+. **Add a regression test** that two tenants with same-named collections cannot observe each
+  other's rows through the WAL/memtable path — the case the predicate is currently covering.
+
+== Non-goals
+
+* Removing `ProximaRecord.tenant_id` itself. It remains useful as an audit/attribution field
+  and as defense-in-depth; the point is that **reads must not depend on comparing it**.
+* Changing object-store path layout — that half is already correct.
+
+== Deps
+
+* Blocked by: ADR-0083 D2 re-keying (WAL/memtable/admission on the composite).
+* Related: CLAUDE.md mandate #3 (structural isolation); ADR-0083 (composite identity);
+  TD-TENANT-1 (header trust policy); the ABAC push-down that owns row-level access.
+* Discovered while auditing OQ-4 of
+  link:TD-V1SUNSET-2-vectorrecord-to-proximatecord-first-slice.adoc[TD-V1SUNSET-2].

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1606,16 +1606,38 @@ impl VectorOperationsService {
     pub async fn vector_batch_v1(
         &self,
         req: crate::proto::proximadb_v1::VectorBatchRequest,
+        tenant_id: Option<&str>,
     ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
         let start_time = std::time::Instant::now();
         let collection_id = req.collection_id.clone();
 
         // Convert v1 wire VectorRecord → ProximaRecord at the protocol boundary.
+        //
+        // The v1 `VectorRecord` has no tenant field, so the bridge cannot carry one:
+        // `From<&VectorRecord> for ProximaRecord` leaves `tenant_id` as `String::new()`.
+        // An empty tenant is NOT a safe resting state — the read filters in this file
+        // treat it as matching every tenant, so an untenanted record would be readable
+        // cross-tenant. Isolation must be structural, never a sentinel value that
+        // happens to match (CLAUDE.md mandate #3).
+        //
+        // Fall back to the canonical `DEFAULT_TENANT` for insecure/dev deployments that
+        // run without tenant resolution — the same value REST middleware already assigns
+        // to unauthenticated requests (`network/middleware/tenant.rs`). "Anonymous" is an
+        // explicit tenant that matches only itself, never a wildcard.
+        let resolved_tenant = tenant_id
+            .filter(|t| !t.is_empty())
+            .unwrap_or(proximadb_tenant::DEFAULT_TENANT);
+
         let mut native_vectors: Vec<proximadb_records::ProximaRecord> = req
             .vectors
             .into_iter()
             .map(crate::proto::defaults::vector_record_to_proxima_record)
             .collect();
+
+        // Reuse the canonical stamper rather than assigning inline: it also REJECTS a
+        // record that already carries a different tenant (cross-tenant write attempt),
+        // which a bare assignment would silently overwrite.
+        super::write::ensure_tenant_on_records(&mut native_vectors, resolved_tenant)?;
 
         // Coerce embeddings to the collection's canonical precision so
         // REST / gRPC inserts into a non-fp32 collection produce the
@@ -6521,9 +6543,12 @@ impl proximadb_runtime::VectorOpsPort for VectorOperationsService {
     async fn batch_upsert(
         &self,
         request: crate::proto::proximadb_v1::VectorBatchRequest,
-        _tenant_id: Option<&str>,
+        tenant_id: Option<&str>,
     ) -> anyhow::Result<crate::proto::proximadb_v1::VectorOperationResponse> {
-        self.vector_batch_v1(request).await
+        // Was `_tenant_id` — the caller's tenant was plumbed the whole way down this
+        // port and then discarded here, so every record inserted through it landed with
+        // an empty `tenant_id`, which the read filters treat as matching every tenant.
+        self.vector_batch_v1(request, tenant_id).await
     }
 
     async fn get_vector(


### PR DESCRIPTION
Two parts: a bug fix for a tenant that was plumbed and then discarded, and the TD for the architectural problem that bug exposed.

## Fix — the v1 batch port dropped its caller's tenant

`VectorOpsPort::batch_upsert` took `_tenant_id: Option<&str>` and threw it away:

```rust
async fn batch_upsert(&self, request: VectorBatchRequest,
                      _tenant_id: Option<&str>) -> ... {
    self.vector_batch_v1(request).await          // tenant never passed on
}
```

The v1 wire `VectorRecord` has no tenant field, so the bridge leaves `tenant_id` as `String::new()` — and the read filters **in the same file** treat an empty tenant as matching *every* tenant. The caller's tenant was known at the top of the port, carried all the way down, and dropped at the last step.

`vector_batch_v1` now takes the tenant and stamps it, falling back to the canonical **`proximadb_tenant::DEFAULT_TENANT`** for insecure/dev deployments — the same value REST middleware already assigns to unauthenticated requests. An explicit tenant that matches only itself, never a wildcard.

Stamping **reuses `write::ensure_tenant_on_records`** rather than assigning inline. That helper also *rejects* a record already carrying a different tenant (cross-tenant write attempt); my first draft assigned inline and would have silently overwritten it.

**Not an incident:** no network route wires this port, and the v1 REST surface is default-OFF (`None => false`). Latent defect, fixed before anything wires it.

## TD-TENANT-2 — the architecture the bug exposed

Enforcing tenancy with a per-row predicate

```rust
record.tenant_id.is_empty() || record.tenant_id == ctx.tenant_id
```

is wrong on three counts: it **contradicts mandate #3** (*"isolation is structural, never a per-query predicate"*), it **has a bypass value** (empty matches everything), and it is **the wrong mechanism** — a collection belongs to exactly one tenant, so within-collection access control is ABAC's job.

**But it cannot simply be deleted, and that reason is the real debt.** Structural isolation is genuine — paths are `accounts/{account}/{tenant}/{namespace}/{collection}/` and ADR-0083 makes the composite the sole identity — but it **stops at the object-store boundary**. The in-memory layer still keys on a bare string:

```rust
// write_ahead_log/mod.rs:3021
pub async fn get_collection_vectors_raw(&self, collection_id: &str)
```

So two tenants with same-named collections can share a memtable, making the predicate **load-bearing there**. The guarantee is real at rest and absent in memory; the predicate has been papering over the gap.

The fix is already decided and unimplemented: **ADR-0083 D2** re-keys WAL/memtable/admission on `CollectionIdentity`. Only *after* that can the predicate retire. The TD records that sequencing explicitly so nobody deletes it first, and assigns row-level access to the existing ABAC push-down.

| concern | mechanism |
|---|---|
| tenant | structural — path + composite identity (which collection you can open) |
| row-level | ABAC `FilterExpression` via ACORN push-down (which rows within it) |
| per-row `tenant_id` | retire once step 1 lands; keep the field for audit/attribution |

## Verification

`cargo check --lib` clean (`LIB=0`) · `make work-commit-check` green · `check_td_adr_unique.py` clean (353 TD ids).

Ref TD-TENANT-2, TD-V1SUNSET-2 (OQ-4), ADR-0083 D2, mandate #3.