### PR TITLE
fix(authz): owner-keyed grant lookup, non-truncating Target, delete dead fail-open surface

### DIFF
--- a/crates/control/proximadb-catalog/src/fc_metamodel.rs
+++ b/crates/control/proximadb-catalog/src/fc_metamodel.rs
@@ -902,6 +902,31 @@ pub struct Target {
     pub column: Option<u32>,
 }
 
+impl Target {
+    /// Build a `Target` from a catalog object id, refusing rather than truncating.
+    ///
+    /// `CollectionId` is `u32` while catalog object ids come from a global
+    /// monotonic **u64** allocator. Casting `as u32` silently wraps, and
+    /// [`scope_covers`] compares with `==` — so a wrapped id can COLLIDE with a
+    /// legitimately-bound table and be authorized by someone else's policy or
+    /// grant. That is an authorization-correctness bug, not a lossy cast.
+    ///
+    /// Widening `CollectionId` to u64 is the eventual fix but is a persisted
+    /// format migration: `Scope` is serde-persisted in policy bindings and
+    /// `grants.json`, so a widened writer would emit values an older reader
+    /// cannot parse. Until then this constructor makes the unrepresentable case
+    /// **fail closed** — callers map `None` onto their existing deny path, so an
+    /// id that cannot be represented can never be authorized.
+    pub fn try_from_object_ids(namespace: NamespaceId, object_id: u64) -> Option<Self> {
+        let table = CollectionId::try_from(object_id).ok()?;
+        Some(Self {
+            namespace,
+            table,
+            column: None,
+        })
+    }
+}
+
 /// The composed policy for a [`Target`] — the **model** output. It records the
 /// effect-level decision (assuming every predicate holds), the row-predicate refs
 /// to AND, and the field masks. It does **not** evaluate predicates against a
