### PR TITLE
feat(authz): L0.3 — one gRPC port-identity construction (ADR-090 gap 13)

### DIFF
--- a/src/network/grpc/auth.rs
+++ b/src/network/grpc/auth.rs
@@ -350,6 +350,35 @@ pub fn tenant_stable_id<T>(request: &Request<T>) -> Option<u64> {
         .and_then(|context| context.tenant_stable_id)
 }
 
+/// L0.3 (ADR-090): the ONE construction of a port identity from gRPC auth
+/// state. Composes the three extraction primitives above — it deliberately
+/// re-derives NOTHING, so it cannot drift from them — and owns the single
+/// auth-class rule for this surface: gRPC subjects come only from the
+/// authenticated [`GrpcAuthContext`] (there is no assertion path), so subject
+/// presence decides `Authenticated` vs `Anonymous`.
+///
+/// Replaces the four hand-built `PortIdentity { .. }` literals in
+/// `grpc/v2/record_service.rs`, each of which repeated that ternary inline
+/// (ADR-090 appendix A gap 13).
+pub fn port_identity<T>(
+    request: &Request<T>,
+) -> Result<proximadb_runtime::OwnedPortIdentity, Status> {
+    let tenant_id = resolved_tenant_id(request)?;
+    let subject = user_id(request);
+    let tenant_stable_id = tenant_stable_id(request);
+    let auth_class = if subject.is_some() {
+        proximadb_tenant::AuthClass::Authenticated
+    } else {
+        proximadb_tenant::AuthClass::Anonymous
+    };
+    Ok(proximadb_runtime::OwnedPortIdentity {
+        tenant_id: Some(tenant_id),
+        subject,
+        tenant_stable_id,
+        auth_class,
+    })
+}
+
 pub fn enforce_data_plane_request<T>(
     request: &Request<T>,
     operation: &str,
@@ -562,6 +591,50 @@ fn grpc_status_code(code: Code) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    // --- L0.3 port_identity spec (ADR-090) -------------------------------
+
+    fn authed_request(user: &str, stable: Option<u64>) -> Request<()> {
+        let mut request = Request::new(());
+        let mut user_context = proximadb_tenant::UnifiedUserContext::anonymous();
+        user_context.user_id = user.to_string();
+        request.extensions_mut().insert(GrpcAuthContext {
+            user_context,
+            capability: None,
+            resolved_tenant: Some("tenant-a".to_string()),
+            tenant_stable_id: stable,
+        });
+        request
+    }
+
+    /// Subject present ⇒ Authenticated, with tenant + stable id mapped through
+    /// the SAME primitives the individual helpers expose.
+    #[test]
+    fn port_identity_authenticated_when_subject_present() {
+        let request = authed_request("alice", Some(7));
+        let identity = port_identity(&request).expect("identity");
+        assert_eq!(identity.subject.as_deref(), Some("alice"));
+        assert_eq!(identity.tenant_stable_id, Some(7));
+        assert!(identity.tenant_id.is_some());
+        assert!(matches!(
+            identity.auth_class,
+            proximadb_tenant::AuthClass::Authenticated
+        ));
+    }
+
+    /// Empty user id ⇒ no subject ⇒ Anonymous (gRPC has no assertion path;
+    /// the class comes ONLY from authenticated context presence).
+    #[test]
+    fn port_identity_anonymous_when_subject_absent() {
+        let request = authed_request("", None);
+        let identity = port_identity(&request).expect("identity");
+        assert_eq!(identity.subject, None);
+        assert_eq!(identity.tenant_stable_id, None);
+        assert!(matches!(
+            identity.auth_class,
+            proximadb_tenant::AuthClass::Anonymous
+        ));
+    }
+
     use super::*;
     use std::collections::HashMap;
 

--- a/src/network/grpc/v2/record_service.rs
+++ b/src/network/grpc/v2/record_service.rs
@@ -1447,9 +1447,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<TypedSearchResponse>, Status> {
-        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
-        let subject = grpc_auth::user_id(&request);
-        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
+        let identity = grpc_auth::port_identity(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1478,21 +1476,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
             crate::observability::predicate_diagnostics::scope(async {
                 let outcome = self
                     .record_ops
-                    .handle_record_search_for_tenant(
-                        search_request,
-                        proximadb_runtime::PortIdentity {
-                            tenant_id: Some(tenant_id.as_str()),
-                            subject: subject.as_deref(),
-                            tenant_stable_id,
-                            // gRPC subjects come only from the authenticated
-                            // GrpcAuthContext — no assertion path.
-                            auth_class: if subject.is_some() {
-                                proximadb_tenant::AuthClass::Authenticated
-                            } else {
-                                proximadb_tenant::AuthClass::Anonymous
-                            },
-                        },
-                    )
+                    .handle_record_search_for_tenant(search_request, identity.as_borrowed())
                     .await;
                 let tq = crate::observability::predicate_diagnostics::take_turboquant_hints();
                 (outcome, tq)
@@ -1549,9 +1533,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<TypedSearchRequest>,
     ) -> Result<Response<Self::SearchStreamStream>, Status> {
-        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
-        let subject = grpc_auth::user_id(&request);
-        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
+        let identity = grpc_auth::port_identity(&request)?;
         grpc_auth::enforce_data_plane_request(
             &request,
             "search",
@@ -1577,21 +1559,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         // Execute search
         let response = self
             .record_ops
-            .handle_record_search_for_tenant(
-                search_request,
-                proximadb_runtime::PortIdentity {
-                    tenant_id: Some(tenant_id.as_str()),
-                    subject: subject.as_deref(),
-                    tenant_stable_id,
-                    // gRPC subjects come only from the authenticated
-                    // GrpcAuthContext (grpc_auth::user_id) — no assertion path.
-                    auth_class: if subject.is_some() {
-                        proximadb_tenant::AuthClass::Authenticated
-                    } else {
-                        proximadb_tenant::AuthClass::Anonymous
-                    },
-                },
-            )
+            .handle_record_search_for_tenant(search_request, identity.as_borrowed())
             .await
             .map_err(|e| Status::internal(format!("Search stream failed: {}", e)))?;
 
@@ -2312,11 +2280,9 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<V2QueryRequest>,
     ) -> Result<Response<V2QueryResponse>, Status> {
-        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
         // TD-ABAC-5: capture the authenticated subject before the request is moved;
         // threaded to ABAC enforcement at the relational read boundary.
-        let user_id = grpc_auth::user_id(&request);
-        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
+        let identity = grpc_auth::port_identity(&request)?;
         let q = request.into_inner();
         let collection = if q.collection_id.is_empty() {
             None
@@ -2325,21 +2291,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         };
         let resp = self
             .api_handlers
-            .execute_sql(
-                q.query,
-                None,
-                collection,
-                proximadb_runtime::PortIdentity {
-                    tenant_id: Some(tenant_id.as_str()),
-                    subject: user_id.as_deref(),
-                    tenant_stable_id,
-                    auth_class: if user_id.is_some() {
-                        proximadb_tenant::AuthClass::Authenticated
-                    } else {
-                        proximadb_tenant::AuthClass::Anonymous
-                    },
-                },
-            )
+            .execute_sql(q.query, None, collection, identity.as_borrowed())
             .await
             .map_err(|e| {
                 // A DML lock conflict → ABORTED (retryable); other errors → INTERNAL.
@@ -2390,9 +2342,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
         &self,
         request: Request<proximadb_v2::GetRecordRequest>,
     ) -> Result<Response<proximadb_v2::GetRecordResponse>, Status> {
-        let tenant_id = grpc_auth::resolved_tenant_id(&request)?;
-        let subject = grpc_auth::user_id(&request);
-        let tenant_stable_id = grpc_auth::tenant_stable_id(&request);
+        let identity = grpc_auth::port_identity(&request)?;
         let req = request.into_inner();
         let result = self
             .record_ops
@@ -2403,18 +2353,7 @@ impl ProximaRecordService for ProximaRecordServiceImpl {
                     include_vector: req.include_vector,
                     include_props: true,
                 },
-                proximadb_runtime::PortIdentity {
-                    tenant_id: Some(tenant_id.as_str()),
-                    subject: subject.as_deref(),
-                    tenant_stable_id,
-                    // gRPC subjects come only from the authenticated
-                    // GrpcAuthContext (grpc_auth::user_id) — no assertion path.
-                    auth_class: if subject.is_some() {
-                        proximadb_tenant::AuthClass::Authenticated
-                    } else {
-                        proximadb_tenant::AuthClass::Anonymous
-                    },
-                },
+                identity.as_borrowed(),
             )
             .await
             .map_err(|e| Status::internal(format!("GetRecord failed: {e}")))?;


### PR DESCRIPTION
TD-AUTHZ-1 **L0.3**: replaces the four hand-built `PortIdentity { .. }` literals in `grpc/v2/record_service.rs` — each repeating the same auth-class ternary inline — with **one** construction: `grpc_auth::port_identity(&request)`.

## The design decision worth reviewing

The helper is **composed of the three existing extraction primitives** (`resolved_tenant_id` / `user_id` / `tenant_stable_id`) rather than mapping `GrpcAuthContext` fields directly. A `From<&GrpcAuthContext>` impl was considered and **rejected**: it would be a second, subtly-different derivation of the same identity — the exact drift-seam class ADR-090 exists to kill. Composition means the helper *cannot* disagree with the primitives.

It also owns the surface's single auth-class rule: gRPC subjects come only from the authenticated `GrpcAuthContext` (no assertion path), so **subject presence decides `Authenticated` vs `Anonymous`** — previously copy-pasted as an inline ternary at all four sites.

## Behavior-preserving, verified

- The `?` on a missing tenant fires inside the helper via the **same** `resolved_tenant_id` call the sites made before.
- 12 now-redundant per-site extraction lets removed — each flagged unused by the compiler *and* content-checked before deletion; the TD-ABAC-5 subject-capture comment retained where it still describes the identity binding.
- 2/2 spec tests (real `tonic::Request` with the extension installed) pin the mapping and both class outcomes.

## Note on Cargo.lock

Carries a one-hunk lock regeneration that belongs to **develop**, not this change: #1510 (Catapult extraction) landed its `Cargo.toml` edit without the regenerated lock; the first build here produced it.

## Verification

2/2 `port_identity` spec tests green · `cargo check --lib` clean, zero warnings after the cleanup · `make work-commit-check` green · rustfmt applied.

Ref ADR-090 (appendix A gap 13), TD-AUTHZ-1 L0.3, #1513, #1514.