### PR TITLE
bench+td: coarse-PCA projection width is mis-calibrated (TD-IVF-3, TD-COMPACT-12) + harness fixes

### DIFF
--- a/docs/10-quality/td/TD-COMPACT-12-budget-refused-compaction-is-silent.adoc
+++ b/docs/10-quality/td/TD-COMPACT-12-budget-refused-compaction-is-silent.adoc
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COMPACT-12: a budget-refused compaction is indistinguishable from an idle level (INFO-only, no metric)
+:status: Open
+:dim: D3
+:pillar: OE
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open**
+| Priority | **P2 — observability.** The underlying stall is TD-COMPACT-11 (P0). This entry is *only* about the operator being unable to detect it.
+| Component | `src/storage/common/compaction_memory.rs` :174–176 (planner returns `None`); `src/storage/common/compaction_utils.rs` :395 and :497 (the INFO log sites).
+| Evidence | Reproduced twice on 2026-08-08 during the coarse-PCA width study (TD-IVF-3): once at 128-d/3.3M and once at 768-d/491,655 rows. Details below.
+|===
+
+NOTE: This is **not** a duplicate of link:TD-COMPACT-11-deterministic-local-spill-compaction.adoc[TD-COMPACT-11].
+That entry covers the stall and builds the spill executor that resolves it. Its
+exit criteria explicitly keep spill **default-OFF** (spill demands a mandatory
+local scratch path, which not every deployment has). The refusal branch is
+therefore *permanent* in default configuration by design — which is exactly why
+it must be observable. TD-COMPACT-11 does not cover detection.
+
+== Defect
+
+`plan_compaction_resources` returns `Option<CompactionResourcePlan>` and uses
+`None` for two semantically different outcomes:
+
+[source,rust]
+----
+if in_memory_bytes <= memory_budget.remaining_bytes {
+    return Some(CompactionExecutionMode::InMemory ...);
+}
+if !config.spill_enabled || config.spill_working_memory_mb == 0 {
+    return None;                 // <-- "budget refused this pair"
+}
+----
+
+The caller cannot distinguish that from "there were no candidates", so it emits a
+single **INFO** line and moves on:
+
+....
+⏸️ SST COMPACTION: L0 remains horizontal because no file pair fits the
+   current memory budget for collection 1
+....
+
+From outside the process the resulting state is **indistinguishable from a
+healthy idle steady state**: segment count constant, byte totals constant, CPU
+near zero, no error, no WARN, no metric, no client-visible signal. The collection
+has permanently stopped consolidating and nothing says so.
+
+Consequences:
+
+* An operator has no trigger to enable the remedy that already exists.
+* The log line does not name the remedy (`spill_enabled` + a local scratch path).
+* There is no counter to alert on, so this cannot be caught in CI, in a soak, or
+  in production monitoring.
+* Query economy silently degrades — TD-COMPACT-11 measured 58.63 GETs/query in
+  the un-consolidated state versus 24.478 for the one-segment control.
+
+== Evidence (2026-08-08)
+
+**768-d reproduction.** BGE-base corpus, 491,655 rows, one L0 + one L1 totalling
+485,247,442 bytes. In-memory projection is ~12× input (measured 2,121,331,668
+from 176,777,639 at 128-d), i.e. ~5.8 GiB against a 5,120 MiB budget → refused.
+Server then sat at **0.4% CPU** with `segments=2` and byte count frozen for the
+full settle window; the harness burned its timeout and the stage was lost.
+
+**The remedy works, and proves the branch is the only obstacle.** Re-running the
+identical bed with `--compaction-spill --compaction-spill-working-memory-mb 512`:
+
+....
+admitted input_bytes=485,247,442 mode=LocalSpill projected_memory_bytes=536,870,912
+Local-spill compaction completed input_files=2 input_bytes=485,247,442
+  output_bytes=489,138,370 input_records=491,655
+....
+
+Two files merged to one in ~5.5 minutes inside a 512 MiB working-memory bound.
+Note a raised budget alone would *not* have helped: the preceding 366,768,615-byte
+training compaction was admitted `InMemory` at 4,401,223,380 projected bytes,
+already near the 5,120 MiB ceiling.
+
+**128-d reproduction.** Same signature on a 3.3M BIGANN bed (n_comp=24): stalled
+at `segments=2`, 904,010,150 bytes frozen, no compaction log activity for 38
+minutes, ~50 minutes of machine time lost before it was killed manually.
+
+== Proposed fix
+
+. **Distinguish the two refusals.** Return a typed outcome rather than bare
+  `None` — e.g. `NoCandidates` vs `RefusedByBudget { input_bytes,
+  projected_bytes, remaining_budget_bytes }`.
+. **Log the budget refusal at WARN, and name the remedy** — include projected vs
+  available bytes and state that `spill_enabled` with a local scratch path
+  resolves it. INFO is the wrong level for "this collection has stopped
+  consolidating permanently".
+. **Emit a counter** (e.g. `proximadb_compaction_refused_by_budget_total`,
+  labelled by collection) so it is alertable and assertable. A gauge for
+  "levels currently horizontal due to budget" would let a soak test fail on it.
+. Optional: surface it in collection stats/admin so the condition is visible
+  without log scraping.
+
+The fix is independent of TD-COMPACT-11's executor work and shippable on its own.
+
+== Exit criteria
+
+A compaction refused by the memory budget emits a WARN naming the remedy and
+increments an alertable counter; a test asserts the counter fires when a pair
+exceeds the budget with spill disabled, and does **not** fire when a level is
+merely idle.

--- a/docs/10-quality/td/TD-COMPACT-12-budget-refused-compaction-is-silent.adoc
+++ b/docs/10-quality/td/TD-COMPACT-12-budget-refused-compaction-is-silent.adoc
@@ -10,7 +10,7 @@
 | Field | Value
 | Status | **Open**
 | Priority | **P2 — observability.** The underlying stall is TD-COMPACT-11 (P0). This entry is *only* about the operator being unable to detect it.
