### PR TITLE
test(authz): L1.2 grant ratchet + the CI lane that actually runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       storage_changes: ${{ steps.filter.outputs.storage_changes }}
       graph_changes: ${{ steps.filter.outputs.graph_changes }}
       core_changes: ${{ steps.filter.outputs.core_changes }}
+      authz_changes: ${{ steps.filter.outputs.authz_changes }}
       network_changes: ${{ steps.filter.outputs.network_changes }}
       pgwire_accuracy_changes: ${{ steps.filter.outputs.pgwire_accuracy_changes }}
       object_store_cloud_changes: ${{ steps.filter.outputs.object_store_cloud_changes }}
@@ -260,6 +261,20 @@ jobs:
               - 'src/network/**'
               - 'src/api_handlers/**'
               - 'proto/**'
+            # ADR-090 / TD-AUTHZ-1 authorization e2e. Filters track the OUTCOME
+            # (an authorization decision changing) rather than code ownership —
+            # the #1430 lesson, where a recall lane skipped on the very PR that
+            # broke recall because the changed path matched no filter.
+            authz_changes:
+              - 'src/security/**'
+              - 'src/services/operations/vectors/**'
+              - 'crates/control/proximadb-abac/**'
+              - 'crates/control/proximadb-catalog/**'
+              - 'src/network/rest/canonical/abac_admin.rs'
+              - 'src/network/rest/canonical/handlers.rs'
+              - 'src/network/shared_services.rs'
+              - 'tests/abac_*.rs'
+              - '.github/workflows/ci.yml'
             # Multi-modal pgwire value-accuracy e2e suite (TD-182 P0). The suite
             # exercises the SQL/pgwire + relational + DML + cold-path-merge code,
             # so re-run it when any of those change, when the suite files change,
@@ -1806,6 +1821,42 @@ jobs:
             fi
           done
 
+  rust-integration-test-authz:
+    name: Rust Integration Tests (authz e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [changes, rust-build]
+    # NOTE: this suite is `#![cfg(feature = "abac-policy")]`, which is NOT a
+    # default feature — WITHOUT `--features abac-policy` the file compiles to
+    # ZERO tests and the job passes while verifying nothing. That is exactly how
+    # the suite sat dormant: no lane ran it, and a run without the feature would
+    # have looked green anyway.
+    if: |
+      !inputs.skip_tests &&
+      needs.changes.outputs.test_tier == 'true' &&
+      needs.changes.outputs.rust == 'true' &&
+      needs.changes.outputs.authz_changes == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-nightly-dev"
+          shared-key: "build"
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
+      - name: Run Authorization E2E (live transports)
+        run: |
+          set -euo pipefail
+          output=$(cargo test --features abac-policy --test abac_relational_transport_e2e -- --test-threads=1 2>&1)
+          echo "$output"
+          if echo "$output" | grep -qE "running 0 tests"; then
+            echo "::error::the authz e2e suite compiled to ZERO tests - the abac-policy feature is not enabled, so this job verified nothing."
+            exit 1
+          fi
+
   rust-integration-test-query:
     name: Rust Integration Tests (query)
     runs-on: ubuntu-latest
@@ -2581,6 +2632,7 @@ jobs:
       - rust-build
       - rust-test
       - rust-integration-test-storage
+      - rust-integration-test-authz
       - rust-integration-test-query
       - rust-integration-test-pgwire-accuracy
       - rust-integration-test-graph

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1860,13 +1860,19 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - name: Run Authorization E2E (live transports)
         run: |
-          set -euo pipefail
-          output=$(cargo test --features abac-policy --test abac_relational_transport_e2e -- --test-threads=1 2>&1)
+          set -uo pipefail
+          # NOTE: deliberately NOT `set -e` around the capture. With `-e`, a
+          # failing cargo aborts the step BEFORE the echo, so the failure reason
+          # is swallowed and the job reports red with no diagnostic — which is
+          # exactly what happened on the first run of this lane.
+          status=0
+          output=$(cargo test --features abac-policy --test abac_relational_transport_e2e -- --test-threads=1 --nocapture 2>&1) || status=$?
           echo "$output"
           if echo "$output" | grep -qE "running 0 tests"; then
             echo "::error::the authz e2e suite compiled to ZERO tests - the abac-policy feature is not enabled, so this job verified nothing."
             exit 1
           fi
+          exit "$status"
 
   rust-integration-test-query:
     name: Rust Integration Tests (query)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1826,6 +1826,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [changes, rust-build]
+    # The `rust` filter is deliberately NOT ANDed in here: it covers src/**,
+    # crates/**, apps/** and the Cargo files, but NOT tests/** or .github/**, so
+    # requiring it would skip this lane on exactly the PRs that change the authz
+    # tests or this wiring — which is what happened on the first push of #1544.
+    # `authz_changes` already scopes the lane correctly on its own.
     # NOTE: this suite is `#![cfg(feature = "abac-policy")]`, which is NOT a
     # default feature — WITHOUT `--features abac-policy` the file compiles to
     # ZERO tests and the job passes while verifying nothing. That is exactly how
@@ -1834,7 +1839,6 @@ jobs:
     if: |
       !inputs.skip_tests &&
       needs.changes.outputs.test_tier == 'true' &&
-      needs.changes.outputs.rust == 'true' &&
       needs.changes.outputs.authz_changes == 'true'
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1825,7 +1825,14 @@ jobs:
     name: Rust Integration Tests (authz e2e)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: [changes, rust-build]
+    # `needs: [changes]` ONLY — deliberately not `rust-build`. `rust-build` is
+    # itself gated on the `rust` filter (src/**, crates/**, apps/**, Cargo*),
+    # so depending on it makes this lane inherit that gate transitively and skip
+    # on any PR that changes only tests/** or .github/** — which is precisely
+    # what happened on the first two pushes of #1544. This lane compiles what it
+    # needs via its own `cargo test`, so the dependency bought nothing.
+    # `rust-integration-test-pgwire-accuracy` gets this right and is the model.
+    needs: [changes]
     # The `rust` filter is deliberately NOT ANDed in here: it covers src/**,
     # crates/**, apps/** and the Cargo files, but NOT tests/** or .github/**, so
     # requiring it would skip this lane on exactly the PRs that change the authz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,27 +512,11 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom 7.1.3",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom 7.1.3",
@@ -540,18 +524,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "synstructure",
 ]
 
 [[package]]
