### PR TITLE
feat(authz): escalation-safe cross-tenant open decision (ADR-090 item 3 core)

### DIFF
--- a/crates/control/proximadb-catalog/src/grants.rs
+++ b/crates/control/proximadb-catalog/src/grants.rs
@@ -174,6 +174,59 @@ pub fn evaluate_grants(
     }
 }
 
+/// The decision at the **collection-open seam** when the acting identity does not
+/// own the collection (ADR-090 L1.2 / TD-AUTHZ-1 item 3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrossTenantOpen {
+    /// The acting tenant OWNS the collection — this path does not apply, and the
+    /// caller must use its ordinary owner-scoped resolution. Kept distinct from
+    /// `Admitted` so an owner can never be mistaken for a grantee in an audit
+    /// record.
+    NotApplicable,
+    /// A grant admits the acting identity to the owner's collection.
+    Admitted,
+    /// No applicable grant. The caller MUST fail closed exactly as it does today.
+    Denied,
+}
+
+/// Decide whether `acting` may open a collection owned by `owner`.
+///
+/// This is the seam that makes cross-tenant sharing observable: today a foreign
+/// grantee is rejected by the owner-scoped catalog lookup before any row filter
+/// runs, so a grant that the catalog correctly evaluates has no visible effect.
+///
+/// # The escalation rule this function exists to enforce
+///
+/// The collection-open seam guards **reads and writes alike** — in the vector
+/// service the same validator fronts `search`/`get` AND
+/// `insert_batch`/`insert_records_only`. So the action is a REQUIRED parameter,
+/// never defaulted: a `Read` grant must not admit an INSERT. Callers pass the
+/// action they are actually performing, and a grant admits only if it carries
+/// that exact action.
+///
+/// # Cost
+///
+/// Only reached when the owner-scoped lookup already MISSED, so the ordinary
+/// same-tenant path pays nothing. Cross-tenant opens cost one grant-slice scan,
+/// evaluated once per open rather than per row — the ADR-090 L1 rule that
+/// sharing is a catalog decision, not a query predicate.
+pub fn cross_tenant_open_decision(
+    owner_grants: &[GrantRecord],
+    acting: &GrantSubject<'_>,
+    owner: TenantStableId,
+    resource: &Target,
+    action: GrantAction,
+    now_ms: i64,
+) -> CrossTenantOpen {
+    if acting.tenant_stable_id == owner {
+        return CrossTenantOpen::NotApplicable;
+    }
+    match evaluate_grants(owner_grants, acting, resource, action, now_ms) {
+        GrantDecision::Permit { .. } => CrossTenantOpen::Admitted,
+        GrantDecision::Deny(_) => CrossTenantOpen::Denied,
+    }
+}
+
 /// ADR-090 L1 composition: **deny > absence-of-grant > grant**. A policy-layer
 /// deny vetoes any entitlement.
 pub fn compose_with_policy(policy_denied: bool, grants: GrantDecision) -> GrantDecision {
@@ -622,6 +675,153 @@ mod tests {
             ),
             GrantDecision::Deny(_)
         ));