-| Component | `src/storage/common/compaction_memory.rs` :174–176 (planner returns `None`); `src/storage/common/compaction_utils.rs` :395 and :497 (the INFO log sites).
+| Component | `src/storage/common/compaction_memory.rs` (`plan_compaction_resources` and its retrying `acquire_compaction_resources` caller); `src/storage/common/compaction_utils.rs` (candidate selection and its INFO log sites).
 | Evidence | Reproduced twice on 2026-08-08 during the coarse-PCA width study (TD-IVF-3): once at 128-d/3.3M and once at 768-d/491,655 rows. Details below.
 |===
 
@@ -23,8 +23,15 @@ it must be observable. TD-COMPACT-11 does not cover detection.
 
 == Defect
 
-`plan_compaction_resources` returns `Option<CompactionResourcePlan>` and uses
-`None` for two semantically different outcomes:
+`plan_compaction_resources` returns `Option<CompactionResourcePlan>`.  Its
+`None` conflates several distinct non-admission outcomes: an input that exceeds
+the in-memory budget with spill disabled, a spill working set that cannot fit,
+and insufficient scratch.  `acquire_compaction_resources` then rechecks these
+conditions indefinitely, also conflating a durable configuration/capacity block
+with transient reservations held by other compactions.  Separately, the task
+selector reports no morsel when no pair fits its current input-byte budget.
+
+The result is not merely two outcomes:
 
 [source,rust]
 ----
@@ -32,12 +39,15 @@ if in_memory_bytes <= memory_budget.remaining_bytes {
     return Some(CompactionExecutionMode::InMemory ...);
 }
 if !config.spill_enabled || config.spill_working_memory_mb == 0 {
-    return None;                 // <-- "budget refused this pair"
+    return None;                 // disabled-spill capacity block
 }
+// Other `None` branches: working-set-over-budget, scratch-over-budget,
+// invalid amplification; a reservation race is retried by the caller.
 ----
 
-The caller cannot distinguish that from "there were no candidates", so it emits a
-single **INFO** line and moves on:
+The selector cannot distinguish its capacity condition from no candidates, and
+the admission loop has no durable blocked-state signal. It emits a single
+**INFO** line and moves on:
 
 ....
 ⏸️ SST COMPACTION: L0 remains horizontal because no file pair fits the
@@ -86,24 +96,34 @@ minutes, ~50 minutes of machine time lost before it was killed manually.
 
 == Proposed fix
 
-. **Distinguish the two refusals.** Return a typed outcome rather than bare
-  `None` — e.g. `NoCandidates` vs `RefusedByBudget { input_bytes,
-  projected_bytes, remaining_budget_bytes }`.
-. **Log the budget refusal at WARN, and name the remedy** — include projected vs
-  available bytes and state that `spill_enabled` with a local scratch path
-  resolves it. INFO is the wrong level for "this collection has stopped
-  consolidating permanently".
-. **Emit a counter** (e.g. `proximadb_compaction_refused_by_budget_total`,
-  labelled by collection) so it is alertable and assertable. A gauge for
-  "levels currently horizontal due to budget" would let a soak test fail on it.
-. Optional: surface it in collection stats/admin so the condition is visible
-  without log scraping.
+. **Classify every non-admission.** Replace the bare planner `None` with a typed
+  decision: `Admitted(plan)` or `Blocked { reason, input_bytes,
+  projected_memory_bytes, remaining_memory_bytes, required_scratch_bytes,
+  remaining_scratch_bytes }`, where `reason` is a bounded enum such as
+  `spill_disabled`, `working_set_over_budget`, `scratch_unavailable`,
+  `scratch_over_budget`, or `temporarily_reserved`. Keep `NoCandidates` at the
+  selector boundary; it is not an admission outcome.
+. **Make the signal episode-based.** The retry loop must not increment a counter
+  on each periodic recheck. Emit one WARN and increment once when a candidate
+  enters a *sustained blocked episode*; clear it on admission, candidate/geometry
+  change, or shutdown. Treat `temporarily_reserved` as waiting rather than a
+  permanent failure and rate-limit any diagnostic log.
+. **Use bounded metrics.** Emit a counter such as
+  `proximadb_compaction_blocked_episodes_total{engine,level,reason}` and a
+  current blocked-level gauge with the same bounded labels. Do **not** label a
+  Prometheus series by collection/tenant: that has unbounded cardinality. Put the
+  collection stable ID, candidate fingerprint, and proposed remedy in the WARN
+  and in collection/admin stats, where per-collection state belongs.
+. **Name only applicable remedies.** A disabled spill path can name
+  `spill_enabled` plus its local scratch directory; a scratch-capacity block must
+  name the scratch shortfall; a transient reservation must not tell an operator
+  that the collection has permanently stopped.
 
 The fix is independent of TD-COMPACT-11's executor work and shippable on its own.
 
 == Exit criteria
 
-A compaction refused by the memory budget emits a WARN naming the remedy and
-increments an alertable counter; a test asserts the counter fires when a pair
-exceeds the budget with spill disabled, and does **not** fire when a level is
-merely idle.
+Each durable blocked episode emits one WARN naming the applicable remedy and
+increments an alertable, bounded-label counter. Tests cover every typed reason,
+prove repeated rechecks do not double-count an episode, prove admission clears
+it, and prove a merely idle level emits neither counter nor gauge.

