### PR TITLE
feat(authz): L1.2 — grant enforcement at the read-admission seam, default-OFF (ADR-090)

### DIFF
--- a/crates/control/proximadb-abac/src/context.rs
+++ b/crates/control/proximadb-abac/src/context.rs
@@ -49,6 +49,10 @@ pub enum DenyReason {
     /// A binding at some scope explicitly denied (deny wins over any permit).
     #[error("an applicable policy binding denies this read")]
     ExplicitDeny,
+    /// ADR-090 L1.2: grant enforcement is armed and no applicable grant admits
+    /// the subject to the target. Fail-closed: absence of entitlement is deny.
+    #[error("no applicable grant admits this subject to the target")]
+    NoApplicableGrant,
 }
 
 /// The outcome of resolving a read: an admitted context, or a reason and nothing

--- a/docs/12-design/ENV_GATE_REGISTRY.adoc
+++ b/docs/12-design/ENV_GATE_REGISTRY.adoc
@@ -42,6 +42,7 @@ the emergency off) · *config-mirror* (env overrides a config field) ·
 | Variable | Semantic | Default | Tier; Owner | Declared in
 
 | `PROXIMADB_ADVISOR_OBS_DISK_SIDECAR` | Path to append advisor search observations as JSONL for offline analysis. | OFF (unset = no-op) | opt-in; — | src/services/advisor_observations.rs
+| `PROXIMADB_AUTHZ_REQUIRE_GRANTS` | ADR-090 L1.2: a policy admit additionally requires an applicable Grant (deny > absence-of-grant > grant) at the ABAC read-admission seam (`AbacEnforcer::resolve_read_context`). Armed with no grant store attached fails CLOSED. Grant predicate-ref composition into the row filter is L2; this gate enforces admit/deny only. Flip-precondition: the provision→permit→deny→revoke e2e ratchet (TD-AUTHZ-1 L1.2) is green. | OFF (unset ⇒ policy-only admission, today's behavior) | opt-in; TD-AUTHZ-1 | src/security/rls/abac_adapter.rs
 | `PROXIMADB_AZURE_EMULATOR` | Point the Azure blob backend at the Azurite emulator. | OFF (false) | test-only; — | src/storage/persistence/filesystem/mod.rs
 | `PROXIMADB_AZURE_TEST` | Gate that enables the `#[ignore]`d Azure dual-store integration test. | test skipped unless set | test-only; — | src/index/axis/indexes/dual_store_ivf.rs
 | `PROXIMADB_CACHE_PREFILL` | restart warming replay (0=off) | ON | TD-CACHE-1 | `src/database.rs (+1)`

--- a/src/network/shared_services.rs
+++ b/src/network/shared_services.rs
@@ -498,6 +498,8 @@ struct AbacDurableStores {
     authority: Arc<proximadb_abac::FileSystemAttributeAuthority>,
     bindings: Arc<proximadb_abac::FileSystemPolicyBindingStore>,
     predicate_objects: Arc<proximadb_abac::FileSystemPredicateObjectStore>,
+    /// ADR-090 L1.2: the grant (entitlement) store, in the same durable dir.
+    grants: Arc<proximadb_catalog::grants::FileSystemGrantStore>,
 }
 
 impl SharedServices {
@@ -639,10 +641,19 @@ impl SharedServices {
             "abac-policy: durable ABAC stores active at {} (authority + policy binding store + predicate object store)",
             abac_dir.display()
         );
+        let grants = match proximadb_catalog::grants::FileSystemGrantStore::open(&abac_dir) {
+            Ok(store) => Arc::new(store),
+            Err(error) => {
+                tracing::warn!("abac-policy: could not open grant store: {error}");
+                return None;
+            }
+        };
+
         Some(AbacDurableStores {
             authority,
             bindings,
             predicate_objects,
+            grants,
         })
     }
 
@@ -660,7 +671,8 @@ impl SharedServices {
             stores.predicate_objects.clone(),
             Arc::new(InMemoryPolicyEpochs::new()),
         )
-        .with_binding_store(stores.bindings.clone());
+        .with_binding_store(stores.bindings.clone())
+        .with_grant_store(stores.grants.clone());
         Arc::new(enforcer)
     }
 

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -103,6 +103,10 @@ pub struct AbacEnforcer {
     /// visible to the enforcer's next read without a restart (hot-reload,
     /// TD-ABAC control-plane).
     binding_store: Option<Arc<dyn PolicyBindingStore + Send + Sync>>,
+    /// ADR-090 L1.2: the durable grant store (entitlement layer). Shared `Arc`
+    /// for the same hot-reload reason as `binding_store`. Consulted only when
+    /// `PROXIMADB_AUTHZ_REQUIRE_GRANTS` is armed.
+    grant_store: Option<Arc<proximadb_catalog::grants::FileSystemGrantStore>>,
 }
 
 #[cfg(feature = "abac-policy")]
