### PR TITLE
docs(authz): cross-tenant sharing is authorized but not observable — verified blocker (TD-TENANT-2)

### DIFF
--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -115,3 +115,22 @@ the cloud-emulator suite (Azurite/MinIO); recall unaffected (the standing
 * TD-TENANT-2 (per-row predicate retirement — L1/L2 supersede its interim state);
   TD-ABAC-6 (orchestrator adoption, finished by L0.3); TD-SDK-2 unaffected.
 * The 53-gap inventory: ADR-090 appendices A–C.
+
+
+== Sequencing update (2026-08-07) — verified blocker on the cross-tenant ratchet
+
+Tracing the cross-tenant read path for the L1.2 e2e ratchet found that
+`src/services/operations/vectors/legacy.rs:1123/:1175/:1346` retain rows by
+`record.tenant_id == tenant_context.tenant_id`, so a foreign grantee is admitted by the
+catalog and then filtered to zero rows. See the 2026-08-07 addendum in TD-TENANT-2.
+
+Revised order for the remaining L1/L2 work:
+
+. **Same-tenant e2e ratchet** (provision → permit → deny → revoke over live transports) —
+  reachable now that the grants admin surface has landed (#1534); this is the flip-precondition
+  for arming enforcement, whether via the env default or a tenant `Enforce` posture (#1537).
+. **TD-TENANT-2** — retire the per-row tenant predicate. Promoted to the critical path: until
+  it lands, cross-tenant sharing is authorized but not observable.
+. **Cross-tenant e2e ratchet** — only meaningful after (2); writing it earlier yields a test
+  that fails for reasons unrelated to grants.
+. Then L2 (`$subject.attr`, the six `System` bypasses, predicate-store tenant partitioning).

--- a/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
+++ b/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
@@ -123,3 +123,43 @@ collections, no cross-observation) remains required and gains a sibling: a grant
   TD-TENANT-1 (header trust policy); the ABAC push-down that owns row-level access.
 * Discovered while auditing OQ-4 of
   link:TD-V1SUNSET-2-vectorrecord-to-proximatecord-first-slice.adoc[TD-V1SUNSET-2].
+
+== Addendum (2026-08-07) — VERIFIED: this TD blocks ADR-090's headline capability
+
+While scoping the L1.2 e2e ratchet, the cross-tenant read path was traced end to end. The
+result promotes this TD from "consistency cleanup" to **the blocker for cross-tenant
+sharing**:
+
+Three live vector read paths retain records by comparing the record's stamped tenant against
+the *acting* tenant — `src/services/operations/vectors/legacy.rs:1123`, `:1175`, `:1346`:
+
+[source,rust]
+----
+records.retain(|record| {
+    record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
+});
+----
+
+Consequence, stated precisely: a foreign grantee reading a shared collection is **authorized
+and then filtered to nothing**. The catalog seam admits them — `evaluate_grants` returns
+`Permit`, and the L1.1 spec test `foreign_grantee_admits_and_only_that_grantee` passes — but
+every row belongs to the owner tenant, so this predicate drops all of them. The grantee
+observes an empty result set indistinguishable from "no data".
+
+**So ADR-090's headline capability is currently authorized but not observable.** Grant
+enforcement is genuinely end-to-end *within* a tenant; cross-tenant sharing is expressible,
+durable, and correctly decided at the catalog seam, and stops at the data path.
+
+This has two consequences for sequencing:
+
+. The L1.2 flip-precondition ratchet splits in two. The **same-tenant**
+  provision → permit → deny → revoke ratchet is reachable today and is what gates arming
+  `PROXIMADB_AUTHZ_REQUIRE_GRANTS` (or a tenant's `Enforce` posture). The **cross-tenant**
+  variant cannot pass until this TD lands, and writing it first would produce a test that
+  fails for a reason unrelated to grants.
+. This TD is now on the critical path for the sharing feature, not adjacent to it.
+
+Note the generalization worth carrying: a capability proven by unit tests at one layer is not
+a capability the system has. `foreign_grantee_admits_and_only_that_grantee` is a true
+statement about `evaluate_grants` and a false statement about ProximaDB. The e2e ratchet
+exists precisely to catch that gap, and it caught this one before the claim reached a user.


### PR DESCRIPTION
Scoping the L1.2 e2e ratchet meant tracing the cross-tenant read path end to end. The trace produced a finding that **changes the program's ordering**.

## The finding

Three **live** vector read paths retain rows by comparing the record's stamped tenant against the *acting* tenant — `src/services/operations/vectors/legacy.rs:1123`, `:1175`, `:1346`:

```rust
records.retain(|record| {
    record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
});
```

So a foreign grantee reading a shared collection is **authorized and then filtered to nothing**. The catalog seam admits them — `evaluate_grants` returns `Permit`, and the L1.1 spec test `foreign_grantee_admits_and_only_that_grantee` passes — but every row belongs to the owner tenant, so this predicate drops all of them. The grantee observes an empty result set indistinguishable from "no data".

**ADR-090's headline capability is currently authorized but not observable.** Grant enforcement is genuinely end-to-end *within* a tenant; cross-tenant sharing is expressible, durable, and correctly decided at the catalog seam — and stops at the data path.

## Consequences (recorded in both TDs)

1. **The L1.2 ratchet splits.** The **same-tenant** provision → permit → deny → revoke ratchet is reachable today and is what gates arming enforcement. The **cross-tenant** variant cannot pass until TD-TENANT-2 lands — writing it first would produce a test that fails for reasons unrelated to grants.
2. **TD-TENANT-2 moves onto the critical path** for the sharing feature rather than sitting adjacent to it.

## Why this is worth a commit of its own

A capability proven by unit tests at one layer is not a capability the system has. `foreign_grantee_admits_and_only_that_grantee` is a true statement about `evaluate_grants` and a false statement about ProximaDB. The e2e ratchet exists to catch exactly that gap — and it caught this one before the claim reached a user, which is the argument for keeping the ratchet as the gate's flip-precondition.

Docs only. `make work-commit-check` green.

Ref ADR-090, TD-AUTHZ-1, TD-TENANT-2, #1517, #1529, #1534, #1537.
