### PR TITLE
refactor(decomp): extract key_store → existing security crate (TD-DECOMP-31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6708,6 +6708,7 @@ dependencies = [
  "proximadb-cache",
  "proximadb-catalog",
  "proximadb-catalog-introspection",
+ "proximadb-catapult",
  "proximadb-cdc",
  "proximadb-cks-local",
  "proximadb-clustering-kernel",
@@ -8320,10 +8321,13 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "proximadb-kernel",
+ "ring",
  "serde",
  "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/crates/horizontal/proximadb-security/Cargo.toml
+++ b/crates/horizontal/proximadb-security/Cargo.toml
@@ -20,3 +20,6 @@ async-trait.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+ring = "0.17"
+base64 = "0.22"
+thiserror.workspace = true

--- a/crates/horizontal/proximadb-security/src/key_store.rs
+++ b/crates/horizontal/proximadb-security/src/key_store.rs
@@ -140,7 +140,7 @@ impl EncryptionKey {
     }
 
     /// Create an AEAD key for encryption/decryption
-    pub(crate) fn to_aead_key(&self) -> Result<LessSafeKey, KeyStoreError> {
+    pub fn to_aead_key(&self) -> Result<LessSafeKey, KeyStoreError> {
         let unbound = UnboundKey::new(&AES_256_GCM, &self.key_material)
             .map_err(|_| KeyStoreError::InvalidKeyMaterial("Failed to create AEAD key".into()))?;
         Ok(LessSafeKey::new(unbound))

--- a/crates/horizontal/proximadb-security/src/lib.rs
+++ b/crates/horizontal/proximadb-security/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod audit;
 pub mod audit_config;
 pub mod audit_storage;
+pub mod key_store;
 
 pub use audit::{
     AuditEvent, AuditEventType, AuditResource, AuditResult, SecurityAlert, SecurityAlertSeverity,

--- a/docs/10-quality/td/TD-DECOMP-31-extract-key-store.adoc
+++ b/docs/10-quality/td/TD-DECOMP-31-extract-key-store.adoc
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-31: Extract key_store → existing proximadb-security crate (horizontal)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export into existing crate (NO new crate)
+| Component | `crates/horizontal/proximadb-security`; root `src/security/encryption/mod.rs`
+| Relates to | [[TD-DECOMP-1]] (recipe)
+|===
+
+== Why
+
+`src/security/encryption/key_store.rs` (**11 tests**) is the encryption key store (ring AES-256-GCM
+key management: `KeyStore`, `KeyInfo`, `KeyStoreConfig`, `KeyStoreError`). Clean leaf: zero `crate::`
+climb-out, deps anyhow/chrono/ring/serde/thiserror. Moves into the **existing** `proximadb-security`
+crate (the natural home — already has anyhow/chrono/serde; ring + thiserror added). No new crate.
+
+== What moved (behavior-neutral)
+
+* `src/security/encryption/key_store.rs` → `crates/horizontal/proximadb-security/src/key_store.rs`.
+* Root `src/security/encryption/mod.rs`: `pub mod key_store;` → `pub use proximadb_security::key_store;`.
+* Security crate gains ring + thiserror deps. Root Cargo.toml **unchanged** (root already depends on
+  proximadb-security). **Zero root Cargo.tomlo changes** — simplest extraction yet.
+* No `CAPABILITY_MATRIX.toml` pointer.
+
+== Follow-ups
+
+* **Running total once merged: ~981 tests out of root** (970 + 11).
+* Standalone crate `--all-targets` compiled in ~11s with `RUSTC_WRAPPER=sccache`.
+* Pattern: extracting into an EXISTING crate (no new crate, no root Cargo.tomlo changes) is the lowest-
+  effort extraction when the module fits an existing crate's deps + semantics.

--- a/src/security/encryption/mod.rs
+++ b/src/security/encryption/mod.rs
@@ -12,7 +12,7 @@
 //! - Integration with UnifiedCachingFilesystem
 
 pub mod field_encryption;
-pub mod key_store;
+pub use proximadb_security::key_store;
 
 pub use field_encryption::{
     EncryptedField, EncryptionConfig, EncryptionType, FieldEncryption, FieldEncryptionError,


### PR DESCRIPTION
Moves src/security/encryption/key_store.rs (ring AES-256-GCM key management, 11 tests) into the EXISTING proximadb-security crate (no new crate, zero root Cargo.toml changes). Root encryption/mod.rs re-exports it. Verified: standalone --all-targets EXIT 0 in ~11s. Running total once merged: ~981 tests. See TD-DECOMP-31.