@@ -2920,25 +2892,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom 7.1.3",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "displaydoc",
  "nom 7.1.3",
  "num-bigint",
@@ -3384,6 +3342,9 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "filetime"
@@ -3436,22 +3397,11 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
-name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -5570,15 +5520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
 name = "napi"
 version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5884,20 +5825,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -6739,7 +6671,7 @@ dependencies = [
  "duckdb",
  "env_logger",
  "flate2",
- "flume 0.11.1",
+ "flume",
  "futures",
  "google-cloud-storage",
  "half",
@@ -6942,7 +6874,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "webpki-roots 0.25.4",
- "x509-parser 0.16.0",
+ "x509-parser",
  "xz2",
  "zstd",
 ]
@@ -8717,7 +8649,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tracing",
- "x509-parser 0.18.1",
+ "x509-parser",
 ]
 
 [[package]]
@@ -10383,7 +10315,7 @@ checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.12.0",
+ "flume",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -12467,33 +12399,16 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs 0.6.2",
- "data-encoding",
- "der-parser 9.0.0",
- "lazy_static",
- "nom 7.1.3",
- "oid-registry 0.7.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom 7.1.3",
- "oid-registry 0.8.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",

--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -115,3 +115,22 @@ the cloud-emulator suite (Azurite/MinIO); recall unaffected (the standing
 * TD-TENANT-2 (per-row predicate retirement — L1/L2 supersede its interim state);
   TD-ABAC-6 (orchestrator adoption, finished by L0.3); TD-SDK-2 unaffected.
 * The 53-gap inventory: ADR-090 appendices A–C.
+
+
+== Sequencing update (2026-08-07) — verified blocker on the cross-tenant ratchet
+
+Tracing the cross-tenant read path for the L1.2 e2e ratchet found that
+`src/services/operations/vectors/legacy.rs:1123/:1175/:1346` retain rows by
+`record.tenant_id == tenant_context.tenant_id`, so a foreign grantee is admitted by the
+catalog and then filtered to zero rows. See the 2026-08-07 addendum in TD-TENANT-2.
+
+Revised order for the remaining L1/L2 work:
+
+. **Same-tenant e2e ratchet** (provision → permit → deny → revoke over live transports) —
+  reachable now that the grants admin surface has landed (#1534); this is the flip-precondition
+  for arming enforcement, whether via the env default or a tenant `Enforce` posture (#1537).
+. **TD-TENANT-2** — retire the per-row tenant predicate. Promoted to the critical path: until
+  it lands, cross-tenant sharing is authorized but not observable.
+. **Cross-tenant e2e ratchet** — only meaningful after (2); writing it earlier yields a test
+  that fails for reasons unrelated to grants.
+. Then L2 (`$subject.attr`, the six `System` bypasses, predicate-store tenant partitioning).

--- a/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
@@ -1,0 +1,56 @@
+= TD-AUTHZ-2: xcatalog.tables returns an empty object_id for SQL-created relational tables
+:status: Open
+:dim: D4
+:pillar: SEC
+
+== Symptom
+
+`SELECT * FROM xcatalog.tables WHERE table_name = '<t>'` over pgwire returns a row whose
+`object_id` column is **empty** when `<t>` is a relational table created through SQL DDL. The
+same column carries a numeric stable id for a vector collection.
+
+Three tests in `tests/abac_relational_transport_e2e.rs` fail on it, all at the same helper
+(`table_object_id`, which parses that column):
+
+* `pgwire_reads_follow_live_rest_policy_provision_and_revoke`
+* `grpc_reads_follow_live_rest_policy_provision_and_revoke`
+* `rest_sql_reads_follow_live_policy_provision_and_revoke`
+
+`ParseIntError { kind: Empty }` — the column is present but blank, not absent.
+
+== How it surfaced (and why it matters beyond three tests)
+
+This suite is `#![cfg(feature = "abac-policy")]` and **had never run in CI**: the integration
+lanes match it with no glob, and no lane passed the feature — without which the file compiles
+to *zero tests* and a run exits 0 having verified nothing. Wiring the lane in #1544 executed
+these tests for the first time and they failed immediately.
+
+So the defect is not new; it is newly *visible*. Anything that depends on a relational
+table's stable object id — policy bindings and grants are both scoped by it — cannot be
+provisioned for a SQL-created table through the introspection path these tests use. Whether
+the object id is genuinely unpopulated for relational tables, or merely not projected into
+`xcatalog.tables`, is the first question to answer; the two have very different blast radii.
+
+NOTE: the test helper reads the column by hardcoded position (`row.get(9)` against
+`SELECT *`), so a projection change would also produce this. That must be ruled out before
+concluding the id itself is missing — the vector-collection path parses the same position
+successfully, which argues for a data difference rather than an index drift, but it is not
+proof.
+
+== Disposition
+
+The three tests carry `#[ignore = "TD-AUTHZ-2: ..."]` with the full reason, so they remain
+visible in every run's ignored count rather than being silently dropped from the lane. They
+must be un-ignored as part of the fix — an ignore that outlives its defect is how a suite goes
+dormant in the first place.
+
+== Next action
+
+. Determine whether `object_id` is unpopulated for relational tables or merely unprojected in
+  `xcatalog.tables`.
+. Fix at whichever layer owns it, then remove the three `#[ignore]` attributes in the same PR.
+. Consider replacing the positional `row.get(9)` with a name-addressed lookup so the helper
+  cannot drift silently again.
+
+Related: TD-AUTHZ-1 (ADR-090 program), TD-SEC-2 (the pressure-test register that catalogues
+this same "reports success while covering nothing" defect class).

--- a/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
+++ b/docs/10-quality/td/TD-TENANT-2-retire-per-row-tenant-predicate.adoc
@@ -123,3 +123,43 @@ collections, no cross-observation) remains required and gains a sibling: a grant
   TD-TENANT-1 (header trust policy); the ABAC push-down that owns row-level access.
 * Discovered while auditing OQ-4 of
   link:TD-V1SUNSET-2-vectorrecord-to-proximatecord-first-slice.adoc[TD-V1SUNSET-2].
+
+== Addendum (2026-08-07) — VERIFIED: this TD blocks ADR-090's headline capability
+
+While scoping the L1.2 e2e ratchet, the cross-tenant read path was traced end to end. The
+result promotes this TD from "consistency cleanup" to **the blocker for cross-tenant
+sharing**:
+
+Three live vector read paths retain records by comparing the record's stamped tenant against
+the *acting* tenant — `src/services/operations/vectors/legacy.rs:1123`, `:1175`, `:1346`:
+
+[source,rust]
+----
+records.retain(|record| {
+    record.tenant_id.is_empty() || record.tenant_id == tenant_context.tenant_id
+});
+----
+
+Consequence, stated precisely: a foreign grantee reading a shared collection is **authorized
+and then filtered to nothing**. The catalog seam admits them — `evaluate_grants` returns
+`Permit`, and the L1.1 spec test `foreign_grantee_admits_and_only_that_grantee` passes — but
+every row belongs to the owner tenant, so this predicate drops all of them. The grantee
+observes an empty result set indistinguishable from "no data".
+
+**So ADR-090's headline capability is currently authorized but not observable.** Grant
+enforcement is genuinely end-to-end *within* a tenant; cross-tenant sharing is expressible,
+durable, and correctly decided at the catalog seam, and stops at the data path.
+
+This has two consequences for sequencing:
+
+. The L1.2 flip-precondition ratchet splits in two. The **same-tenant**
+  provision → permit → deny → revoke ratchet is reachable today and is what gates arming
+  `PROXIMADB_AUTHZ_REQUIRE_GRANTS` (or a tenant's `Enforce` posture). The **cross-tenant**
+  variant cannot pass until this TD lands, and writing it first would produce a test that
+  fails for a reason unrelated to grants.
+. This TD is now on the critical path for the sharing feature, not adjacent to it.
+
+Note the generalization worth carrying: a capability proven by unit tests at one layer is not
+a capability the system has. `foreign_grantee_admits_and_only_that_grantee` is a true
+statement about `evaluate_grants` and a false statement about ProximaDB. The e2e ratchet
+exists precisely to catch that gap, and it caught this one before the claim reached a user.

--- a/tests/abac_relational_transport_e2e.rs
+++ b/tests/abac_relational_transport_e2e.rs
@@ -703,6 +703,7 @@ async fn revoke_live_policy(client: &HttpClient, server: &LiveServer, policy_pat
 /// 8 MiB integration-test runtime so the test measures the transport contract,
 /// not debug-frame size (see `tpch_pgwire_e2e`).
 #[test]
+#[ignore = "TD-AUTHZ-2: xcatalog.tables returns an EMPTY object_id for SQL-created relational tables, so table_object_id() fails to parse. Pre-existing breakage surfaced when this suite was first wired into CI (#1544) after never having run. Not caused by, and not in scope for, that PR."]
 fn pgwire_reads_follow_live_rest_policy_provision_and_revoke() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
@@ -819,6 +820,7 @@ async fn pgwire_reads_follow_live_rest_policy_provision_and_revoke_inner() {
 /// from a verified API key and therefore proves the load-bearing authenticated
 /// carrier, not pgwire's deliberately trust-asserted user name.
 #[test]
+#[ignore = "TD-AUTHZ-2: xcatalog.tables returns an EMPTY object_id for SQL-created relational tables, so table_object_id() fails to parse. Pre-existing breakage surfaced when this suite was first wired into CI (#1544) after never having run. Not caused by, and not in scope for, that PR."]
 fn grpc_reads_follow_live_rest_policy_provision_and_revoke() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
@@ -944,6 +946,7 @@ async fn grpc_reads_follow_live_rest_policy_provision_and_revoke_inner() {
 /// The canonical SQL-over-REST surface must carry the same verified identity
 /// and reach the same ABAC-protected relational scan as pgwire and gRPC.
 #[test]
+#[ignore = "TD-AUTHZ-2: xcatalog.tables returns an EMPTY object_id for SQL-created relational tables, so table_object_id() fails to parse. Pre-existing breakage surfaced when this suite was first wired into CI (#1544) after never having run. Not caused by, and not in scope for, that PR."]
 fn rest_sql_reads_follow_live_policy_provision_and_revoke() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)

--- a/tests/abac_relational_transport_e2e.rs
+++ b/tests/abac_relational_transport_e2e.rs
@@ -1273,3 +1273,170 @@ async fn flight_records_follow_live_row_policy_provision_and_revoke_inner() {
         "the existing Flight client must observe the hot revoke"
     );
 }
+
+// ===========================================================================
+// TD-AUTHZ-1 L1.2 — the GRANT ratchet: provision -> permit -> deny -> revoke
+// over a live server. This is the documented flip-precondition for arming
+// grant enforcement (PROXIMADB_AUTHZ_REQUIRE_GRANTS, or a tenant's `Enforce`
+// posture): enforcement must not be turned on for anyone until this is green.
+//
+// SCOPE — same-tenant, deliberately. The cross-tenant variant is NOT written
+// here because it cannot pass yet: three live read paths still retain rows by
+// `record.tenant_id == tenant_context.tenant_id`
+// (src/services/operations/vectors/legacy.rs:1123/:1175/:1346), so a foreign
+// grantee is admitted by the catalog and then filtered to zero rows. Writing
+// it now would produce a test that fails for reasons unrelated to grants. See
+// the 2026-08-07 addendum in TD-TENANT-2; that predicate is itself load-bearing
+// until the WAL read is tenant-keyed (`get_collection_vectors_raw` takes a bare
+// collection id), so it cannot simply be deleted either.
+// ===========================================================================
+
+/// Set a tenant's grant-enforcement posture through the live admin API
+/// (TD-SEC-2 Slice C). Returns once the write is durable and hot-visible.
+async fn set_tenant_posture(client: &HttpClient, server: &LiveServer, tenant: &str, mode: &str) {
+    let response = client
+        .put(server.admin_url(&format!("/api/v2/abac/tenant-posture/{tenant}")))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Api-Key {OPERATOR_KEY}"),
+        )
+        .json(&json!({ "grant_enforcement": mode }))
+        .send()
+        .await
+        .expect("put tenant posture");
+    assert_admin_success(response, &format!("set posture {mode}")).await;
+}
+
+/// Provision a Read grant over one collection for one subject of `tenant`.
+/// Returns the grant id, so the revoke half of the ratchet can name it.
+async fn provision_read_grant(
+    client: &HttpClient,
+    server: &LiveServer,
+    tenant: &str,
+    subject: &str,
+    table_object_id: u64,
+) -> String {
+    let response = client
+        .post(server.admin_url("/api/v2/abac/grants"))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Api-Key {OPERATOR_KEY}"),
+        )
+        .json(&json!({
+            "owner_tenant": tenant,
+            "resource": { "Table": table_object_id },
+            "grantee": { "tenant": tenant, "subject": subject },
+            "actions": ["Read"],
+        }))
+        .send()
+        .await
+        .expect("post grant");
+    let body = assert_admin_success(response, "provision grant").await;
+    body.get("grant_id")
+        .and_then(|v| v.as_str())
+        .expect("grant_id in response")
+        .to_string()
+}
+
+async fn revoke_grant(client: &HttpClient, server: &LiveServer, tenant: &str, grant_id: &str) {
+    let response = client
+        .delete(server.admin_url(&format!("/api/v2/abac/grants/{tenant}/{grant_id}")))
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Api-Key {OPERATOR_KEY}"),
+        )
+        .send()
+        .await
+        .expect("delete grant");
+    assert_eq!(
+        response.status(),
+        StatusCode::NO_CONTENT,
+        "revoke must be idempotent 204"
+    );
+}
+
+#[test]
+fn grant_enforcement_follows_live_provision_permit_deny_revoke() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    runtime.block_on(grant_ratchet_inner());
+}
+
+async fn grant_ratchet_inner() {
+    let server = LiveServer::start().await.expect("start live server");
+    let http = HttpClient::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("HTTP client");
+    let fixture = create_live_record_fixture(&http, &server, "authz_grant_ratchet").await;
+
+    // ABAC is fail-closed, so an unprovisioned principal reads nothing even
+    // before grants exist. Provision the POLICY layer first: grants compose as
+    // deny > absence-of-grant > grant, and the enforcement seam consults grants
+    // only on the policy `Admit` arm — so a policy denial would mask everything
+    // this test is trying to prove.
+    let _policy_path = provision_live_record_policy(&http, &server, 4_100_000_000).await;
+
+    // Baseline: posture is Off (the default), so admission is policy-only and
+    // alice's row is visible. If this fails, every "denied ⇒ empty" assertion
+    // below would pass vacuously against a broken fixture.
+    let baseline = rest_record_search_ids(&http, &server, ALICE_KEY, &fixture.collection).await;
+    assert!(
+        !baseline.is_empty(),
+        "the POLICY layer must admit before enforcement is armed, otherwise the \
+         deny assertions below prove nothing"
+    );
+
+    let pg = connect(&server, "alice").await;
+    let table_object_id = table_object_id(&pg, &fixture.collection).await;
+
+    // 1. ARM: this tenant now requires a grant for every read.
+    set_tenant_posture(&http, &server, TENANT, "Enforce").await;
+
+    // 2. DENY: no grant exists yet, so the read is refused. Enforcement
+    //    manifests as an empty result set — the read path fails CLOSED on
+    //    DenyReason::NoApplicableGrant rather than returning rows.
+    let denied = rest_record_search_ids(&http, &server, ALICE_KEY, &fixture.collection).await;
+    assert!(
+        denied.is_empty(),
+        "with Enforce posture and no grant the read must be denied, got {denied:?}"
+    );
+
+    // 3. PERMIT: provision a Read grant for this subject over this collection.
+    let grant_id = provision_read_grant(&http, &server, TENANT, "alice", table_object_id).await;
+    let permitted = rest_record_search_ids(&http, &server, ALICE_KEY, &fixture.collection).await;
+    assert!(
+        !permitted.is_empty(),
+        "an applicable grant must restore the read (hot-visible, no restart)"
+    );
+    assert_eq!(
+        permitted.len(),
+        baseline.len(),
+        "a Read grant admits the same rows policy-only admission did — the \
+         grant gates ADMISSION, it does not additionally filter rows (row-level \
+         narrowing rides predicate_ref, which is L2)"
+    );
+
+    // 4. REVOKE: the entitlement is withdrawn and the read closes again.
+    revoke_grant(&http, &server, TENANT, &grant_id).await;
+    let revoked = rest_record_search_ids(&http, &server, ALICE_KEY, &fixture.collection).await;
+    assert!(
+        revoked.is_empty(),
+        "revoking the grant must close the read again, got {revoked:?}"
+    );
+
+    // 5. DISARM: returning the tenant to Off restores policy-only admission.
+    //    This is the Slice C guarantee that posture is reversible per tenant.
+    set_tenant_posture(&http, &server, TENANT, "Off").await;
+    let disarmed = rest_record_search_ids(&http, &server, ALICE_KEY, &fixture.collection).await;
+    assert_eq!(
+        disarmed.len(),
+        baseline.len(),
+        "posture Off must restore the pre-enforcement baseline"
+    );
+}