+    }
+
+    /// The acting tenant OWNS the collection ⇒ this seam does not apply, even
+    /// when a grant would also admit. Owners must never be recorded as grantees.
+    #[test]
+    fn owner_is_not_applicable_not_admitted() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::Tenant(OWNER),
+            read_only(),
+            None,
+            None,
+            None,
+        )
+        .expect("grant");
+        assert_eq!(
+            cross_tenant_open_decision(
+                &s.grants_for_owner(OWNER),
+                &subject(OWNER, "alice"),
+                OWNER,
+                &target(1, 10),
+                GrantAction::Read,
+                now(),
+            ),
+            CrossTenantOpen::NotApplicable
+        );
+    }
+
+    /// ⭐ THE ESCALATION TEST. The collection-open seam fronts reads AND writes
+    /// (search/get alongside insert_batch/insert_records_only), so a Read grant
+    /// must NOT admit a Write open. If this ever passes as Admitted, a shared
+    /// read has silently become shared write access.
+    #[test]
+    fn read_grant_never_admits_a_write_open() {
+        let (_d, s) = store();
+        s.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::User {
+                tenant_stable_id: FOREIGN,
+                subject: SubjectId("bob".into()),
+            },
+            read_only(),
+            None,
+            None,
+            None,
+        )
+        .expect("grant");
+        let grants = s.grants_for_owner(OWNER);
+        let bob = subject(FOREIGN, "bob");
+
+        assert_eq!(
+            cross_tenant_open_decision(
+                &grants,
+                &bob,
+                OWNER,
+                &target(1, 10),
+                GrantAction::Read,
+                now()
+            ),
+            CrossTenantOpen::Admitted,
+            "the granted action opens"
+        );
+        for escalated in [GrantAction::Write, GrantAction::Ddl, GrantAction::Grant] {
+            assert_eq!(
+                cross_tenant_open_decision(&grants, &bob, OWNER, &target(1, 10), escalated, now()),
+                CrossTenantOpen::Denied,
+                "a Read grant must never admit {escalated:?}"
+            );
+        }
+    }
+
+    /// Absent, revoked, and expired grants all leave the seam CLOSED — the
+    /// caller's existing rejection is preserved unchanged.
+    #[test]
+    fn seam_stays_closed_without_a_live_grant() {
+        let (_d, s) = store();
+        let bob = subject(FOREIGN, "bob");
+        let t = target(1, 10);
+
+        assert_eq!(
+            cross_tenant_open_decision(&[], &bob, OWNER, &t, GrantAction::Read, now()),
+            CrossTenantOpen::Denied,
+            "no grants at all"
+        );
+
+        let id = s
+            .grant(
+                OWNER,
+                Scope::Table(10),
+                Grantee::Tenant(FOREIGN),
+                read_only(),
+                None,
+                None,
+                None,
+            )
+            .expect("grant");
+        assert_eq!(
+            cross_tenant_open_decision(
+                &s.grants_for_owner(OWNER),
+                &bob,
+                OWNER,
+                &t,
+                GrantAction::Read,
+                now()
+            ),
+            CrossTenantOpen::Admitted
+        );
+        s.revoke(OWNER, &id).expect("revoke");
+        assert_eq!(
+            cross_tenant_open_decision(
+                &s.grants_for_owner(OWNER),
+                &bob,
+                OWNER,
+                &t,
+                GrantAction::Read,
+                now()
+            ),
+            CrossTenantOpen::Denied,
+            "revocation closes the seam"
+        );
+
+        let (_d2, s2) = store();
+        s2.grant(
+            OWNER,
+            Scope::Table(10),
+            Grantee::Tenant(FOREIGN),
+            read_only(),
+            None,
+            None,
+            Some(now() - 1),
+        )
+        .expect("grant");
+        assert_eq!(
+            cross_tenant_open_decision(
+                &s2.grants_for_owner(OWNER),
+                &bob,
+                OWNER,
+                &t,
+                GrantAction::Read,
+                now()
+            ),
+            CrossTenantOpen::Denied,
+            "expiry closes the seam"
+        );
     }
 
     /// Deny > absence > grant: a policy deny vetoes an otherwise-valid grant.

--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -225,3 +225,60 @@ METHOD NOTE: while checking this, a `grep | head -6` truncated the call-site lis
 read path look unguarded — a security asymmetry that does not exist. Caught before it was
 written down. Truncated search output is evidence of nothing; re-run unbounded before
 asserting an absence.