@@ -122,6 +126,7 @@ impl AbacEnforcer {
             epochs,
             bindings: Vec::new(),
             binding_store: None,
+            grant_store: None,
         }
     }
 
@@ -141,6 +146,14 @@ impl AbacEnforcer {
     /// Takes a shared `Arc` so the caller (boot wiring) can retain its own clone
     /// of the same durable store for the admin-provisioning writer — a provision
     /// is then visible to this enforcer without a restart.
+    pub fn with_grant_store(
+        mut self,
+        store: Arc<proximadb_catalog::grants::FileSystemGrantStore>,
+    ) -> Self {
+        self.grant_store = Some(store);
+        self
+    }
+
     pub fn with_binding_store(mut self, store: Arc<dyn PolicyBindingStore + Send + Sync>) -> Self {
         self.binding_store = Some(store);
         self
@@ -198,7 +211,21 @@ impl AbacEnforcer {
             target,
         ) {
             proximadb_abac::ReadDecision::Deny(reason) => Err(reason),
-            proximadb_abac::ReadDecision::Admit(ctx) => Ok(ctx),
+            proximadb_abac::ReadDecision::Admit(ctx) => {
+                // ADR-090 L1.2 (deny > absence-of-grant > grant): with grant
+                // enforcement armed, a policy admit is necessary but not
+                // sufficient — an applicable GRANT must also admit the subject.
+                // Armed with NO store attached fails closed too: "required"
+                // cannot degrade to "optional" because wiring is incomplete.
+                // Grant predicate-ref composition into the row filter is L2
+                // (today only admit/deny is enforced here).
+                if grants_required()
+                    && !grant_admits_read(self.grant_store.as_deref(), tenant, &subject.0, &target)
+                {
+                    return Err(DenyReason::NoApplicableGrant);
+                }
+                Ok(ctx)
+            }
         }
     }
 
@@ -849,5 +876,123 @@ mod tests {
             &bindings,
         );
         assert!(outcome.is_err(), "unbound subject denied");
+    }
+}
+
+/// ADR-090 L1.2 opt-in gate: when `PROXIMADB_AUTHZ_REQUIRE_GRANTS` is truthy,
+/// a policy admit additionally requires an applicable grant (deny > absence >
+/// grant). Default OFF — absent means today's behavior, unchanged.
+#[cfg(feature = "abac-policy")]
+fn grants_required() -> bool {
+    match std::env::var("PROXIMADB_AUTHZ_REQUIRE_GRANTS") {
+        Ok(v) => {
+            let v = v.trim();
+            v == "1"
+                || v.eq_ignore_ascii_case("true")
+                || v.eq_ignore_ascii_case("on")
+                || v.eq_ignore_ascii_case("yes")
+        }
+        Err(_) => false,
+    }
+}
+
+/// ADR-090 L1.2 pure decision: does an applicable grant admit `subject` (a
+/// user of `tenant`) to read `target`? `None` store ⇒ **false** — when
+/// enforcement is armed, "required" cannot degrade to "optional" because
+/// wiring is incomplete.
+#[cfg(feature = "abac-policy")]
+fn grant_admits_read(
+    store: Option<&proximadb_catalog::grants::FileSystemGrantStore>,
+    tenant: u64,
+    subject: &str,
+    target: &Target,
+) -> bool {
+    let Some(store) = store else {
+        return false;
+    };
+    matches!(
+        proximadb_catalog::grants::evaluate_grants(
+            &store.grants_for_owner(tenant),
+            &proximadb_catalog::grants::GrantSubject {
+                tenant_stable_id: tenant,
+                subject,
+            },
+            target,
+            proximadb_catalog::grants::GrantAction::Read,
+            chrono::Utc::now().timestamp_millis(),
+        ),
+        proximadb_catalog::grants::GrantDecision::Permit { .. }
+    )
+}
+
+// ADR-090 L1.2 specification for the seam's NEW logic. The full
+// provision→permit→deny→revoke e2e across live transports is the gate's
+// flip-precondition (registry row) and lands with the admin surface; these
+// pin the decision semantics the seam composes.
+#[cfg(all(test, feature = "abac-policy"))]
+mod grant_gate_tests {
+    use super::*;
+    use proximadb_catalog::grants::{FileSystemGrantStore, GrantAction, Grantee};
+    use std::collections::BTreeSet;
+
+    fn target(table: u32) -> Target {
+        Target {
+            namespace: 0,
+            table,
+            column: None,
+        }
+    }
+
+    /// Armed with NO store ⇒ deny (fail-closed on incomplete wiring).
+    #[test]
+    fn no_store_never_admits() {
+        assert!(!grant_admits_read(None, 7, "alice", &target(10)));
+    }
+
+    /// No applicable grant ⇒ deny; an applicable grant ⇒ admit; revoke ⇒ deny.
+    #[test]
+    fn grant_lifecycle_drives_admission() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FileSystemGrantStore::open(dir.path()).expect("open");
+        assert!(!grant_admits_read(Some(&store), 7, "alice", &target(10)));
+
+        let id = store
+            .grant(
+                7,
+                proximadb_catalog::fc_metamodel::Scope::Table(10),
+                Grantee::User {
+                    tenant_stable_id: 7,
+                    subject: proximadb_catalog::fc_metamodel::SubjectId("alice".into()),
+                },
+                BTreeSet::from([GrantAction::Read]),
+                None,
+                None,
+                None,
+            )
+            .expect("grant");
+        assert!(grant_admits_read(Some(&store), 7, "alice", &target(10)));
+        assert!(
+            !grant_admits_read(Some(&store), 7, "mallory", &target(10)),
+            "another subject must not ride alice's grant"
+        );
+
+        store.revoke(7, &id).expect("revoke");
+        assert!(!grant_admits_read(Some(&store), 7, "alice", &target(10)));
+    }
+
+    /// The env gate parses the standard truthy set and defaults OFF.
+    #[test]
+    fn gate_parsing_defaults_off() {
+        // nextest process-per-test isolation makes set_var safe here (the same
+        // justification as compaction_tests::RecordVersionGate).
+        unsafe { std::env::remove_var("PROXIMADB_AUTHZ_REQUIRE_GRANTS") };
+        assert!(!grants_required());
+        for v in ["1", "true", "ON", "yes"] {
+            unsafe { std::env::set_var("PROXIMADB_AUTHZ_REQUIRE_GRANTS", v) };
+            assert!(grants_required(), "{v} must arm the gate");
+        }
+        unsafe { std::env::set_var("PROXIMADB_AUTHZ_REQUIRE_GRANTS", "0") };
+        assert!(!grants_required());
+        unsafe { std::env::remove_var("PROXIMADB_AUTHZ_REQUIRE_GRANTS") };
     }
 }