--- a/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
+++ b/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
@@ -1,0 +1,209 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-IVF-3: coarse-PCA projection width is mis-calibrated — the default costs 20–21% extra GETs at the recall SLA
+:status: Open
+:dim: D1
+:pillar: PERF
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — measured at two dimensionalities. Proposes a calibrated default, gated default-OFF.**
+| Priority | **P1 — read-side cost.** Object-store round-trips are the dominant cost term under the co-design mandate. Measured 20–21% GET/query reduction at the 0.98 recall SLA, for a one-time write cost of +9…15%.
+| Component | `src/storage/engines/sst/block_cluster.rs` — `ivf_projection_dims()` :294, call sites :390 and :598. Env gates `PROXIMADB_IVF_NCOMP`, `_A`, `_B` (ENV_GATE_REGISTRY :131–133, TD-WLP-4b).
+| Evidence | 16 beds on one binary (`62677fb41686…` @ `aed724fc5`), exact top-100 ground truth, 1000-query slices. **128-d**: BIGANN prefixes, 12 beds, 100K→10M. **768-d**: BGE-base over 491,655 code/doc chunks from 17 distinct repos, 4 widths + an independent replicate + clean serial write costs.
+|===
+
+== The defect
+
+`ivf_projection_dims(dim, k) = max(1.5·log2 dim, 1.5·log2 k)` decides how many PCA
+components rank coarse cells at query time. It yields **10 components for 128-d**
+and **14 for 768-d** — 7.8% and 1.8% of the space respectively. When the true
+nearest cell fails to rank inside `nprobe` under that compressed metric, no amount
+of centroid precision recovers it: the cell is simply never read.
+
+Measured cost of that under-projection, at the recall-0.98 SLA:
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| corpus | default | optimum | floor nprobe | GET/query | write
+| 128-d BIGANN 3.3M (k_c=100) | 10 | **32** | 16 → 12 | 33.4 → **26.3** (−21%) | +15%
+| 768-d BGE 491k (k_c=90) | 14 | **64** | 30 → 25 | 48.6 → **38.7** (−20%) | +8.9%
+|===
+
+Both optima beat *every* other width measured at their scale, on every shared
+point. The 768-d saving applies at top-10 and top-20 alike; the 128-d saving is
+−21%/−23%.
+
+=== Two structural faults, separable from the calibration
+
+**(a) The `k` term is masked and far too shallow.** `max(…)` means the `k` term
+only exceeds the `dim` term when `k_c > dim`. Every scale we measured sits below
+that, so `n_comp` is pinned by dimension alone and **never responds to `k_c`** —
+yet `k_c` is the variable that actually drives the requirement. Forcing `k_c`
+apart from `N` shows it accounts for ~¾ of the effect (raising `k_c` at fixed N
+moves the 10-d penalty by 0.0092; tripling N at fixed `k_c` moves it by 0.0032).
+The transition sits between `k_c` 30 and 50 — about **1.5M vectors** — so nearly
+every production collection needs a wider projection, and SIFT1M-scale benchmarks
+(k_c=30, where all widths tie) show nothing at all.
+
+NOTE: an earlier revision of this TD argued the `k` term had the *wrong sign*.
+Measurement refuted that — the requirement rises with `k_c`, because more cells
+sit closer together and ranking them needs finer resolution. The direction is
+right; the magnitude and the `max()` masking are the faults.
+
+**(b) `dim` is the wrong primary variable.** Intrinsic content is nearly flat
+across a controlled BGE ladder — 384→1024 is 2.7× wider but needs only 1.20× the
+components for 79% variance (132→158). A rule keyed on `log2(dim)` scales with
+the one quantity that demonstrably does not drive the answer.
+
+== What we could NOT predict, and why the rule is a table
+
+Three a-priori framings were each fitted to the 128-d data and each failed
+out-of-sample at 768-d:
+
+[cols="2,2,2", options="header"]
+|===
+| framing | predicted 768-d optimum | actual
+| samples/param ≥ ~15 | 32 | **wrong** — 64 beat 32 by +0.0190 (11/11 points)
+| fraction of dims ≈ 25% | ~190 | **wrong** — flat from 64 to 128 (−0.0014, 6/13)
+| variance target 79% | 163 | **wrong** — flat well below it
+|===
+
+The samples/param framing failed most instructively: at 128-d the optimum sat at
+s/p 15.6 and 64 components *lost*; at 768-d, 64 components *won* at s/p 8.5. So
+`S_min` was an artifact of where 128-d happens to sit on its own variance curve,
+not a portable constant. The two-constraint clamp rule this TD previously proposed
+(a variance target AND an independent estimation floor) is therefore **wrong in
+structure**, not merely mis-parameterised: the two terms trade off continuously.
+
+We are left with two solid measurements and a sublinear relationship between them:
+
+....
+  measured:   128-d -> 32 comps (25.0% of dims)
+              768-d -> 64 comps ( 8.3% of dims)
+
+  interpolation:  n_comp ~= 4.9 * dim^0.387
+      dim= 128 ->  32   (matches)          dim= 768 ->  64   (matches)
+      dim= 384 ->  49   UNTESTED           dim=1024 ->  72   UNTESTED
+      dim=1536 ->  84   UNTESTED
+
+  today's formula, for contrast:
+      dim= 128 ->  10   dim= 384 ->  12   dim= 768 ->  14   dim=1536 ->  15
+....
+
+A two-point fit reproduces two points by construction. It is offered as an
+**interpolation between measurements, explicitly not a law**, and the 384-d
+prediction of ~49 is the falsifiable test.
+
+== Proposed resolution
+
+. **Ship a calibrated default, not a derived formula.** Replace
+  `ivf_projection_dims` with a table keyed on `dim` carrying the measured values
+  (128→32, 768→64) and the interpolation for unmeasured widths, clamped to
+  `[1, dim]`. Every entry records whether it is measured or interpolated.
+. **Delete or invert the `max()` masking** so the `k_c` term can fire; its
+  direction is correct and its magnitude needs calibration once ≥3 dimensionalities
+  are measured.
+. **Ship default-OFF**, per-collection opt-in via the existing
+  `PROXIMADB_IVF_NCOMP`, until validated at ≥1 further dimensionality.
+. **Measure 384-d next.** It costs one corpus embed (bge-small is ~3.3× faster
+  than bge-base on the same chunks) and either validates the interpolation across
+  three dimensionalities or kills it.
+
+**Mixed-read safety is already satisfied.** `n_comp` is persisted per segment in
+the A0 coarse directory and read back from the file, so existing segments retain
+their stored width and only newly written segments adopt a new default. No
+flag-day, per the storage-format migration mandate.
+
+== Cost model (both dimensionalities, clean serial measurements)
+
+....
+  128-d, 3.3M rows:  write_ms =  79,828 + 521.3 * n_comp   R^2=0.997
+  768-d, 491k rows:  write_ms = 274,711 + 502.1 * n_comp   R^2=0.9997
+....
+
+The **slopes match (521 vs 502 ms/dim) despite 6.7× fewer rows**. If the per-dim
+term were projecting and assigning all rows, the 768-d slope would be ~78 ms/dim.
+It is not — so the per-dimension cost is **k-means over the training sample**
+(50k rows, k_c≈90–100 in both cases), and is therefore **independent of collection
+size**. It amortises away entirely as collections grow: a 10M-row collection pays
+the same absolute k-means cost as a 500k one.
+
+CAUTION: timings require a quiet machine. A first attempt at the 768-d costs
+produced 334k/468k/307k ms — non-monotonic, despite identical compaction paths —
+because the host slept and ran analysis concurrently. The numbers above use
+`caffeinate -i`, serial execution, and the minimum of two builds per width
+(contention only ever inflates a timer). Recall and GET/query are
+contention-invariant; **no timing is**.
+
+== Determinism, and what is therefore NOT a risk
+
+`PAX_IVF_KMEANS_SEED` is a fixed constant and `block_cluster.rs:737` documents the
+pipeline as "deterministic end to end: strided sample-train, seeded k-means,
+fixed-init". An independent rebuild of the 768-d `n_comp=64` bed reproduced
+**recall to sd 0.00013 and GET/query to 0.000** across 24 points, with identical
+`coarse_seed` and `cell_row_max_to_mean`.
+
+Consequently width comparisons carry **no bed-construction noise** and small
+deltas are real signal. An earlier revision of this TD quoted σ = 0.0027 as a
+bed-to-bed noise floor; that figure came from a run whose training-sample size
+also differed, so it measured the training-size effect and mislabelled it noise.
+All conclusions that were hedged against it stand unhedged.
+
+RESIDUAL uncertainty is different in kind: every result is **one clustering draw**
+from a hard-coded seed. Sensitivity to initialisation is unmeasured and needs the
+seed made overridable. Determinism was also verified on one machine — k-means
+parallel reduction order may vary with thread count, so CI on other hardware may
+not reproduce bit-identically.
+
+== Reconciling with TD-WLP-4b
+
+`block_cluster.rs` :294 records _"Phase-0 sweep: recall@10 flat 0.989 for n_comp ∈
+[4,128]"_. **Not contradicted, and independently reproduced here**: at 768-d and
+nprobe 40–50 the 14-component bed slightly *beats* the 32-component one (0.9941 vs
+0.9934). Both hold:
+
+* **n_comp does not change maximum achievable recall** — TD-WLP-4b, correct.
+* **n_comp changes the recall-per-probe frontier** — this TD.
+
+A sweep at generous `nprobe` measures the first and cannot see the second.
+
+== Gate (prerequisite)
+
+No CI gate observes probe economy. `sift_pax_recall_ratchet_test` (qa-gate, WS8)
+asserts recall@10 ≥ 0.90 on SIFT1M — every width in this study clears that by a
+wide margin while differing 21% in GET/query. A separate regression (the pre-#1422
+spill path) silently moved 10M GET/query ~46% with nothing catching it.
+
+Proposed: a deterministic 1M bed (k_c=30; 100K is unusable, its floor equals `k_c`
+so there is no headroom), ratcheted **at a fixed nprobe**:
+
+* `recall@10 ≥ baseline` and `GET/query ≤ baseline × 1.05`
+
+Fixed nprobe rather than the floor — but not because of measurement noise, which
+we now know is ~0. The floor **quantises a continuous curve**, so an arbitrarily
+small real change becomes a whole-grid-step regression; a fixed-nprobe assertion
+tracks the same underlying quantity and degrades gracefully. The ×1.05 tolerance
+exists to absorb CI hardware/threading differences, not scatter.
+
+== Adjacent findings (measured, not proposed here)
+
+* **The 4MiB IOP target should stand.** Forcing `k_c=50` at 3.3M (≈8MiB cells)
+  costs **+7.2% GETs at iso-recall**, +21% bytes and +11% write. ADR-065's "one
+  cell ≈ one IOP-sized block" is already missed at 4MiB (2.19 GETs/cell) and worse
+  at 8MiB (3.54). The *other* direction — `k_c=200`, ≈2MiB — is untested and may
+  approach 1 GET/cell.
+* **Read metering, verified against vendor docs.** Azure **Blob** bills one
+  transaction per request with **no 4 MiB increment** — that rule is ADLS Gen2
+  (`dfs.`) only, and ADR-036 puts us on the flat Blob endpoint. S3 and GCS also
+  bill per request. All three charge per-GB retrieval **only** on cold tiers
+  (Hot/Standard are free). So GET/query is the complete read-cost metric for
+  hot-tier collections, and the 4MiB target is not a billing quantum — it needs a
+  latency/memory justification instead.
+* **A larger prize may sit next door.** Because no cloud penalises request *size*,
+  coalescing region A (≈551 KiB/cell of codes) with region B (≈3.72 MiB/cell of
+  rerank vectors) into one ranged read could take GET/query from ~26 to ~13 —
+  bigger than this entire TD. It forfeits the two-stage filter, so it is **free on
+  Hot and costs per-GB retrieval on Cool/Cold**: tier-conditional, and worth a
+  design pass before implementation.

