### PR TITLE
fix(flush): catalog-authoritative collection resolution at the auto-flush boundary (TD-FLUSH-8)

### DIFF
--- a/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
+++ b/crates/control/proximadb-metrics/src/wal_flush_metrics.rs
@@ -102,6 +102,11 @@ lazy_static! {
         "Count of write-backpressure engagements at the critical watermark, per collection (ADR-069 D3)",
         &["collection"],
     );
+    static ref FLUSH_CATALOG_UNRESOLVED_TOTAL: IntCounterVec = build_counter(
+        "proximadb_wal_flush_catalog_unresolved_total",
+        "Auto-flush ticks that could not resolve a WAL collection id in the catalog (TD-FLUSH-8: identity-invariant violation — the flush is skipped and the unflushed window keeps growing)",
+        &["collection"],
+    );
     static ref FLUSH_ADMISSION_TOTAL: IntCounterVec = build_counter(
         "proximadb_wal_flush_admission_total",
         "Flush pre-materialization admission verdicts (ADR-081)",
@@ -290,6 +295,15 @@ pub fn set_backpressure_active(collection: &str, active: bool) {
 /// Count a backpressure engagement (paired with `set_backpressure_active(.., true)`).
 pub fn inc_backpressure(collection: &str) {
     BACKPRESSURE_TOTAL.with_label_values(&[collection]).inc();
+}
+
+/// Count an auto-flush tick that could not resolve a WAL collection id in the
+/// catalog (TD-FLUSH-8). A non-zero rate on this counter is a durability
+/// incident signal: the collection's unflushed window can grow without bound.
+pub fn inc_catalog_unresolved(collection: &str) {
+    FLUSH_CATALOG_UNRESOLVED_TOTAL
+        .with_label_values(&[collection])
+        .inc();
 }
 
 /// Record an engine admission verdict before source records are materialized.

--- a/docs/10-quality/td/TD-FLUSH-8-auto-flush-catalog-identity-skip.adoc
+++ b/docs/10-quality/td/TD-FLUSH-8-auto-flush-catalog-identity-skip.adoc
@@ -1,73 +1,100 @@
 // Copyright (C) 2025 ProximaDB
 // SPDX-License-Identifier: Apache-2.0
-= TD-FLUSH-8: auto-flush skips WAL collections it cannot resolve in the catalog — REST-created collections never reach PAX
-:status: Open
+= TD-FLUSH-8: auto-flush driver's catalog list was weaker than the write path — periodic (RPO) flushes skipped for resolvable collections
+:status: Fixed (driver seam); e2e regression harness follow-up open
 :dim: D3/D5
 :pillar: REL
 
-Problem (found by the ADR-089 P1 evidence run, 2026-08-06): with the flush
-envelope armed (`memory_flush_size_bytes = 2 MiB`, `flush_floor_predicted_mb =
-0`, `flush_interval_secs = 5`, hermetic storage roots), a REST-v2-created
-collection ingesting ~20k-80k vectors NEVER flushes. The ADR-069 auto-flush
-driver ticks, the size/time triggers fire, and then every cycle logs:
+Problem (found by the ADR-089 P1 evidence run, 2026-08-06): the ADR-069
+auto-flush driver's periodic tick logged, every cycle, for a REST-v2-created
+collection with unflushed data:
 
   WARN ⚠️ ADR-069 auto-flush: no catalog metadata for '1', skipping
   WARN ⚠️ STORAGE_ENGINE: 1 collections failed to flush: [("1", "no catalog metadata")]
 
-Mechanism: the WAL write buffer lists unflushed collections by the id the write
-path keyed the memtable with — here the literal string `'1'` — while
-`list_collections_from_catalog`
-(`src/storage/persistence/write_ahead_log/mod.rs:1097`) walks the **default
-catalog's** namespaces/tables and returns collections whose `.id` is the
-catalog identity. The driver's lookup
-(`src/storage/auto_flush_driver.rs:157`, `catalog.iter().find(|c| &c.id ==
-collection_id)`) never matches, so the flush is skipped **forever** — the
-memtable grows, and every read stays on the WAL/memtable scan path.
+== Corrected diagnosis (2026-08-06, traced + reproduced)
 
-This is an ADR-0083-class identity seam ("two identity systems disagree" — the
-same failure family as the #1325 flush-plan regression): the WAL keys one id
-form, the catalog another, and the flush boundary is where they meet.
+The original filing over-claimed "REST-created collections never reach PAX".
+Empirical repro corrected this:
 
-Consequences:
-* The PAX serving tier (coalesced cascade, ADR-062/065; filter-aware cascade,
-  ADR-089) is **dark end-to-end** for this surface — segments are never
-  produced, so segment-path work cannot be exercised from the public API.
-* All context-corridor benchmark measurements to date (TD-CTXCORR-1, including
-  the 38x filtered-search baseline) were **memtable-scan measurements**, not
-  segment-path measurements. The competitive gap is real but its mechanism is
-  the WAL exact scan, with the segment exact scan measured separately at the
-  engine level (see ADR-089 P1 evidence harness).
-* Durability/RPO: collections in this state accumulate unbounded unflushed
-  windows (the ADR-069 time floor cannot drain them).
+* **The INLINE size-flush path works.** With the size trigger armed, REST-v2
+  ingest flushes fine (`✅ inline size-flush '1': 6000 entries` → real `.pax`
+  under `…/d3/1/data/L0_*.pax`) and compaction runs (L0/L2/L3 observed at 80k).
+  The earlier "0 segments" observation was the corridor benchmark deleting its
+  per-run collection in `close()`.
+* **Both sides use the SAME id form** — the ADR-031 decimal `object_id` string
+  (`"1"`): the memtable key (`wal_behavior.rs:391` via
+  `legacy.rs:2422-2425` / `:847-856`) and the catalog's `collection.id`
+  property (`collection_mapping.rs:158`, written at `:569`, minted at
+  `manager.rs:1053/2464`). No form divergence.
+* **The real bug: the driver's catalog list was strictly weaker than the write
+  path's.** The driver used the free function `list_collections_from_catalog`
+  (`write_ahead_log/mod.rs`), whose namespace walk relied solely on
+  `list_namespaces(None)`. The write path's `read_collections_from_catalog`
+  (`manager.rs:2592-2601`) ALWAYS includes `["default"]` even when the listing
+  omits it, and the write path's resolver additionally has a `resolve_table`
+  fast-path. So in any namespace-listing gap (reload/visibility), a collection
+  that resolves on INSERT was invisible to the driver's `find` → the periodic
+  (time/RPO and capacity) flush was skipped forever for it, WARN-spamming per
+  tick, while the unflushed window grew without bound.
 
-Direction (owner, 2026-08-06): **the catalog is the identity authority.** A
-collection that exists MUST be resolvable in the catalog — there is no
-legitimate "catalog-less collection" state, so the fix is proper catalog
-integration at the flush boundary, NOT tolerating unresolvable collections
-(no fallback flush plans for unknown ids, no bypass registration in tests).
+Still an ADR-0083-class identity-seam bug — but the disagreement is between two
+catalog *read paths*, not two id systems.
 
-Next actions:
-1. Find where the write path derives the WAL collection key (`'1'`) for
-   REST-v2 collections and make the WAL key on the **catalog identity**
-   (ADR-0083: ONE identity, the composite) — or make the flush boundary
-   resolve through the catalog by the same canonical form. The invariant to
-   restore: `WAL key ⇒ catalog-resolvable`, always. If the REST create path
-   is registering the collection under a different catalog (tenant vs default)
-   than `list_collections_from_catalog` walks, fix the walk to be the real
-   catalog surface — the collection IS in the catalog; the lookup must reach it.
-2. Fail loud, not skip-forever: an unflushable-because-unresolvable collection
-   is an identity-invariant violation (durability incident) — escalate
-   (metric + rate-limited error), never spin silently at WARN per tick.
-3. Regression test through the REAL catalog path: REST-create (proper catalog
-   registration) → ingest past the size trigger → assert a `.pax` segment
-   exists under the collection's `DrPathBuilder` path. Test fixtures and
-   benchmark harnesses must create collections via the catalog like
-   production does — no catalog-less shortcuts that mask this class of bug.
-4. Re-run the corridor benchmark end-to-end once fixed, so the segment-path
-   filtered cascade (ADR-089 P1) is measurable from the public API
-   (TD-FPRUNE-1 evidence gate).
+== Direction (owner, 2026-08-06)
+
+**The catalog is the identity authority.** A collection that exists MUST be
+catalog-resolvable; fix the seam so the flush boundary reaches the collection
+that IS in the catalog. No catalog-less fallbacks, and test fixtures/harnesses
+must register collections through the real catalog path like production.
+
+== Fix (this TD's PR)
+
+1. **Shared namespace walk** (`catalog_default_namespaces`,
+   `write_ahead_log/mod.rs`): both flush-side free functions
+   (`list_collections_from_catalog` via `collections_from_catalog_walk`, and
+   `resolve_collection_from_catalog`'s scan fallback) now enumerate namespaces
+   exactly like the write path — `list_namespaces(None)` PLUS a guaranteed
+   `["default"]` — and the list dedups by id. The two paths can no longer
+   disagree on the default namespace.
+2. **Per-id resolve fallback in the driver** (`auto_flush_driver.rs`): on a
+   bulk-list miss, the driver now calls `resolve_collection_from_catalog`
+   (which also has the `resolve_table` fast-path the write path trusts) before
+   declaring the collection unresolvable.
+3. **Fail loud, not skip-forever**: when BOTH miss, the driver now emits
+   `proximadb_wal_flush_catalog_unresolved_total{collection}` and a
+   rate-visible `tracing::error!` — an unresolvable WAL id is an
+   identity-invariant violation (durability incident: the unflushed window
+   grows without bound), not a per-tick WARN curiosity.
+4. **Regression tests at the exact seam**
+   (`td_flush_8_catalog_walk_tests`): a mock catalog reproducing the gap shape
+   (table registered under `["default"]` while `list_namespaces(None)` omits
+   it) asserts the walk still includes `["default"]` and that the flush-side
+   list finds the collection id the WAL keys on.
+
+== Remaining follow-up
+
+* End-to-end regression harness through the REAL catalog + driver tick:
+  REST-create → ingest below the size trigger → let the TIME (RPO) trigger
+  fire → assert a `.pax` segment exists under the collection's
+  `DrPathBuilder` path (no `force_flush`/`materialize_collection` shortcuts —
+  existing tests use those entry points and masked this bug; no
+  `AutoFlushDriver::tick` test existed at all).
+* Sweep other callers of the free functions (recovery_manager.rs:451,
+  database.rs:847) for the same weaker-walk assumption — they now inherit the
+  fixed walk automatically, but their skip-handling should be reviewed for the
+  same fail-loud treatment.
+
+Consequences (corrected):
+* The PAX serving tier was NEVER fully dark — inline size-flushes produce
+  segments. What was broken: periodic/RPO flushes for collections caught in a
+  namespace-listing gap, plus low-traffic collections that never hit the size
+  target (they rely on the time floor the driver owns).
+* Corridor benchmark measurements: runs whose ingest crossed the size trigger
+  DID exercise segments; the ADR-089 P1 end-to-end A/B on a persistent 80k
+  collection measured filtered p50 128 ms (gate OFF, exact path) → 63 ms
+  (gate ON, filter-aware cascade) through the public REST API.
 
 Refs: ADR-069 (flush decision boundary), ADR-0083 (consolidated identity),
-ADR-089 / TD-FPRUNE-1 (blocked evidence), TD-FLUSH-2 (small corpora never
-flush — the *threshold* face of the same "never flushes" symptom; this TD is
-the *identity* face).
+ADR-089 / TD-FPRUNE-1 (evidence + the P1 cascade this unblocked),
+TD-FLUSH-2 (threshold face of "never flushes"; this TD is the identity face).

--- a/src/storage/auto_flush_driver.rs
+++ b/src/storage/auto_flush_driver.rs
@@ -153,10 +153,30 @@ impl AutoFlushDriver {
                 wal_flush_metrics::inc_backpressure(collection_id);
             }
 
-            let Some(meta) = catalog.iter().find(|c| &c.id == collection_id) else {
-                tracing::warn!(
-                    "⚠️ ADR-069 auto-flush: no catalog metadata for '{}', skipping",
-                    collection_id
+            // TD-FLUSH-8: the catalog is the identity authority — a WAL id MUST
+            // be catalog-resolvable. The bulk list (now `["default"]`-fallback
+            // aware) is the fast path; on a miss, fall back to the per-id
+            // resolver, which additionally has the `resolve_table` fast-path
+            // the write path trusts. Only when BOTH miss is the invariant
+            // violated — escalate loudly (metric + error) instead of spinning
+            // silently at WARN: a permanently unflushable collection is a
+            // durability incident (its unflushed window grows without bound).
+            let resolved_fallback = match catalog.iter().find(|c| &c.id == collection_id) {
+                Some(meta) => Some(meta.clone()),
+                None => {
+                    crate::storage::persistence::write_ahead_log::resolve_collection_from_catalog(
+                        collection_id,
+                    )
+                    .await
+                }
+            };
+            let Some(meta) = resolved_fallback.as_ref() else {
+                wal_flush_metrics::inc_catalog_unresolved(collection_id);
+                tracing::error!(
+                    collection_id,
+                    "🚨 ADR-069/TD-FLUSH-8 auto-flush: WAL collection id is NOT \
+                     catalog-resolvable (identity-invariant violation) — flush \
+                     skipped; unflushed window keeps growing"
                 );
                 continue;
             };

--- a/src/storage/persistence/write_ahead_log/mod.rs
+++ b/src/storage/persistence/write_ahead_log/mod.rs
@@ -1062,11 +1062,13 @@ pub(crate) async fn resolve_collection_from_catalog(
         return Some(collection);
     }
 
-    // Fallback: the identifier is an opaque collection id (UUID). Scan the
-    // catalog and match by id or name.
+    // Fallback: the identifier is an opaque collection id. Scan the catalog and
+    // match by id or name. TD-FLUSH-8: use the `["default"]`-guaranteed namespace
+    // walk so this agrees with the write path even when `list_namespaces(None)`
+    // omits `["default"]`.
     let catalog = catalog_manager.default_catalog().await.ok()?;
-    for namespace in catalog.list_namespaces(None).await.ok()? {
-        let Ok(table_ids) = catalog.list_tables(&namespace.levels).await else {
+    for namespace in catalog_default_namespaces(catalog.as_ref()).await {
+        let Ok(table_ids) = catalog.list_tables(&namespace).await else {
             continue;
         };
         for table_id in table_ids {
@@ -1102,12 +1104,25 @@ pub(crate) async fn list_collections_from_catalog() -> Vec<crate::proto::proxima
     let Ok(catalog) = catalog_manager.default_catalog().await else {
         return Vec::new();
     };
+    collections_from_catalog_walk(catalog.as_ref()).await
+}
+
+/// TD-FLUSH-8: the catalog walk behind [`list_collections_from_catalog`],
+/// factored over `&dyn Catalog` so the flush-side listing is testable without
+/// global state. Enumerates namespaces the SAME way the write path's
+/// `read_collections_from_catalog` does — always including `["default"]`, even
+/// when `list_namespaces(None)` omits it (a reload/visibility gap) — and dedups
+/// by id. Without the fallback this walk was strictly weaker than the write
+/// path: a collection that resolved on INSERT was invisible to the auto-flush
+/// driver (`no catalog metadata for '1'`), so time-triggered (RPO) flushes for
+/// it never fired. The catalog is the identity authority; both paths must agree.
+async fn collections_from_catalog_walk(
+    catalog: &dyn proximadb_catalog::Catalog,
+) -> Vec<crate::proto::proximadb_v1::Collection> {
     let mut collections = Vec::new();
-    let Ok(namespaces) = catalog.list_namespaces(None).await else {
-        return collections;
-    };
-    for namespace in namespaces {
-        let Ok(table_ids) = catalog.list_tables(&namespace.levels).await else {
+    let mut seen_ids = std::collections::HashSet::new();
+    for namespace in catalog_default_namespaces(catalog).await {
+        let Ok(table_ids) = catalog.list_tables(&namespace).await else {
             continue;
         };
         for table_id in table_ids {
@@ -1118,12 +1133,32 @@ pub(crate) async fn list_collections_from_catalog() -> Vec<crate::proto::proxima
                 crate::storage::metadata::collection_mapping::collection_from_catalog_schema(
                     &table_id, &schema,
                 )
+                && seen_ids.insert(collection.id.clone())
             {
                 collections.push(collection);
             }
         }
     }
     collections
+}
+
+/// TD-FLUSH-8: the namespaces to walk when the catalog is the authority for the
+/// full collection set — every namespace `list_namespaces(None)` reports, plus a
+/// guaranteed `["default"]` even when the listing omits it (mirrors the write
+/// path's `read_collections_from_catalog`, `manager.rs:2592-2601`). Shared by the
+/// list + resolve free functions so they can never disagree with the write path.
+async fn catalog_default_namespaces(catalog: &dyn proximadb_catalog::Catalog) -> Vec<Vec<String>> {
+    let mut namespaces: Vec<Vec<String>> = catalog
+        .list_namespaces(None)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|namespace| namespace.levels)
+        .collect();
+    if !namespaces.iter().any(|namespace| namespace == &["default"]) {
+        namespaces.push(vec!["default".to_string()]);
+    }
+    namespaces
 }
 
 /// Get the global write buffer behavior singleton if it has been initialized
@@ -3951,5 +3986,108 @@ mod optimization_validation_tests {
         debug!("   Batch hint: {:?}", context.batch_size_hint);
         debug!("   Priority: {:?}", context.priority);
         debug!("🎉 Context contains all required metadata for background operations!");
+    }
+}
+
+#[cfg(test)]
+mod td_flush_8_catalog_walk_tests {
+    use super::{catalog_default_namespaces, collections_from_catalog_walk};
+    use proximadb_catalog::{Catalog, CatalogTableSchema, TableIdentifier};
+
+    /// Build the exact production gap shape (TD-FLUSH-8): a collection table
+    /// registered under `["default"]` while `list_namespaces(None)` does NOT
+    /// report the `default` namespace (here: the mock's configured database is
+    /// `other`, and `create_table` — like a reload/visibility gap — does not
+    /// re-register the namespace).
+    async fn catalog_with_unlisted_default_collection() -> proximadb_catalog::hive::HiveCatalog {
+        let cache = std::sync::Arc::new(proximadb_catalog::cache::CatalogCache::new(16, 60));
+        let config = proximadb_catalog::hive::HiveCatalogConfig {
+            database: "other".to_string(),
+            ..Default::default()
+        };
+        let catalog = proximadb_catalog::hive::HiveCatalog::new("t".to_string(), config, cache)
+            .await
+            .expect("mock hive catalog");
+
+        let mut schema = CatalogTableSchema {
+            name: "diag_coll".to_string(),
+            // `validate_schema` requires at least one column.
+            columns: vec![proximadb_catalog::CatalogColumn {
+                id: 1,
+                object_id: None,
+                name: "oid".to_string(),
+                data_type: proximadb_data_model::ProximaType::String,
+                nullable: false,
+                default_value: None,
+                comment: None,
+                properties: Default::default(),
+                is_deleted: false,
+                original_id: None,
+            }],
+            ..Default::default()
+        };
+        schema
+            .properties
+            .insert("asset.kind".to_string(), "collection".to_string());
+        schema
+            .properties
+            .insert("collection.id".to_string(), "1".to_string());
+        schema
+            .properties
+            .insert("collection.name".to_string(), "diag_coll".to_string());
+        let table_id = TableIdentifier::new(vec!["default".to_string()], "diag_coll");
+        catalog
+            .create_table(&table_id, schema)
+            .await
+            .expect("register collection table under default");
+        catalog
+    }
+
+    /// The namespace walk must ALWAYS include `["default"]`, mirroring the
+    /// write path's `read_collections_from_catalog` — this is the mechanism
+    /// that keeps the flush-side listing in agreement with the write path.
+    #[tokio::test]
+    async fn namespace_walk_always_includes_default() {
+        let catalog = catalog_with_unlisted_default_collection().await;
+
+        // Precondition: the fixture really reproduces the gap — the namespace
+        // listing omits `default` while the table under it is resolvable.
+        let listed: Vec<Vec<String>> = catalog
+            .list_namespaces(None)
+            .await
+            .expect("list namespaces")
+            .into_iter()
+            .map(|namespace| namespace.levels)
+            .collect();
+        assert!(
+            !listed.iter().any(|namespace| namespace == &["default"]),
+            "fixture must omit the default namespace from the listing, got {listed:?}"
+        );
+
+        let walked = catalog_default_namespaces(&catalog).await;
+        assert!(
+            walked.iter().any(|namespace| namespace == &["default"]),
+            "the walk must include [\"default\"] even when the listing omits it"
+        );
+    }
+
+    /// TD-FLUSH-8 regression: the flush-side catalog list must find a
+    /// collection whose namespace is missing from `list_namespaces` — the
+    /// exact state where the auto-flush driver previously logged
+    /// `no catalog metadata for '1'` every tick and never flushed (while the
+    /// write path resolved the same collection fine).
+    #[tokio::test]
+    async fn flush_side_list_finds_collection_in_unlisted_default_namespace() {
+        let catalog = catalog_with_unlisted_default_collection().await;
+
+        let collections = collections_from_catalog_walk(&catalog).await;
+        assert!(
+            collections.iter().any(|collection| collection.id == "1"),
+            "the WAL id '1' must be catalog-resolvable by the flush-side walk; got ids {:?}",
+            collections
+                .iter()
+                .map(|collection| collection.id.clone())
+                .collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
Stacked on #1520 (P1 filter-aware cascade, which files TD-FLUSH-8). Auto-merge OFF until the base merges; after #1520 lands this retargets to develop.

## The bug (corrected diagnosis, traced + reproduced)
The ADR-069 auto-flush driver's periodic tick skipped REST-created collections forever (`no catalog metadata for '1'` every tick) while the write path resolved the same collection fine. Root cause is NOT an id-form mismatch — both sides key the ADR-031 decimal id (`"1"`). **The driver's catalog list was strictly weaker than the write path's**: `list_collections_from_catalog` relied solely on `list_namespaces(None)`, while the write path's `read_collections_from_catalog` always includes `["default"]` even when the listing omits it (and its resolver adds a `resolve_table` fast-path). Any namespace-listing gap ⇒ periodic/RPO flush skipped forever, unflushed window grows unbounded. (Inline size-flush was never broken — it produces real `.pax` segments; empirically confirmed.)

## The fix (catalog is the identity authority — owner direction: no catalog-less fallbacks)
1. **Shared `catalog_default_namespaces` walk**: flush-side list (`collections_from_catalog_walk`) + `resolve_collection_from_catalog`'s scan now enumerate namespaces exactly like the write path (guaranteed `["default"]`, dedup by id) — the two catalog read paths can no longer disagree.
2. **Driver per-id resolve fallback**: bulk-list miss → `resolve_collection_from_catalog` (with the `resolve_table` fast-path) before declaring unresolvable.
3. **Fail loud, not skip-forever**: new `proximadb_wal_flush_catalog_unresolved_total{collection}` counter + `tracing::error!` — an unresolvable WAL id is an identity-invariant violation (durability incident), not per-tick WARN spam.
4. **Regression tests at the exact seam** (`td_flush_8_catalog_walk_tests`, 2/2 green): a mock catalog reproducing the production gap shape (collection table under `["default"]` while `list_namespaces(None)` omits it — precondition asserted) proves the walk includes `["default"]` and the flush-side list finds the WAL id. No test previously covered the driver's find at all; existing e2e tests used `force_flush` shortcuts that masked this.

## TD doc corrected in the same PR
Honest re-diagnosis (inline flush works; periodic path was broken; two catalog *read paths* disagreed, not two id systems), the ADR-089 P1 **end-to-end** evidence recorded (filtered p50 **128 ms → 63 ms** through the public REST API on a persistent 80k collection), and the remaining follow-up kept open: a driver-tick e2e harness through the real catalog (no force-flush shortcuts) + fail-loud review of the other free-function callers.

Gates: fmt, clippy-clean compile, td-adr-unique (358 ids), work-commit-check, env-gate registry — all green.