### PR TITLE
docs(security): file TD-SEC-2 — the security pressure-test findings register

### DIFF
--- a/docs/10-quality/td/TD-SEC-2-security-pressure-test-register.adoc
+++ b/docs/10-quality/td/TD-SEC-2-security-pressure-test-register.adoc
@@ -1,0 +1,220 @@
+= TD-SEC-2: Multi-tenant SaaS security pressure-test — findings register
+:status: Partial
+:dim: D5
+:pillar: SEC
+
+== Why this exists
+
+After the ADR-090 first arc landed (identity → grants → enforcement → admin surface), the
+whole authn/authz/audit/privacy surface was pressure-tested against common multi-tenant SaaS
+practice (OWASP ASVS V2/V4/V8, tenant-isolation patterns, SOC2-class controls, GDPR basics).
+
+**The headline finding was not missing controls. It was controls that exist, look
+implemented, and never fire.** That is worse than absence: an absent control does not appear
+on an architecture diagram as coverage, and does not stop anyone from looking for the real
+one. Five such controls were found; all five are now armed (Slice A, #1536).
+
+This file is the register: every finding, its evidence, and its disposition. It also carries
+the *worked design* for the one deferred item that is large enough to need one (the
+tamper-evident audit ledger) so the next session starts from the design rather than from
+scratch.
+
+NOTE: This TD was cited in the merged commits for #1536/#1537 and in the
+`PROXIMADB_AUTHZ_REQUIRE_GRANTS` registry row *before the file was filed*. That dangling
+reference was itself an instance of the defect this TD is about — a document asserting
+coverage that did not exist — and is recorded here rather than quietly fixed.
+
+== A. Controls that existed and never fired — RESOLVED in #1536
+
+[cols="1,4,1"]
+|===
+| # | Finding (evidence) | State
+
+| A1
+| **No authentication event has ever been persisted.** `set_audit_logger`
+(`src/security/auth_service.rs:226`) had **zero callers**, so `auth_service.audit_logger` was
+always `None` (`:157`, `:193`) and the emit hook in `authenticate()` was dead code.
+| ✅ #1536
+
+| A2
+| **Brute-force detection collapsed into one bucket.** Failed auth was attributed to
+`UnifiedUserContext::anonymous()`, and `count_recent_auth_failures` keys on `event.user_id`,
+so every failure in the system shared one counter — an account under attack was
+indistinguishable from background noise. *Wiring A1 alone would NOT have fixed this; the
+initial plan claimed it would and was wrong.*
+| ✅ #1536
+
+| A3
+| **Bounded audit queries returned an arbitrary subset.** `query_events` truncated to `limit`
+while iterating the directory and sorted only afterwards, so the brute-force check — which
+samples the newest 100 — could miss recent failures entirely and never trip.
+| ✅ #1536
+
+| A4
+| **The cross-tenant access alert could never fire.** It compared `event.tenant_id` with
+`event.tenant_id` — the same field twice — an unsatisfiable condition. Fixed by adding
+`AuditResource.resource_tenant_id` (the tenant that *owns* the resource, distinct from the
+acting tenant) behind `#[serde(default)]` so pre-existing audit records still parse.
+| ✅ #1536
+
+| A5
+| **`RateLimitingService` had zero call sites.** Fully implemented, never constructed.
+Now `record_failed_auth` counts failures per attempted principal with its own budget knob
+(`failed_auth_per_minute_per_principal`), deliberately *not* reusing the request-rate knob.
+| ✅ #1536
+|===
+
+Two defects fixed alongside them:
+
+* **Boot footgun** — `security.enabled = true` plus the *shipped* `config.toml` default
+  (`enable_audit_logging = false`) **refused to boot**. Now mode-gated: Development gets a
+  documented no-op sink plus a startup warning; every other mode still fails fast. Written as
+  `!matches!(mode, Development)` rather than `matches!(mode, Production)` **on purpose** —
+  `Enterprise` is production-grade too, and any mode added later must fail *closed*.
+* **Silent audit failure** — `let _ = log_event(..)` became a visible policy: `error!` plus an
+  `AUDIT_WRITE_FAILURES` counter, **default fail-open**, opt-in `audit_fail_closed`. Rationale
+  (stated in-code so it can be argued with): the credible failure is operational — a full disk,
+  and note the retention job has *no production caller* — and denying on it converts that into
+  a total authentication outage for every tenant, a self-inflicted DoS; an adversary who can
+  break the sink can already rewrite the unchained history. What matters is that the loss of
+  accountability is **visible**. Separately, on the authorization-denial path an audit-write
+  failure used to *replace* the "Insufficient permissions" error; the denial now always stands.
+
+**Attribution secrecy rule** (introduced with A2, applies to anything that identifies a
+credential in a record): a `pxk_` key contributes its *public* key id (the part before the
+`.`); every other credential shape contributes a truncated SHA-256 **fingerprint** — stable
+enough to count against, useless to replay. Secret material must never reach an audit record.
+
+== B. Process-global enforcement — RESOLVED in #1537
+
+ADR-090 L1.2 gated grant enforcement on one process-global env var. That is the wrong shape
+for SaaS: an operator cannot flag-day every customer onto strict authorization at once, so in
+practice the switch never gets flipped and the enforcement stays permanently dark.
+
+Resolved by per-tenant `TenantSecurityPosture { Off | Audit | Enforce }`
+(`<data_dir>/abac/tenant-posture.json`, admin at `PUT|GET /api/v2/abac/tenant-posture/{tenant}`).
+`PROXIMADB_AUTHZ_REQUIRE_GRANTS` is demoted to the *default* for tenants with no record, so
+existing deployments are unchanged; the record overrides it in both directions. **`Audit` mode
+— evaluate, log the would-be denial, admit — is the rehearsal ramp without which a binary gate
+never gets turned on.**
+
+== C. Open findings (evidence + disposition)
+
+=== C1. Tamper-evident audit ledger — DESIGNED, NOT BUILT
+
+Today's audit files are plain JSONL with **no fsync, no sequence numbers, no hash chain, no
+checksum**, written by a process whose retention job deletes them. The design below is
+complete; it was deliberately *not* half-built, because a partially-trustworthy ledger would
+have become the sixth control that looks armed and isn't.
+
+*Format* — keep JSONL; add a segment-header line as the mixed-read marker (old files simply
+lack it) and an envelope per event:
+
+[source,json]
+----
+{"pxdb_audit_chain":{"version":1,"segment_id":"…","genesis_seq":1042,
+  "prev_segment":{"file":"…","segment_id":"…","last_seq":1041,"last_hash":"…"}}}
+{"seq":1042,"prev_hash":"<hex64>","event":{…verbatim…},"hash":"<hex64>"}
+----
+
+`hash = SHA256(seq_le || prev_hash_raw || raw_event_json_bytes)`. Hash the **exact bytes as
+written** (`serde_json::value::RawValue` on both write and verify) — `AuditEvent.details` is a
+`HashMap`, so re-serializing to verify would produce false tamper positives from key reorder.
+
+*Key constraints* — chain state (seq, prev_hash, open file) lives inside the storage struct
+behind one mutex, never on the `Clone`-able `AuditLogger` (clones would fork the chain);
+rotation seals a segment and anchors it in the successor's header; retention appends an
+`audit_retention_delete` anchor event *before* deleting the oldest segment, so `verify_chain`
+can distinguish lawful retention from tampering; ship writer default-OFF, reader auto-detects
+per file forever (mandate #8). Mirror `io_trace_sink.rs:567-576` for durable append
+(`write_all` → `sync_all` → **parent-directory fsync** on new segments) and
+`batch_sync_coordinator.rs` for the group-commit option, since one fdatasync per auth event
+is 50 µs–5 ms depending on storage.
+
+*Honest limits — tamper classes this design can NEVER detect* (must ship in the module
+rustdoc, not just here):
+
+. **Suffix rewrite**: there is no secret in the chain, so an attacker with write access can
+  edit entry k and recompute every hash from k to the head.
+. **Active-segment tail truncation** at any complete-line boundary.
+. **Whole-directory replacement** with a forged, internally consistent chain (genesis has no
+  external root of trust).
+. **Legacy pre-feature files** are forgeable forever.
+. Anything done by the same uid/root between verifications.
+
+Raising the bar requires an external anchor: HMAC with a `KeyStore` key, periodic head-hash
+export via the existing `external_audit_endpoint`, a WORM mirror (the `Combined` backend is
+unimplemented), or `chattr +a`.
+
+=== C2. Other open findings
+
+[cols="1,4"]
+|===
+| Finding | Note
+
+| Retention never runs
+| `cleanup_old_logs` has **zero production callers** — the audit directory grows unbounded, which makes disk-full the most likely audit-write failure (and is why A5's policy is fail-open-but-loud).
+
+| Scoped / least-privilege API keys
+| A key is the whole user. No per-key scopes or expiry classes. `ApiKeyInfo.ip_restrictions` and `rate_limit_per_minute` remain dead fields.
+
+| Key hygiene
+| No max-age enforcement, no `last_used` tracking (dormant-key detection is a SOC2 staple), and the `pxk_` format carries no algo/version tag, so a future hash migration has no in-band signal.
+
+| JWT revocation is not durable
+| The blacklist is an in-process `HashSet` — lost on restart, unshared across nodes, keyed on the full token string, never pruned. `revoke_token` has no caller: there is no `/logout` and no admin revocation path.
+
+| MFA is inert
+| `requires_mfa` is hardcoded `false` at ~15 construction sites and read once into a field nothing branches on. No challenge gate exists on any request path.
+
+| No tenant self-service admin
+| `authorize_operator` is platform SystemAdmin ∪ ConfigureSystem only; tenants cannot manage their own grants or keys.
+
+| Predicate store is not tenant-partitioned
+| Grant `predicate_ref` dereferences into a globally-keyed store — L1.1 added a consumer to a pre-existing flaw.
+
+| `GrantAction::Grant` unenforced
+| Delegation is representable but never checked; no re-grant path, no delegation depth.
+
+| Six `System` bypasses
+| Client-facing read paths still construct a System context (TD-AUTHZ-1 L2.2).
+
+| No write-path authorization
+| The action model covers reads; writes have no grant check.
+
+| `FieldMask` dormant
+| Column masking is representable end-to-end but no PII redaction actually fires.
+
+| No right-to-erasure workflow
+| Deletes exist; nothing guarantees erasure across WAL, segments, caches, and audit for a subject or tenant.
+
+| No BYOK / per-tenant encryption
+| Deferred with ADR-090 L3 (BYOB storage bindings).
+
+| Residency is recorded, not routed
+| `DrPlacement` carries regions that nothing enforces.
+
+| Store consolidation
+| Four JSON snapshot stores (identity, bindings, grants, posture) with no cross-store atomicity — a grant can reference a predicate object whose write failed — plus in-memory policy epochs that reset on restart. Acceptable single-node mechanism; the migration path is catalog-DB backing.
+
+| Revoked grants accumulate
+| Soft-revoked grants are retained deliberately (audit trail) but need a compaction/archival policy.
+|===
+
+== D. Correction on the record
+
+An early review note asserted that *no* rate limiting exists anywhere on the request path.
+That is too strong: an opt-in **per-IP limiter does exist on the pgwire path**
+(`PROXIMADB_PGWIRE_RATE_LIMIT_RPM`, default off, `src/network/multi_server.rs`). The accurate
+statement is that nothing throttles the REST/gRPC **auth** path, and nothing counted auth
+*failures* on any transport until #1536.
+
+== E. Next action
+
+The highest-value remaining item is not on this list — it is the **provision → permit → deny
+→ revoke live e2e ratchet** (TD-AUTHZ-1 L1.2), which is the documented flip-precondition for
+`PROXIMADB_AUTHZ_REQUIRE_GRANTS` and became writable once the grants admin surface landed
+(#1534). Enforcement cannot be turned on for any tenant until that ratchet is green.
+
+Then, in order: C1 (ledger), predicate-store partitioning, the six `System` bypasses, and
+tenant self-service admin.


### PR DESCRIPTION
**TD-SEC-2 was cited in the merged commits for #1536 and #1537, and in the `PROXIMADB_AUTHZ_REQUIRE_GRANTS` registry row — but the file was never created.** That dangling reference is itself an instance of the defect this TD is about (a document asserting coverage that doesn't exist), so it is recorded in the file rather than quietly fixed.

## Contents

- **§A — the five controls that existed and never fired**, with evidence: audit logger with zero callers, brute-force counter collapsed into one bucket, limit-before-sort, a cross-tenant alert comparing a field to itself, an unwired rate limiter. Includes the note that **wiring the audit logger alone would not have armed the detector** — the initial plan claimed it would and was wrong. Also states the **attribution secrecy rule** now binding on anything that identifies a credential in a record.
- **§B —** the process-global enforcement gate and its replacement by per-tenant posture with the `Audit` rehearsal ramp.
- **§C1 — the full worked design for the deferred tamper-evident ledger**: format, chain over *exact written bytes* (re-serializing a `HashMap` would give false tamper positives from key reorder), rotation anchoring, retention-anchor events, concurrency, fsync cost — **and the tamper classes it could never detect** (suffix rewrite, active-tail truncation, whole-directory forgery, legacy files). Deliberately not half-built: a partially trustworthy ledger would have become the sixth control that looks armed and isn't.
- **§C2 —** remaining open findings, including that the audit **retention job has no production caller** (which is *why* the audit-failure policy is fail-open-but-loud).
- **§D — a correction on the record**: an opt-in per-IP limiter *does* exist on the pgwire path; the accurate claim is that nothing throttles REST/gRPC auth and nothing counted auth failures anywhere until #1536.
- **§E —** next action: the live provision→permit→deny→revoke e2e ratchet, the documented flip-precondition for the enforcement gate.

Guards: `check_td_adr_unique` clean (90 ADRs, 365 TD ids, 0 errors) · `make work-commit-check` green.

Ref #1536, #1537, ADR-090, TD-AUTHZ-1.