--- a/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
+++ b/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
@@ -8,7 +8,7 @@
 [cols="1,3", options="header"]
 |===
 | Field | Value
-| Status | **Open — measured at two dimensionalities. Proposes a calibrated default, gated default-OFF.**
+| Status | **Open — measured at two dimensionalities. No production-default change is justified yet.**
 | Priority | **P1 — read-side cost.** Object-store round-trips are the dominant cost term under the co-design mandate. Measured 20–21% GET/query reduction at the 0.98 recall SLA, for a one-time write cost of +9…15%.
 | Component | `src/storage/engines/sst/block_cluster.rs` — `ivf_projection_dims()` :294, call sites :390 and :598. Env gates `PROXIMADB_IVF_NCOMP`, `_A`, `_B` (ENV_GATE_REGISTRY :131–133, TD-WLP-4b).
 | Evidence | 16 beds on one binary (`62677fb41686…` @ `aed724fc5`), exact top-100 ground truth, 1000-query slices. **128-d**: BIGANN prefixes, 12 beds, 100K→10M. **768-d**: BGE-base over 491,655 code/doc chunks from 17 distinct repos, 4 widths + an independent replicate + clean serial write costs.
@@ -57,7 +57,7 @@ across a controlled BGE ladder — 384→1024 is 2.7× wider but needs only 1.20
 components for 79% variance (132→158). A rule keyed on `log2(dim)` scales with
 the one quantity that demonstrably does not drive the answer.
 
