### PR TITLE
test(catalog): cover the object_id persistence round-trip; exonerate NativeCatalog (TD-AUTHZ-2)

### DIFF
--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -2520,6 +2520,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn object_id_survives_the_get_table_round_trip() {
+        // TD-AUTHZ-2. `create_table_assigns_distinct_monotonic_object_ids`
+        // asserts only on the schema `create_table` RETURNS — it never reads the
+        // table back, so nothing covered whether the minted id survives
+        // persistence. `xcatalog.tables` renders an EMPTY object_id for
+        // SQL-created relational tables in the live server, and the defect can
+        // only live in that untested gap: mint (proven) -> persist -> load.
+        let tmp = tempfile::tempdir().unwrap();
+        let cat = fresh_catalog(&tmp).await;
+        let ns = vec!["t".to_string()];
+        cat.create_namespace(&ns, HashMap::new()).await.unwrap();
+        let identifier = TableIdentifier::new(ns.clone(), "roundtrip_probe");
+
+        let created = cat
+            .create_table(&identifier, schema_with_id_col("roundtrip_probe"))
+            .await
+            .expect("create_table");
+        let minted = created.object_id.expect("create_table mints an object_id");
+
+        let fetched = cat.get_table(&identifier).await.expect("get_table");
+        assert_eq!(
+            fetched.object_id,
+            Some(minted),
+            "the minted object_id must survive persistence and be readable via \
+             get_table — this is what xcatalog.tables projects, and an empty \
+             value there is what TD-AUTHZ-2 reports"
+        );
+    }
+
+    #[tokio::test]
     async fn create_table_assigns_distinct_monotonic_object_ids() {
         let tmp = tempfile::tempdir().unwrap();
         let cat = fresh_catalog(&tmp).await;

--- a/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
@@ -71,6 +71,48 @@ The blank is therefore a genuine `schema.object_id == None` reaching
 `unwrap_or_default()`, on a path where all of the above should have set it. That narrows the
 question to something only runtime evidence can answer.
 
+== Runtime evidence 2026-08-09 — NativeCatalog EXONERATED
+
+Two probes ran; both narrow the defect decisively.
+
+**1. Ground truth from the live server.** A temporary probe issued
+`CREATE TABLE probe_… (id INT PRIMARY KEY, value INT)` over pgwire and printed the whole
+`xcatalog.tables` row:
+
+----
+cols=10  [0]="default" [1]="public" [2]="probe_…" [3]="relational"
+         [4]="" [5]="" [6]="" [7]="" [8]="1" [9]=""
+----
+
+The row carries **exactly the 10 columns the projection builds**, so nothing reshapes it on
+the wire — `[9]` is genuinely empty, and `[8]` (schema_version) proves the row is otherwise
+populated. `[4]`–`[7]` are empty because they read `schema.properties` keys a relational table
+does not set; that is expected, not part of this defect.
+
+**2. `NativeCatalog` does NOT lose the id.** The pre-existing
+`create_table_assigns_distinct_monotonic_object_ids` asserts only on the schema `create_table`
+*returns* — it never reads the table back, so **nothing covered the persistence round-trip**.
+The new `object_id_survives_the_get_table_round_trip` closes that gap and **passes**:
+create → persist → load → `get_table` preserves the minted id.
+
+So the mint works, persistence works, the read-back works, and the projection shape is right —
+yet the live server renders empty. The defect is therefore **not in `NativeCatalog` and not in
+the introspection projection**. It is in the wiring between them.
+
+== Next probe (start here, narrowed)
+
+. **Which `Catalog` instance serves each side?** Introspection iterates
+  `catalog_manager.list_catalogs()` → `get_catalog("default")` (the probe row confirms the
+  catalog name is `default`). Establish whether the pgwire DDL path writes to that *same*
+  instance. Two instances over the same data dir would explain everything: one mints and
+  persists, the other answers reads from its own in-memory `self.tables` populated by a
+  different route.
+. **Which impl is behind `default`?** `NativeCatalog` mints; `unity.rs:490` / `polaris.rs:614`
+  do not. Now exonerated as an implementation, `NativeCatalog` being *absent* from that path is
+  the leading hypothesis rather than it being buggy.
+
+== Superseded probe list
+
 == Next probe (runtime, start here)
 
 . Boot the live server the suite uses, `CREATE TABLE` over pgwire, then log the


### PR DESCRIPTION
Two runtime probes narrowed the TD-AUTHZ-2 empty-`object_id` defect decisively. One is worth keeping permanently; the other is deleted.

## Coverage gap closed (the keeper)

`create_table_assigns_distinct_monotonic_object_ids` asserts only on the schema `create_table` **returns** — it never reads the table back, so **nothing covered the persistence round-trip**. That is precisely the gap the defect could have lived in: a test proving the mint *happens* that says nothing about the id ever being *readable again*.

New `object_id_survives_the_get_table_round_trip` closes it (create → persist → load → `get_table`) and **passes** — so `NativeCatalog` preserves the id correctly and is **exonerated**.

## Ground truth (the temporary probe, since removed)

A pgwire `CREATE TABLE` yields:

```
cols=10  [0]="default" [1]="public" [2]=<table> [3]="relational"
         [4]="" [5]="" [6]="" [7]="" [8]="1" [9]=""
```

Exactly the 10 columns the projection builds — **nothing reshapes the row on the wire**. `[9]` is genuinely empty while `[8]` shows the row is otherwise populated. (`[4]`–`[7]` read `schema.properties` keys a relational table doesn't set — expected, not this defect.)

## Where that leaves it

Mint works · persistence works · read-back works · projection shape is right — and the live server still renders empty. **The defect is not in `NativeCatalog` and not in the introspection projection; it's in the wiring between them.**

TD's next probe rewritten accordingly:
1. Do the pgwire DDL path and the introspection path resolve the **same catalog instance**? Two instances over one data dir explains everything — one mints and persists, the other answers from its own in-memory map.
2. Which impl sits behind the `default` catalog? `NativeCatalog` mints; `unity`/`polaris` don't. Now that it's exonerated as an implementation, its **absence** from that path is the leading hypothesis.

The temporary probe is deleted rather than left behind — a probe that outlives its question is how the next dormant test gets created.

Ref TD-AUTHZ-2, TD-SEC-2, #1544, #1546.