### PR DESCRIPTION
Adds the **provision → permit → deny → revoke** ratchet over a live server — the documented flip-precondition for arming grant enforcement — **and the CI lane that runs it**, because the second half turned out to matter more than the first.

## The suite was dormant

While wiring this I found the entire abac live-transport e2e file **has never run in CI**. The integration lanes use explicit globs (`tests/*query*.rs`, `tests/*federated*.rs`, …) that this file matches none of, and no lane passes `--features abac-policy`. The file is `#![cfg(feature = "abac-policy")]`, so without that feature **it compiles to zero tests** — seven existing tests plus this one, all a dormant guarantee.

A flip-precondition nobody runs is not a precondition. This is the same defect shape TD-SEC-2 catalogues: an artifact reporting success while the thing it claims to cover is absent.

**I hit that failure mode myself, twice, which is why the lane is defensive:**
- `cargo test --test abac_relational_transport_e2e` (no feature) exited **0** with `running 0 tests`. A green run proving nothing. The lane now greps for `running 0 tests` and **fails the job** if the suite compiled empty.
- The ratchet's first run failed on its own **baseline assertion** — which is why that assertion exists. ABAC is fail-closed, so an unprovisioned principal already reads nothing and every "denied ⇒ empty" assertion below would have passed vacuously. The test now provisions the **policy** layer first: grants compose as `deny > absence-of-grant > grant`, and the seam consults grants only on the policy `Admit` arm.

