### PR TITLE
refactor(decomp): extract mvcc_resolution → new crate (TD-DECOMP-45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6770,6 +6770,7 @@ dependencies = [
  "proximadb-montecarlo",
  "proximadb-multimodel-plan",
  "proximadb-multimodel-query",
+ "proximadb-mvcc-resolution",
  "proximadb-network-middleware",
  "proximadb-object-store",
  "proximadb-observability",
@@ -7770,6 +7771,14 @@ dependencies = [
  "proximadb-query-filter",
  "proximadb-query-fusion",
  "proximadb-vector-query",
+]
+
+[[package]]
+name = "proximadb-mvcc-resolution"
+version = "0.2.0"
+dependencies = [
+ "proximadb-records",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "crates/horizontal/proximadb-type-validators",
     "crates/horizontal/proximadb-tcp-multiplexer",
     "crates/horizontal/proximadb-pushdown",
+    "crates/horizontal/proximadb-mvcc-resolution",
     "crates/horizontal/proximadb-auth-sso",
     "crates/horizontal/proximadb-catapult",
     "crates/horizontal/proximadb-axis-tunnel",
@@ -306,6 +307,7 @@ proximadb-connectors-types = { path = "crates/horizontal/proximadb-connectors-ty
 proximadb-type-validators = { path = "crates/horizontal/proximadb-type-validators" }
 proximadb-tcp-multiplexer = { path = "crates/horizontal/proximadb-tcp-multiplexer" }
 proximadb-pushdown = { path = "crates/horizontal/proximadb-pushdown" }
+proximadb-mvcc-resolution = { path = "crates/horizontal/proximadb-mvcc-resolution" }
 proximadb-auth-sso = { path = "crates/horizontal/proximadb-auth-sso" }
 proximadb-catapult = { path = "crates/horizontal/proximadb-catapult" }
 proximadb-axis-tunnel = { path = "crates/horizontal/proximadb-axis-tunnel" }
@@ -442,6 +444,7 @@ proximadb-connectors-types = { workspace = true }
 proximadb-type-validators = { workspace = true }
 proximadb-tcp-multiplexer = { workspace = true }
 proximadb-pushdown = { workspace = true }
+proximadb-mvcc-resolution = { workspace = true }
 proximadb-auth-sso = { workspace = true }
 proximadb-catapult = { workspace = true }
 proximadb-axis-tunnel = { workspace = true }

--- a/crates/horizontal/proximadb-mvcc-resolution/Cargo.toml
+++ b/crates/horizontal/proximadb-mvcc-resolution/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "proximadb-mvcc-resolution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "MVCC version resolution for vector freshness (effective_version, append-only OID, delta-merge resolver) — extracted from root core/search (TD-DECOMP-45)"
+
+[lib]
+name = "proximadb_mvcc_resolution"
+path = "src/lib.rs"
+
+[dependencies]
+proximadb-records = { workspace = true }
+tracing = { workspace = true }

--- a/crates/horizontal/proximadb-mvcc-resolution/src/lib.rs
+++ b/crates/horizontal/proximadb-mvcc-resolution/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! MVCC version resolution for vector freshness, extracted from the root
+//! `core/search` module (TD-DECOMP-45).
+//!
+//! [`mvcc_resolution`] resolves the effective version of a
+//! [`proximadb_records::ProximaRecord`] under multi-version concurrency —
+//! [`mvcc_resolution::MvccResolver`] merges deltas, handles append-only OIDs,
+//! and computes the effective version for read-after-write correctness. Depends
+//! only on `proximadb-records` + `tracing`, keeping it a clean horizontal-tier leaf.
+
+pub mod mvcc_resolution;

--- a/crates/horizontal/proximadb-mvcc-resolution/src/mvcc_resolution.rs
+++ b/crates/horizontal/proximadb-mvcc-resolution/src/mvcc_resolution.rs
@@ -250,7 +250,7 @@ impl MvccResolver {
 
 /// Treat `record_version == 0` as version 1 for historical stored records.
 #[inline]
-pub(crate) fn effective_version(r: &ProximaRecord) -> u64 {
+pub fn effective_version(r: &ProximaRecord) -> u64 {
     if r.record_version == 0 {
         1
     } else {
@@ -259,7 +259,7 @@ pub(crate) fn effective_version(r: &ProximaRecord) -> u64 {
 }
 
 #[inline]
-pub(crate) fn is_append_only_oid(oid: &str) -> bool {
+pub fn is_append_only_oid(oid: &str) -> bool {
     oid.is_empty() || oid == "null" || oid == "none" || oid.trim().is_empty()
 }
 

--- a/docs/10-quality/td/TD-DECOMP-45-extract-mvcc-resolution.adoc
+++ b/docs/10-quality/td/TD-DECOMP-45-extract-mvcc-resolution.adoc
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-45: Extract mvcc_resolution → new proximadb-mvcc-resolution crate (horizontal)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export (+ pub(crate)→pub widening of 2 internal helpers)
+| Component | `crates/horizontal/proximadb-mvcc-resolution`; root `src/core/search/mod.rs`
+|===
+
+== What moved
+`src/core/search/mvcc_resolution.rs` (11 tests) → new horizontal crate `proximadb-mvcc-resolution`.
+Root `core/search/mod.rs` re-exports it (`pub use proximadb_mvcc_resolution::mvcc_resolution;`),
+so the lone consumer (`crate::core::search::mvcc_resolution::MvccResolver` in
+`multi_tier_deduplication.rs`) resolves unchanged. Deps: `proximadb-records` (ProximaRecord) +
+tracing (zero `crate::` climb-out). The 2 internal helper fns (`effective_version`,
+`is_append_only_oid`) were widened `pub(crate) → pub` so they remain reachable across the crate
+boundary (same byte-identical behavior; they were already part of the module's surface via
+`MvccResolver`). Verified: standalone + clippy -D warnings + root lib all pass. SIFT recall ratchet
+SKIPS (core/search is core_changes, not storage_changes).

--- a/src/core/search/mod.rs
+++ b/src/core/search/mod.rs
@@ -22,7 +22,7 @@ pub mod integrated_search_optimization;
 pub mod merge;
 pub mod metadata_filter_pushdown;
 pub mod multi_tier_deduplication;
-pub mod mvcc_resolution;
+pub use proximadb_mvcc_resolution::mvcc_resolution;
 pub mod progressive_quantization;
 pub mod progressive_search_pipeline;
 pub mod queries;


### PR DESCRIPTION
Part of the P2 god-crate decomposition initiative (root `proximadb` lib bundles 9,538 inline tests → OOMs the 16 GB runner at `BUILD_JOBS=1`; the structural fix is moving `src/` modules into workspace crates so tests leave with the code).

## What moves
`src/core/search/mvcc_resolution.rs` (**11 tests**: `MvccResolver` — effective-version resolution, append-only OID handling, delta-merge for vector freshness) → **new horizontal crate `proximadb-mvcc-resolution`**.

## Why this leaf
Clean extraction: deps are **`proximadb-records` (ProximaRecord) + tracing** (zero `crate::` climb-out). The 2 internal helper fns (`effective_version`, `is_append_only_oid`) are widened `pub(crate) → pub` so they remain reachable across the crate boundary — byte-identical behavior (they were already part of the module's surface via `MvccResolver`).

## Shim
Root `core/search/mod.rs`:
```rust
- pub mod mvcc_resolution;
+ pub use proximadb_mvcc_resolution::mvcc_resolution;
```
so the lone consumer (`crate::core::search::mvcc_resolution::MvccResolver` in `multi_tier_deduplication.rs`) resolves unchanged.

## CI note
Touches only `src/core/**` (core_changes, not `storage_changes`) + `Cargo.toml` → **SIFT recall ratchet SKIPS** this PR.

## Verified locally
- standalone `cargo check --all-targets` ✓ + `cargo clippy --all-targets -- -D warnings` ✓
- root `cargo check -p proximadb --lib` ✓ (shim resolves)
- `check-layering.sh` (exit 0) + `check_workspace_boundaries.py` — No boundary findings ✓
- `cargo fmt --check` ✓; 11 tests pass in-crate (nextest) ✓

Behavior-neutral, mixed-read-safe (no on-disk/wire format change), no AI attribution.