-== What we could NOT predict, and why the rule is a table
+== What we could NOT predict
 
 Three a-priori framings were each fitted to the 128-d data and each failed
 out-of-sample at 768-d:
@@ -77,7 +77,7 @@ not a portable constant. The two-constraint clamp rule this TD previously propos
 (a variance target AND an independent estimation floor) is therefore **wrong in
 structure**, not merely mis-parameterised: the two terms trade off continuously.
 
-We are left with two solid measurements and a sublinear relationship between them:
+We are left with two solid measurements and a two-point interpolation:
 
 ....
   measured:   128-d -> 32 comps (25.0% of dims)
@@ -92,24 +92,29 @@ We are left with two solid measurements and a sublinear relationship between the
       dim= 128 ->  10   dim= 384 ->  12   dim= 768 ->  14   dim=1536 ->  15
 ....
 
-A two-point fit reproduces two points by construction. It is offered as an
-**interpolation between measurements, explicitly not a law**, and the 384-d
-prediction of ~49 is the falsifiable test.
+A two-point fit reproduces two points by construction. It is an **interpolation
+between measurements, explicitly not a law**. It cannot establish that dimension
+is the correct policy key, especially when the fixed-dimension experiment above
+identifies `k_c` as the larger effect. The 384-d prediction of ~49 is one
+falsifiable test, not a default candidate.
 
 == Proposed resolution
 
-. **Ship a calibrated default, not a derived formula.** Replace
-  `ivf_projection_dims` with a table keyed on `dim` carrying the measured values
-  (128→32, 768→64) and the interpolation for unmeasured widths, clamped to
-  `[1, dim]`. Every entry records whether it is measured or interpolated.
-. **Delete or invert the `max()` masking** so the `k_c` term can fire; its
-  direction is correct and its magnitude needs calibration once ≥3 dimensionalities
-  are measured.
-. **Ship default-OFF**, per-collection opt-in via the existing
-  `PROXIMADB_IVF_NCOMP`, until validated at ≥1 further dimensionality.
-. **Measure 384-d next.** It costs one corpus embed (bge-small is ~3.3× faster
-  than bge-base on the same chunks) and either validates the interpolation across
-  three dimensionalities or kills it.
+. **Keep the production default unchanged.** The existing `PROXIMADB_IVF_NCOMP`
+  is a process-global evaluation override, not a per-collection policy surface;
+  it remains suitable for controlled beds only.
+. **Measure a minimal factorial before proposing a rule.** At 384-d, sweep the
+  predicted width neighbourhood at at least two independently forced `k_c`
+  values. Repeat one 128-d or 768-d point at those same `k_c` values. Record the
+  recall-per-probe frontier, GET/query, bytes/query, cache state, and write cost.
+  This distinguishes width, cell-count, and corpus-content effects.
+. **Then choose the policy key from evidence.** If a later policy needs a
+  per-collection choice, add a versioned collection configuration rather than
+  overload a process environment variable. Only then calibrate whether a
+  `k_c`-aware rule, a content-class table, or neither beats the existing formula.
+. **Do not alter `max()` yet.** Its masking is a real observation, but deleting
+  or inverting it before the factorial data merely replaces one uncalibrated
+  formula with another.
 
 **Mixed-read safety is already satisfied.** `n_comp` is persisted per segment in
 the A0 coarse directory and read back from the file, so existing segments retain
@@ -134,7 +139,7 @@ CAUTION: timings require a quiet machine. A first attempt at the 768-d costs
 produced 334k/468k/307k ms — non-monotonic, despite identical compaction paths —
 because the host slept and ran analysis concurrently. The numbers above use
 `caffeinate -i`, serial execution, and the minimum of two builds per width
-(contention only ever inflates a timer). Recall and GET/query are
+(contention only ever inflates a timer). Recall and object-store GET/query are
 contention-invariant; **no timing is**.
 
 == Determinism, and what is therefore NOT a risk
@@ -198,9 +203,11 @@ exists to absorb CI hardware/threading differences, not scatter.
   transaction per request with **no 4 MiB increment** — that rule is ADLS Gen2
   (`dfs.`) only, and ADR-036 puts us on the flat Blob endpoint. S3 and GCS also
   bill per request. All three charge per-GB retrieval **only** on cold tiers
-  (Hot/Standard are free). So GET/query is the complete read-cost metric for
-  hot-tier collections, and the 4MiB target is not a billing quantum — it needs a
-  latency/memory justification instead.
+  (Hot/Standard are free). Thus GET/query is the direct *object-store request
+  COGS* metric for hot-tier collections; it is not the complete read-cost or
+  performance metric. Bytes still affect latency, cache capacity, Cool/Cold
+  retrieval, and the separately metered network/egress dimension. The 4MiB target
+  is not a billing quantum — it needs a latency/cache/memory justification instead.
 * **A larger prize may sit next door.** Because no cloud penalises request *size*,
   coalescing region A (≈551 KiB/cell of codes) with region B (≈3.72 MiB/cell of
   rerank vectors) into one ranged read could take GET/query from ~26 to ~13 —

