### PR TITLE
feat(sst): filter-aware PAX cascade P1 — metadata row allow-set + row-restricted cascade (ADR-089 / TD-FPRUNE-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,11 +499,27 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom 7.1.3",
@@ -511,6 +527,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
 ]
 
 [[package]]
@@ -2879,11 +2907,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom 7.1.3",
  "num-bigint",
@@ -3329,9 +3371,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "filetime"
@@ -3384,11 +3423,22 @@ dependencies = [
 
 [[package]]
 name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
+name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -5507,6 +5557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "napi"
 version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,11 +5871,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -6658,7 +6726,7 @@ dependencies = [
  "duckdb",
  "env_logger",
  "flate2",
- "flume",
+ "flume 0.11.1",
  "futures",
  "google-cloud-storage",
  "half",
@@ -6860,7 +6928,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "webpki-roots 0.25.4",
- "x509-parser",
+ "x509-parser 0.16.0",
  "xz2",
  "zstd",
 ]
@@ -8616,7 +8684,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tracing",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -10282,7 +10350,7 @@ checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.12.0",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -12366,16 +12434,33 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom 7.1.3",
- "oid-registry",
+ "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",

--- a/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
+++ b/crates/storage/proximadb-block-format/src/coalesced_rabitq.rs
@@ -316,6 +316,49 @@ impl RaBitQRegion {
         scored.truncate(pool);
         scored
     }
+
+    /// ADR-089 / TD-FPRUNE-1 P1: rank only the rows in `allow`, returning up to
+    /// `pool` global row indices nearest-first. Restricting *inside* the rank
+    /// (instead of post-filtering the survivor pool) is what preserves filtered
+    /// recall: the pool fills with predicate-matching candidates only.
+    pub fn rank_allowed(
+        &self,
+        query: &[f32],
+        metric: RankMetric,
+        pool: usize,
+        allow: &crate::row_allow::RowAllow,
+    ) -> Vec<usize> {
+        use proximadb_codec::baseline::functions::rabitq::QueryLut;
+        if allow.is_empty() || pool == 0 {
+            return Vec::new();
+        }
+        let params = self.header.to_params();
+        let rotation = build_rotation_cached(params.dim, params.seed);
+        let q_rotated = rotate_query(query, &params, &rotation);
+        let lut = QueryLut::build(&q_rotated);
+        let mut scored: Vec<(usize, f32)> = self
+            .codes
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| allow.contains(*i))
+            .filter_map(|(i, c)| {
+                c.as_ref().map(|c| {
+                    let score = match metric {
+                        RankMetric::L2 => lut.l2_rank_score(c),
+                        RankMetric::Cosine | RankMetric::DotProduct => lut.ip_rank_score(c),
+                    };
+                    (i, score)
+                })
+            })
+            .collect();
+        scored.sort_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        scored.truncate(pool);
+        scored.into_iter().map(|(i, _)| i).collect()
+    }
 }
 
 /// Per-row code stride in a coalesced region: `dist f32 | inv f32 | bits`.
@@ -342,6 +385,21 @@ pub fn rank_probed_rows(
     query: &[f32],
     metric: RankMetric,
     pool: usize,
+) -> Result<Vec<usize>> {
+    rank_probed_rows_allowed(header, runs, query, metric, pool, None)
+}
+
+/// ADR-089 / TD-FPRUNE-1 P1: [`rank_probed_rows`] restricted to an optional
+/// row allow-set — disallowed rows are skipped before scoring, so the survivor
+/// pool holds only predicate-matching candidates. `None` = rank every probed
+/// row (identical to [`rank_probed_rows`]).
+pub fn rank_probed_rows_allowed(
+    header: &CoalescedRaBitQHeader,
+    runs: &[(usize, &[u8])],
+    query: &[f32],
+    metric: RankMetric,
+    pool: usize,
+    allow: Option<&crate::row_allow::RowAllow>,
 ) -> Result<Vec<usize>> {
     let dim = header.dim as usize;
     if dim == 0 {
@@ -375,6 +433,16 @@ pub fn rank_probed_rows(
     let mut scored = Vec::with_capacity(total_rows);
     for &(row_start, bytes) in runs {
         for (local_row, packed) in bytes.chunks_exact(stride).enumerate() {
+            let global_row = row_start
+                .checked_add(local_row)
+                .ok_or_else(|| anyhow::anyhow!("coarse-probe global row overflow"))?;
+            // ADR-089 P1: skip rows the metadata predicate excluded — before
+            // scoring, so the pool fills with matching candidates only.
+            if let Some(allow) = allow
+                && !allow.contains(global_row)
+            {
+                continue;
+            }
             let dist_to_centroid = f32::from_le_bytes(packed[0..4].try_into()?);
             let inv_factor = f32::from_le_bytes(packed[4..8].try_into()?);
             let bits = &packed[8..];
@@ -385,9 +453,6 @@ pub fn rank_probed_rows(
                 }
             }
             .ok_or_else(|| anyhow::anyhow!("coarse-probe packed bit width mismatch"))?;
-            let global_row = row_start
-                .checked_add(local_row)
-                .ok_or_else(|| anyhow::anyhow!("coarse-probe global row overflow"))?;
             scored.push((global_row, score));
         }
     }
@@ -448,6 +513,100 @@ mod tests {
             parsed.code(ranked[0]).is_some(),
             "top survivor must be present"
         );
+    }
+
+    /// ADR-089 P1: rank_allowed returns only allowed rows, and with a full
+    /// pool it equals the unrestricted scored rank filtered to the allow-set
+    /// (identical scoring; restriction happens before pooling).
+    #[test]
+    fn rank_allowed_matches_filtered_full_rank() {
+        const DIM: usize = 64;
+        const N: usize = 256;
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| synth_vec(i as u64, DIM)).collect();
+        let vectors: Vec<Option<&[f32]>> = corpus.iter().map(|v| Some(v.as_slice())).collect();
+        let (region, _) = encode_region(&vectors, DIM as u32, RABITQ_SEED_BASE ^ 7).unwrap();
+        let parsed = RaBitQRegion::from_bytes(&region).unwrap();
+        let query = synth_vec(9999, DIM);
+
+        // allow every third row.
+        let mut allow = crate::row_allow::RowAllow::new(N);
+        for row in (0..N).step_by(3) {
+            allow.insert(row);
+        }
+
+        for metric in [RankMetric::L2, RankMetric::Cosine] {
+            let got = parsed.rank_allowed(&query, metric, N, &allow);
+            assert_eq!(
+                got.len(),
+                allow.len(),
+                "full pool returns every allowed row"
+            );
+            assert!(got.iter().all(|&r| allow.contains(r)), "survivors ⊆ allow");
+
+            // Reference: unrestricted scored rank, filtered to the allow-set.
+            let reference: Vec<usize> = parsed
+                .rank_range_scored(&query, metric, N, 0..N)
+                .into_iter()
+                .map(|(r, _)| r)
+                .filter(|r| allow.contains(*r))
+                .collect();
+            assert_eq!(
+                got, reference,
+                "restricted rank == filtered full rank ({metric:?})"
+            );
+
+            // Small pool: the top-p of the restricted rank is the prefix of
+            // the filtered full rank.
+            let top5 = parsed.rank_allowed(&query, metric, 5, &allow);
+            assert_eq!(top5, reference[..5].to_vec());
+        }
+
+        // Empty allow ⇒ no survivors.
+        let empty = crate::row_allow::RowAllow::new(N);
+        assert!(
+            parsed
+                .rank_allowed(&query, RankMetric::L2, N, &empty)
+                .is_empty()
+        );
+    }
+
+    /// ADR-089 P1: rank_probed_rows_allowed(pool=all) equals the unrestricted
+    /// probed rank filtered to the allow-set, and None preserves the original.
+    #[test]
+    fn rank_probed_rows_allowed_matches_filtered_probed_rank() {
+        const DIM: usize = 32;
+        const N: usize = 200;
+        let corpus: Vec<Vec<f32>> = (0..N).map(|i| synth_vec(i as u64, DIM)).collect();
+        let vectors: Vec<Option<&[f32]>> = corpus.iter().map(|v| Some(v.as_slice())).collect();
+        let (region, _) = encode_region(&vectors, DIM as u32, RABITQ_SEED_BASE ^ 13).unwrap();
+        let header = CoalescedRaBitQHeader::parse(&region).unwrap();
+        let codes = &region[region_header_len(header.dim)..];
+        // Skip the validity bitmap: probed runs carry packed codes only.
+        let bitmap_len = N.div_ceil(8);
+        let runs = [(0usize, &codes[bitmap_len..])];
+        let query = synth_vec(4242, DIM);
+
+        let mut allow = crate::row_allow::RowAllow::new(N);
+        for row in (0..N).filter(|r| r % 4 == 1) {
+            allow.insert(row);
+        }
+
+        let unrestricted = rank_probed_rows(&header, &runs, &query, RankMetric::L2, N).unwrap();
+        let restricted =
+            rank_probed_rows_allowed(&header, &runs, &query, RankMetric::L2, N, Some(&allow))
+                .unwrap();
+        let reference: Vec<usize> = unrestricted
+            .iter()
+            .copied()
+            .filter(|r| allow.contains(*r))
+            .collect();
+        assert_eq!(restricted, reference);
+        assert!(restricted.iter().all(|&r| allow.contains(r)));
+
+        // None = unchanged behavior.
+        let via_none =
+            rank_probed_rows_allowed(&header, &runs, &query, RankMetric::L2, N, None).unwrap();
+        assert_eq!(via_none, unrestricted);
     }
 
     /// TD-FLUSH-5: the parallel pass-2 encode (n >= 4096 -> rayon) must be