+
+
+== Item 3 wiring — the identity constraint at the seam (2026-08-10)
+
+The decision core (`cross_tenant_open_decision`) is merged and escalation-safe. Wiring it into
+`validate_tenant_collection_access` runs into a constraint that determines the shape of the
+remaining work, and it is NOT the one the earlier notes anticipated.
+
+**`TenantContext` carries only `tenant_id: String`.** No subject, no stable id
+(`crates/platform/proximadb-api/src/rest/state.rs:16`). But:
+
+* grants may be per-user — `Grantee::User { tenant_stable_id, subject }`;
+* `evaluate_grants` needs a `TenantStableId` (u64) for the acting tenant;
+* the grant store is partitioned by the OWNER's stable id, so even finding the candidate
+  grants requires resolving a string tenant to its stable id.
+
+So the seam cannot evaluate a per-user grant, and cannot even load the owner's grant slice,
+from what it is handed today.
+
+=== Safe interim: tenant-wide grants only, per-user FAIL-CLOSED
+
+`evaluate_grants` already gives the correct answer if the acting subject is a value that can
+never match a `Grantee::User`: `Grantee::Tenant(t)` matches on tenant alone and admits, while
+`Grantee::User { .. }` requires a subject equality that fails. That yields exactly the right
+partial capability:
+
+* tenant-to-tenant sharing works at the seam;
+* user-scoped sharing stays CLOSED until identity is threaded — it must never widen to "any
+  subject of the grantee tenant", which would be a second escalation of the same family as the
+  read-grant-admits-write case the decision core already rules out.
+
+This has to be asserted, not assumed: a spec test must pin that a `Grantee::User` grant does
+NOT admit at the seam while identity is missing.
+
+=== Plumbing the wiring still needs
+
+. A grant store handle on the vector service (`SharedServices.abac_grant_store` already exists
+  and is hot-reload shared — same pattern as the enforcer).
+. A `TenantStableIdResolver` on the vector service to map both the acting tenant string and
+  the owner to stable ids (`CatalogTenantStableIdResolver` exists and is used by the admin
+  endpoints).
+. Owner resolution for a collection the acting tenant cannot see: the owner-agnostic
+  `get_or_load_collection(collection_id)` already exists and is used by the non-multi-tenant
+  branch of this very function.
+. A default-OFF env gate (`PROXIMADB_AUTHZ_CROSS_TENANT_GRANTS`) with its ENV_GATE_REGISTRY
+  row, so cross-tenant opens are an explicit operator opt-in rather than an emergent property
+  of a grant existing.
+. The action passed explicitly per call site — read paths pass `Read`. The shared
+  `validate_tenant_collection_access` MUST NOT gain a defaulted action: it fronts
+  `insert_batch_with_tenant_context` and `insert_records_only_with_tenant_context` as well as
+  the read paths.
+
+=== The real end-state
+
+Threading `PortIdentity` (subject + tenant + stable id, already the documented carrier at
+`CollectionPort`) to this seam removes the interim restriction and is the same change item 3's
+design note scoped at one call site. The interim above is what can land safely before it.


### PR DESCRIPTION
The decision core that makes cross-tenant sharing **observable**. Today a foreign grantee is rejected by the owner-scoped catalog lookup *before any row filter runs*, so a grant the catalog evaluates correctly has no visible effect (TD-TENANT-2, 2026-08-08 addendum).

## The design-review finding that shaped this

**The collection-open seam guards reads and writes alike.** `validate_tenant_collection_access` fronts `search` / `get` / `record_exists` **and** `insert_batch_with_tenant_context` / `insert_records_only_with_tenant_context` (`:2456`, `:2507`).

So the obvious implementation — *"make the seam grant-aware for reads"* — would have let a **Read grant admit an INSERT**: a silent upgrade from shared-read to shared-**write**, at the very seam meant to enforce sharing.

`cross_tenant_open_decision` therefore takes the action as a **required parameter, never defaulted**, and a grant admits only if it carries that exact action. Pinned by `read_grant_never_admits_a_write_open`: `Read` opens; `Write` / `Ddl` / `Grant` all stay `Denied`.

## Other deliberate choices

- **`NotApplicable` ≠ `Admitted`** for the owner's own collection — an owner must never be recorded as a grantee in an audit trail.
- **Absent, revoked, and expired all return `Denied`**, leaving the caller's existing rejection unchanged. Fail-closed by construction, not by the caller remembering to check.
- **Zero cost on the common path** — only reached after the owner-scoped lookup already missed. A cross-tenant open costs one grant-slice scan, evaluated **once per open, not per row**: the ADR-090 L1 rule that sharing is a catalog decision, not a query predicate.
- **Composed from the existing `evaluate_grants`** rather than reimplementing the matching rules, so grant semantics can't drift between the enforcement seam and the open seam.

## Not wired yet — deliberately

The seam call site, its default-OFF gate, and plumbing a grant store into the vector service are the follow-on. Landing the decision core separately keeps the escalation rule reviewable on its own.

## Verification

Rebased onto current `origin/develop` (two crate extractions landed under this branch) and re-verified rather than assumed: **11/11** grants spec tests green · `clippy --all-targets -D warnings` clean · `make work-commit-check` green.

Ref ADR-090 L1.2, TD-AUTHZ-1 item 3, TD-TENANT-2, #1517, #1529, #1560.
