### PR TITLE
docs(td): file TD-FPRUNE-2 — records/scan materializes the whole collection before filtering

### DIFF
--- a/docs/10-quality/td/TD-FPRUNE-2-record-scan-materializes-before-filtering.adoc
+++ b/docs/10-quality/td/TD-FPRUNE-2-record-scan-materializes-before-filtering.adoc
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-FPRUNE-2: `records/scan` materializes the whole collection before applying the filter — declared secondary indexes are never consulted
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open.** Found 2026-08-07 while evaluating PAX as the backing store for a code-property-graph edge set (Victor TD-13). Measured on `develop` @ `b9d2c5d9c`, SST engine, dim-1 collection.
+| Priority | **P2 — blocks record-scan as a lookup surface.** Any equality lookup over records is O(collection), regardless of selectivity or declared schema. It does not corrupt data; it makes an entire access pattern unusable and, because a schema *can* declare `indexed: true`, it silently does nothing.
+| Component | `src/services/operations/vectors/legacy.rs:1211` (`scan_records_paginated`) → `list_all_records_with_tenant_context` (`:1272`).
+| Sibling | TD-FPRUNE-1 (filter-aware PAX cascade, ADR-089) is the same disease on the *vector search* surface: the coalesced cascade declines filtered queries and falls to whole-object brute force. This TD is the *record scan* surface. ADR-089's metadata-first cell/block pruning is plausibly the shared fix; the two call sites are distinct.
+|===
+
+== The finding
+
+`scan_records_paginated` reads **every record in the collection** and then filters
+in memory:
+
+[source,rust]
+----
+let mut records = self
+    .list_all_records_with_tenant_context(&collection_id, tenant_context)
+    .await?;                                   // <- materializes the whole collection
+records.retain(|record| {
+    record.is_visible_at(now_ns)
+        && filter.as_ref().is_none_or(|filter| {
+            crate::core::search::sql_value_filter::evaluate_filter_proxima(
+                filter, &record.props,
+            )
+        })
+});
+----
+
+The filter is applied *after* full materialization, so it is O(n) by
+construction. No index is consulted, and none can be — there is no point in the
+call chain where an index could narrow the read.
+
+== Why this is more than a performance note
+
+The v2 create-collection API accepts a schema whose columns carry
+`indexed: Option<bool>`, documented as:
+
+____
+Create secondary index for this column. Improves query performance for
+equality/range filters.
+____
+
+Declaring it changes nothing on this path. A caller who reads the API, declares
+the right columns, and measures will find the documented knob inert — the same
+class of defect as #1525 (`vector_engine` accepted and never transmitted) and
+#1526 (`vector_count_threshold` parsed and never read).
+
+== Evidence
+
+81,001 records in one dim-1 SST collection; props `{src, dst, etype}`; 200 probes
+of `{"filter": {"src": <id>}}`, each matching ~3 rows (mean 3.4, max 10). Baseline
+is SQLite holding the identical rows with the index the real consumer uses
+(`idx_cpg_fragment_edge_src ON cpg_fragment_edge(src, type)`).
+
+[cols="1,1,1,1", options="header"]
+|===
+| | SQLite | ProximaDB | ratio
+| filtered lookup p50 | 0.005 ms | **158.8 ms** | ~29,000×
+| filtered lookup p95 | 0.009 ms | 170.7 ms | ~19,000×
+| ingest (81k rows) | 0.61 s | 0.85 s | comparable
+| on-disk | 12.97 MB | 23.23 MB | 1.8× larger
+|===
+
+Re-run with `enable_proxima_record: true` and `src`/`dst`/`etype` declared
+`{"indexed": true, "filterable": true}`: **158.8 ms, unchanged.** That is the
+direct evidence that the declared index is not on this path.
+
+158 ms is not round-trip cost — a UDS round trip on the same box is ~1 ms. It is
+the cost of decoding 81k records to return 3.
+
+== Secondary finding: record footprint for narrow rows
+
+The same measurement shows PAX at 1.8× SQLite for narrow, high-cardinality rows
+(23.23 MB vs 12.97 MB; a single 17 MB L0 `.pax` segment). Records repeat prop
+names per row where SQLite has a compact row format plus B-trees. Worth stating
+explicitly in guidance: the record/PAX path is the right home for dense vectors
+with payloads, and currently the wrong home for narrow relational-shaped rows.
+This is a design characteristic, not necessarily a defect — but it is not
+documented anywhere a caller would find it.
+
+== Next action
+
+1. Decide whether record scan should participate in ADR-089 metadata-first
+   pruning, or whether equality lookup over records is explicitly out of scope
+   for this API (both are defensible; today's behaviour reads as neither).
+2. If out of scope: make `indexed: true` either honoured or **rejected** at
+   create time for a collection whose engine cannot use it, so the knob stops
+   being decorative. Silently accepting it is what cost this investigation.
+3. If in scope: the prune must land before `list_all_records_with_tenant_context`
+   materializes, i.e. push the predicate into the segment reader rather than
+   filtering its output.
+
+== Reproduction
+
+Spike script and full output archived with the reporting session; the shape is:
+load N records with `props: {src, dst, etype}` into a dim-1 SST collection,
+then time `POST /api/v2/collections/<c>/records/scan` with
+`{"limit": 100, "filter": {"src": "<value>"}}` at N = 2,000 and N = 81,001.
+Latency scales with N, not with the number of matching rows (5 ms → 158 ms for a
+40× data increase returning the same ~3 rows).
+
+NOTE: the flat `{"filter": {"field": value}}` form is the one that matches; the
+verbose `{"field": ..., "op": "eq", "value": ...}` form returns 0 rows silently.
+That is arguably its own small TD.


### PR DESCRIPTION
Files **TD-FPRUNE-2** under the existing FPRUNE prefix. Docs only — no code change.

## What it records

`scan_records_paginated` reads every record in the collection and filters afterwards (`legacy.rs:1211`):

```rust
let mut records = self.list_all_records_with_tenant_context(...).await?;  // whole collection
records.retain(|r| r.is_visible_at(now_ns) && evaluate_filter_proxima(filter, &r.props));
```

So equality lookup over records is O(collection) by construction, whatever the selectivity — there is no point in the chain where an index could narrow the read.

## Measured

81,001 records, dim-1 SST collection, 200 probes each matching ~3 rows, against SQLite holding identical rows with the index its real consumer uses:

| | SQLite | ProximaDB | |
|---|---|---|---|
| filtered lookup p50 | 0.005 ms | **158.8 ms** | ~29,000× |
| filtered lookup p95 | 0.009 ms | 170.7 ms | |
| on-disk | 12.97 MB | 23.23 MB | 1.8× larger |

Latency scales with collection size, not match count: 5 ms at N=2,000 → 158 ms at N=81,001 returning the same ~3 rows. 158 ms is not round-trip cost — a UDS round trip here is ~1 ms.

**The part I think matters most:** re-running with `enable_proxima_record: true` and the probed columns declared `{"indexed": true, "filterable": true}` changed nothing. The v2 API documents that flag as *"Create secondary index for this column. Improves query performance for equality/range filters"*, and on this path it is inert. That is the same accepted-and-ignored shape as #1525 (`vector_engine` never transmitted) and #1526 (`vector_count_threshold` never read) — a caller who reads the API, configures correctly, and measures finds the knob does nothing.

## Why FPRUNE

TD-FPRUNE-1 is the same disease on the *vector search* surface (cascade declines filtered queries → whole-object brute force). This is the *record scan* surface. ADR-089's metadata-first cell/block pruning is plausibly the shared fix, but the call sites are distinct, so it is a sibling rather than a phase of FPRUNE-1.

## Secondary finding included

PAX is 1.8× SQLite on-disk for narrow, high-cardinality rows. That reads as a design characteristic rather than a defect — records repeat prop names per row where SQLite has a compact row format plus B-trees — but it is not documented anywhere a caller would find it, so the TD states it explicitly. The practical guidance: records/PAX are the right home for dense vectors with payloads, and currently the wrong home for narrow relational-shaped rows.

## Next action proposed (not taken here)

Decide whether record scan should participate in ADR-089 pruning, or whether equality lookup over records is explicitly out of scope for this API. Both are defensible; today's behaviour reads as neither. If out of scope, `indexed: true` should be rejected at create time rather than silently accepted.

`scripts/check_td_adr_unique.py` passes: 90 ADR files, 360 TD ids, 0 errors, 0 warnings.