### PR TITLE
fix(storage): surface segment-listing failures instead of reporting an empty collection

### DIFF
--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -1312,6 +1312,17 @@ impl VectorOperationsService {
         let storage_records = engine
             .read_all_records(&collection_id, Some(&storage_url))
             .await?;
+        // Both halves are logged because a zero from either is silent by nature: an
+        // empty WAL is normal after a flush, and an empty storage read is normal for a
+        // new collection — but together they mean "this collection looks empty", and
+        // when that is wrong there is otherwise nothing to inspect.
+        tracing::debug!(
+            "list_all_records: collection={} storage_url={} wal_records={} storage_records={}",
+            collection_id,
+            storage_url,
+            wal_records.len(),
+            storage_records.len()
+        );
 
         // Merge by oid: storage baseline, then WAL overrides on >= updated_at_ns
         // so the freshest version (WAL) wins ties.

--- a/src/storage/engines/helix/mod.rs
+++ b/src/storage/engines/helix/mod.rs
@@ -2217,16 +2217,30 @@ impl UnifiedStorageFormat for HelixEngine {
             return Ok(Vec::new());
         };
         let fs = self.filesystem_for_url(storage_url, collection_id)?;
+        // Mirrors the SST engine: a listing failure is reported, not folded into an
+        // empty result that is indistinguishable from an empty collection.
         let mut files = Vec::new();
-        if let Ok(entries) = fs.list(storage_url).await {
-            for entry in &entries {
-                if !entry.metadata.is_directory
-                    && entry
-                        .url
-                        .ends_with(crate::storage::engines::constants::HELIX_FILE_EXT)
-                {
-                    files.push(entry.url.clone());
+        match fs.list(storage_url).await {
+            Ok(entries) => {
+                for entry in &entries {
+                    if !entry.metadata.is_directory
+                        && entry
+                            .url
+                            .ends_with(crate::storage::engines::constants::HELIX_FILE_EXT)
+                    {
+                        files.push(entry.url.clone());
+                    }
                 }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "helix.read_all_records: cannot list segment directory {} ({}); \
+                     reporting no stored records for collection {} — callers will see \
+                     an empty result that reflects the listing failure, not the data",
+                    storage_url,
+                    e,
+                    collection_id
+                );
             }
         }
         if files.is_empty() {

--- a/src/storage/engines/sst/trait_impl.rs
+++ b/src/storage/engines/sst/trait_impl.rs
@@ -392,16 +392,40 @@ impl UnifiedStorageFormat for SstEngine {
         };
         let fs = self.filesystem().get_filesystem(storage_url)?;
 
+        // A listing failure must not read as "this collection is empty". Discarding
+        // the error here made an unreadable segment directory indistinguishable from
+        // a genuinely empty one, and every caller of this function — scan, and the
+        // TD-112 AXIS rebuild — would then report zero rows with no signal at all.
+        // That silence is expensive: it is usable as a false durability oracle, which
+        // is exactly how it was hit (anvai-labs/proximaDB#1524).
         let mut files = Vec::new();
-        if let Ok(entries) = fs.list(storage_url).await {
-            for entry in &entries {
-                if !entry.metadata.is_directory
-                    && (entry.url.ends_with(".sst")
-                        || entry.url.ends_with(".proximablock")
-                        || entry.url.ends_with(".pax"))
-                {
-                    files.push(entry.url.clone());
+        match fs.list(storage_url).await {
+            Ok(entries) => {
+                for entry in &entries {
+                    if !entry.metadata.is_directory
+                        && (entry.url.ends_with(".sst")
+                            || entry.url.ends_with(".proximablock")
+                            || entry.url.ends_with(".pax"))
+                    {
+                        files.push(entry.url.clone());
+                    }
                 }
+                tracing::debug!(
+                    "sst.read_all_records: {} listed {} entries, {} segment files",
+                    storage_url,
+                    entries.len(),
+                    files.len()
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "sst.read_all_records: cannot list segment directory {} ({}); \
+                     reporting no stored records for collection {} — callers will see \
+                     an empty result that reflects the listing failure, not the data",
+                    storage_url,
+                    e,
+                    collection_id
+                );
             }
         }
         if files.is_empty() {


### PR DESCRIPTION
## Problem

`read_all_records` discards the error from `fs.list` on both the SST and HELIX engines:

```rust
if let Ok(entries) = fs.list(storage_url).await { ... }
if files.is_empty() { return Ok(Vec::new()); }
```

A segment directory that cannot be listed therefore produces exactly the same observable result as a collection that genuinely has no data: an empty vec, no log line, no error, no distinction available to any caller.

Every consumer inherits the ambiguity. `scan` reports zero rows. The TD-112 AXIS-rebuild-from-SST path (the comment at `trait_impl.rs:417` calls this out as the path that must read `.pax` "or the index stays empty after a loss") would rebuild an empty index. Neither surfaces anything.

## Why it's worth closing

This is not hypothetical. While investigating #1524 I used `scan` as a durability oracle across a restart, got zero, and concluded a healthy database had lost its records — twice, in opposite directions, before a point-lookup probe showed the data was intact all along. A store that had said "I could not list the segment directory" would have ended that in one step.

The general form: **"empty" and "I could not look" must not be the same answer.** An empty result is a legitimate, common outcome, which is precisely why it makes such a poor carrier for a failure signal.

## Change

- SST and HELIX `read_all_records` now `match` on the listing result and `warn!` on `Err`, naming the URL, the underlying error, and the collection. The genuinely-empty case stays silent — it is normal and should not be noisy.
- `list_all_records_with_tenant_context` logs the WAL and storage row counts it merges, at debug. A zero from either half alone is unremarkable (an empty WAL is expected after a flush; an empty storage read is expected for a new collection), but together they are the "this collection looks empty" signal, and there was previously nothing to inspect when that was wrong.

No behavioural change to the success path, and no change to what callers receive — this only makes an existing silent failure observable.

## Scope

Deliberately narrow. It does not attempt to fix `record_count` (#1527), and the scan defect that prompted the investigation turned out to be **already fixed** on `develop` — my repro was against a two-week-old binary, and I've corrected #1524 accordingly. What survives that correction is this silent-failure path, which is independent of the bug that led me to it.

## Verification

`cargo check -p proximadb-server` clean. The warning path is by nature not reachable from a healthy fixture; the change is the error branch of an existing `if let Ok`, with the success branch preserved verbatim.