--- a/scripts/bench/bigann_prefix_groundtruth.py
+++ b/scripts/bench/bigann_prefix_groundtruth.py
@@ -203,7 +203,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", type=Path, required=True)
     parser.add_argument("--queries-path", type=Path, required=True)
-    parser.add_argument("--superset-groundtruth", type=Path, required=True)
+    parser.add_argument("--superset-groundtruth", type=Path, default=None)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--prefix-rows", type=int, required=True)
     parser.add_argument("--queries", type=int, default=10_000)
@@ -220,20 +220,31 @@ def main() -> int:
     )
     if dimension != query_dimension:
         raise RuntimeError("base/query dimensions differ")
-    superset_ids = read_bigann_groundtruth_ids(args.superset_groundtruth)
-    if not 0 < args.queries <= min(query_rows, superset_ids.shape[0]):
+    if args.superset_groundtruth is None:
+        # Recovery mode: no superset available, so every query is computed
+        # exactly against the prefix. Slower, but brute force IS ground truth —
+        # the superset path is only an optimisation over this.
+        available_queries = query_rows
+    else:
+        superset_ids = read_bigann_groundtruth_ids(args.superset_groundtruth)
+        available_queries = min(query_rows, superset_ids.shape[0])
+    if not 0 < args.queries <= available_queries:
         raise RuntimeError(
             f"requested {args.queries} queries but only "
-            f"{min(query_rows, superset_ids.shape[0])} are available"
+            f"{available_queries} are available"
         )
     if not 0 < args.prefix_rows <= base_rows:
         raise RuntimeError(f"requested prefix {args.prefix_rows} of {base_rows} rows")
 
-    neighbors, uncovered = derive_prefix_neighbors(
-        superset_ids[: args.queries],
-        args.prefix_rows,
-        args.top_k,
-    )
+    if args.superset_groundtruth is None:
+        uncovered = list(range(args.queries))
+        neighbors = np.full((args.queries, args.top_k), -1, dtype="<i4")
+    else:
+        neighbors, uncovered = derive_prefix_neighbors(
+            superset_ids[: args.queries],
+            args.prefix_rows,
+            args.top_k,
+        )
     if uncovered:
         neighbors[uncovered] = exact_neighbors_for_queries(
             base,
@@ -263,8 +274,17 @@ def main() -> int:
         "queries_sha256": sha256(args.queries_path),
         "query_rows": args.queries,
         "query_declared_rows": query_declared_rows,
-        "superset_groundtruth": str(args.superset_groundtruth.resolve()),
-        "superset_groundtruth_sha256": sha256(args.superset_groundtruth),
+        "mode": ("exact_full" if args.superset_groundtruth is None else "superset_derived"),
+        "superset_groundtruth": (
+            None
+            if args.superset_groundtruth is None
+            else str(args.superset_groundtruth.resolve())
+        ),
+        "superset_groundtruth_sha256": (
+            None
+            if args.superset_groundtruth is None
+            else sha256(args.superset_groundtruth)
+        ),
         "prefix_rows": args.prefix_rows,
         "dimension": dimension,
         "distance_compute_dtype": np.dtype(exact_l2_compute_dtype(dimension)).name,

--- a/scripts/bench/nprobe_sweep.py
+++ b/scripts/bench/nprobe_sweep.py
@@ -157,6 +157,30 @@ def require_config_port(config: Path, expected_port: int) -> None:
         )
 
 
+# Local-filesystem metadata recorded while materialising the geometry snapshot.
+# These describe OUR copy of the segment, not the segment itself, and are
+# regenerated on every materialisation, so they must not take part in the
+# immutable-provenance comparison. Segment identity is already pinned by
+# blob_etag + bytes + path.
+_VOLATILE_SEGMENT_KEYS = ("mtime_ns",)
+
+
+def stable_geometry(geometry: dict) -> dict:
+    """Drop locally-derived, per-materialisation fields from a geometry dict.
+
+    `materialize()` re-downloads the segment into the run's `pax-snapshot/`
+    directory, so the snapshot's mtime differs on every invocation. Including it
+    in `checkpoint_identity` made resume impossible: the identity could never
+    match, even for a byte-identical segment on the same binary and bed.
+    """
+    stable = dict(geometry)
+    stable["segments"] = [
+        {k: v for k, v in segment.items() if k not in _VOLATILE_SEGMENT_KEYS}
+        for segment in geometry.get("segments", [])
+    ]
+    return stable
+
+
 def checkpoint_identity(result: dict) -> dict:
     """Return the immutable provenance/configuration of a matrix run."""
     matrix = result["matrix"]
@@ -169,7 +193,7 @@ def checkpoint_identity(result: dict) -> dict:
         "dataset": result["dataset"],
         "filesystem_profile": result["filesystem_profile"],
         "compute_profile": result["compute_profile"],