--- a/crates/storage/proximadb-block-format/src/lib.rs
+++ b/crates/storage/proximadb-block-format/src/lib.rs
@@ -77,6 +77,7 @@ pub mod prune;
 pub mod ranged;
 pub mod reader;
 pub mod record;
+pub mod row_allow;
 pub mod row_dir;
 pub mod rowgroup;
 pub mod stripe;
@@ -87,7 +88,7 @@ pub mod writer;
 
 pub use coalesced_rabitq::{
     CoalescedRaBitQHeader, RABITQ_SEED_BASE, REGION_FIXED_HEADER_LEN, RaBitQRegion, code_stride,
-    encode_region, rank_probed_rows, region_header_len, region_len,
+    encode_region, rank_probed_rows, rank_probed_rows_allowed, region_header_len, region_len,
 };
 pub use coalesced_sq8::{
     CoalescedSq8Header, REGION_SQ8_FIXED_HEADER_LEN, Sq8Region, codes_offset as sq8_codes_offset,
@@ -105,6 +106,7 @@ pub use record::{
     ColumnDescriptor, FlatRow, canonical_columns, col_id, encode_f32_vec_col, encode_i64_col,
     encode_str_col, update_i64_bounds,
 };
+pub use row_allow::RowAllow;
 pub use row_dir::{ROW_ENTRY_SIZE, RowDirectory, RowEntry, row_flags};
 pub use rowgroup::{ROW_GROUP_SIZE, RowGroupBlock, RowGroupEntry};
 pub use stripe::{BlockStats, COLUMN_META_SIZE, ColumnMeta, ColumnRole, ColumnStripe, SegmentMeta};

--- a/crates/storage/proximadb-block-format/src/record.rs
+++ b/crates/storage/proximadb-block-format/src/record.rs
@@ -308,6 +308,16 @@ impl FlatRow {
     /// dropped (catalog-resolution). Segments that still store the column keep their
     /// own value, so this is mixed-read-safe (old and new segments both reconstruct
     /// the correct tenant). Pass `None` to keep the stored value verbatim.
+    /// Decode this row's props msgpack into a `ProximaTree` WITHOUT building a
+    /// full `ProximaRecord` — the filter-aware cascade's Stage-F row predicate
+    /// (ADR-089 P1) only needs props for `evaluate_filter_proxima`.
+    pub fn props_tree(&self) -> anyhow::Result<proximadb_records::ProximaTree> {
+        match &self.props_bytes {
+            Some(b) => Ok(rmp_serde::from_slice(b)?),
+            None => Ok(Default::default()),
+        }
+    }
+
     pub fn into_record(
         self,
         embedding_model_ids: &[String],

--- a/crates/storage/proximadb-block-format/src/row_allow.rs
+++ b/crates/storage/proximadb-block-format/src/row_allow.rs
@@ -1,0 +1,141 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+
+//! Row allow-set for the filter-aware cascade (ADR-089 / TD-FPRUNE-1 P1).
+//!
+//! A dense bitset over a segment's **global row ordinals** (the shared currency
+//! of the PAX regions — ADR-065 row-ordinal identity). The metadata pre-stage
+//! marks the rows whose scalar predicate matched; the RaBitQ/SQ8 rank stages
+//! then score **only** allowed rows, so the survivor pool is filled with
+//! predicate-matching candidates instead of being diluted by rows the filter
+//! would discard (post-filtering the pool would silently lose recall).
+
+/// Dense bitset keyed by global row ordinal `0..n_slots`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RowAllow {
+    words: Vec<u64>,
+    n_slots: usize,
+    len: usize,
+}
+
+impl RowAllow {
+    /// An empty allow-set over `n_slots` rows (nothing allowed).
+    pub fn new(n_slots: usize) -> Self {
+        Self {
+            words: vec![0u64; n_slots.div_ceil(64)],
+            n_slots,
+            len: 0,
+        }
+    }
+
+    /// Number of allowed rows.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// True when no row is allowed.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Total row slots the set was sized for.
+    pub fn n_slots(&self) -> usize {
+        self.n_slots
+    }
+
+    /// Allow row `row`. Out-of-range rows are ignored (the set is sized from
+    /// the footer row count; anything beyond it cannot be a real row).
+    pub fn insert(&mut self, row: usize) {
+        if row >= self.n_slots {
+            return;
+        }
+        let (w, b) = (row / 64, row % 64);
+        let mask = 1u64 << b;
+        if self.words[w] & mask == 0 {
+            self.words[w] |= mask;
+            self.len += 1;
+        }
+    }
+
+    /// Whether row `row` is allowed.
+    pub fn contains(&self, row: usize) -> bool {
+        if row >= self.n_slots {
+            return false;
+        }
+        self.words[row / 64] & (1u64 << (row % 64)) != 0
+    }
+
+    /// Whether ANY row in `range` is allowed — used to skip whole A0 cells
+    /// (contiguous global-row ranges) before their Region-A extents are
+    /// fetched.
+    pub fn any_in_range(&self, range: std::ops::Range<usize>) -> bool {
+        let start = range.start.min(self.n_slots);
+        let end = range.end.min(self.n_slots);
+        if start >= end {
+            return false;
+        }
+        let (first_w, last_w) = (start / 64, (end - 1) / 64);
+        for w in first_w..=last_w {
+            let mut word = self.words[w];
+            if w == first_w {
+                word &= u64::MAX << (start % 64);
+            }
+            if w == last_w {
+                let tail = (end - 1) % 64;
+                word &= u64::MAX >> (63 - tail);
+            }
+            if word != 0 {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl FromIterator<usize> for RowAllow {
+    /// Build from row ordinals; the set is sized to the max ordinal + 1.
+    /// (Production callers size via [`RowAllow::new`] from the footer row
+    /// count; this is a test/utility convenience.)
+    fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+        let rows: Vec<usize> = iter.into_iter().collect();
+        let n = rows.iter().max().map_or(0, |m| m + 1);
+        let mut set = Self::new(n);
+        for r in rows {
+            set.insert(r);
+        }
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_contains_len_and_bounds() {
+        let mut s = RowAllow::new(130);
+        assert!(s.is_empty());
+        s.insert(0);
+        s.insert(63);
+        s.insert(64);
+        s.insert(129);
+        s.insert(129); // idempotent
+        s.insert(130); // out of range — ignored
+        assert_eq!(s.len(), 4);
+        assert!(s.contains(0) && s.contains(63) && s.contains(64) && s.contains(129));
+        assert!(!s.contains(1) && !s.contains(128) && !s.contains(130) && !s.contains(9999));
+    }
+
+    #[test]
+    fn any_in_range_hits_and_misses_across_word_boundaries() {
+        let s: RowAllow = [70usize, 200].into_iter().collect();
+        assert!(s.any_in_range(0..71));
+        assert!(s.any_in_range(70..71));
+        assert!(s.any_in_range(64..128));
+        assert!(!s.any_in_range(0..70));
+        assert!(!s.any_in_range(71..200));
+        assert!(s.any_in_range(128..201));
+        assert!(!s.any_in_range(201..500)); // beyond slots
+        assert!(!s.any_in_range(10..10)); // empty range
+    }
+}

--- a/docs/10-quality/td/TD-FLUSH-8-auto-flush-catalog-identity-skip.adoc
+++ b/docs/10-quality/td/TD-FLUSH-8-auto-flush-catalog-identity-skip.adoc
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FLUSH-8: auto-flush skips WAL collections it cannot resolve in the catalog — REST-created collections never reach PAX
+:status: Open
+:dim: D3/D5
+:pillar: REL
+
+Problem (found by the ADR-089 P1 evidence run, 2026-08-06): with the flush
+envelope armed (`memory_flush_size_bytes = 2 MiB`, `flush_floor_predicted_mb =
+0`, `flush_interval_secs = 5`, hermetic storage roots), a REST-v2-created
+collection ingesting ~20k-80k vectors NEVER flushes. The ADR-069 auto-flush
+driver ticks, the size/time triggers fire, and then every cycle logs:
+
+  WARN ⚠️ ADR-069 auto-flush: no catalog metadata for '1', skipping
+  WARN ⚠️ STORAGE_ENGINE: 1 collections failed to flush: [("1", "no catalog metadata")]
+
+Mechanism: the WAL write buffer lists unflushed collections by the id the write
+path keyed the memtable with — here the literal string `'1'` — while
+`list_collections_from_catalog`
+(`src/storage/persistence/write_ahead_log/mod.rs:1097`) walks the **default
+catalog's** namespaces/tables and returns collections whose `.id` is the
+catalog identity. The driver's lookup
+(`src/storage/auto_flush_driver.rs:157`, `catalog.iter().find(|c| &c.id ==
+collection_id)`) never matches, so the flush is skipped **forever** — the
+memtable grows, and every read stays on the WAL/memtable scan path.
+
+This is an ADR-0083-class identity seam ("two identity systems disagree" — the
+same failure family as the #1325 flush-plan regression): the WAL keys one id
+form, the catalog another, and the flush boundary is where they meet.
+
+Consequences:
+* The PAX serving tier (coalesced cascade, ADR-062/065; filter-aware cascade,
+  ADR-089) is **dark end-to-end** for this surface — segments are never
+  produced, so segment-path work cannot be exercised from the public API.
+* All context-corridor benchmark measurements to date (TD-CTXCORR-1, including
+  the 38x filtered-search baseline) were **memtable-scan measurements**, not
+  segment-path measurements. The competitive gap is real but its mechanism is
+  the WAL exact scan, with the segment exact scan measured separately at the
+  engine level (see ADR-089 P1 evidence harness).
+* Durability/RPO: collections in this state accumulate unbounded unflushed
+  windows (the ADR-069 time floor cannot drain them).
+
+Direction (owner, 2026-08-06): **the catalog is the identity authority.** A
+collection that exists MUST be resolvable in the catalog — there is no
+legitimate "catalog-less collection" state, so the fix is proper catalog
+integration at the flush boundary, NOT tolerating unresolvable collections
+(no fallback flush plans for unknown ids, no bypass registration in tests).
+
+Next actions:
+1. Find where the write path derives the WAL collection key (`'1'`) for
+   REST-v2 collections and make the WAL key on the **catalog identity**
+   (ADR-0083: ONE identity, the composite) — or make the flush boundary
+   resolve through the catalog by the same canonical form. The invariant to
+   restore: `WAL key ⇒ catalog-resolvable`, always. If the REST create path
+   is registering the collection under a different catalog (tenant vs default)
+   than `list_collections_from_catalog` walks, fix the walk to be the real
+   catalog surface — the collection IS in the catalog; the lookup must reach it.
+2. Fail loud, not skip-forever: an unflushable-because-unresolvable collection
+   is an identity-invariant violation (durability incident) — escalate
+   (metric + rate-limited error), never spin silently at WARN per tick.
+3. Regression test through the REAL catalog path: REST-create (proper catalog
+   registration) → ingest past the size trigger → assert a `.pax` segment
+   exists under the collection's `DrPathBuilder` path. Test fixtures and
+   benchmark harnesses must create collections via the catalog like
+   production does — no catalog-less shortcuts that mask this class of bug.
+4. Re-run the corridor benchmark end-to-end once fixed, so the segment-path
+   filtered cascade (ADR-089 P1) is measurable from the public API
+   (TD-FPRUNE-1 evidence gate).
+
+Refs: ADR-069 (flush decision boundary), ADR-0083 (consolidated identity),
+ADR-089 / TD-FPRUNE-1 (blocked evidence), TD-FLUSH-2 (small corpora never
+flush — the *threshold* face of the same "never flushes" symptom; this TD is
+the *identity* face).

--- a/docs/10-quality/td/TD-FPRUNE-1-filter-aware-cascade-arc.adoc
+++ b/docs/10-quality/td/TD-FPRUNE-1-filter-aware-cascade-arc.adoc
@@ -18,18 +18,31 @@ filter as the correctness backstop. This TD tracks the phases.
 
 == Phases (each evidence-gated; mixed-read-safe; default-OFF until baked)
 
-* **P1 — wire what exists (no format change).** At the `mod.rs:420` gate,
-  instead of declining: ranged-read footer + per-block `ColumnMeta`, prune via
-  the existing `evaluate_block`/`evaluate_row_groups` kernel
-  (`crates/storage/proximadb-block-format/src/prune.rs:60-160`; live precedent
-  `read_records_pruned` on the record-store path), map surviving blocks →
-  global-row ranges (footer cumulative row counts), run the cascade restricted
-  to those rows (the coalesced planners already take row lists:
-  `plan_coalesced_row_ranges` `segment_format.rs:853`), residual per-record
-  check at D-resolve (decode props beside OID). Requires **arming P-Shred**
-  (ADR-055) for schema columns marked `filterable` — per-collection opt-in —
-  since user tags live in opaque PROPS msgpack without it. Canonical columns
-  (tenant, timestamps, valid_from/to) prune without shredding.
+* **P1 — wire what exists (no format change): IMPLEMENTED (engine level).**
+  Landed as: `RowAllow` bitset + allow-aware ranking (`rank_allowed`,
+  `rank_probed_rows_allowed`) in `proximadb-block-format`; Stage-F builder
+  `pax_filtered_row_allow` (header/footer → coalesced D-block fetch →
+  conservative `evaluate_block` stats prune (skips DECODE; fetch pruning is
+  P2) → row-accurate `evaluate_filter_proxima` per row — the SAME evaluator as
+  the exact path, so match semantics are identical by construction);
+  `rabitq_search_segment_coalesced_allowed` (pool sized on the allowed count;
+  geometric probe bypassed under a filter — probe∩filter nprobe policy is P3);
+  the `mod.rs:420` gate now routes filtered queries through Stage-F + the
+  restricted cascade behind default-OFF `PROXIMADB_PAX_FILTERED_CASCADE`
+  (fail-safe: any stage-F failure or non-coalesced segment falls back to the
+  exact path; a provably-empty allow-set short-circuits to an empty per-file
+  result). TDD: allow-aware rank equivalence tests (block-format), Stage-F
+  exactness vs an independent decode, filtered-cascade recall vs filtered
+  brute force, gate default-off. Evidence: the engine-level A/B harness
+  (`p1_evidence_filtered_exact_vs_cascade`, ignored — run in release).
+  **P1 residual scope:** P-Shred arming for `filterable` schema columns (user
+  tags live in opaque PROPS msgpack, so stats pruning currently helps only
+  canonical columns — row accuracy comes from the per-row eval either way),
+  and the D-resolve residual check (defense-in-depth; the P1 row set is
+  already row-accurate). **End-to-end server evidence is BLOCKED by
+  TD-FLUSH-8** (auto-flush cannot resolve REST-created collections in the
+  catalog — segments are never produced from the public API, so all corridor
+  measurements to date were memtable-scan measurements).
 * **P2 — footer-resident block stats (zero-GET pruning).** Populate the
   reserved `StatsKind::MinMax`/`BloomOid` slots in the segment footer block
   table (`segment_layout.rs:222-262`; today always `StatsKind::None`,

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -169,6 +169,7 @@ the emergency off) · *config-mirror* (env overrides a config field) ·
 | `PROXIMADB_PAX_COALESCE_RANGE` | coalesce max_range override (bytes) | backend profile | ADR-065/073 | `src/storage/engines/sst/segment_format.rs`
 | `PROXIMADB_PAX_DROP_TENANT_COL` | Drops the tenant column from the on-disk PAX block | OFF (`var_os`) | opt-in; — | `crates/storage/proximadb-block-format/src/writer.rs`
 | `PROXIMADB_PAX_F32_TIER` | Emits exact-f32 stripe (Phase D) for exact rerank / include_vectors | OFF (per-collection tag overrides) | opt-in; P3 Phase D | `src/storage/engines/sst/flush/mod.rs`
+| `PROXIMADB_PAX_FILTERED_CASCADE` | Filter-aware cascade: Stage-F metadata row allow-set + row-restricted RaBitQ/SQ8 for filtered PAX queries (vs whole-object exact scan) | OFF (default-OFF-until-baked) | opt-in; ADR-089/TD-FPRUNE-1 P1 | `src/storage/engines/sst/segment_format.rs`
 | `PROXIMADB_PAX_FLUSH_CLUSTER` | Upgrades L0 flush ordering to full PCA+IVF recluster | OFF (`=ivf/pca_ivf/1/...` enables) | eval; TD-WLP-4/WLP-9 | `src/storage/engines/sst/block_cluster.rs`
 | `PROXIMADB_PAX_LOSSLESS_CLUSTERED` | Enables lossless clustered PAX codec path | OFF | eval; — | `src/storage/engines/sst/segment_format.rs`
 | `PROXIMADB_PAX_LOSSLESS_SCALAR` | Enables lossless scalar PAX codec path | OFF | eval; — | `src/storage/engines/sst/segment_format.rs`

--- a/src/storage/engines/sst/search/mod.rs
+++ b/src/storage/engines/sst/search/mod.rs
@@ -407,18 +407,51 @@ impl SstEngine {
         // the in-block RaBitQ cascade below (mixed-read). Any I/O error / `None`
         // also falls through (safe degradation, never an incorrect result).
         //
-        // UNFILTERED only: the coalesced scan ranks by vector distance and does
-        // not apply `filter_expression`, so a filtered query is routed past it to
-        // the exact materialize-and-rank path (which applies the filter) below —
-        // matching the ranged cascade's "unfiltered only" contract.
+        // Filtered queries: with the ADR-089 P1 gate ON, a Stage-F metadata
+        // pre-scan builds a row allow-set and the cascade ranks ONLY matching
+        // rows (row-accurate — same `evaluate_filter_proxima` semantics as the
+        // exact path). Gate OFF (default), a non-coalesced segment, or any
+        // stage-F failure routes the filtered query past the cascade to the
+        // exact materialize-and-rank path below, exactly as before.
         {
-            use crate::storage::engines::sst::segment_format::rabitq_search_segment_coalesced;
+            use crate::storage::engines::sst::segment_format::{
+                pax_filtered_cascade_enabled, pax_filtered_row_allow,
+                rabitq_search_segment_coalesced_allowed,
+            };
+            // ADR-089 / TD-FPRUNE-1 P1: a filtered query builds a predicate
+            // row allow-set from the Region-D metadata (Stage F) and runs the
+            // cascade restricted to matching rows — instead of declining into
+            // the whole-object exact scan. Default-OFF env gate; any stage-F
+            // failure or a non-coalesced segment falls back to the exact path
+            // (fail-safe, never an incorrect result).
+            let row_allow = match filter_expression {
+                Some(filter) if pax_filtered_cascade_enabled() => {
+                    match pax_filtered_row_allow(fs.as_ref(), sstable_path, filter).await {
+                        Ok(Some((allow, _stats))) if allow.is_empty() => {
+                            // Provably zero matching rows in THIS segment —
+                            // an empty per-file result (other segments/WAL
+                            // still contribute via the caller's merge).
+                            return Ok(Some(Vec::new()));
+                        }
+                        Ok(Some((allow, _stats))) => Some(allow),
+                        Ok(None) => None, // non-coalesced → exact fallback
+                        Err(e) => {
+                            tracing::warn!(
+                                "stage-F row allow-set failed for {sstable_path} \
+                                 (falling back to exact scan): {e}"
+                            );
+                            None
+                        }
+                    }
+                }
+                _ => None,
+            };
             // ADR-065: call the coalesced path directly — it reads the 56 B
             // header-prefix internally (cached) + returns Ok(None) for a non-
             // coalesced segment, so no separate 4 B magic-detection GET is needed
             // (collapses the redundant offset-0 prefix read the FS trace found).
-            if filter_expression.is_none() {
-                let coalesced_hits = rabitq_search_segment_coalesced(
+            if filter_expression.is_none() || row_allow.is_some() {
+                let coalesced_hits = rabitq_search_segment_coalesced_allowed(
                     fs.as_ref(),
                     sstable_path,
                     query_vector,
@@ -426,6 +459,7 @@ impl SstEngine {
                     rank_metric,
                     self.segment_invariants_cache.as_deref(),
                     self.survivor_cache.as_deref(),
+                    row_allow.as_ref(),
                 )
                 .await?;
                 if let Some(hits) = coalesced_hits {

--- a/src/storage/engines/sst/segment_format.rs
+++ b/src/storage/engines/sst/segment_format.rs
@@ -739,6 +739,166 @@ pub(crate) fn pax_field_to_col(field: &str) -> Option<i32> {
     }
 }
 
+/// ADR-089 / TD-FPRUNE-1 P1: default-OFF gate for the filter-aware cascade.
+/// `PROXIMADB_PAX_FILTERED_CASCADE=1|on|true|yes` routes filtered PAX queries
+/// through the metadata pre-stage + row-restricted cascade instead of the
+/// whole-object exact scan. Mixed-read-safe: OFF preserves today's behavior.
+pub(crate) fn pax_filtered_cascade_enabled() -> bool {
+    matches!(
+        std::env::var("PROXIMADB_PAX_FILTERED_CASCADE")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1" | "on" | "true" | "yes")
+    )
+}
+
+/// Stage-F observability counters (ADR-089 P1): what the metadata pre-stage
+/// pruned and matched, per segment.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct FilteredRowAllowStats {
+    pub blocks_total: usize,
+    /// Blocks skipped by conservative `ColumnMeta` stats (`evaluate_block`)
+    /// without decoding a row. (P1 prunes DECODE, not fetch — footer-resident
+    /// stats that prune the fetch itself are TD-FPRUNE-1 P2.)
+    pub blocks_pruned: usize,
+    pub rows_matched: usize,
+}
+
+/// ADR-089 / TD-FPRUNE-1 P1 Stage F: build the predicate row allow-set for a
+/// coalesced PAX segment from its Region-D metadata, without touching Regions
+/// A/B and without decoding any vector data.
+///
+/// Reads: header prefix + footer + the D-block bodies (coalesced ranged GETs).
+/// Per block: conservative stats pruning via the shared [`evaluate_block`]
+/// kernel (skips decode; never skips a matching row — `prune.rs` soundness
+/// contract), then a row-accurate `evaluate_filter_proxima` over each row's
+/// props — the SAME evaluator the exact fallback path uses, so match semantics
+/// are identical by construction. Returns `Ok(None)` for a non-coalesced
+/// segment (caller falls back to the exact path, fail-safe).
+pub(crate) async fn pax_filtered_row_allow(
+    fs: &dyn proximadb_storage_filesystem_types::FileSystem,
+    path: &str,
+    filter: &proximadb_filter_expression::FilterExpression,
+) -> Result<Option<(proximadb_block_format::RowAllow, FilteredRowAllowStats)>> {
+    use proximadb_block_format::{PaxBlockReader, RowAllow, evaluate_block, record::FlatRow};
+    use proximadb_storage_common::segment_layout::{
+        SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN, SegmentFooterIndex, SegmentHeaderPrefix,
+    };
+
+    // 1. Header prefix → coalesced? (mirrors the cascade's detection).
+    let size = fs
+        .metadata(path)
+        .await
+        .map_err(|e| anyhow::anyhow!("filtered stage-F stat {path}: {e}"))?
+        .size;
+    if size < (SEG_HEADER_PREFIX_LEN as u64 + SEGMENT_MAGIC.len() as u64) {
+        return Ok(None);
+    }
+    let read_len = (SEG_HEADER_PREFIX_V3_LEN as u64).min(size);
+    let header_bytes = fs
+        .read_range(path, 0, read_len)
+        .await
+        .map_err(|e| anyhow::anyhow!("filtered stage-F header {path}: {e}"))?;
+    let header = match SegmentHeaderPrefix::parse(&header_bytes) {
+        Ok(h) => h,
+        Err(_) => return Ok(None), // not coalesced → exact fallback
+    };
+
+    // 2. Footer → block table (+ cumulative start ordinals).
+    let footer_bytes = fs
+        .read_range(path, header.footer_off, header.footer_len)
+        .await
+        .map_err(|e| anyhow::anyhow!("filtered stage-F footer {path}: {e}"))?;
+    let footer = SegmentFooterIndex::parse(&footer_bytes)?;
+    let mut block_start: Vec<u64> = Vec::with_capacity(footer.blocks.len());
+    let mut acc = 0u64;
+    for b in &footer.blocks {
+        block_start.push(acc);
+        acc += b.row_count as u64;
+    }
+    let n_rows = acc as usize;
+    let mut allow = RowAllow::new(n_rows);
+    let mut stats = FilteredRowAllowStats {
+        blocks_total: footer.blocks.len(),
+        ..Default::default()
+    };
+
+    // 3. Fetch ALL D-block bodies via the same IOP-aligned coalescing the
+    //    cascade's OID resolve uses. (P1 reads the metadata blocks and prunes
+    //    the DECODE via stats; pruning the FETCH needs footer-resident stats —
+    //    TD-FPRUNE-1 P2.) Coalesced D blocks carry no vector stripes (ADR-065),
+    //    so these bytes are scalar/metadata only.
+    let iop_target =
+        proximadb_storage_common::iops_budget::IopsBudget::for_path(path).target_block_bytes();
+    let policy =
+        crate::storage::engines::sst::readers::sst_query_engine::ObjectRangeCoalescePolicy {
+            max_gap_bytes: env_u64_or(
+                "PROXIMADB_PAX_COALESCE_GAP",
+                (iop_target / 4).max(64 * 1024),
+            ),
+            max_range_bytes: env_u64_or("PROXIMADB_PAX_COALESCE_RANGE", iop_target),
+        };
+    let all_blocks: Vec<usize> = (0..footer.blocks.len()).collect();
+    let fetches = plan_coalesced_block_ranges(&footer, &all_blocks, &policy);
+    for fetch in &fetches {
+        let buf = fs
+            .read_range(path, fetch.start, fetch.end - fetch.start)
+            .await
+            .map_err(|e| anyhow::anyhow!("filtered stage-F blocks {path}: {e}"))?;
+        for &bi in &fetch.blocks {
+            let Some(b) = footer.blocks.get(bi) else {
+                continue;
+            };
+            let Some(rel) = b.offset.checked_sub(fetch.start).map(|r| r as usize) else {
+                continue;
+            };
+            let end = rel + b.size as usize;
+            let Some(block_bytes) = buf.get(rel..end) else {
+                continue;
+            };
+            let reader = PaxBlockReader::open(block_bytes)
+                .map_err(|e| anyhow::anyhow!("filtered stage-F block open {path}: {e}"))?;
+            // Conservative stats prune: provably-no-match blocks skip decode.
+            // NOTE: the `&pax_field_to_col` coercion is a per-call temporary —
+            // a `&dyn Fn` binding held across the fetch `.await` would make
+            // this future (and every async caller up to the REST handlers)
+            // `!Send`.
+            if evaluate_block(&reader, filter, &pax_field_to_col)
+                == proximadb_block_format::PruneResult::Skip
+            {
+                stats.blocks_pruned += 1;
+                continue;
+            }
+            let start_ordinal = block_start[bi] as usize;
+            for (local, flat) in FlatRow::from_block_reader(&reader)
+                .map_err(|e| anyhow::anyhow!("filtered stage-F rows {path}: {e}"))?
+                .into_iter()
+                .enumerate()
+            {
+                let props = flat
+                    .props_tree()
+                    .map_err(|e| anyhow::anyhow!("filtered stage-F props {path}: {e}"))?;
+                if crate::core::search::sql_value_filter::evaluate_filter_proxima(filter, &props) {
+                    allow.insert(start_ordinal + local);
+                    stats.rows_matched += 1;
+                }
+            }
+        }
+    }
+    tracing::debug!(
+        path,
+        blocks_total = stats.blocks_total,
+        blocks_pruned = stats.blocks_pruned,
+        rows_matched = stats.rows_matched,
+        n_rows,
+        "ADR-089 P1 stage-F row allow-set built"
+    );
+    Ok(Some((allow, stats)))
+}
+
 /// Whether the coalesced-RaBitQ layout is engaged for new RaBitQ writes
 /// (ADR-062 / TD-RDSTRAT-6). **Default ON** — coalesced scan-then-rerank is the
 /// canonical PAX RaBitQ path (pre-GA: no serialized legacy data, so no back-compat
@@ -2394,6 +2554,29 @@ pub async fn rabitq_search_segment_coalesced(
     cache: Option<&SegmentInvariantsCache>,
     survivor_cache: Option<&SurvivorRangeCache>,
 ) -> Result<Option<Vec<CascadeHit>>> {
+    rabitq_search_segment_coalesced_allowed(fs, path, query, k, metric, cache, survivor_cache, None)
+        .await
+}
+
+/// ADR-089 / TD-FPRUNE-1 P1: [`rabitq_search_segment_coalesced`] restricted to
+/// an optional predicate row allow-set (global row ordinals). When `Some`,
+/// Stage-1 ranks ONLY allowed rows — the survivor pool holds
+/// predicate-matching candidates, so filtered recall equals the RaBitQ
+/// approximation over the matching rows (same quality bar as the unfiltered
+/// whole-region scan). The geometric coarse probe is bypassed under a filter
+/// for P1 — probe∩filter composition (nprobe policy under selectivity) is the
+/// TD-FPRUNE-1 P3 concern.
+#[allow(clippy::too_many_arguments)]
+pub async fn rabitq_search_segment_coalesced_allowed(
+    fs: &dyn proximadb_storage_filesystem_types::FileSystem,
+    path: &str,
+    query: &[f32],
+    k: usize,
+    metric: RankMetric,
+    cache: Option<&SegmentInvariantsCache>,
+    survivor_cache: Option<&SurvivorRangeCache>,
+    row_allow: Option<&proximadb_block_format::RowAllow>,
+) -> Result<Option<Vec<CascadeHit>>> {
     use proximadb_block_format::{PaxBlockReader, RaBitQRegion, coalesced_sq8, col_id};
     use proximadb_storage_common::segment_layout::{
         SEG_HEADER_PREFIX_LEN, SEG_HEADER_PREFIX_V3_LEN, SEG_LAYOUT_VERSION_TWO_LEVEL,
@@ -2478,7 +2661,10 @@ pub async fn rabitq_search_segment_coalesced(
     //    probe miss falls through, fail-safe, to the whole-region path.
     let probe_armed = header.layout_version == SEG_LAYOUT_VERSION_TWO_LEVEL
         && header.a0_len > 0
-        && coarse_probe_enabled();
+        && coarse_probe_enabled()
+        // ADR-089 P1: filtered queries take the whole-region allowed rank
+        // (see `row_allow` doc above) — never the geometric probe.
+        && row_allow.is_none();
     let probe = if probe_armed {
         coarse_probe_survivors(
             fs,
@@ -2539,9 +2725,23 @@ pub async fn rabitq_search_segment_coalesced(
                 Arc::from(bytes)
             };
         let region = RaBitQRegion::from_bytes(&region_bytes)?;
-        // ADR-062 PR2: adaptive survivor pool — scale M with the segment's rows.
-        let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());
-        let survivors = rank_region_morsels(region, query, metric, pool.max(k)).await;
+        let survivors = match row_allow {
+            // ADR-089 P1: rank only predicate-matching rows. The pool scales
+            // with the ALLOWED row count (not the segment total), so selective
+            // filters don't over-fetch SQ8 survivor ranges. Sequential rank is
+            // deliberate: the allowed count is typically well below the morsel
+            // threshold; morsel-parallel allowed rank is a P3 follow-up.
+            Some(allow) => {
+                let pool = pax_rabitq_pool_for_top_k(k, allow.len().max(1));
+                region.rank_allowed(query, metric, pool.max(k), allow)
+            }
+            None => {
+                // ADR-062 PR2: adaptive survivor pool — scale M with the
+                // segment's rows.
+                let pool = pax_rabitq_pool_for_top_k(k, region.n_rows());
+                rank_region_morsels(region, query, metric, pool.max(k)).await
+            }
+        };
         (survivors, Some(region_bytes))
     };
     if survivors.is_empty() {
@@ -4004,6 +4204,349 @@ mod tests {
             hits[0].oid, "r137",
             "the query vector itself must be the top hit"
         );
+    }
+
+    /// ADR-089 P1 test helper: a record carrying a `partition` prop (`p{i%8}`),
+    /// mirroring the context-corridor benchmark's filter shape.
+    fn rec_with_partition(i: usize, vec: Vec<f32>) -> ProximaRecord {
+        let mut r = rec(&format!("r{i}"), 1000 + i as i64, vec);
+        r.props.insert(
+            "partition".to_string(),
+            proximadb_records::ProximaTreeNode::Value(proximadb_data_model::ProximaValue::String(
+                format!("p{}", i % 8),
+            )),
+        );
+        r
+    }
+
+    fn partition_filter(value: &str) -> proximadb_filter_expression::FilterExpression {
+        proximadb_filter_expression::FilterExpression::Comparison {
+            field: "partition".to_string(),
+            operator: proximadb_filter_expression::ComparisonOperator::Equals,
+            value: serde_json::Value::String(value.to_string()),
+        }
+    }
+
+    /// ADR-089 / TD-FPRUNE-1 P1: the Stage-F row allow-set is row-accurate —
+    /// exactly the segment rows whose props match the predicate, in global
+    /// (cluster-ordered) row-ordinal space, verified by an independent decode.
+    #[tokio::test]
+    async fn stage_f_row_allow_set_is_exact() {
+        enable_coalesced_rabitq();
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+        use proximadb_block_format::{PaxBlockReader, record::FlatRow};
+        use proximadb_storage_common::segment_layout::{SegmentFooterIndex, SegmentHeaderPrefix};
+
+        const DIM: usize = 32;
+        const N: usize = 300;
+        let records: Vec<ProximaRecord> = (0..N)
+            .map(|i| {
+                let v: Vec<f32> = (0..DIM)
+                    .map(|d| (((i * 131 + d * 17) % 251) as f32) * 0.01)
+                    .collect();
+                rec_with_partition(i, v)
+            })
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        // Small blocks ⇒ multi-block segment (exercises cross-block ordinals).
+        write_pax_segment(
+            &path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let p = path.to_str().unwrap();
+
+        let filter = partition_filter("p3");
+        let (allow, stats) = pax_filtered_row_allow(&fs, p, &filter)
+            .await
+            .unwrap()
+            .expect("coalesced segment must produce a stage-F allow-set");
+
+        // Independent verification: decode every D-block row in file order and
+        // recompute the expected ordinal set from each row's props.
+        let bytes = std::fs::read(&path).unwrap();
+        let header = SegmentHeaderPrefix::parse(&bytes).unwrap();
+        let footer_off = header.footer_off as usize;
+        let footer =
+            SegmentFooterIndex::parse(&bytes[footer_off..footer_off + header.footer_len as usize])
+                .unwrap();
+        let mut expected = std::collections::BTreeSet::new();
+        let mut g = 0usize;
+        for b in &footer.blocks {
+            let reader = PaxBlockReader::open(
+                &bytes[b.offset as usize..(b.offset + b.size as u64) as usize],
+            )
+            .unwrap();
+            for flat in FlatRow::from_block_reader(&reader).unwrap() {
+                let oid_index: usize = flat.oid.trim_start_matches('r').parse().unwrap();
+                if oid_index % 8 == 3 {
+                    expected.insert(g);
+                }
+                g += 1;
+            }
+        }
+        assert_eq!(g, N, "independent decode covers every row");
+        let got: std::collections::BTreeSet<usize> =
+            (0..N).filter(|&row| allow.contains(row)).collect();
+        assert_eq!(got, expected, "allow-set == filter-matching rows, exactly");
+        assert_eq!(allow.len(), (0..N).filter(|i| i % 8 == 3).count());
+        assert_eq!(stats.rows_matched, allow.len());
+        assert_eq!(stats.blocks_total, footer.blocks.len());
+
+        // A predicate matching nothing yields an empty (but Some) allow-set.
+        let (empty_allow, _) = pax_filtered_row_allow(&fs, p, &partition_filter("p999"))
+            .await
+            .unwrap()
+            .expect("coalesced segment");
+        assert!(empty_allow.is_empty());
+    }
+
+    /// ADR-089 / TD-FPRUNE-1 P1: the row-restricted cascade returns ONLY
+    /// predicate-matching hits, at recall parity with a filtered brute-force
+    /// ground truth (same bar as the unfiltered cascade's recall test).
+    #[tokio::test]
+    async fn filtered_cascade_matches_filtered_bruteforce() {
+        enable_coalesced_rabitq();
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+
+        const DIM: usize = 64;
+        const N: usize = 400;
+        const K: usize = 10;
+        let corpus: Vec<Vec<f32>> = (0..N)
+            .map(|i| {
+                (0..DIM)
+                    .map(|d| (((i * 131 + d * 17) % 251) as f32) * 0.01)
+                    .collect()
+            })
+            .collect();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| rec_with_partition(i, v.clone()))
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        write_pax_segment(
+            &path,
+            &records,
+            "col",
+            1,
+            VectorQuant::RaBitQ,
+            Some(16 * 1024),
+        )
+        .unwrap();
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let p = path.to_str().unwrap();
+
+        let filter = partition_filter("p3");
+        let (allow, _) = pax_filtered_row_allow(&fs, p, &filter)
+            .await
+            .unwrap()
+            .expect("stage-F allow-set");
+        let query = corpus[137].clone();
+        let hits = rabitq_search_segment_coalesced_allowed(
+            &fs,
+            p,
+            &query,
+            K,
+            RankMetric::L2,
+            None,
+            None,
+            Some(&allow),
+        )
+        .await
+        .unwrap()
+        .expect("restricted cascade returns hits");
+        assert!(!hits.is_empty());
+
+        // Every hit satisfies the predicate (row-accurate restriction).
+        for h in &hits {
+            let i: usize = h.oid.trim_start_matches('r').parse().unwrap();
+            assert_eq!(i % 8, 3, "hit {} violates the filter", h.oid);
+        }
+
+        // Recall vs the FILTERED brute-force ground truth.
+        let l2 =
+            |a: &[f32], b: &[f32]| a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum::<f32>();
+        let mut matching: Vec<usize> = (0..N).filter(|i| i % 8 == 3).collect();
+        matching.sort_by(|&a, &b| {
+            l2(&corpus[a], &query)
+                .partial_cmp(&l2(&corpus[b], &query))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let truth: std::collections::HashSet<String> =
+            matching.iter().take(K).map(|i| format!("r{i}")).collect();
+        let got: std::collections::HashSet<String> = hits.iter().map(|h| h.oid.clone()).collect();
+        let recall = truth.iter().filter(|o| got.contains(*o)).count() as f32 / K as f32;
+        assert!(
+            recall >= 0.90,
+            "filtered cascade recall@{K} = {recall:.2} vs filtered brute force"
+        );
+
+        // An empty allow-set yields an empty result (not an error).
+        let empty = proximadb_block_format::RowAllow::new(N);
+        let none_hits = rabitq_search_segment_coalesced_allowed(
+            &fs,
+            p,
+            &query,
+            K,
+            RankMetric::L2,
+            None,
+            None,
+            Some(&empty),
+        )
+        .await
+        .unwrap()
+        .expect("cascade runs");
+        assert!(none_hits.is_empty());
+    }
+
+    /// ADR-089 P1: the filter-aware cascade is DEFAULT-OFF (mixed-read-safe).
+    #[test]
+    fn filtered_cascade_gate_defaults_off() {
+        // The suite never sets the gate env, so the default must hold here.
+        assert!(!pax_filtered_cascade_enabled());
+    }
+
+    /// ADR-089 / TD-FPRUNE-1 P1 EVIDENCE HARNESS (engine-level A/B on a real
+    /// segment). Not part of the suite — run explicitly, in release, for the
+    /// before/after timing that gates the phase:
+    ///
+    /// ```text
+    /// cargo test --release -p proximadb --lib -- --ignored p1_evidence --nocapture
+    /// ```
+    ///
+    /// A = today's filtered path over a flushed segment: whole-object read +
+    ///     `read_segment_records` (decode ALL rows) + per-record
+    ///     `evaluate_filter_proxima` + exact scoring of survivors.
+    /// B = P1: Stage-F row allow-set + row-restricted RaBitQ/SQ8 cascade.
+    ///
+    /// Engine-level by design: the end-to-end server path cannot serve segments
+    /// for REST-created collections until the TD-FLUSH-8 catalog-identity skip
+    /// is fixed, and this seam is exactly what ADR-089 P1 changes.
+    #[tokio::test]
+    #[ignore = "evidence harness — run explicitly in release for timing"]
+    async fn p1_evidence_filtered_exact_vs_cascade() {
+        enable_coalesced_rabitq();
+        use crate::storage::persistence::filesystem::local::{LocalConfig, LocalFileSystem};
+        use std::time::Instant;
+
+        const DIM: usize = 128;
+        const N: usize = 80_000;
+        const K: usize = 10;
+        const QUERIES: usize = 15;
+
+        let corpus: Vec<Vec<f32>> = (0..N)
+            .map(|i| {
+                (0..DIM)
+                    .map(|d| (((i * 131 + d * 17) % 251) as f32) * 0.01)
+                    .collect()
+            })
+            .collect();
+        let records: Vec<ProximaRecord> = corpus
+            .iter()
+            .enumerate()
+            .map(|(i, v)| rec_with_partition(i, v.clone()))
+            .collect();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.pax");
+        write_pax_segment(&path, &records, "col", 1, VectorQuant::RaBitQ, None).unwrap();
+        let seg_bytes = std::fs::metadata(&path).unwrap().len();
+        let fs = LocalFileSystem::new_with_encryption(LocalConfig::default(), None)
+            .await
+            .unwrap();
+        let p = path.to_str().unwrap();
+        let filter = partition_filter("p3");
+
+        // --- A: exact-path emulation (mirrors search_pax_file_exact's shape).
+        let mut a_times = Vec::new();
+        for q in 0..QUERIES {
+            let query = &corpus[(q * 5119) % N];
+            let t = Instant::now();
+            let bytes = std::fs::read(&path).unwrap();
+            let recs = read_segment_records(&bytes, &[], &[], None).unwrap();
+            let mut scored: Vec<(f32, &ProximaRecord)> = recs
+                .iter()
+                .filter(|r| {
+                    crate::core::search::sql_value_filter::evaluate_filter_proxima(
+                        &filter, &r.props,
+                    )
+                })
+                .filter_map(|r| {
+                    r.embeddings.first().map(|e| {
+                        let v = e.as_fp32_slice();
+                        let d: f32 = v.iter().zip(query).map(|(x, y)| (x - y) * (x - y)).sum();
+                        (d, r)
+                    })
+                })
+                .collect();
+            scored.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+            scored.truncate(K);
+            a_times.push(t.elapsed());
+            assert!(!scored.is_empty());
+        }
+
+        // --- B: P1 Stage-F + restricted cascade (allow-set rebuilt per query,
+        //     the worst case — a per-(segment, filter) cache is a P2 lever).
+        let mut b_times = Vec::new();
+        for q in 0..QUERIES {
+            let query = &corpus[(q * 5119) % N];
+            let t = Instant::now();
+            let (allow, _stats) = pax_filtered_row_allow(&fs, p, &filter)
+                .await
+                .unwrap()
+                .expect("stage-F allow-set");
+            let hits = rabitq_search_segment_coalesced_allowed(
+                &fs,
+                p,
+                query,
+                K,
+                RankMetric::L2,
+                None,
+                None,
+                Some(&allow),
+            )
+            .await
+            .unwrap()
+            .expect("restricted cascade");
+            b_times.push(t.elapsed());
+            assert!(!hits.is_empty());
+            for h in &hits {
+                let i: usize = h.oid.trim_start_matches('r').parse().unwrap();
+                assert_eq!(i % 8, 3);
+            }
+        }
+
+        let ms = |d: &std::time::Duration| d.as_secs_f64() * 1e3;
+        let mean = |v: &[std::time::Duration]| {
+            ms(&(v.iter().sum::<std::time::Duration>())) / v.len() as f64
+        };
+        let min = |v: &[std::time::Duration]| v.iter().map(ms).fold(f64::INFINITY, f64::min);
+        println!(
+            "P1 EVIDENCE  N={N} dim={DIM} K={K} queries={QUERIES} segment={:.1}MB",
+            seg_bytes as f64 / 1e6
+        );
+        println!(
+            "  A exact whole-object : mean={:.2}ms  min={:.2}ms",
+            mean(&a_times),
+            min(&a_times)
+        );
+        println!(
+            "  B stage-F + cascade  : mean={:.2}ms  min={:.2}ms",
+            mean(&b_times),
+            min(&b_times)
+        );
+        println!("  speedup: {:.1}x (mean)", mean(&a_times) / mean(&b_times));
     }
 
     /// TD-CACHE-1 S1: `prefetch_segment_invariants` warms the CONTROL plane


### PR DESCRIPTION
Implements **TD-FPRUNE-1 P1** — the first slice of ADR-089's filter-aware cascade. Filtered PAX vector queries stop being whole-object brute-force scans.

## The change (default-OFF: `PROXIMADB_PAX_FILTERED_CASCADE=1`)
Today, any filtered vector query on a `.pax` segment declines the coalesced cascade (`search/mod.rs:420`, "UNFILTERED only") and falls to `search_pax_file_exact`: **read the whole object, decode every record, filter per-record, exact-score survivors**. P1 instead:
1. **Stage F** (`pax_filtered_row_allow`): header + footer → coalesced Region-D block fetch → conservative `evaluate_block` stats prune (skips *decode*; fetch-pruning via footer stats is P2) → **row-accurate** `evaluate_filter_proxima` per row (the *same* evaluator the exact path uses — identical match semantics by construction) → a `RowAllow` bitset over global row ordinals.
2. **Restricted cascade** (`rabitq_search_segment_coalesced_allowed`): RaBitQ/SQ8 rank **only allowed rows** (`rank_allowed` / `rank_probed_rows_allowed`), pool sized on the allowed count. Restricting *inside* the rank is what preserves filtered recall (post-filtering the pool would silently lose it).
3. Fail-safe: any Stage-F failure or non-coalesced segment falls back to the exact path; a provably-empty allow-set short-circuits to an empty per-file result. Unfiltered path untouched. Geometric A0 probe is bypassed under a filter (probe∩filter is P3).

## Evidence (engine A/B, real 22.7 MB / 80k-row / dim-128 segment, filter = 1-of-8 partition)
| Path | mean | min |
|---|---|---|
| A — exact whole-object (today) | 113.2 ms | 102.5 ms |
| B — Stage-F + restricted cascade (P1) | **33.5 ms** | 32.8 ms |
| | **3.4× faster** | |

Filtered recall held vs a filtered brute-force ground truth. Run: `cargo test --release -p proximadb --lib -- --ignored p1_evidence --nocapture`. (Engine-level A/B by necessity — see TD-FLUSH-8 below.)

## TDD
- block-format: `RowAllow` bitset (insert/contains/any_in_range across word boundaries); `rank_allowed` == filtered full rank; `rank_probed_rows_allowed` == filtered probed rank; `None` preserves original. **76/76**.
- engine: Stage-F allow-set == filter-matching rows vs an *independent* block decode (exact, cross-block ordinals); filtered cascade recall vs filtered brute force + every hit satisfies the predicate; empty-set semantics; gate default-off. **All green.**
- fmt / clippy (`--lib --bins -D warnings`) / TD-ADR-unique / work-commit-check / env-gate registry (232) — all pass.

## Also files TD-FLUSH-8 (a real product bug found while gathering evidence)
ADR-069 auto-flush skips collections it can't resolve in the catalog (`no catalog metadata for '1'`), so **REST-created collections never flush** — the PAX serving tier is dark end-to-end from the public API, and prior corridor measurements (incl. the 38× filtered baseline) were *memtable-scan* measurements. Per owner direction, the TD encodes the correct invariant: **the catalog is the identity authority — `WAL key ⇒ catalog-resolvable` always; fix the seam, fail loud, no catalog-less fallbacks, and fixtures/harnesses must register via the real catalog.** This is why P1's evidence is engine-level; end-to-end re-measurement is gated on TD-FLUSH-8.

## Scope / next
P1 residual (this arc): arm P-Shred for `filterable` schema columns (user tags are opaque PROPS msgpack — stats pruning currently helps only canonical columns; row accuracy holds via the per-row eval regardless) + D-resolve residual check (defense-in-depth). Then P2 (footer StatsKind → zero-GET pruning), P3 (per-cell stats ∩ probe), P4 (selectivity policy) per TD-FPRUNE-1.