### PR TITLE
refactor(decomp): cascade step 2 — query_result_cache + invalidation → query-cache (TD-DECOMP-33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7942,7 +7942,13 @@ dependencies = [
 name = "proximadb-query-cache"
 version = "0.2.0"
 dependencies = [
+ "arrow",
+ "dashmap",
+ "proximadb-query-fusion",
+ "proximadb-search-types",
+ "thiserror 2.0.19",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/query/proximadb-query-cache/Cargo.toml
+++ b/crates/query/proximadb-query-cache/Cargo.toml
@@ -15,3 +15,9 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio.workspace = true
+proximadb-query-fusion = { path = "../../query/proximadb-query-fusion" }
+proximadb-search-types.workspace = true
+arrow.workspace = true
+dashmap.workspace = true
+tracing.workspace = true
+thiserror.workspace = true

--- a/crates/query/proximadb-query-cache/src/invalidation.rs
+++ b/crates/query/proximadb-query-cache/src/invalidation.rs
@@ -526,9 +526,9 @@ mod tests {
 
     fn create_test_cache() -> Arc<FederatedQueryResultCache> {
         use super::super::query_result_cache::{QueryKey, QueryResultCacheConfig};
-        use crate::query::federated::ExecutionResult;
         use arrow::array::{ArrayRef, RecordBatch, StringArray};
         use arrow::datatypes::{DataType, Field, Schema};
+        use proximadb_query_fusion::execution_result::ExecutionResult;
 
         let config = QueryResultCacheConfig::default();
         let cache = Arc::new(FederatedQueryResultCache::new(config));

--- a/crates/query/proximadb-query-cache/src/lib.rs
+++ b/crates/query/proximadb-query-cache/src/lib.rs
@@ -6,7 +6,9 @@
 //! stay root-side until their root-only deps (ExecutionResult, PlanOutput, QueryCache) extract.
 
 pub mod category_classifier;
+pub mod invalidation;
 pub mod mismatch_cost;
 pub mod per_category_policy;
+pub mod query_result_cache;
 pub mod result_cache_gate;
 // trigger CI

--- a/crates/query/proximadb-query-cache/src/query_result_cache.rs
+++ b/crates/query/proximadb-query-cache/src/query_result_cache.rs
@@ -41,8 +41,8 @@ use dashmap::DashMap;
 use thiserror::Error;
 use tracing::{debug, info};
 
-use crate::core::search::VectorFreshnessMode;
-use crate::query::federated::ExecutionResult;
+use proximadb_query_fusion::execution_result::ExecutionResult;
+use proximadb_search_types::search_params::VectorFreshnessMode;
 
 /// Unique identifier for a cached query result
 pub type QueryCacheKey = u64;

--- a/docs/10-quality/td/TD-DECOMP-33-cascade-query-cache-step2.adoc
+++ b/docs/10-quality/td/TD-DECOMP-33-cascade-query-cache-step2.adoc
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-33: Cascade step 2 — move query_result_cache + invalidation → query-cache (30 tests)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Medium — structural cascade payoff (30 tests unlocked by TD-DECOMP-32)
+| Component | `crates/query/proximadb-query-cache`; root `src/query/cache/mod.rs`
+| Relates to | [[TD-DECOMP-29]] (query-cache crate created); [[TD-DECOMP-32]] (ExecutionResult extracted)
+|===
+
+== Why
+
+TD-DECOMP-32 extracted `ExecutionResult` types to query-fusion, unblocking the root-only dep that
+kept `query_result_cache.rs` (19t) and `invalidation.rs` (11t) stuck in root. This TD moves them
+into the existing `proximadb-query-cache` crate — the **30-test payoff** of the structural cascade.
+
+== What moved (behavior-neutral)
+
+* `query_result_cache.rs` (19t) + `invalidation.rs` (11t) → query-cache crate.
+* Imports rewritten: `crate::query::federated::ExecutionResult` → `proximadb_query_fusion::execution_result::ExecutionResult`;
+  `crate::core::search::VectorFreshnessMode` → `proximadb_search_types::search_params::VectorFreshnessMode`;
+  intra-module refs (`crate::query::cache::X`) → `crate::X`.
+* Root `query/cache/mod.rs`: 2 `pub mod X;` → `pub use proximadb_query_cache::X;`.
+* query-cache gains deps: `proximadb-query-fusion` (inline path — not a workspace dep), `proximadb-search-types`,
+  `arrow`, `dashmap`, `tracing`, `thiserror` (all workspace).
+* query-cache crate now holds **70 tests** (40 from TD-DECOMP-29 + 30 from this TD).
+
+== Follow-ups
+
+* Remaining root-staying query/cache files: `plan_cache.rs` (14t, blocked by PlanOutput → layering),
+  `invalidation_coordinator.rs` (11t, 14 crate:: refs → QueryCache dep), `adaptive_cache.rs` (3t → QueryCacheKey dep).
+* Verified: standalone --all-targets EXIT 0 + root lib check zero errors (BOTH on first try).

--- a/src/query/cache/mod.rs
+++ b/src/query/cache/mod.rs
@@ -120,12 +120,12 @@
 pub mod adaptive_cache;
 pub use proximadb_batch_group_cache::batch_group;
 pub use proximadb_query_cache::category_classifier;
-pub mod invalidation;
+pub use proximadb_query_cache::invalidation;
 pub mod invalidation_coordinator;
 pub use proximadb_query_cache::mismatch_cost;
 pub use proximadb_query_cache::per_category_policy;
 pub mod plan_cache;
-pub mod query_result_cache;
+pub use proximadb_query_cache::query_result_cache;
 pub use proximadb_query_cache::result_cache_gate;
 
 // Re-export main types


### PR DESCRIPTION
Moves query_result_cache.rs (19t) + invalidation.rs (11t) = **30 tests** into the existing query-cache crate. Their ExecutionResult dep now resolves from query-fusion (TD-DECOMP-32). Imports rewritten to crate paths. query-cache crate now holds **70 tests total**. Verified: standalone + root lib check BOTH passed on first try. See TD-DECOMP-33.