### PR TITLE
ci: bump SIFT recall ratchet timeout 30m → 45m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2582,7 +2582,12 @@ jobs:
     name: SIFT PAX recall ratchet (N=10k)
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Release-mode compile of the recall test binary (pulls the full root crate) +
+    # 10k-vector ingest measured 30m17s on 2026-08-09 (#1552) — right at the prior
+    # 30m cap, so it tipped to CANCELLED under normal runner variance and blocked
+    # every storage/query-touching PR via the `ci-success` aggregator. 45m gives
+    # comfortable headroom without masking a genuine hang.
+    timeout-minutes: 45
     # only run when search/flush/WAL/PAX/cascade code changes
     if: >
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Problem
The `sift-recall-ratchet` CI job does a **release-mode compile of the recall test binary** (it pulls the full root crate) **+ a 10k-vector ingest**. On 2026-08-09 this measured **30m17s** on PR #1552 — right at the prior `timeout-minutes: 30` cap, so it tipped to **CANCELLED** under normal runner variance.

Because `ci-success` aggregates `sift-recall-ratchet` in its `needs` with `if: always()`, a CANCELLED SIFT job **fails CI Success and blocks the merge of every `storage`/`query`/`WAL`/`PAX`-touching PR** — even behavior-neutral ones (e.g. the `geo_index` extraction #1552) that cannot affect ANN recall. Two consecutive runs on #1552 both hit exactly the 30m cap (13:58:49→14:29:06).

## Fix
Bump `timeout-minutes: 30 → 45` for the SIFT job only, for comfortable headroom. Actions runners are isolated VMs, so this is not runner-pool contention — the job genuinely needs >30m.

## What's NOT changed
- The recall **floor (0.85)** and the recall assertion are unchanged.
- This only widens the wall-clock budget; a genuine hang is still caught at 45m.
- Only the `sift-recall-ratchet` job's timeout — no other job touched.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML valid ✓
- Diff is 1 line changed + rationale comment (6 insertions, 1 deletion).

This unblocks #1552 and the broader storage-extraction decomposition train.