### PR TITLE
fix(graph): make ORION reads see recovered edges after restart (#1524)

### DIFF
--- a/crates/modalities/proximadb-orion-engine/src/persistence.rs
+++ b/crates/modalities/proximadb-orion-engine/src/persistence.rs
@@ -135,6 +135,14 @@ pub struct OrionPersistence {
     /// segments were actually reclaimed (and operators can see truncation work).
     last_truncate_reclaimed: std::sync::atomic::AtomicU64,
 
+    /// True while `replay_wal` is applying recovered frames through the engine's
+    /// public insert/delete paths. Those paths unconditionally append to the WAL,
+    /// so without this gate every restart re-logged the whole history — doubling
+    /// the WAL per restart and, worse, poisoning it with duplicate `CreateEdge`
+    /// frames whose replay aborted the NEXT recovery on the CSR's duplicate-edge
+    /// check (#1524). All `write_*_operation` methods no-op while this is set.
+    replaying: std::sync::atomic::AtomicBool,
+
     /// Base URL for storage (e.g., "file:///data", "s3://bucket", etc.)
     base_url: String,
 
@@ -325,7 +333,15 @@ impl OrionPersistence {
             incremental_snapshots: false,
             last_replay_applied: std::sync::atomic::AtomicU64::new(0),
             last_truncate_reclaimed: std::sync::atomic::AtomicU64::new(0),
+            replaying: std::sync::atomic::AtomicBool::new(false),
         })
+    }
+
+    /// True while `replay_wal` is re-applying recovered frames (see the
+    /// `replaying` field). WAL appends are suppressed for the duration so
+    /// recovery never re-logs what it reads.
+    fn is_replaying(&self) -> bool {
+        self.replaying.load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Inject the path to the shared canonical WAL
@@ -862,6 +878,9 @@ impl OrionPersistence {
 
     /// Write node operation to WAL
     pub async fn write_node_operation(&self, node: Node) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             tracing::debug!("Writing node operation to WAL for node: {}", node.id);
 
@@ -892,6 +911,9 @@ impl OrionPersistence {
 
     /// Write edge operation to WAL
     pub async fn write_edge_operation(&self, edge: Edge) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             let graph_op = GraphOperation::CreateEdge {
                 graph_id: self.graph_id.clone(),
@@ -915,6 +937,9 @@ impl OrionPersistence {
 
     /// Write a batch of edge operations to WAL in a single record
     pub async fn write_edge_batch_operation(&self, edges: &[Edge]) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if edges.is_empty() {
             return Ok(());
         }
@@ -949,6 +974,9 @@ impl OrionPersistence {
 
     /// Write a batch of node operations to WAL in a single record
     pub async fn write_node_batch_operation(&self, nodes: &[Node]) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if nodes.is_empty() {
             return Ok(());
         }
@@ -984,6 +1012,9 @@ impl OrionPersistence {
     /// Write node update operation to WAL
     /// For updates, we write the full updated node (upsert semantic)
     pub async fn write_update_node_operation(&self, node: Node) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             tracing::debug!("Writing update node operation to WAL for node: {}", node.id);
 
@@ -1017,6 +1048,9 @@ impl OrionPersistence {
 
     /// Write node delete operation to WAL
     pub async fn write_delete_node_operation(&self, node_id: &NodeId) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             tracing::debug!("Writing delete node operation to WAL for node: {}", node_id);
 
@@ -1050,6 +1084,9 @@ impl OrionPersistence {
     /// Write edge update operation to WAL
     /// For updates, we write the full updated edge (upsert semantic)
     pub async fn write_update_edge_operation(&self, edge: Edge) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             tracing::debug!("Writing update edge operation to WAL for edge: {}", edge.id);
 
@@ -1083,6 +1120,9 @@ impl OrionPersistence {
 
     /// Write edge delete operation to WAL
     pub async fn write_delete_edge_operation(&self, edge_id: &EdgeId) -> Result<()> {
+        if self.is_replaying() {
+            return Ok(());
+        }
         if let Some(ref wal_writer) = self.wal_writer {
             tracing::debug!("Writing delete edge operation to WAL for edge: {}", edge_id);
 
@@ -1214,20 +1254,47 @@ impl OrionPersistence {
                 }
             }
 
+            // Replay drives the engine's public insert/delete paths, which
+            // append to this same WAL. Suppress those appends for the duration
+            // — otherwise every restart re-logs the whole history (#1524).
+            // Cleared before every return path below; replay runs during
+            // startup recovery, before the engine serves traffic.
+            self.replaying
+                .store(true, std::sync::atomic::Ordering::Release);
+
             let mut replayed: u64 = 0;
+            let mut skipped_failed: u64 = 0;
             for entry in entries.into_iter().skip(start_index) {
                 // `entries` is already projected to graph records; apply the
                 // data ops and skip the canonical-sync markers (they carry no
                 // engine state to reapply).
                 if let GraphWalRecord::Op(graph_op) = entry.record {
-                    self.apply_graph_operation(engine, *graph_op).await?;
-                    replayed += 1;
+                    // Apply per-entry, warn-and-continue on failure: aborting
+                    // the whole replay on one bad frame leaves the graph EMPTY
+                    // (strictly worse than a partial recovery), and WALs
+                    // written before the re-append fix above legitimately
+                    // contain duplicate CreateEdge frames that must not poison
+                    // recovery.
+                    match self.apply_graph_operation(engine, *graph_op).await {
+                        Ok(()) => replayed += 1,
+                        Err(e) => {
+                            skipped_failed += 1;
+                            tracing::warn!(
+                                graph_id = %self.graph_id,
+                                error = %e,
+                                "WAL replay: frame failed to apply; continuing with remaining frames"
+                            );
+                        }
+                    }
                 }
             }
+            self.replaying
+                .store(false, std::sync::atomic::Ordering::Release);
             tracing::info!(
                 graph_id = %self.graph_id,
                 skipped = start_index,
                 replayed,
+                skipped_failed,
                 "WAL replay completed for graph"
             );
             self.last_replay_applied
@@ -1249,7 +1316,18 @@ impl OrionPersistence {
                     engine.create_node(node).await?;
                 }
                 GraphOperation::CreateEdge { graph_id: _, edge } => {
-                    engine.create_edge(edge).await?;
+                    // Idempotent: WALs written before replay suppressed its own
+                    // re-appends carry duplicate CreateEdge frames; re-applying
+                    // one would trip the CSR's duplicate-edge check and (before
+                    // the per-frame tolerance in `replay_wal`) abort recovery.
+                    if engine.memory_pool.get_edge(&edge.id).is_some() {
+                        debug!(
+                            "WAL replay: edge {} already applied; skipping duplicate frame",
+                            edge.id
+                        );
+                    } else {
+                        engine.create_edge(edge).await?;
+                    }
                 }
                 GraphOperation::UpdateNode {
                     graph_id: _,

--- a/src/graph/engines/orion_recovery_tests.rs
+++ b/src/graph/engines/orion_recovery_tests.rs
@@ -236,6 +236,233 @@ mod td066_replay_scope_tests {
 }
 
 #[cfg(test)]
+mod read_after_restart_tests {
+    //! #1524: ORION edges survived a restart but every read surface answered
+    //! empty, while re-creating the same edge was rejected as a duplicate.
+    //! Three compounding defects, each pinned by a test below:
+    //! 1. WAL replay drove the engine's public insert paths, which re-appended
+    //!    every replayed frame — doubling the WAL per restart.
+    //! 2. The re-appended duplicate `CreateEdge` frame tripped the CSR's
+    //!    duplicate-edge check on the NEXT restart, aborting that graph's
+    //!    recovery entirely (reads then hit a lazily-created empty engine).
+    //! 3. Even when recovery succeeded, the service-level read state
+    //!    (adjacency projection, CSR-freshness epoch, edge counters) was never
+    //!    rebuilt, so endpoint-bound queries and count surfaces stayed blind.
+    use crate::graph::engines::orion::OrionGraphEngine;
+    use crate::graph::service::GraphOperationsService;
+    use crate::proto::proximadb_v1::CreateGraphRequest;
+    use proximadb_graph_model::{Edge, EdgeQuery, Node};
+    use std::sync::Arc;
+
+    fn node(id: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            labels: vec!["Sym".to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn edge(id: &str, from: &str, to: &str) -> Edge {
+        Edge {
+            id: id.to_string(),
+            from_node_id: from.to_string(),
+            to_node_id: to.to_string(),
+            edge_type: "CALLS".to_string(),
+            ..Default::default()
+        }
+    }
+
+    async fn engine(graph_id: &str, base_url: &str) -> OrionGraphEngine {
+        OrionGraphEngine::with_persistence_for_graph(
+            graph_id.to_string(),
+            base_url.to_string(),
+            true,
+            crate::graph::unified_wal_factory(),
+        )
+        .await
+        .expect("engine with persistence")
+    }
+
+    /// Defects 1+2 at the engine layer: replay must not re-append what it
+    /// reads, so a graph recovers identically on EVERY restart, not just the
+    /// first. Before the fix the second recovery replayed a doubled WAL and
+    /// aborted on its own duplicate `CreateEdge` frame.
+    #[tokio::test]
+    async fn repeated_recovery_does_not_amplify_wal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base_url = format!("file://{}", tmp.path().display());
+        let gid = "restart_amplify";
+
+        {
+            let e = engine(gid, &base_url).await;
+            e.create_node(node("n1")).await.expect("n1");
+            e.create_node(node("n2")).await.expect("n2");
+            e.create_edge(edge("n1|calls|n2", "n1", "n2"))
+                .await
+                .expect("edge");
+            e.flush_wal().await.expect("flush");
+        }
+
+        for restart in 1..=3u32 {
+            let e = engine(gid, &base_url).await;
+            e.recover()
+                .await
+                .expect("recovery must succeed on every restart");
+            assert_eq!(e.memory_pool.nodes.len(), 2, "restart {restart}: nodes");
+            assert_eq!(
+                e.memory_pool.edges.len(),
+                1,
+                "restart {restart}: the edge must be readable after recovery"
+            );
+            let replayed = e
+                .persistence()
+                .expect("persistence configured")
+                .last_replay_applied();
+            assert_eq!(
+                replayed, 3,
+                "restart {restart}: exactly the 3 original frames replay; more means \
+                 replay re-appended frames to the WAL on an earlier restart"
+            );
+            e.flush_wal().await.expect("flush");
+        }
+    }
+
+    /// WALs written BEFORE the re-append fix already carry duplicate
+    /// `CreateEdge` frames. Replay must treat them as no-ops instead of
+    /// aborting recovery and leaving the graph empty.
+    #[tokio::test]
+    async fn recovery_tolerates_poisoned_wal_with_duplicate_edge_frames() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base_url = format!("file://{}", tmp.path().display());
+        let gid = "restart_poisoned";
+
+        {
+            let e = engine(gid, &base_url).await;
+            e.create_node(node("n1")).await.expect("n1");
+            e.create_node(node("n2")).await.expect("n2");
+            let dup = edge("n1|calls|n2", "n1", "n2");
+            e.create_edge(dup.clone()).await.expect("edge");
+            // Poison the WAL the way pre-fix replay did: a second CreateEdge
+            // frame for the same edge.
+            e.persistence()
+                .expect("persistence configured")
+                .write_edge_operation(dup)
+                .await
+                .expect("duplicate frame");
+            e.flush_wal().await.expect("flush");
+        }
+
+        let e = engine(gid, &base_url).await;
+        e.recover()
+            .await
+            .expect("recovery must survive duplicate CreateEdge frames");
+        assert_eq!(e.memory_pool.nodes.len(), 2);
+        assert_eq!(
+            e.memory_pool.edges.len(),
+            1,
+            "duplicate frame applies as a no-op, not an abort"
+        );
+    }
+
+    /// Defect 3 at the service layer: after recovery, endpoint-bound edge
+    /// queries, the adjacency projection, and the stats counters must see the
+    /// recovered edges. Before the fix all three answered zero while the
+    /// engine held the data (and re-creating the edge was rejected as a
+    /// duplicate — no client-side repair path).
+    #[tokio::test]
+    async fn recovered_graph_serves_edge_reads_and_counts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base_url = format!("file://{}", tmp.path().display());
+        let gid = "restart_reads";
+        let collection_service = Arc::new(
+            crate::services::graph_collection::GraphCollectionService::new_with_path(
+                tmp.path().join("graph_collections.json"),
+            ),
+        );
+
+        let service_over =
+            |collection: Arc<crate::services::graph_collection::GraphCollectionService>| {
+                let mut svc = GraphOperationsService::new_with_collection_service(collection);
+                svc.set_base_storage_url(base_url.clone());
+                svc
+            };
+
+        // Session 1: create graph + 3 nodes + 1 edge, verify live read, flush.
+        {
+            let svc = service_over(collection_service.clone());
+            svc.create_graph_collection(CreateGraphRequest {
+                graph_id: gid.to_string(),
+                name: None,
+                description: None,
+                schema: None,
+                storage_config: None,
+                engine_config: None,
+                access_control: None,
+            })
+            .await
+            .expect("create graph");
+            for id in ["n1", "n2", "n3"] {
+                svc.create_node(gid, node(id)).await.expect("node");
+            }
+            svc.create_edge(gid, edge("n1|calls|n2", "n1", "n2"))
+                .await
+                .expect("edge");
+            let live = svc
+                .query_edges(
+                    gid,
+                    EdgeQuery {
+                        from_node_id: Some("n1".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("live query");
+            assert_eq!(live.len(), 1, "live endpoint-bound read sees the edge");
+            svc.flush_wal(gid).await.expect("flush");
+        }
+
+        // Sessions 2 and 3: fresh service over the same storage — reads must
+        // see the recovered edge on every restart, not just the first.
+        for restart in 1..=2u32 {
+            let svc = service_over(collection_service.clone());
+            svc.recover_all_graphs().await.expect("recover");
+
+            let recovered = svc
+                .query_edges(
+                    gid,
+                    EdgeQuery {
+                        from_node_id: Some("n1".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .expect("recovered query");
+            assert_eq!(
+                recovered.len(),
+                1,
+                "restart {restart}: endpoint-bound read must see the recovered edge"
+            );
+            assert_eq!(recovered[0].id, "n1|calls|n2");
+
+            assert_eq!(
+                svc.adjacency_projection_edge_count(gid)
+                    .expect("projection count"),
+                1,
+                "restart {restart}: adjacency projection rebuilt from recovery"
+            );
+
+            let stats = svc.get_stats(gid).await.expect("stats");
+            assert_eq!(stats.total_nodes, 3, "restart {restart}: node count");
+            assert_eq!(
+                stats.total_edges, 1,
+                "restart {restart}: edge count surface must not report 0 for a \
+                 populated collection"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod topology_only_snapshot_tests {
     use crate::graph::engines::orion::OrionGraphEngine;
     use proximadb_graph_engine_traits::GraphEngine;

--- a/src/graph/service.rs
+++ b/src/graph/service.rs
@@ -1070,8 +1070,46 @@ impl GraphOperationsService {
         };
 
         // Store in graphs map
+        let engine = Arc::new(engine_impl);
         self.graphs
-            .insert(graph_id.to_string(), Arc::new(engine_impl));
+            .insert(graph_id.to_string(), Arc::clone(&engine));
+
+        // #1524: engine recovery rebuilt the ENGINE's state, but endpoint-bound
+        // edge reads are served from the service-level adjacency projection +
+        // CSR-freshness epoch, and count surfaces from the service-level
+        // counters — all process-local and empty after a restart. Rebuild them
+        // from the recovered engine (mirroring what create_edge maintains per
+        // write); otherwise every edge read answers empty for a graph whose
+        // data survived, while re-creating the same edge is rejected as a
+        // duplicate — no client-side repair path exists.
+        let recovered_edges = engine.get_all_edges()?;
+        if !recovered_edges.is_empty() {
+            let records: Vec<_> = recovered_edges
+                .iter()
+                .map(|edge| edge_to_canonical_record(graph_id, edge))
+                .collect();
+            self.adjacency_projection(graph_id).apply_edges(&records)?;
+            for edge in &recovered_edges {
+                self.edge_type_counts
+                    .entry(edge.edge_type.clone())
+                    .or_insert_with(|| AtomicU64::new(0))
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            self.stats_edges
+                .fetch_add(recovered_edges.len() as u64, Ordering::Relaxed);
+            self.advance_edge_epoch(graph_id);
+            // Rebuild the CSR from the projection and mark it fresh (stores the
+            // rebuild epoch) so endpoint-bound queries serve from engine
+            // topology instead of falling through to a projection that, before
+            // this block, was empty.
+            self.rebuild_orion_csr_from_adjacency_projection(graph_id)
+                .await?;
+            tracing::info!(
+                graph_id,
+                edges = recovered_edges.len(),
+                "read projections rebuilt from recovered graph state"
+            );
+        }
 
         // TD-066 Part 2 (gated, default-OFF): engine-WAL replay above rebuilt the
         // in-memory engine, but the canonical/cold record store — a buffered store


### PR DESCRIPTION
Closes the ORION half of #1524 and removes the graph-WAL replay amplification mechanism behind #1479.

## The bug, as re-diagnosed on the issue

ORION persisted edges fine — its read paths could not see them after a restart. Reproduced against a develop-tip binary: write one edge, restart, and `get_all_edges`/`query/edges`/`traverse`/`neighbors` all answer empty while re-creating the identical edge is rejected with `Edge n1|calls|n2 already exists`. `POST /graphs/{id}/rag` and the graph arm of hybrid fusion traverse the same paths, so both returned confidently wrong answers after any restart, and no client-side repair existed (can't read them, can't rewrite them).

## Three compounding defects

1. **WAL replay re-appended everything it read.** `replay_wal` applies frames through the engine's public `create_node`/`create_edge` paths, which append to the same WAL — every restart re-logged the whole history (4 frames → 9 after one restart in the repro), doubling the WAL per restart.
2. **The re-appended duplicate `CreateEdge` frame aborted the NEXT restart's recovery.** Replay hit the CSR duplicate-edge check, the error propagated out of `recover_graph`, the warn was swallowed (`⚠️ Failed to recover graph g1`), no engine was registered — and the first read lazily created an **empty** engine (`Creating new graph engine for 'g1'` in the log), which is why `traverse` reported `Start node n1 not found` for a node that survived.
3. **Even a successful recovery left the read surfaces blind.** Endpoint-bound edge queries serve from the CSR-freshness epoch and the in-memory adjacency projection; `get_stats` serves from session-local counters. All are process-local, all were empty after restart, and nothing rebuilt them from the recovered engine — so reads answered empty while the engine's CSR held the edge (which is exactly why re-creates were rejected as duplicates).

## Fixes

- `proximadb-orion-engine/persistence.rs`
  - a `replaying` flag suppresses every `write_*_operation` WAL append for the duration of `replay_wal` — recovery never re-logs what it reads;
  - duplicate `CreateEdge` frames (already on disk in field WALs, including the one a rejected re-create appends before the CSR check fires) apply as no-ops;
  - frames apply warn-and-continue (`skipped_failed` counter in the completion log): one bad frame now degrades to partial recovery instead of an empty graph.
- `src/graph/service.rs::recover_graph` — after engine recovery, rebuild the service-level read state from the recovered engine, mirroring what `create_edge` maintains per write: adjacency projection (batch `apply_edges`), `edge_type_counts`/`stats_edges`, edge epoch, and the CSR-freshness epoch (via the existing `rebuild_orion_csr_from_adjacency_projection`).

## Verification

- New tests in `orion_recovery_tests.rs`:
  - `repeated_recovery_does_not_amplify_wal` — three consecutive recoveries each replay exactly the original frames;
  - `recovery_tolerates_poisoned_wal_with_duplicate_edge_frames` — a WAL poisoned the way pre-fix replay poisoned it recovers to the correct state;
  - `recovered_graph_serves_edge_reads_and_counts` — endpoint-bound queries, projection counts, and `get_stats` are correct across two restarts. **Teeth-checked**: reverting only the `recover_graph` change makes this test fail.
- Live end-to-end on the built server binary across three restarts of the same data dir: endpoint-bound `query/edges`, `traverse`, and `neighbors` all return the edge; `stats.total_edges` stays 1; recovery logs `replayed=5 skipped_failed=0` with no WAL growth.
- `cargo test -p proximadb-orion-engine` (78 passed), root-lib graph/recovery suites (17 passed), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build -p proximadb-server`, `make work-commit-check` all green.

## Adjacent observations (not fixed here, noting for follow-up)

- `GraphOperationsService.memory_pool.edge_composite_index` is checked by `create_edge`/`batch_create_edges` but **never populated** on the server path (only engine-local pools are) — the service-level composite-uniqueness check can never fire. Same "exists but never wired" shape as the #1524 issue thread catalogs.
- `insert_edge` appends the WAL frame **before** the CSR duplicate check, so every rejected duplicate create leaves a frame behind. Harmless now (replay treats it as a no-op) but worth reordering someday.
- `stats_edges` is a single global counter, not per-graph; `get_stats.total_edges` conflates graphs. Pre-existing, unchanged here.

## What this does NOT cover

The ProximaRecord half of #1524 (record scan-after-restart) was already fixed on develop per the issue thread; `record_count: 0` remains open as #1527.