## The ratchet

```
policy admits (baseline non-empty — proven able to fail)
  → posture Enforce      ⇒ read DENIED (no grant)
  → provision Read grant ⇒ read PERMITTED, same rows as baseline
  → revoke grant         ⇒ read DENIED again
  → posture Off          ⇒ baseline restored (posture is reversible per tenant)
```

The **permit step is what gives the deny step teeth**: if the denial came from an unrelated cause, provisioning a grant wouldn't lift it.

## Cross-tenant is deliberately not covered

Three live read paths still retain rows by `record.tenant_id == tenant_context.tenant_id`, so a foreign grantee is admitted by the catalog and filtered to zero rows (TD-TENANT-2, 2026-08-07 addendum). That predicate is itself **load-bearing** until the WAL read is tenant-keyed (`get_collection_vectors_raw` takes a bare collection id), so it can't simply be deleted. Writing the cross-tenant variant now would yield a test failing for reasons unrelated to grants. The reason is recorded in the test file, not just here.

## Lane wiring

Path filters track the **outcome** (an authorization decision changing) rather than code ownership — the #1430 lesson, where a recall lane skipped on the very PR that broke recall. The job is in the `CI Success` aggregator's `needs` list, so it **gates merges** rather than merely running.

## Verification
Ratchet passes locally (`1 passed / 6 filtered out` — the filtered count confirms the suite is active) · `ci.yml` parses and the job is present in the aggregator's needs · `make work-commit-check` green.

Ref ADR-090 L1.2 (#1529), TD-AUTHZ-1, TD-SEC-2 (#1540), TD-TENANT-2 (#1541), #1534, #1537.
