### PR TITLE
fix(sdk): repair remaining CI-gated stale SDK unit tests

### DIFF
--- a/clients/python/tests/unit/test_arrow_flight_protocol.py
+++ b/clients/python/tests/unit/test_arrow_flight_protocol.py
@@ -156,15 +156,26 @@ def test_metadata_from_exchange_chunk_reads_app_metadata():
 
 
 @pytest.mark.skipif(not ARROW_AVAILABLE, reason="PyArrow is required")
-def test_call_options_include_auth_and_tenant_headers():
+def test_call_options_include_auth_and_tenant_headers(monkeypatch):
+    # pyarrow's FlightCallOptions does not expose the headers it was constructed
+    # with, so capture the kwargs the SDK passes to it instead of reading them back.
+    import proximadb_sdk.protocols.arrow_flight as af
+
+    captured = {}
+
+    class _CapturedOptions:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(af.flight, "FlightCallOptions", _CapturedOptions)
+
     client = ArrowFlightClient(
         "localhost:5680", api_key="token-1", tenant_id="tenant-a"
     )
+    client._get_call_options()
 
-    options = client._get_call_options()
-
-    assert (b"authorization", b"API-Key token-1") in options.headers
-    assert (b"x-proximadb-tenant-id", b"tenant-a") in options.headers
+    assert (b"authorization", b"API-Key token-1") in captured["headers"]
+    assert (b"x-proximadb-tenant-id", b"tenant-a") in captured["headers"]
 
 
 @pytest.mark.skipif(not ARROW_AVAILABLE, reason="PyArrow is required")

--- a/clients/python/tests/unit/test_code_knowledge_cov.py
+++ b/clients/python/tests/unit/test_code_knowledge_cov.py
@@ -374,7 +374,10 @@ def test_prepare_text_minimal():
 # ---------------------------------------------------------------------------
 
 
-def test_insert_records_uses_insert_records():
+def test_insert_records_uses_insert_records(monkeypatch):
+    # Exercise the legacy symbol_id path; the ADR-044 canonical oid (default-on) is
+    # a separate concern with its own coverage.
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "0")
     client, collection, _ = make_client()
     b = make_builder(client)
     chunks = [
@@ -418,7 +421,10 @@ def test_insert_records_empty_noop():
     collection.insert_records.assert_not_awaited()
 
 
-def test_insert_records_default_symbol_id_uses_chunk_id():
+def test_insert_records_default_symbol_id_uses_chunk_id(monkeypatch):
+    # Legacy id fallback (symbol_id -> chunk_id); the ADR-044 canonical oid is gated
+    # off here so we exercise that fallback path.
+    monkeypatch.setenv("VICTOR_CODEGRAPH_STABLE_OID", "0")
     client, collection, _ = make_client()
     b = make_builder(client)
     run(

--- a/clients/python/tests/unit/test_embedded_cov.py
+++ b/clients/python/tests/unit/test_embedded_cov.py
@@ -681,8 +681,12 @@ def test_get_collection_cached(patched_http):
 
 
 def test_get_collection_from_server(patched_http):
+    # get_collection resolves from the LIST endpoint (GET /collections/{name} returns
+    # 200 even for non-existent collections), so mock the flat v2 LIST payload.
     patched_http.responder = staticmethod(
-        lambda v, u, **kw: FakeResp({"collection": {"config": {"dimension": 12}}})
+        lambda v, u, **kw: FakeResp(
+            {"collections": [{"name": "remote", "dimension": 12}]}
+        )
     )
     db = make_started_db()
     got = run(db.get_collection("remote"))


### PR DESCRIPTION
Completes the SDK-test cleanup surfaced by gating python-test at medium_tier. Fixes 4 CI-gated stale tests (validated locally):
- **arrow_flight**: pyarrow `FlightCallOptions` dropped readable `.headers` -> capture the kwargs passed to it.
- **code_knowledge** (x2): record id is the ADR-044 canonical oid (default-on) -> gate off to test the legacy symbol_id/chunk_id fallback.
- **embedded get_collection**: resolves via LIST now -> mock the flat v2 LIST payload.

The 2 remaining local failures are in `test_chunking_code_cov.py`, which CI **intentionally `--ignore`s** (deprecated in-SDK chunker, tree-sitter-grammar flakiness) — not CI-gating. With this + #1488/#1518, the Python SDK gate goes green.