@@ -1114,6 +1139,32 @@ impl SubjectAttributes {
 
 #[cfg(test)]
 mod tests {
+    /// B3: a `Target` must never be built by truncation. `scope_covers` matches
+    /// with `==`, so a wrapped object id could collide with a legitimately-bound
+    /// table and be authorized by someone else's binding.
+    #[test]
+    fn target_refuses_object_ids_that_do_not_fit() {
+        // Representable ids build normally.
+        let ok = Target::try_from_object_ids(0, 42).expect("small id fits");
+        assert_eq!(ok.table, 42);
+        let max = Target::try_from_object_ids(0, u32::MAX as u64).expect("u32::MAX fits");
+        assert_eq!(max.table, u32::MAX);
+
+        // One past the boundary must REFUSE, not wrap to 0.
+        assert_eq!(
+            Target::try_from_object_ids(0, u32::MAX as u64 + 1),
+            None,
+            "an id one past u32::MAX must fail closed, not alias to 0"
+        );
+
+        // The aliasing pair the old `as u32` produced: N and N + 2^32 both
+        // truncated to N. They must not both resolve to the same target.
+        let a = Target::try_from_object_ids(0, 7);
+        let aliased = Target::try_from_object_ids(0, 7u64 + (1u64 << 32));
+        assert!(a.is_some());
+        assert_eq!(aliased, None, "the 2^32 alias must be refused outright");
+    }
+
     use super::*;
 
     fn pk(keyspace: &str, col: &str) -> CompositeKeySpec {

--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -350,3 +350,38 @@ should be treated as higher priority than the sharing capability.
   while collection object_ids come from a global monotonic `u64` allocator. Two collections whose
   ids differ by exactly 2^32 alias to the **same grant target** — a silent authorization-aliasing
   hazard. Not reachable at today's id magnitudes; record it before this seam is formalized.
+
+
+== 🔴 `resolve_vector_read_context` degrades to UNFILTERED on any resolution failure (2026-08-11)
+
+Found while wiring the B3 Target guard. `records_read_context`
+(`src/services/operations/vectors/legacy.rs:~734`) maps the resolver's outcome as:
+
+[source,rust]
+----
+Some(Ok(ctx))  => ReadContext::Client(ctx),      // enforced
+Some(Err(_))   => None,                          // deny => fail-closed  ✔
+None           => ReadContext::system(Statistics) // UNFILTERED          ✘
+----
+
+So **every `?` early-return inside `resolve_vector_read_context` is a fail-OPEN path**, not a
+neutral "couldn't decide". Two already exist and predate this work:
+
+* `self.get_or_load_collection(collection_id).await.ok()?` — a collection that fails to load
+  yields an unfiltered System read.
+* `collection.id.parse().ok()?` — a collection whose id does not parse as a `u64` likewise
+  yields an unfiltered System read.
+
+(`self.abac_enforcer.as_ref()?` is legitimate: no enforcer configured genuinely means ABAC is
+off. The other two are failures being reported as absence.)
+
+This is the same defect family TD-SEC-2 catalogues — a mechanism whose FAILURE mode is
+indistinguishable from its "not applicable" mode, so it reads as coverage. The B3 guard added
+here deliberately returns `Some(Err(NoApplicablePolicy))` rather than `None` for exactly this
+reason, and says so at the call site.
+
+**Not fixed here** — changing the two pre-existing `?`s to denials is a behavior change on the
+live read path (a transient collection-load failure would begin denying instead of returning
+unfiltered results) and deserves its own slice with its own ratchet. Sequence it with the L2.2
+`System`-bypass work, which is already the owner of "client-facing reads must not run as
+System".

--- a/src/security/rls/abac_adapter.rs
+++ b/src/security/rls/abac_adapter.rs
@@ -248,6 +248,12 @@ impl AbacEnforcer {
                         // "possibly break production", so nobody ever flips it.
                         if !grant_admits_read(
                             self.grant_store.as_deref(),
+                            // owner == acting tenant: L1.2 enforces same-tenant
+                            // reads only, so this is bit-for-bit today's
+                            // behavior. Cross-tenant opens supply the real
+                            // owner (ADR-090 item 3), which is why the
+                            // parameter exists rather than being derived here.
+                            tenant,
                             tenant,
                             &subject.0,
                             &target,
@@ -266,6 +272,12 @@ impl AbacEnforcer {
                     PostureDecision::Enforce => {
                         if !grant_admits_read(
                             self.grant_store.as_deref(),
+                            // owner == acting tenant: L1.2 enforces same-tenant
+                            // reads only, so this is bit-for-bit today's
+                            // behavior. Cross-tenant opens supply the real
+                            // owner (ADR-090 item 3), which is why the
+                            // parameter exists rather than being derived here.
+                            tenant,
                             tenant,
                             &subject.0,
                             &target,
@@ -968,9 +980,20 @@ fn grants_required() -> bool {
 /// enforcement is armed, "required" cannot degrade to "optional" because
 /// wiring is incomplete.
 #[cfg(feature = "abac-policy")]
+/// Does a live grant admit `subject` (a user of `acting_tenant`) to read `target`?
+///
+/// B2 FIX: `owner` and `acting_tenant` are SEPARATE parameters. A grant is
+/// issued BY the resource owner, and `FileSystemGrantStore` is partitioned by
+/// `owner_tenant_stable_id` — so the OWNER's slice is the one that must be
+/// loaded. This previously passed the acting tenant for both, which asks "what
+/// has this tenant granted itself": correct by accident when owner == acting
+/// (the only case L1.2 enforced), and structurally unable to find any
+/// cross-tenant share. Callers that genuinely mean same-tenant pass the acting
+/// tenant for both, which reduces to the previous expression bit-for-bit.
 fn grant_admits_read(
     store: Option<&proximadb_catalog::grants::FileSystemGrantStore>,
-    tenant: u64,
+    owner: u64,
+    acting_tenant: u64,
     subject: &str,
     target: &Target,
 ) -> bool {
@@ -979,9 +1002,9 @@ fn grant_admits_read(
     };
     matches!(
         proximadb_catalog::grants::evaluate_grants(
-            &store.grants_for_owner(tenant),
+            &store.grants_for_owner(owner),
             &proximadb_catalog::grants::GrantSubject {
-                tenant_stable_id: tenant,
+                tenant_stable_id: acting_tenant,
                 subject,
             },
             target,
@@ -1010,10 +1033,62 @@ mod grant_gate_tests {
         }
     }
 
+    /// B2 REGRESSION: a grant is issued BY the resource owner, and the store is
+    /// partitioned by `owner_tenant_stable_id`. Loading the ACTING tenant's
+    /// slice asks "what has this tenant granted itself" — so a cross-tenant
+    /// share is structurally unreachable: the grant written by owner A never
+    /// appears in tenant B's slice.
+    ///
+    /// This test FAILS before the fix (the owner's slice is never loaded) and
+    /// passes after. Same-tenant behavior is unchanged because owner == acting
+    /// there, which is why the defect stayed invisible.
+    #[test]
+    fn a_grant_from_another_owner_is_found() {
+        use proximadb_catalog::grants::{FileSystemGrantStore, GrantAction, Grantee};
+        use std::collections::BTreeSet;
+
+        const OWNER: u64 = 7;
+        const GRANTEE: u64 = 9;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FileSystemGrantStore::open(dir.path()).expect("open");
+
+        // Owner 7 shares its collection with tenant 9.
+        store
+            .grant(
+                OWNER,
+                proximadb_catalog::fc_metamodel::Scope::Table(10),
+                Grantee::Tenant(GRANTEE),
+                BTreeSet::from([GrantAction::Read]),
+                None,
+                None,
+                None,
+            )
+            .expect("grant");
+
+        let target = Target {
+            namespace: 0,
+            table: 10,
+            column: None,
+        };
+
+        assert!(
+            grant_admits_read(Some(&store), OWNER, GRANTEE, "bob", &target),
+            "a grant written by owner {OWNER} for tenant {GRANTEE} must be found \
+             when the OWNER's slice is consulted"
+        );
+
+        // And a tenant with no grant from this owner still gets nothing.
+        assert!(
+            !grant_admits_read(Some(&store), OWNER, 11, "bob", &target),
+            "an ungranted tenant must stay denied"
+        );
+    }
+
     /// Armed with NO store ⇒ deny (fail-closed on incomplete wiring).
     #[test]
     fn no_store_never_admits() {
-        assert!(!grant_admits_read(None, 7, "alice", &target(10)));
+        assert!(!grant_admits_read(None, 7, 7, "alice", &target(10)));
     }
 
     /// No applicable grant ⇒ deny; an applicable grant ⇒ admit; revoke ⇒ deny.
@@ -1021,7 +1096,7 @@ mod grant_gate_tests {
     fn grant_lifecycle_drives_admission() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = FileSystemGrantStore::open(dir.path()).expect("open");
-        assert!(!grant_admits_read(Some(&store), 7, "alice", &target(10)));
+        assert!(!grant_admits_read(Some(&store), 7, 7, "alice", &target(10)));
 
         let id = store
             .grant(
@@ -1037,14 +1112,14 @@ mod grant_gate_tests {
                 None,
             )
             .expect("grant");
-        assert!(grant_admits_read(Some(&store), 7, "alice", &target(10)));
+        assert!(grant_admits_read(Some(&store), 7, 7, "alice", &target(10)));
         assert!(
-            !grant_admits_read(Some(&store), 7, "mallory", &target(10)),
+            !grant_admits_read(Some(&store), 7, 7, "mallory", &target(10)),
             "another subject must not ride alice's grant"
         );
 
         store.revoke(7, &id).expect("revoke");
-        assert!(!grant_admits_read(Some(&store), 7, "alice", &target(10)));
+        assert!(!grant_admits_read(Some(&store), 7, 7, "alice", &target(10)));
     }
 
     /// The env gate parses the standard truthy set and defaults OFF.

--- a/src/services/dml/mod.rs
+++ b/src/services/dml/mod.rs
@@ -1471,15 +1471,18 @@ impl DmlService {
             ));
         };
         let tenant = identity.tenant_stable_id?;
-        Some(enforcer.predicate_for(
-            &subject,
-            tenant,
-            Target {
-                namespace,
-                table: table as u32,
-                column: None,
-            },
-        ))
+        // B3: build the Target fallibly. `table` is a u64 catalog object id but
+        // `Target.table` is u32, and `scope_covers` matches with `==` — a
+        // truncating `as u32` could WRAP an id onto a different, legitimately
+        // bound table and authorize this read under someone else's policy.
+        // Fold the unrepresentable case into the same fail-closed deny the
+        // missing-id case above already uses.
+        let Some(target) = Target::try_from_object_ids(namespace, table) else {
+            return Some(crate::security::rls::AbacScanResult::Denied(
+                proximadb_abac::DenyReason::NoApplicablePolicy,
+            ));
+        };
+        Some(enforcer.predicate_for(&subject, tenant, target))
     }
 
     /// Scan a catalog table for the relational pipeline (PATH B), pushing the

--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -677,15 +677,21 @@ impl VectorOperationsService {
         let enforcer = self.abac_enforcer.as_ref()?;
         let collection = self.get_or_load_collection(collection_id).await.ok()?;
         let object_id: crate::core::stable_id::CollectionObjectId = collection.id.parse().ok()?;
-        Some(enforcer.resolve_read_context(
-            subject,
-            tenant_stable_id,
-            proximadb_catalog::fc_metamodel::Target {
-                namespace: 0,
-                table: object_id as u32,
-                column: None,
-            },
-        ))
+        // B3: build the Target FALLIBLY rather than truncating `object_id as u32`.
+        // `Target.table` is u32 while catalog object ids come from a global u64
+        // allocator, and `scope_covers` matches with `==` — a wrapped id can
+        // collide with a different, legitimately bound table.
+        //
+        // The deny MUST be `Some(Err(..))`, never `None`: `records_read_context`
+        // maps `None` to `ReadContext::system(..)`, i.e. an UNFILTERED read. A
+        // `?` here would turn an unrepresentable id into unfiltered access —
+        // the exact inverse of this fix.
+        let Some(target) =
+            proximadb_catalog::fc_metamodel::Target::try_from_object_ids(0, object_id)
+        else {
+            return Some(Err(proximadb_abac::DenyReason::NoApplicablePolicy));
+        };
+        Some(enforcer.resolve_read_context(subject, tenant_stable_id, target))
     }
 
     /// **The ONE read-context composition rule** (ADR-087): resolve
@@ -856,21 +862,6 @@ impl VectorOperationsService {
         Ok(object_id)
     }
 
-    /// Execute a v1 vector search after validating that the caller has access to the collection
-    /// under the provided tenant context.
-    pub async fn search_v1_with_tenant_context(
-        &self,
-        mut req: crate::proto::proximadb_v1::VectorSearchRequest,
-        tenant_context: Option<&crate::storage::tenant::context::TenantContext>,
-    ) -> Result<crate::proto::proximadb_v1::VectorOperationResponse> {
-        req.collection_id = self
-            .validate_tenant_collection_access(&req.collection_id, tenant_context)
-            .await?
-            .to_string();
-        self.search_v1(req, proximadb_runtime::PortIdentity::anonymous())
-            .await
-    }
-
     /// Execute canonical rich-record vector search.
     ///
     /// The caller supplies `ProximaValue` predicates. The temporary v1 filter
@@ -914,7 +905,8 @@ impl VectorOperationsService {
         tenant_stable_id: Option<u64>,
         auth_class: proximadb_tenant::AuthClass,
     ) -> Result<RichSearchResponse> {
-        // Authorize before touching data, matching `search_v1_with_tenant_context`.
+        // Authorize before touching data (collection-level) BEFORE the ABAC
+        // row/vector decision below — deny at the cheaper boundary first.
         let collection_id = self
             .validate_tenant_collection_access(&request.collection_id, tenant_context)
             .await?


### PR DESCRIPTION
Three defects found while verifying the item-3 open seam (#1571). **Two are in code I merged earlier in this program.**

## B2 — `grant_admits_read` loaded the wrong grant slice

It passed the **acting** tenant as both the store partition key and the grantee key. But a grant is issued **by the resource owner**, and `FileSystemGrantStore` is partitioned by `owner_tenant_stable_id` — so `grants_for_owner(acting)` asks *"what has this tenant granted itself"*. Correct by accident when `owner == acting` (the only case L1.2 enforces) and **structurally unable to find any cross-tenant share**.

`owner` and `acting_tenant` are now separate parameters. Both production call sites pass the acting tenant for both, which reduces to the previous expression **bit-for-bit** — nothing changes for existing deployments; what changes is that a cross-owner grant becomes findable at all.

**The regression test is teeth-proven, not assumed:**

| step | result |
|---|---|
| 1. with the fix | ✅ PASS |
| 2. **revert only the impl line**, tests untouched | ❌ **FAIL** — *"a grant written by owner 7 for tenant 9 must be found…"* |
| 3. restore | ✅ PASS |

Stashing the whole change would have removed the test along with the fix and passed vacuously.

## B3 — `Target.table` truncated `u64 → u32`

Object ids come from a global monotonic **u64** allocator; `Target.table` is `u32` and `scope_covers` matches with `==`. So `object_id as u32` could **wrap one collection's id onto a different, legitimately-bound table** and authorize a read under someone else's policy or grant — an authorization-correctness bug, not a lossy cast.

One fallible constructor `Target::try_from_object_ids` beside the struct (one place to test the boundary, one place to migrate later); both production sites map `None` onto their **existing** deny paths.

Deliberately **not** widening `CollectionId` to u64 — `Scope` is serde-persisted in policy bindings and `grants.json`, so widening is a format migration for a currently-unreachable hazard. Fail-closed now; widening filed as a TD.

**The two call sites deny differently, and that asymmetry is the substance:**
- `dml/mod.rs` → `return Denied(NoApplicablePolicy)`, folded into the existing missing-stable-id deny.
- `legacy.rs` → `Some(Err(..))`, because `records_read_context` maps `None` to `ReadContext::system` — an **unfiltered** read. A reflexive `?` would have turned an unrepresentable id into *unrestricted access*, the exact inverse of the fix. Documented at the call site so it isn't "simplified" back.

## B4 — deleted dead fail-open surface

`search_v1_with_tenant_context` hardcoded `PortIdentity::anonymous()` ⇒ `ReadContext::System`. Verified dead: 3 repo-wide references, none a caller; no trait declares the name; not a trait impl, so no dyn dispatch. Dead fail-open surface is **deleted rather than fixed** — fixing implies purpose.

## Recorded, not fixed here

Every `?` early-return inside `resolve_vector_read_context` is **fail-open**: `None` maps to an unfiltered System read, so a collection that fails to load — or whose id won't parse — silently becomes unrestricted. Changing those is a live-path behavior change (a transient load failure would begin denying) and needs its own slice and ratchet with the L2.2 System-bypass work. In TD-AUTHZ-1.

## Verification

catalog boundary test ✅ · `--features abac-policy` ✅ · default `--lib` ✅ · **`cargo check --all-targets` ✅** (the signature gate — B2 changed arity and `--lib` cannot see `tests/`) · `make work-commit-check` ✅

Ref ADR-090, TD-AUTHZ-1, TD-SEC-2, #1562, #1571.
