### PR TITLE
feat(authz): L1.1 — the Grant catalog object; cross-tenant sharing expressible (ADR-090)

### DIFF
--- a/crates/control/proximadb-catalog/src/fc_metamodel.rs
+++ b/crates/control/proximadb-catalog/src/fc_metamodel.rs
@@ -926,7 +926,7 @@ pub struct EffectivePolicy {
 
 /// Does a binding's [`Scope`] cover the [`Target`] (broader-or-equal in the
 /// namespace ⊇ table ⊇ column hierarchy)?
-fn scope_covers(scope: &Scope, target: &Target) -> bool {
+pub(crate) fn scope_covers(scope: &Scope, target: &Target) -> bool {
     match *scope {
         Scope::Namespace(ns) => ns == target.namespace,
         Scope::Table(t) => t == target.table,

--- a/crates/control/proximadb-catalog/src/grants.rs
+++ b/crates/control/proximadb-catalog/src/grants.rs
@@ -1,0 +1,645 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! ADR-090 L1.1 — the `Grant` catalog object: the ENTITLEMENT half of
+//! authorization, and the one place cross-tenant sharing is expressible.
+//!
+//! Division of labour with the existing FC metamodel:
+//! * [`crate::fc_metamodel::PolicyBinding`] is the *constraint* layer —
+//!   subjectless, deny-biased restrictions scoped to a tenant's own resources.
+//! * [`GrantRecord`] is the *entitlement* layer — "this grantee may perform
+//!   these actions on this resource", where the grantee may be a **foreign
+//!   tenant or a foreign tenant's user**. Ownership stays structural (the
+//!   resource lives under its owner's path and bill); access is granted.
+//!
+//! Multi-modality falls out of resource choice, not code: grants scope over
+//! [`crate::fc_metamodel::Scope`] — the same `Namespace` / `Table(collection)`
+//! / `Column` lattice policy uses — and a collection id is the modality-
+//! agnostic unit (vector, graph, document, timeseries, relational alike).
+//! `scope_covers` is REUSED from the metamodel, not reimplemented, so grant
+//! and policy coverage can never drift.
+//!
+//! Contract (the tests below are the specification):
+//! * **Fail-closed**: no applicable grant ⇒ `Deny(NoApplicableGrant)`.
+//!   Revoked and expired grants are not applicable.
+//! * **Deny > absence > grant**: [`compose_with_policy`] makes a policy deny
+//!   veto any grant (ADR-090 L1 composition rule).
+//! * **Foreign grantees admit** — the invariant the pre-ADR-090 model made
+//!   impossible by construction at four layers. A grant naming
+//!   `Grantee::User { tenant_stable_id: B, .. }` admits that user of tenant B
+//!   to tenant A's resource; every *other* subject of tenant B stays denied.
+//! * Persistence is the OSS mechanism shared with the ABAC stores and the
+//!   principal registry: JSON snapshot, atomic tmp+rename+fsync,
+//!   load-on-open, synchronous persist, partitioned by **owner** tenant.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+use crate::fc_metamodel::{FieldMask, ObjectId, Scope, SubjectId, Target, TenantStableId};
+
+const GRANTS_FILE: &str = "grants.json";
+
+/// Who a grant admits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Grantee {
+    /// Every subject of the named tenant.
+    Tenant(TenantStableId),
+    /// One specific user of the named tenant (which may be — and for sharing,
+    /// is — a different tenant from the resource owner).
+    User {
+        tenant_stable_id: TenantStableId,
+        subject: SubjectId,
+    },
+}
+
+/// What a grant permits. Deliberately coarse; row-level nuance rides the
+/// attached `predicate_ref`, not extra verbs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum GrantAction {
+    Read,
+    Write,
+    Ddl,
+    /// Permission to further delegate (re-grant). Not consulted by
+    /// [`evaluate_grants`] for data access; the admin surface checks it.
+    Grant,
+}
+
+/// A durable entitlement, owned (and revocable) by the resource's tenant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GrantRecord {
+    pub grant_id: String,
+    /// The RESOURCE OWNER — the partition key. Only the owner's store slice
+    /// is consulted when their resource is opened, mirroring the structural
+    /// tenant wall everywhere else.
+    pub owner_tenant_stable_id: TenantStableId,
+    pub resource: Scope,
+    pub grantee: Grantee,
+    pub actions: BTreeSet<GrantAction>,
+    /// Optional row-filter predicate attached to the share (same predicate-
+    /// object space the policy layer dereferences).
+    pub predicate_ref: Option<ObjectId>,
+    pub field_mask: Option<FieldMask>,
+    pub created_at_ms: i64,
+    pub expires_at_ms: Option<i64>,
+    pub revoked_at_ms: Option<i64>,
+}
+
+/// The acting subject, as resolved by L0 identity: a user of some tenant.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GrantSubject<'a> {
+    pub tenant_stable_id: TenantStableId,
+    pub subject: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GrantDecision {
+    /// Admitted. Predicate refs / masks from every applicable grant are
+    /// surfaced for the read path to AND into the plan (same compile path as
+    /// policy predicates).
+    Permit {
+        predicate_refs: Vec<ObjectId>,
+        field_masks: Vec<FieldMask>,
+    },
+    Deny(GrantDenyReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrantDenyReason {
+    /// Fail-closed default: nothing applicable admitted the subject.
+    NoApplicableGrant,
+    /// A policy-layer deny vetoed the grant (deny > absence > grant).
+    PolicyDeny,
+}
+
+/// Pure decision: which of `grants` admit `subject` to `target` for `action`
+/// at time `now_ms`. Fail-closed on absence; revoked/expired never apply.
+pub fn evaluate_grants(
+    grants: &[GrantRecord],
+    subject: &GrantSubject<'_>,
+    target: &Target,
+    action: GrantAction,
+    now_ms: i64,
+) -> GrantDecision {
+    let mut predicate_refs = Vec::new();
+    let mut field_masks = Vec::new();
+    let mut applicable = 0usize;
+
+    for grant in grants {
+        if grant.revoked_at_ms.is_some() {
+            continue;
+        }
+        if let Some(exp) = grant.expires_at_ms
+            && now_ms >= exp
+        {
+            continue;
+        }
+        if !grant.actions.contains(&action) {
+            continue;
+        }
+        if !crate::fc_metamodel::scope_covers(&grant.resource, target) {
+            continue;
+        }
+        let admits = match &grant.grantee {
+            Grantee::Tenant(t) => *t == subject.tenant_stable_id,
+            Grantee::User {
+                tenant_stable_id,
+                subject: s,
+            } => *tenant_stable_id == subject.tenant_stable_id && s.0 == subject.subject,
+        };
+        if !admits {
+            continue;
+        }
+        applicable += 1;
+        if let Some(p) = grant.predicate_ref {
+            predicate_refs.push(p);
+        }
+        if let Some(m) = grant.field_mask {
+            field_masks.push(m);
+        }
+    }
+
+    if applicable == 0 {
+        GrantDecision::Deny(GrantDenyReason::NoApplicableGrant)
+    } else {
+        GrantDecision::Permit {
+            predicate_refs,
+            field_masks,
+        }
+    }
+}
+
+/// ADR-090 L1 composition: **deny > absence-of-grant > grant**. A policy-layer
+/// deny vetoes any entitlement.
+pub fn compose_with_policy(policy_denied: bool, grants: GrantDecision) -> GrantDecision {
+    if policy_denied {
+        GrantDecision::Deny(GrantDenyReason::PolicyDeny)
+    } else {
+        grants
+    }
+}
+
+#[derive(Debug)]
+pub enum GrantStoreError {
+    UnknownGrant { grant_id: String },
+    Io(String),
+    Serde(String),
+}
+
+impl fmt::Display for GrantStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownGrant { grant_id } => write!(f, "no grant with id '{grant_id}'"),
+            Self::Io(e) => write!(f, "grant store io error: {e}"),
+            Self::Serde(e) => write!(f, "grant store serde error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for GrantStoreError {}
+
+/// Durable grant store, partitioned by owner tenant. Same OSS persistence
+/// mechanism as the ABAC stores and the principal registry.
+pub struct FileSystemGrantStore {
+    dir: PathBuf,
+    state: RwLock<BTreeMap<TenantStableId, Vec<GrantRecord>>>,
+}
+
+impl FileSystemGrantStore {
+    pub fn open(dir: impl Into<PathBuf>) -> Result<Self, GrantStoreError> {
+        let dir = dir.into();
+        fs::create_dir_all(&dir).map_err(|e| GrantStoreError::Io(e.to_string()))?;
+        let state: BTreeMap<TenantStableId, Vec<GrantRecord>> =
+            match fs::read(dir.join(GRANTS_FILE)) {
+                Ok(bytes) => serde_json::from_slice(&bytes)
+                    .map_err(|e| GrantStoreError::Serde(e.to_string()))?,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+                Err(e) => return Err(GrantStoreError::Io(e.to_string())),
+            };
+        Ok(Self {
+            dir,
+            state: RwLock::new(state),
+        })
+    }
+
+    /// Mint and persist a grant on behalf of `owner`. Returns the grant id.
+    #[allow(clippy::too_many_arguments)]
+    pub fn grant(
+        &self,
+        owner: TenantStableId,
+        resource: Scope,
+        grantee: Grantee,
+        actions: BTreeSet<GrantAction>,
+        predicate_ref: Option<ObjectId>,
+        field_mask: Option<FieldMask>,
+        expires_at_ms: Option<i64>,
+    ) -> Result<String, GrantStoreError> {
+        let mut id_bytes = [0u8; 8];
+        rand::rngs::OsRng.fill_bytes(&mut id_bytes);
+        let grant_id: String = {
+            let mut s = String::with_capacity(16);
+            for b in id_bytes {
+                use fmt::Write as _;
+                let _ = write!(s, "{b:02x}");
+            }
+            s
+        };
+        let record = GrantRecord {
+            grant_id: grant_id.clone(),
+            owner_tenant_stable_id: owner,
+            resource,
+            grantee,
+            actions,
+            predicate_ref,
+            field_mask,
+            created_at_ms: chrono::Utc::now().timestamp_millis(),
+            expires_at_ms,
+            revoked_at_ms: None,
+        };
+        let mut state = write_lock(&self.state);
+        state.entry(owner).or_default().push(record);
+        self.persist(&state)?;
+        Ok(grant_id)
+    }
+
+    /// Revoke by owner + grant id. Only the owner's slice is searched — a
+    /// tenant cannot revoke (or even name) another owner's grants.
+    pub fn revoke(&self, owner: TenantStableId, grant_id: &str) -> Result<(), GrantStoreError> {
+        let mut state = write_lock(&self.state);
+        let found = state
+            .get_mut(&owner)
+            .and_then(|v| v.iter_mut().find(|g| g.grant_id == grant_id));
+        match found {
+            Some(g) => g.revoked_at_ms = Some(chrono::Utc::now().timestamp_millis()),
+            None => {
+                return Err(GrantStoreError::UnknownGrant {
+                    grant_id: grant_id.to_string(),
+                });
+            }
+        }
+        self.persist(&state)
+    }
+
+    /// The owner's grant slice — the input to [`evaluate_grants`] when one of
+    /// the owner's resources is opened.
+    pub fn grants_for_owner(&self, owner: TenantStableId) -> Vec<GrantRecord> {
+        read_lock(&self.state)
+            .get(&owner)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn persist(
+        &self,
+        state: &BTreeMap<TenantStableId, Vec<GrantRecord>>,
+    ) -> Result<(), GrantStoreError> {
+        let bytes =
+            serde_json::to_vec_pretty(state).map_err(|e| GrantStoreError::Serde(e.to_string()))?;
+        let tmp = self.dir.join(format!("{GRANTS_FILE}.tmp"));
+        {
+            let mut f = fs::File::create(&tmp).map_err(|e| GrantStoreError::Io(e.to_string()))?;
+            f.write_all(&bytes)
+                .map_err(|e| GrantStoreError::Io(e.to_string()))?;
+            f.sync_all()
+                .map_err(|e| GrantStoreError::Io(e.to_string()))?;
+        }
+        fs::rename(&tmp, self.dir.join(GRANTS_FILE))
+            .map_err(|e| GrantStoreError::Io(e.to_string()))?;
+        Ok(())
+    }
+}
+
+fn read_lock<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+    match lock.read() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn write_lock<T>(lock: &RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    match lock.write() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The specification (ADR-090 L1.1 / TD-AUTHZ-1). Written before the
+// implementation; each test names the contract clause it pins.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OWNER: TenantStableId = 7;
+    const FOREIGN: TenantStableId = 9;
+
+    fn target(ns: u16, table: u32) -> Target {
+        Target {
+            namespace: ns,
+            table,
+            column: None,
+        }
+    }
+
+    fn subject(tenant: TenantStableId, s: &'static str) -> GrantSubject<'static> {
+        GrantSubject {
+            tenant_stable_id: tenant,
+            subject: s,
+        }
+    }
+
+    fn read_only() -> BTreeSet<GrantAction> {
+        BTreeSet::from([GrantAction::Read])
+    }
+
+    fn now() -> i64 {
+        chrono::Utc::now().timestamp_millis()
+    }
+
+    fn store() -> (tempfile::TempDir, FileSystemGrantStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let s = FileSystemGrantStore::open(dir.path()).expect("open");
+        (dir, s)
+    }
+
+    /// Fail-closed default: an empty grant slice denies.
+    #[test]
+    fn absence_of_grant_denies() {
+        let d = evaluate_grants(
+            &[],
+            &subject(OWNER, "alice"),
+            &target(1, 10),
+            GrantAction::Read,
+            now(),
+        );
+        assert_eq!(d, GrantDecision::Deny(GrantDenyReason::NoApplicableGrant));
+    }
+
+    /// ⭐ THE ADR-090 invariant the old model made impossible: a grant naming a
+    /// FOREIGN tenant's user admits exactly that user — and no other subject
+    /// of the foreign tenant.
+    #[test]
+    fn foreign_grantee_admits_and_only_that_grantee() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::User {
+                tenant_stable_id: FOREIGN,
+                subject: SubjectId("bob".into()),
+            },
+            read_only(),
+            Some(42), // shared with a row-filter attached
+            None,
+            None,
+        )
+        .expect("grant");
+        let grants = s.grants_for_owner(OWNER);
+
+        // bob@FOREIGN is admitted, and the share's predicate ref surfaces.
+        match evaluate_grants(
+            &grants,
+            &subject(FOREIGN, "bob"),
+            &target(1, 10),
+            GrantAction::Read,
+            now(),
+        ) {
+            GrantDecision::Permit { predicate_refs, .. } => assert_eq!(predicate_refs, vec![42]),
+            other => panic!("foreign grantee must admit, got {other:?}"),
+        }
+        // mallory@FOREIGN is NOT.
+        assert_eq!(
+            evaluate_grants(
+                &grants,
+                &subject(FOREIGN, "mallory"),
+                &target(1, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(GrantDenyReason::NoApplicableGrant)
+        );
+        // and bob is admitted to THIS table only.
+        assert_eq!(
+            evaluate_grants(
+                &grants,
+                &subject(FOREIGN, "bob"),
+                &target(1, 11),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(GrantDenyReason::NoApplicableGrant)
+        );
+    }
+
+    /// A tenant-wide grant admits every subject of the grantee tenant.
+    #[test]
+    fn tenant_grant_covers_all_its_subjects() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::Tenant(FOREIGN),
+            read_only(),
+            None,
+            None,
+            None,
+        )
+        .expect("grant");
+        let grants = s.grants_for_owner(OWNER);
+        for who in ["bob", "carol"] {
+            assert!(matches!(
+                evaluate_grants(
+                    &grants,
+                    &subject(FOREIGN, who),
+                    &target(1, 10),
+                    GrantAction::Read,
+                    now()
+                ),
+                GrantDecision::Permit { .. }
+            ));
+        }
+        // but not subjects of an unrelated tenant
+        assert!(matches!(
+            evaluate_grants(
+                &grants,
+                &subject(11, "bob"),
+                &target(1, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(_)
+        ));
+    }
+
+    /// Lifecycle: grant → permit; revoke → deny. Revocation persists.
+    #[test]
+    fn lifecycle_grant_then_revoke_then_deny_and_it_persists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let id = {
+            let s = FileSystemGrantStore::open(dir.path()).expect("open");
+            let id = s
+                .grant(
+                    OWNER,
+                    Scope::Table(10),
+                    Grantee::Tenant(FOREIGN),
+                    read_only(),
+                    None,
+                    None,
+                    None,
+                )
+                .expect("grant");
+            assert!(matches!(
+                evaluate_grants(
+                    &s.grants_for_owner(OWNER),
+                    &subject(FOREIGN, "bob"),
+                    &target(1, 10),
+                    GrantAction::Read,
+                    now()
+                ),
+                GrantDecision::Permit { .. }
+            ));
+            s.revoke(OWNER, &id).expect("revoke");
+            id
+        };
+        // reopen from disk: revocation survived
+        let s = FileSystemGrantStore::open(dir.path()).expect("reopen");
+        let grants = s.grants_for_owner(OWNER);
+        assert_eq!(grants.len(), 1, "revoked grants stay listed");
+        assert!(grants[0].revoked_at_ms.is_some());
+        assert_eq!(grants[0].grant_id, id);
+        assert!(matches!(
+            evaluate_grants(
+                &grants,
+                &subject(FOREIGN, "bob"),
+                &target(1, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(_)
+        ));
+        // revoking under the WRONG owner cannot touch it
+        assert!(matches!(
+            s.revoke(FOREIGN, &id),
+            Err(GrantStoreError::UnknownGrant { .. })
+        ));
+    }
+
+    /// Expiry is honored at evaluation time.
+    #[test]
+    fn expired_grant_denies() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::Tenant(FOREIGN),
+            read_only(),
+            None,
+            None,
+            Some(now() - 1_000),
+        )
+        .expect("grant");
+        assert!(matches!(
+            evaluate_grants(
+                &s.grants_for_owner(OWNER),
+                &subject(FOREIGN, "bob"),
+                &target(1, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(GrantDenyReason::NoApplicableGrant)
+        ));
+    }
+
+    /// Actions are scoped: Read does not smuggle Write or DDL.
+    #[test]
+    fn actions_are_scoped() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::Tenant(FOREIGN),
+            read_only(),
+            None,
+            None,
+            None,
+        )
+        .expect("grant");
+        let grants = s.grants_for_owner(OWNER);
+        for denied in [GrantAction::Write, GrantAction::Ddl, GrantAction::Grant] {
+            assert!(matches!(
+                evaluate_grants(
+                    &grants,
+                    &subject(FOREIGN, "bob"),
+                    &target(1, 10),
+                    denied,
+                    now()
+                ),
+                GrantDecision::Deny(_)
+            ));
+        }
+    }
+
+    /// A namespace-scoped grant covers every collection in it — the same
+    /// `scope_covers` lattice policy uses, hence uniformly multi-modal (a
+    /// Table id is a collection of ANY modality).
+    #[test]
+    fn namespace_grant_covers_its_collections_only() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Namespace(2),
+            Grantee::Tenant(FOREIGN),
+            read_only(),
+            None,
+            None,
+            None,
+        )
+        .expect("grant");
+        let grants = s.grants_for_owner(OWNER);
+        assert!(matches!(
+            evaluate_grants(
+                &grants,
+                &subject(FOREIGN, "bob"),
+                &target(2, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Permit { .. }
+        ));
+        assert!(matches!(
+            evaluate_grants(
+                &grants,
+                &subject(FOREIGN, "bob"),
+                &target(3, 10),
+                GrantAction::Read,
+                now()
+            ),
+            GrantDecision::Deny(_)
+        ));
+    }
+
+    /// Deny > absence > grant: a policy deny vetoes an otherwise-valid grant.
+    #[test]
+    fn policy_deny_overrides_grant() {
+        let permit = GrantDecision::Permit {
+            predicate_refs: vec![],
+            field_masks: vec![],
+        };
+        assert_eq!(
+            compose_with_policy(true, permit),
+            GrantDecision::Deny(GrantDenyReason::PolicyDeny)
+        );
+        // and composition is a no-op when policy does not deny
+        let permit = GrantDecision::Permit {
+            predicate_refs: vec![1],
+            field_masks: vec![],
+        };
+        assert_eq!(compose_with_policy(false, permit.clone()), permit);
+    }
+}

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -30,6 +30,8 @@ pub mod canonical_precision;
 pub mod corpus_version_fs_store;
 #[cfg(feature = "fc-metamodel")]
 pub mod fc_metamodel;
+#[cfg(feature = "fc-metamodel")]
+pub mod grants;
 pub mod internal;
 pub mod partition_pruning;
 #[cfg(feature = "fc-metamodel")]


### PR DESCRIPTION
TD-AUTHZ-1 **L1.1**: the entitlement half of ADR-090 authorization, spec-first — the eight tests *are* the specification, all green on the first full run.

## The test that matters

**`foreign_grantee_admits_and_only_that_grantee`** ⭐ — a grant naming a *foreign* tenant's user admits exactly that user to the owner's resource, surfaces the share's row-predicate ref, and admits them to that resource only. This is the invariant the pre-ADR-090 model made **impossible by construction at four layers** (binding filter, store partition, authority keying, catalog resolution — appendix B gap 17).

## Model

| piece | shape |
|---|---|
| `GrantRecord` | `{ owner (partition key), resource: Scope, grantee, actions, predicate_ref?, field_mask?, expiry? }` |
| `Grantee` | `Tenant(stable_id)` \| `User{stable_id, subject}` — tenant-wide or single-user shares, either possibly foreign |
| `GrantAction` | `Read / Write / Ddl / Grant` — coarse on purpose; row-level nuance rides the attached `predicate_ref`, not extra verbs |
| `evaluate_grants` | pure, **fail-closed**: revoked/expired/wrong-action/uncovered/wrong-grantee ⇒ not applicable; zero applicable ⇒ `Deny(NoApplicableGrant)` |
| `compose_with_policy` | **deny > absence-of-grant > grant** — `PolicyBinding` stays the subjectless *constraint* layer; `Grant` is the *entitlement* layer |

## Multi-modal by construction, not by code

Grants scope over the **same `Scope` lattice** as policy (`Namespace`/`Table`/`Column`), and `fc_metamodel::scope_covers` is **reused** (widened to `pub(crate)`), not reimplemented — grant coverage and policy coverage cannot drift. A `Table` id is a collection of *any* modality, so vector, graph, document, timeseries, and relational sharing are one mechanism. There's a spec test proving a namespace grant covers its collections and nothing else.

## Store

`FileSystemGrantStore`, partitioned by **owner** tenant — only the owner's slice is consulted when their resource opens, and `revoke` under the wrong owner cannot even *name* the grant (tested). Same OSS persistence mechanism as the ABAC stores and the principal registry (atomic tmp+rename+fsync); revocation durability across reopen is tested.

## Deliberately not in this slice

Wiring into the collection-open gate, the admin/provisioning surface, and the **deliberate rewrite of the two cross-tenant impossibility tests** in the abac crate (`context.rs:492,504`) — those flip only when the enforcement gate lands, default-OFF per TD-AUTHZ-1 ground rules, so this PR changes no live behavior.

## Verification

8/8 spec tests green (0.04 s) · `cargo clippy -p proximadb-catalog --features fc-metamodel --all-targets -- -D warnings` clean · dependent `proximadb-abac` compiles · `make work-commit-check` green.

Ref ADR-090 L1.1 (#1513), TD-AUTHZ-1, appendix B gaps 17–19.