### PR TITLE
refactor(decomp): extract kafka deserializer → new crate (TD-DECOMP-42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6759,6 +6759,7 @@ dependencies = [
  "proximadb-index-types",
  "proximadb-interner",
  "proximadb-kafka-config",
+ "proximadb-kafka-deserializer",
  "proximadb-kernel",
  "proximadb-ledger",
  "proximadb-mcp",
@@ -7616,6 +7617,15 @@ dependencies = [
 name = "proximadb-kafka-config"
 version = "0.2.0"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "proximadb-kafka-deserializer"
+version = "0.2.0"
+dependencies = [
+ "proximadb-kafka-config",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "crates/horizontal/proximadb-pgwire-translator",
     "crates/horizontal/proximadb-kafka-config",
     "crates/horizontal/proximadb-montecarlo",
+    "crates/horizontal/proximadb-kafka-deserializer",
     "crates/platform/proximadb-network-middleware",
     "crates/horizontal/proximadb-runtime-common",
     "crates/horizontal/proximadb-serialization",
@@ -304,6 +305,7 @@ proximadb-write-intent = { path = "crates/horizontal/proximadb-write-intent" }
 proximadb-pgwire-translator = { path = "crates/horizontal/proximadb-pgwire-translator" }
 proximadb-kafka-config = { path = "crates/horizontal/proximadb-kafka-config" }
 proximadb-montecarlo = { path = "crates/horizontal/proximadb-montecarlo" }
+proximadb-kafka-deserializer = { path = "crates/horizontal/proximadb-kafka-deserializer" }
 proximadb-network-middleware = { path = "crates/platform/proximadb-network-middleware" }
 proximadb-storage-common = { path = "crates/storage/proximadb-storage-common" }
 proximadb-storage-ports = { path = "crates/storage/proximadb-storage-ports" }
@@ -434,6 +436,7 @@ proximadb-write-intent = { workspace = true }
 proximadb-pgwire-translator = { workspace = true }
 proximadb-kafka-config = { workspace = true }
 proximadb-montecarlo = { workspace = true }
+proximadb-kafka-deserializer = { workspace = true }
 proximadb-network-middleware = { workspace = true }
 proximadb-storage-common = { path = "crates/storage/proximadb-storage-common" }
 proximadb-storage-ports = { path = "crates/storage/proximadb-storage-ports" }

--- a/crates/horizontal/proximadb-kafka-deserializer/Cargo.toml
+++ b/crates/horizontal/proximadb-kafka-deserializer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "proximadb-kafka-deserializer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Kafka message deserializers (JSON/Avro/Protobuf/Raw → VectorMessage) — extracted from root streaming/kafka (TD-DECOMP-42)"
+
+[lib]
+name = "proximadb_kafka_deserializer"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+proximadb-kafka-config = { workspace = true }

--- a/crates/horizontal/proximadb-kafka-deserializer/src/deserializer.rs
+++ b/crates/horizontal/proximadb-kafka-deserializer/src/deserializer.rs
@@ -19,7 +19,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::config::DeserializationFormat;
+use proximadb_kafka_config::config::DeserializationFormat;
 
 /// Deserialization error
 #[derive(Debug, Clone)]

--- a/crates/horizontal/proximadb-kafka-deserializer/src/lib.rs
+++ b/crates/horizontal/proximadb-kafka-deserializer/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Kafka message deserializers, extracted from the root `streaming/kafka`
+//! module (TD-DECOMP-42).
+//!
+//! [`deserializer`] turns raw Kafka payloads into [`deserializer::VectorMessage`]s
+//! across JSON / Avro / Protobuf / Raw formats, selected by the
+//! [`proximadb_kafka_config::config::DeserializationFormat`] carried in the
+//! consumer config. Depends only on `serde`/`serde_json` + the sibling
+//! `proximadb-kafka-config` crate — the heavy `rdkafka` consumer impl stays
+//! root-side, keeping this a clean horizontal-tier leaf.
+
+pub mod deserializer;

--- a/docs/10-quality/td/TD-DECOMP-42-extract-kafka-deserializer.adoc
+++ b/docs/10-quality/td/TD-DECOMP-42-extract-kafka-deserializer.adoc
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-42: Extract kafka deserializer → new proximadb-kafka-deserializer crate (horizontal)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export
+| Component | `crates/horizontal/proximadb-kafka-deserializer`; root `src/streaming/kafka/mod.rs`
+|===
+
+== What moved
+`src/streaming/kafka/deserializer.rs` (9 tests) → new horizontal crate `proximadb-kafka-deserializer`.
+Root `streaming/kafka/mod.rs` re-exports it (`pub use proximadb_kafka_deserializer::deserializer;`),
+so the existing `pub use deserializer::{DeserializationError, MessageDeserializer, VectorMessage};`
+resolves unchanged. Deps: serde + serde_json + the sibling `proximadb-kafka-config` crate (for
+`DeserializationFormat`, extracted in TD-DECOMP-40); the `use super::config::DeserializationFormat`
+was rewritten to `use proximadb_kafka_config::config::DeserializationFormat`. The heavy `rdkafka`
+consumer impl stays root-side. Verified: standalone + clippy -D warnings + root lib all pass. SIFT
+recall ratchet SKIPS this PR (streaming/** is not in storage_changes).

--- a/src/streaming/kafka/mod.rs
+++ b/src/streaming/kafka/mod.rs
@@ -59,7 +59,7 @@
 
 pub use proximadb_kafka_config::config;
 pub mod consumer;
-pub mod deserializer;
+pub use proximadb_kafka_deserializer::deserializer;
 
 pub use config::{
     CommitStrategy, ConsumerGroupConfig, DeserializationFormat, DlqConfig, KafkaConsumerConfig,


### PR DESCRIPTION
Part of the P2 god-crate decomposition initiative (root `proximadb` lib bundles 9,538 inline tests → OOMs the 16 GB runner at `BUILD_JOBS=1`; the structural fix is moving `src/` modules into workspace crates so tests leave with the code).

## What moves
`src/streaming/kafka/deserializer.rs` (**9 tests**: JSON/Avro/Protobuf/Raw → `VectorMessage` deserializers + `DeserializationError`/`MessageDeserializer` types) → **new horizontal crate `proximadb-kafka-deserializer`**.

## Why this leaf
Clean extraction: deps are **serde + serde_json + the sibling `proximadb-kafka-config`** (for `DeserializationFormat`, extracted in TD-DECOMP-40/#1553). The heavy `rdkafka` consumer impl (`consumer.rs`) stays root-side. The single `use super::config::DeserializationFormat;` is rewritten to `use proximadb_kafka_config::config::DeserializationFormat;` (horizontal→horizontal, layering-legal).

## Shim
Root `streaming/kafka/mod.rs`:
```rust
- pub mod deserializer;
+ pub use proximadb_kafka_deserializer::deserializer;
```
so the existing `pub use deserializer::{DeserializationError, MessageDeserializer, VectorMessage};` resolves unchanged.

## CI note
Touches only `src/streaming/**` (not `storage_changes`) + `Cargo.toml` → **SIFT recall ratchet SKIPS** this PR.

## Verified locally
- standalone `cargo check --all-targets` ✓ + `cargo clippy --all-targets -- -D warnings` ✓
- root `cargo check -p proximadb --lib` ✓ (shim + re-export resolve)
- `check-layering.sh` (exit 0) + `check_workspace_boundaries.py` — No boundary findings ✓
- `cargo fmt --check` ✓; 9 tests pass in-crate (nextest) ✓

Behavior-neutral, mixed-read-safe (no on-disk/wire format change), no AI attribution.