### PR TITLE
fix(sdk): send the configured storage engine when creating a collection

### DIFF
--- a/clients/python/src/proximadb_sdk/embedded.py
+++ b/clients/python/src/proximadb_sdk/embedded.py
@@ -1035,6 +1035,7 @@ prefetch_budget = 4
         dimension: int | None = None,
         distance_metric: str = "cosine",
         embedding_model: BaseEmbeddingModel | str | None = None,
+        engine: str | None = None,
     ) -> EmbeddedCollection:
         """Create a new collection.
 
@@ -1042,6 +1043,9 @@ prefetch_budget = 4
             name: Collection name
             dimension: Vector dimension (auto-detected from embedding model if not provided)
             distance_metric: Distance metric (cosine, euclidean, dot)
+            engine: Storage engine ("sst", "helix", "viper", "auto"). Defaults to
+                ``EmbeddedConfig.vector_engine``. Previously never sent, so the
+                server silently applied "auto".
             embedding_model: Embedding model for auto-embedding. Can be:
                 - BaseEmbeddingModel instance
                 - String model name (uses sentence-transformers)
@@ -1088,12 +1092,20 @@ prefetch_budget = 4
         # The canonical v2 endpoint takes a flat body with a STRING distance
         # metric and returns the created collection record (no {success} envelope).
         # An already-existing collection responds 409/CONFLICT, which is benign.
+        # `EmbeddedConfig.vector_engine` existed but was never transmitted, so the
+        # server fell back to `engine = "auto"` and every embedded collection was
+        # created on HELIX regardless of what the caller configured. That is not a
+        # cosmetic default: engine choice gates real capability (for example
+        # `object_economy_eligible` requires "sst"), and PAX-based features such as
+        # the filter-aware cascade only exist on the SST path. Send it.
+        selected_engine = engine or self.config.vector_engine
         async with self._http_client() as client:
             response = await client.post(
                 f"{self.rest_url}/api/v2/collections",
                 json={
                     "name": name,
                     "dimension": dimension,
+                    "engine": selected_engine.lower(),
                     "distance_metric": distance_metric.lower(),
                 },
                 timeout=30.0,

--- a/clients/python/tests/unit/test_embedded_engine_selection.py
+++ b/clients/python/tests/unit/test_embedded_engine_selection.py
@@ -1,0 +1,84 @@
+"""`EmbeddedConfig.vector_engine` must actually reach the server.
+
+The field existed, defaulted to "SST", and was documented as "Best for real-time
+code indexing" — but `create_collection` never sent it, so the server applied
+`engine = "auto"` and every embedded collection was created on HELIX regardless
+of configuration.
+
+That is not a cosmetic default. Engine choice gates capability server-side
+(`object_economy_eligible` requires "sst"), and PAX-based features such as the
+filter-aware cascade exist only on the SST path — so a caller asking for SST and
+silently getting HELIX loses functionality without any signal.
+"""
+
+import pytest
+
+from proximadb_sdk.embedded import EmbeddedConfig, EmbeddedProximaDB
+
+
+class _CapturingClient:
+    """Captures the create-collection POST body instead of issuing it."""
+
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, json=None, timeout=None):
+        self._sink.append((url, json))
+
+        class _Resp:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"name": json.get("name"), "dimension": json.get("dimension")}
+
+            text = ""
+
+        return _Resp()
+
+
+def _db(monkeypatch, sink, **cfg):
+    db = EmbeddedProximaDB(
+        config=EmbeddedConfig(data_dir="/tmp/does-not-matter", **cfg)
+    )
+    db._started = True
+    monkeypatch.setattr(db, "_http_client", lambda: _CapturingClient(sink))
+    return db
+
+
+@pytest.mark.asyncio
+async def test_configured_engine_is_sent(monkeypatch):
+    sink = []
+    db = _db(monkeypatch, sink, vector_engine="SST")
+    await db.create_collection("c", dimension=8)
+    assert sink, "no create-collection request was issued"
+    _, body = sink[0]
+    assert body["engine"] == "sst", f"engine not transmitted; body was {body}"
+
+
+@pytest.mark.asyncio
+async def test_explicit_engine_argument_wins(monkeypatch):
+    sink = []
+    db = _db(monkeypatch, sink, vector_engine="SST")
+    await db.create_collection("c", dimension=8, engine="viper")
+    _, body = sink[0]
+    assert body["engine"] == "viper"
+
+
+@pytest.mark.asyncio
+async def test_engine_defaults_to_config_not_auto(monkeypatch):
+    """Regression guard: omitting the field let the server pick, and it picked HELIX."""
+    sink = []
+    db = _db(monkeypatch, sink)  # EmbeddedConfig default
+    await db.create_collection("c", dimension=8)
+    _, body = sink[0]
+    assert (
+        "engine" in body
+    ), "engine must always be sent, never left to the server default"
+    assert body["engine"] == EmbeddedConfig().vector_engine.lower()


### PR DESCRIPTION
## Problem

`EmbeddedConfig.vector_engine` defaulted to `"SST"` and carried the comment *"Best for real-time code indexing"* — but **nothing ever read it**. `create_collection` posted only:

```python
{"name": name, "dimension": dimension, "distance_metric": distance_metric.lower()}
```

The server falls back to `engine = request.engine.as_deref().unwrap_or("auto")` (`collections.rs:577`), which resolves to **HELIX**. So every embedded collection has been created on HELIX regardless of configuration, silently.

## Why it matters

- Engine choice **gates capability** server-side: `object_economy_eligible = engine == "sst"` (`collections.rs:2039`).
- PAX-based features — the filter-aware cascade, metadata-first block pruning (ADR-089) — exist only on the SST path. On HELIX you get none of them.
- Any benchmark taken this way characterises an engine nobody selected. Footprint, ingest and determinism numbers gathered against embedded collections need re-taking.

The REST API already accepts `engine: Option<String>` (`collections.rs:135`) and documents `"engine": "sst"` — the client simply never used it.

Same defect class as the dropped `enable_proxima_record` flag: this create path assembles a minimal body and discards intended options.

## Fix

Adds an explicit `engine` argument that falls back to `config.vector_engine`, and sends it.

## Tests

`tests/unit/test_embedded_engine_selection.py` — configured engine is transmitted, an explicit argument overrides config, and a regression guard that the field is **always** sent rather than left to the server default.

Verified end to end against a live embedded server: collections now report `engine: "sst"` where they previously reported `"helix"`.

## Note on scope

This does **not** fix the separate `records/scan` defect (scan returns 0 after a flush while `search` returns hits). I had hoped the engine was the cause; it is not — the behaviour is identical on SST and HELIX, which localises that bug above `read_all_records` rather than inside either engine's reader. Tracked in #1524.