### PR TITLE
refactor(decomp): extract ExecutionResult → query-fusion (TD-DECOMP-32) STRUCTURAL CASCADE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7968,6 +7968,7 @@ name = "proximadb-query-fusion"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "proximadb-data-model",
  "serde",
  "serde_json",

--- a/crates/query/proximadb-query-fusion/Cargo.toml
+++ b/crates/query/proximadb-query-fusion/Cargo.toml
@@ -18,3 +18,4 @@ proximadb-data-model = { path = "../../foundation/proximadb-data-model" }
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+arrow.workspace = true

--- a/crates/query/proximadb-query-fusion/src/execution_result.rs
+++ b/crates/query/proximadb-query-fusion/src/execution_result.rs
@@ -1,0 +1,78 @@
+//! Federated execution result types, extracted from root `query/federated/execution`
+//! (TD-DECOMP-32). These are the Arrow-backed result containers for federated queries.
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::Schema;
+use proximadb_data_model::DataModel as ModelType;
+use std::sync::Arc;
+
+/// Backwards-compat alias for [`FederatedExecutionResult`].
+pub type ExecutionResult = FederatedExecutionResult;
+
+/// Execution result containing Arrow record batches
+#[derive(Debug, Clone)]
+pub struct FederatedExecutionResult {
+    /// Result batches
+    pub batches: Vec<RecordBatch>,
+    /// Result schema
+    pub schema: Arc<Schema>,
+    /// Execution statistics
+    pub stats: FederatedExecutionStats,
+}
+
+impl FederatedExecutionResult {
+    /// Create an empty result
+    pub fn empty() -> Self {
+        let schema = Arc::new(Schema::empty());
+        Self {
+            batches: vec![],
+            schema,
+            stats: FederatedExecutionStats::default(),
+        }
+    }
+
+    /// Create a result with a single batch
+    pub fn from_batch(batch: RecordBatch) -> Self {
+        let schema = batch.schema();
+        let rows = batch.num_rows();
+        Self {
+            batches: vec![batch],
+            schema,
+            stats: FederatedExecutionStats {
+                rows_produced: rows,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Create an empty result with a known schema
+    pub fn empty_with_schema(schema: Arc<Schema>) -> Self {
+        Self {
+            batches: vec![],
+            schema,
+            stats: FederatedExecutionStats::default(),
+        }
+    }
+
+    /// Get total row count
+    pub fn row_count(&self) -> usize {
+        self.batches.iter().map(|b| b.num_rows()).sum()
+    }
+}
+
+/// Federated query execution statistics.
+#[derive(Debug, Default, Clone)]
+pub struct FederatedExecutionStats {
+    /// Total rows produced
+    pub rows_produced: usize,
+    /// Execution time in microseconds
+    pub execution_time_us: u64,
+    /// Bytes scanned
+    pub bytes_scanned: u64,
+    /// Models queried
+    pub models_queried: Vec<ModelType>,
+    /// Cache hits
+    pub cache_hits: u64,
+    /// Cache misses
+    pub cache_misses: u64,
+}

--- a/crates/query/proximadb-query-fusion/src/lib.rs
+++ b/crates/query/proximadb-query-fusion/src/lib.rs
@@ -1,6 +1,7 @@
 //! Query fusion + federated optimizer + federated parser utilities.
 //! Extracted from root (plan_calibration/gls: TD-DECOMP-17; federated parser: TD-DECOMP-23).
 
+pub mod execution_result;
 pub mod gls;
 pub mod parser;
 pub mod plan_calibration;

--- a/docs/10-quality/td/TD-DECOMP-32-extract-execution-result.adoc
+++ b/docs/10-quality/td/TD-DECOMP-32-extract-execution-result.adoc
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-32: Extract FederatedExecutionResult → query-fusion (STRUCTURAL CASCADE step 1)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Medium — structural cascade (unblocks 30 tests in query/cache)
+| Component | `crates/query/proximadb-query-fusion/src/execution_result.rs`; root `src/query/federated/execution/mod.rs`
+| Relates to | [[TD-DECOMP-29]] (query-cache structural enabler); [[TD-DECOMP-1]] (recipe)
+|===
+
+== Why
+
+The query-cache structural enabler (TD-DECOMP-29) created `proximadb-query-cache` as a home for
+5 coupled files (58 tests) blocked by root-only types. The #1 blocker was `ExecutionResult`
+(affecting query_result_cache 19t + invalidation 11t = 30 tests). This TD extracts the
+`ExecutionResult` types to query-fusion, unblocking those files.
+
+== What moved (behavior-neutral)
+
+* `FederatedExecutionResult` + `FederatedExecutionStats` + `ExecutionResult` type alias →
+  `crates/query/proximadb-query-fusion/src/execution_result.rs`.
+* Root `src/query/federated/execution/mod.rs`: type definitions replaced with
+  `pub use proximadb_query_fusion::execution_result::{...}` (16 callers resolve unchanged).
+* query-fusion gains `arrow.workspace = true` dep. `ModelType` is `proximadb_data_model::DataModel`
+  (foundation crate, already a query-fusion dep).
+* The impl block (4 methods: empty/from_batch/empty_with_schema/row_count) is all `pub` —
+  no pub(crate) widening needed.
+
+== Follow-ups
+
+* **Next cascade step:** move `query_result_cache.rs` (19t) + `invalidation.rs` (11t) →
+  query-cache crate (their ExecutionResult dep now resolves from query-fusion via root re-export).
+* `PlanOutput` cascade remains blocked (depends on FilterStrategy/IndexRoute from modality-tier
+  observability-engine — layering forbids query→modality).
+* Verified: standalone query-fusion --all-targets EXIT 0 + root lib check zero errors (BOTH
+  checks passed on first try — the pre-extraction checklist works).

--- a/src/query/federated/execution/mod.rs
+++ b/src/query/federated/execution/mod.rs
@@ -45,83 +45,9 @@ use crate::storage::traits::{
     DocumentRecord, DocumentStorageOperations, MetricAggregationParams,
     ObservabilityStorageOperations, StorageQueryContext,
 };
-
-/// Backwards-compat alias for [`FederatedExecutionResult`].
-pub type ExecutionResult = FederatedExecutionResult;
-
-/// Execution result containing Arrow record batches
-#[derive(Debug, Clone)]
-pub struct FederatedExecutionResult {
-    /// Result batches
-    pub batches: Vec<RecordBatch>,
-    /// Result schema
-    pub schema: Arc<Schema>,
-    /// Execution statistics
-    pub stats: FederatedExecutionStats,
-}
-
-impl FederatedExecutionResult {
-    /// Create an empty result
-    pub fn empty() -> Self {
-        let schema = Arc::new(Schema::empty());
-        Self {
-            batches: vec![],
-            schema,
-            stats: FederatedExecutionStats::default(),
-        }
-    }
-
-    /// Create a result with a single batch
-    pub fn from_batch(batch: RecordBatch) -> Self {
-        let schema = batch.schema();
-        let rows = batch.num_rows();
-        Self {
-            batches: vec![batch],
-            schema,
-            stats: FederatedExecutionStats {
-                rows_produced: rows,
-                ..Default::default()
-            },
-        }
-    }
-
-    /// Create an empty result with a known schema
-    pub fn empty_with_schema(schema: Arc<Schema>) -> Self {
-        Self {
-            batches: vec![],
-            schema,
-            stats: FederatedExecutionStats::default(),
-        }
-    }
-
-    /// Get total row count
-    pub fn row_count(&self) -> usize {
-        self.batches.iter().map(|b| b.num_rows()).sum()
-    }
-}
-
-/// Federated query execution statistics.
-///
-/// Naming note: this type used to be called `ExecutionStats` and collided
-/// with the graph/router/proto `ExecutionStats` types. Renamed to make
-/// the federation-layer scope explicit. The proto
-/// `proximadb.explain.v1::ExecutionStats` remains the canonical EXPLAIN
-/// form per ADR-004.
-#[derive(Debug, Default, Clone)]
-pub struct FederatedExecutionStats {
-    /// Total rows produced
-    pub rows_produced: usize,
-    /// Execution time in microseconds
-    pub execution_time_us: u64,
-    /// Bytes scanned
-    pub bytes_scanned: u64,
-    /// Models queried
-    pub models_queried: Vec<ModelType>,
-    /// Cache hits
-    pub cache_hits: u64,
-    /// Cache misses
-    pub cache_misses: u64,
-}
+pub use proximadb_query_fusion::execution_result::{
+    ExecutionResult, FederatedExecutionResult, FederatedExecutionStats,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum JoinKey {


### PR DESCRIPTION
Moves FederatedExecutionResult + FederatedExecutionStats + ExecutionResult type alias into query-fusion (new execution_result.rs module). Root re-exports them. **Unblocks 30 tests** in query/cache (query_result_cache 19t + invalidation 11t) for the next cascade step. Clean data containers (Arrow + DataModel only). Verified: standalone + root lib check BOTH passed on first try. See TD-DECOMP-32.