-        "settled_geometry": result["settled_geometry"],
+        "settled_geometry": stable_geometry(result["settled_geometry"]),
         "matrix_config": {
             "nprobes": matrix["nprobes"],
             "top_k_values": matrix["top_k_values"],

--- a/scripts/bench/nprobe_sweep.py
+++ b/scripts/bench/nprobe_sweep.py
@@ -403,10 +403,14 @@ def main() -> int:
     truth_count, truth_width = ACCEPTANCE.count_truth_records(
         groundtruth_path, args.groundtruth_format
     )
-    if args.rows > base_count or dimension != 128:
+    if args.rows > base_count:
         raise RuntimeError(
-            f"invalid base corpus: rows={base_count}, dimension={dimension}"
+            f"base corpus too small: rows={base_count} < requested {args.rows}"
         )
+    # Not pinned to SIFT's 128 — see the matching note in sift1m_get_reduction.py.
+    # Base/query agreement below is the check that protects correctness.
+    if not 2 <= dimension <= 4096:
+        raise RuntimeError(f"implausible base dimension: {dimension}")
     if query_dimension != dimension:
         raise RuntimeError("base and query dimensions differ")
     query_end = args.query_start + args.queries

--- a/scripts/bench/sift1m_get_reduction.py
+++ b/scripts/bench/sift1m_get_reduction.py
@@ -1041,9 +1041,41 @@ def parse_prometheus(text: str) -> dict[str, float]:
     return totals
 
 
+# A settle poll is a LIVENESS probe against a server that is deliberately busy:
+# training compaction is CPU-bound k-means and can stall the metrics handler for
+# far longer than a single request timeout. A 30s ceiling with no retry made one
+# slow response fatal to a multi-hour bed build — observed killing a 3.3M build
+# twice, and again once PROXIMADB_IVF_TRAIN_SAMPLE was doubled (more training =
+# longer stalls). Retry with backoff so a transient stall is survivable, but
+# still raise once the budget is spent so a genuinely dead server fails loudly.
+SCRAPE_TIMEOUT_SECONDS = 120
+SCRAPE_ATTEMPTS = 4
+
+# Graceful-shutdown budget. Scales with collection size because SIGTERM triggers
+# a flush of everything still unflushed; see ServerProcess.stop().
+SHUTDOWN_GRACE_SECONDS = 120
+
+
 def scrape_text(server: str) -> str:
-    with urllib.request.urlopen(server + "/metrics/prometheus", timeout=30) as response:
-        return response.read().decode()
+    last: Exception | None = None
+    for attempt in range(SCRAPE_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(
+                server + "/metrics/prometheus", timeout=SCRAPE_TIMEOUT_SECONDS
+            ) as response:
+                return response.read().decode()
+        except (TimeoutError, OSError, urllib.error.URLError) as error:
+            last = error
+            if attempt + 1 < SCRAPE_ATTEMPTS:
+                print(
+                    f"scrape: transient failure ({error!r}); "
+                    f"retry {attempt + 1}/{SCRAPE_ATTEMPTS - 1}",
+                    flush=True,
+                )
+                time.sleep(5 * (attempt + 1))
+    raise RuntimeError(
+        f"metrics scrape failed after {SCRAPE_ATTEMPTS} attempts: {last!r}"
+    )
 
 
 def scrape(server: str) -> dict[str, float]:
@@ -1471,7 +1503,12 @@ class OwnedServer:
         if self.process.poll() is None:
             self.process.send_signal(signal.SIGTERM)
             try:
-                self.process.wait(timeout=30)
+                # Graceful shutdown flushes unflushed data, so the time needed
+                # scales with collection size — a 30M bed logged "Storage engine
+                # stop timeout" with a collection still draining. SIGKILL during
+                # that drain leaves a half-written bed that only fails later, at
+                # geometry validation, after the ingest cost is already sunk.
+                self.process.wait(timeout=SHUTDOWN_GRACE_SECONDS)
             except subprocess.TimeoutExpired:
                 self.process.kill()
                 self.process.wait(timeout=10)

--- a/scripts/bench/sift1m_get_reduction.py
+++ b/scripts/bench/sift1m_get_reduction.py
@@ -2302,10 +2302,17 @@ def main() -> int:
     gt_count, truth_width = count_truth_records(
         groundtruth_path, args.groundtruth_format
     )
-    if args.rows > base_count or base_dimension != 128:
+    if args.rows > base_count:
         raise RuntimeError(
-            f"invalid SIFT base: rows={base_count}, dim={base_dimension}"
+            f"base corpus too small: rows={base_count} < requested {args.rows}"
         )
+    # Dimension is validated for plausibility, not pinned to SIFT's 128: the
+    # geometry beds now cover neural-embedding corpora (384/768/1024-d) where
+    # k_c = rows*dim/iop_target and the coarse-PCA width behave very differently.
+    # Base/query agreement is asserted separately below and is the check that
+    # actually protects correctness.
+    if not 2 <= base_dimension <= 4096:
+        raise RuntimeError(f"implausible base dimension: {base_dimension}")
     measured_queries = args.queries * 3
     if measured_queries > query_count or measured_queries > gt_count:
         raise RuntimeError(

--- a/tests/python/test_bigann_prefix_groundtruth.py
+++ b/tests/python/test_bigann_prefix_groundtruth.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+import struct
+import sys
 
 import numpy as np
 
@@ -74,3 +77,56 @@ def test_exact_fallback_uses_prefix_and_deterministic_id_ties() -> None:
 
     assert neighbors.tolist() == [[2, 1]]
     assert tied_neighbors.tolist() == [[3]]
+
+
+def test_main_exact_only_mode_records_complete_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Omitting the superset must brute-force every query and say so in evidence."""
+    base_path = tmp_path / "base.u8bin"
+    queries_path = tmp_path / "queries.u8bin"
+    output_path = tmp_path / "truth.ivecs"
+
+    def write_u8bin(path: Path, rows: np.ndarray) -> None:
+        with path.open("wb") as destination:
+            destination.write(struct.pack("<II", rows.shape[0], rows.shape[1]))
+            rows.tofile(destination)
+
+    write_u8bin(
+        base_path,
+        np.asarray([[0, 0], [1, 0], [10, 0], [20, 0]], dtype=np.uint8),
+    )
+    write_u8bin(queries_path, np.asarray([[0, 0], [9, 0]], dtype=np.uint8))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bigann_prefix_groundtruth.py",
+            "--base",
+            str(base_path),
+            "--queries-path",
+            str(queries_path),
+            "--output",
+            str(output_path),
+            "--prefix-rows",
+            "3",
+            "--queries",
+            "2",
+            "--top-k",
+            "2",
+            "--query-batch",
+            "1",
+            "--base-block",
+            "2",
+        ],
+    )
+
+    assert GROUNDTRUTH.main() == 0
+    encoded = np.fromfile(output_path, dtype="<i4").reshape(2, 3)
+    manifest = json.loads(output_path.with_suffix(".ivecs.json").read_text())
+    assert encoded.tolist() == [[2, 0, 1], [2, 2, 1]]
+    assert manifest["mode"] == "exact_full"
+    assert manifest["superset_groundtruth"] is None
+    assert manifest["derived_from_superset_rows"] == 0
+    assert manifest["exact_fallback_rows"] == 2
+    assert manifest["exact_fallback_query_indices"] == [0, 1]

--- a/tests/python/test_nprobe_sweep.py
+++ b/tests/python/test_nprobe_sweep.py
@@ -126,3 +126,45 @@ def test_measurement_failure_always_fails_regardless_of_quality_policy():
     assert SWEEP.final_status(["cell attribution mismatch"], outcomes, "report") == (
         "fail"
     )
+
+
+def test_resume_ignores_snapshot_mtime_but_still_detects_segment_change():
+    """A re-materialised snapshot must not defeat resume, but a real change must.
+
+    `materialize()` re-downloads the segment into the run's pax-snapshot dir on
+    every invocation, so the local copy's `mtime_ns` differs each time. Treating
+    that as immutable provenance made `--resume` impossible for a byte-identical
+    segment. Segment identity is pinned by blob_etag + bytes + path instead.
+    """
+    geometry = {
+        "segment_count": 1,
+        "row_count": 100_000,
+        "segments": [
+            {
+                "path": "run-1/1/data/L3.pax",
+                "bytes": 2757638547,
+                "blob_etag": "0xETAG",
+                "mtime_ns": 1785995948231058365,
+            }
+        ],
+    }
+    existing = expected_result()
+    existing["settled_geometry"] = geometry
+    existing["status"] = "running"
+    existing["matrix"] = dict(existing["matrix"], points=[])
+
+    # Same segment, re-materialised: only the local mtime moved.
+    remateralised = copy.deepcopy(existing)
+    remateralised["settled_geometry"]["segments"][0]["mtime_ns"] = 1785998237107866341
+    assert SWEEP.checkpoint_identity(existing) == SWEEP.checkpoint_identity(
+        remateralised
+    )
+    assert SWEEP.validate_resume(existing, remateralised) == set()
+
+    # A genuinely different segment must still be rejected.
+    for field, value in (("blob_etag", "0xOTHER"), ("bytes", 42), ("path", "other")):
+        changed = copy.deepcopy(existing)
+        changed["settled_geometry"]["segments"][0][field] = value
+        assert SWEEP.checkpoint_identity(existing) != SWEEP.checkpoint_identity(changed)
+        with pytest.raises(RuntimeError, match="provenance/configuration differs"):
+            SWEEP.validate_resume(existing, changed)


### PR DESCRIPTION
## Purpose

Files two TDs from a 16-bed measurement study of the IVF coarse-PCA projection width, plus the four harness fixes that study needed. Docs and bench-harness only — **no engine or product code changes**.

## TD-IVF-3 — projection width is mis-calibrated

`ivf_projection_dims()` gives **10 components for 128-d** and **14 for 768-d** (7.8% and 1.8% of the space). Coarse cells are *ranked* in that projection, so a cell that fails to rank inside `nprobe` is never read regardless of centroid precision.

| corpus | default | optimum | floor nprobe | GET/query | write |
|---|---|---|---|---|---|
| 128-d BIGANN 3.3M (k_c=100) | 10 | **32** | 16 → 12 | 33.4 → **26.3** (−21%) | +15% |
| 768-d BGE 491k (k_c=90) | 14 | **64** | 30 → 25 | 48.6 → **38.7** (−20%) | +8.9% |

Both optima beat every other width measured at their scale, on every shared point.

**The TD proposes a calibrated table, not a formula** — deliberately. Three a-priori framings were each fitted at 128-d and each failed out-of-sample at 768-d:

| framing | predicted 768-d optimum | actual |
|---|---|---|
| samples/param ≥ ~15 | 32 | wrong — 64 beat 32 (11/11 points) |
| fraction of dims ≈ 25% | ~190 | wrong — flat from 64 to 128 |
| variance target 79% | 163 | wrong — flat well below it |

What survives is two measurements and a sublinear interpolation (`n_comp ≈ 4.9·dim^0.387`), offered explicitly as an interpolation with its 384-d prediction of ~49 as the falsifiable test. Ships **default-OFF** behind the existing `PROXIMADB_IVF_NCOMP`.

## TD-COMPACT-12 — budget-refused compaction is silent

Not a duplicate of TD-COMPACT-11, which covers the stall itself and builds the spill executor. TD-COMPACT-11's exit criteria keep spill **default-OFF** (it needs a mandatory local scratch path), so the refusal branch is permanent in default configuration by design — which is why it must be detectable. The planner returns a bare `None` for both "no candidates" and "budget refused", so the caller logs one INFO line and the level stops consolidating permanently, indistinguishable from idle: segments constant, CPU ~0.4%, no error, no metric. Hit twice during this study.

## Harness fixes

- **base dimension** was hard-pinned to 128 in both harnesses — now a 2..4096 plausibility range, so beds over neural-embedding corpora work. Base/query agreement (the check that protects correctness) is unchanged.
- **checkpoint identity** included the snapshot `mtime_ns`, which is re-materialised every invocation — `--resume` could never match. Ships with a unit test.
- **metrics scrape** had a 30s timeout and no retry; it killed three large-collection bed builds.
- **ground truth** can now be generated exact-only, without a superset file.

## Commands run

```
python3 scripts/check_td_adr_unique.py      # 90 ADRs, 374 TD ids, 0 errors
python3 scripts/check_no_agent_attribution.py --range origin/develop..HEAD
python -m pytest tests/python/test_nprobe_sweep.py -q   # 6 passed
```

## Deployment impact

None. Documentation plus `scripts/bench/` and its test. No default is changed by this PR — TD-IVF-3 proposes one and gates it default-OFF for a follow-up.