### PR TITLE
fix(embedded): make the python feature build; unblocks the proximadb_embedded wheel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-json",
  "arrow-ord",
+ "arrow-pyarrow",
  "arrow-row",
  "arrow-schema",
  "arrow-select",
@@ -431,6 +432,18 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "arrow-select",
+]
+
+[[package]]
+name = "arrow-pyarrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29abdf672a81c1aeb57fd2661457f9918964d49aed0e9f18932535f2a9e49ce"
+dependencies = [
+ "arrow-array",
+ "arrow-data",
+ "arrow-schema",
+ "pyo3",
 ]
 
 [[package]]
@@ -7303,6 +7316,7 @@ dependencies = [
  "bincode",
  "chrono",
  "crc32fast",
+ "datafusion",
  "hostname 0.4.2",
  "jni 0.21.1",
  "libc",
@@ -7317,6 +7331,7 @@ dependencies = [
  "proximadb-hardware",
  "proximadb-records",
  "proximadb-runtime",
+ "proximadb-storage-common",
  "proximadb-tenant",
  "pyo3",
  "serde",
@@ -7325,6 +7340,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,12 @@ anyhow = "1.0"
 sqlparser = { version = "0.59", features = ["visitor"] }
 arrow = { version = "58", features = ["prettyprint"] }
 arrow-array = { version = "58", default-features = false }
+# Workspace-level so the root crate and `proximadb-embedded` resolve the SAME
+# datafusion. The embedded Python binding passes `SessionContext`/`DataFrame`
+# across the crate boundary, so two independently-specified versions would be two
+# distinct types and fail to compile in a way that is tedious to diagnose.
+datafusion = { version = "54.0", default-features = false, features = ["sql", "regex_expressions", "unicode_expressions", "datetime_expressions", "math_expressions"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bincode = "1.3"
 arrow-flight = { version = "58", features = ["flight-sql-experimental"] }
 arrow-schema = { version = "58", default-features = false }

--- a/crates/binding/proximadb-embedded/Cargo.toml
+++ b/crates/binding/proximadb-embedded/Cargo.toml
@@ -66,6 +66,15 @@ proximadb-tenant = { path = "../../foundation/proximadb-tenant" }
 # server binary no longer compiles embedded bindings.
 pyo3 = { workspace = true, optional = true }
 numpy = { workspace = true, optional = true }
+# `python.rs` / `python_dataframe.rs` use these DIRECTLY (`use datafusion::prelude::*`,
+# `tracing_subscriber::…`). Having them only as transitive deps of the root crate is
+# not enough — a transitive dependency is not in scope — so the `python` feature
+# could never compile. Optional + feature-gated so non-Python builds are unaffected.
+datafusion = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+# `python_dataframe.rs` uses `proximadb_storage_common::proxima_schema::ProximaSchema`
+# directly when inferring a DataFrame schema from a collection.
+proximadb-storage-common = { workspace = true, optional = true }
 jni = { version = "0.21", optional = true }
 napi = { version = "2.14", features = ["napi9"], optional = true }
 napi-derive = { version = "2.14", optional = true }
@@ -101,7 +110,18 @@ axis = ["proximadb/axis"]
 # `--features abac-policy,proximadb-embedded/abac-policy`.
 abac-policy = ["proximadb/abac-policy", "dep:proximadb-abac"]
 # Python bindings (PyO3 + zero-copy numpy).
-python = ["dep:pyo3", "dep:numpy"]
+# `arrow/pyarrow` is required by the `arrow::pyarrow::{PyArrowType, ToPyArrow}`
+# conversions in the binding; without it those items are configured out and the
+# feature does not build. It is enabled here rather than on the base `arrow`
+# dependency so non-Python builds do not pull pyo3 in through arrow.
+python = [
+    "dep:pyo3",
+    "dep:numpy",
+    "dep:datafusion",
+    "dep:tracing-subscriber",
+    "dep:proximadb-storage-common",
+    "arrow/pyarrow",
+]
 # Java bindings (JNI).
 java = ["dep:jni"]
 # Node.js bindings (NAPI-RS).

--- a/crates/binding/proximadb-embedded/src/python.rs
+++ b/crates/binding/proximadb-embedded/src/python.rs
@@ -4577,7 +4577,11 @@ fn notebook_is_simple_ident(value: &str) -> bool {
 fn notebook_partitions_to_json(
     collection: &str,
     requested: u32,
-    partitions: &[proximadb::connectors::spark::SparkInputPartition],
+    // `SparkInputPartition` lives in THIS crate's `spark` module, not in the root
+    // crate's `connectors` — #1021 moved the bindings here. The stale path only
+    // failed to surface because the `#[pymodule] fn proximadb` shadowing above
+    // made every `proximadb::…` path in this file fail first.
+    partitions: &[crate::spark::SparkInputPartition],
 ) -> serde_json::Value {
     serde_json::json!({
         "collection": collection,
@@ -4596,9 +4600,7 @@ fn notebook_partitions_to_json(
     })
 }
 
-fn notebook_partition_to_json(
-    partition: &proximadb::connectors::spark::SparkInputPartition,
-) -> serde_json::Value {
+fn notebook_partition_to_json(partition: &crate::spark::SparkInputPartition) -> serde_json::Value {
     serde_json::json!({
         "partition_id": partition.partition_id,
         "preferred_locations": &partition.preferred_locations,
@@ -4825,8 +4827,15 @@ fn register_python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 /// Python module definition
 /// This exports as "proximadb" which is the module name used by benchmarks
-#[pymodule]
-fn proximadb(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+///
+/// The Rust function is deliberately NOT named `proximadb`. `#[pymodule]` defines
+/// an item in this module's scope, and a function named `proximadb` shadows the
+/// `proximadb` *crate* — every `proximadb::…` path in this file then resolves
+/// against the pymodule instead and fails (`E0659: ambiguous`, plus one
+/// `cannot find X in proximadb` per use site). The `name = "proximadb"` attribute
+/// keeps the Python-visible module name identical, so benchmarks are unaffected.
+#[pymodule(name = "proximadb")]
+fn proximadb_legacy_module(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_python_module(m)
 }
 


### PR DESCRIPTION
## Problem

`cargo build -p proximadb-embedded --features python` fails with **41 errors**, so `maturin build --features python` — the exact invocation `release-python.yml` uses — cannot produce the `proximadb_embedded` wheel at all. The native engine is currently unpublishable.

The count has been reported as "41 errors" more than once without moving, and there is a reason for that: almost all of them are one bug wearing 30 masks.

## Root cause

```rust
#[pymodule]
fn proximadb(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> { ... }
```

`#[pymodule]` defines an item named `proximadb` in the module scope of `python.rs`, which **shadows the `proximadb` crate**. Every `proximadb::…` path in that 4,800-line file then resolves against the pymodule instead of the crate, producing one `E0659: ambiguous` and ~29 `cannot find X in proximadb`. The compiler says so plainly, in the one error easy to dismiss as incidental:

```
error[E0659]: `proximadb` is ambiguous
  = help: use `::proximadb` to refer to this crate unambiguously
```

Fixed at the cause rather than by prefixing 30 call sites:

```rust
#[pymodule(name = "proximadb")]
fn proximadb_legacy_module(...)
```

The Python-visible module name is unchanged, so the benchmarks that import `proximadb` are unaffected.

## What the shadowing was hiding

With it gone, three genuine problems surfaced — previously indistinguishable from the spurious ones, since they all failed at the same first hurdle:

1. **`datafusion` and `tracing_subscriber` used directly but undeclared.** `python.rs` / `python_dataframe.rs` do `use datafusion::prelude::*` and `tracing_subscriber::…`. Both were only transitive dependencies of the root crate, and a transitive dep is not in scope.
2. **`arrow/pyarrow` off.** `arrow::pyarrow::{PyArrowType, ToPyArrow}` were configured out — rustc even reports *"found an item that was configured out"*.
3. **Stale paths from the #1021 extraction.** `SparkInputPartition` moved into this crate's own `spark.rs`, and `ProximaSchema` needs `proximadb-storage-common`. `python.rs` still pointed at `proximadb::connectors::spark::`.

## Notes on the dependency choices

- All three new deps are **optional and gated on `python`**, so non-Python builds are byte-identical.
- `datafusion` and `tracing-subscriber` are hoisted into `[workspace.dependencies]` rather than pinned in the binding. The binding passes `SessionContext`/`DataFrame` across the crate boundary; if root and embedded ever specified different versions those become two distinct types, and the resulting error is genuinely unpleasant to diagnose. One spec removes the possibility structurally.

## Verification

- `cargo check -p proximadb-embedded --features python` — clean, 0 errors (was 41).
- `maturin build --release --features python` — produces `proximadb_embedded-0.3.0-cp310-abi3-macosx_11_0_arm64.whl`.
- The wheel installs into a **clean venv** and imports, with the native extension loaded and 23 symbols exported:

```
import OK: proximadb_embedded
has extension: True
exported symbols: 23
sample: ['CheckpointInfo', 'CollectionInfo', 'DeltaInfo', 'DiskConfig', 'GraphEdge', 'GraphNode']
```

I checked the built artifact rather than stopping at a green `cargo check` — a check does not prove the cdylib links or that the module initialises.

## Suggested follow-up (not in this PR)

Nothing in CI builds `--features python`, which is why this rotted undetected through the #1021 extraction. A cheap `cargo check -p proximadb-embedded --features python` job would have caught it the day it broke, and would be far cheaper than a full wheel build.