### PR TITLE
fix(sdk): repair 5th stale name-validation test (relaxed 8-char min)

### DIFF
--- a/clients/python/tests/unit/test_models_builders_cov.py
+++ b/clients/python/tests/unit/test_models_builders_cov.py
@@ -235,9 +235,10 @@ def test_collection_config_basic():
     assert cfg.quantization is None
 
 
-def test_collection_config_name_too_short():
-    with pytest.raises(ValueError):
-        models.CollectionConfig(name="short", dimension=128)
+def test_collection_config_name_short_accepted():
+    # The former 8-char minimum was relaxed for relational-DDL tables (#1113);
+    # short names are now accepted (empty/whitespace-only still rejected).
+    assert models.CollectionConfig(name="short", dimension=128).name == "short"
 
 
 def test_collection_config_name_empty():


### PR DESCRIPTION
Follow-up to #1488: the medium_tier SDK-test gate surfaced a 5th stale test (`test_collection_config_name_too_short` in test_models_builders_cov.py) still asserting the removed 8-char minimum (#1113). Short names are now accepted. Validated locally.