### PR DESCRIPTION
TD-AUTHZ-1 **L1.2** — the final slice of this session's ADR-090 arc: wires the merged L1.1 `Grant` object into `AbacEnforcer::resolve_read_context`, the seam every governed read already passes.

With `PROXIMADB_AUTHZ_REQUIRE_GRANTS` armed, a policy admit is necessary but no longer sufficient — an applicable grant must also admit, else `DenyReason::NoApplicableGrant`.

- **Deny > absence > grant by construction** — policy deny returns before grants are consulted; the composition order *is* the control flow.
- **Armed-with-no-store fails closed** — "required" cannot degrade to "optional" because wiring is incomplete.
- **Zero caller changes** — every call site already fails closed on `Err`.
- Store opens in `<data_dir>/abac`, attached at the same hot-reload `Arc` seam as the binding store: admin grant/revoke is live without restart.
- **Registry row carries the flip-precondition**: the provision→permit→deny→revoke live e2e ratchet must be green before arming. Default OFF — unset is today's behavior, bit for bit.

3/3 spec tests on the pure decision fn (no-store never admits · lifecycle drives admission incl. revoke and non-transferability · gate parses/defaults OFF).

**Sequencing note**: written against L1.1 while #1517 was in flight; the gated pipeline correctly **refused** to ship it then (the grants module didn't exist on develop). Rebased and re-verified end-to-end after #1517 merged: default build clean (all new code vanishes with `abac-policy` off) · feature build clean · guards green.

Deferred with comments: grant `predicate_ref` → row-filter composition (L2), live e2e (needs the admin surface).

Ref ADR-090 L1.2 (#1513), TD-AUTHZ-1, #1517, #1514.