### PR TITLE
refactor(decomp): move oid_resolver_cache into storage-common crate (TD-DECOMP-53)

### DIFF
--- a/crates/storage/proximadb-storage-common/src/lib.rs
+++ b/crates/storage/proximadb-storage-common/src/lib.rs
@@ -41,6 +41,7 @@ pub mod observability_cardinality;
 pub mod observability_partitioning;
 pub mod observability_rollups;
 pub mod oid_position_resolver;
+pub mod oid_resolver_cache;
 pub mod pax_block;
 pub mod pax_striped_plan;
 pub mod proxima_arrow;

--- a/crates/storage/proximadb-storage-common/src/oid_resolver_cache.rs
+++ b/crates/storage/proximadb-storage-common/src/oid_resolver_cache.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
-use proximadb_storage_common::oid_position_resolver::OidPositionResolver;
+use crate::oid_position_resolver::OidPositionResolver;
 
 const OID_RESOLVER_CACHE_SHARDS: usize = 16;
 

--- a/docs/10-quality/td/TD-DECOMP-53-extract-oid-resolver-cache.adoc
+++ b/docs/10-quality/td/TD-DECOMP-53-extract-oid-resolver-cache.adoc
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-53: Move oid_resolver_cache into existing proximadb-storage-common crate
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export (one self-import rewrite)
+| Component | `crates/storage/proximadb-storage-common`; root `src/storage/engines/sst/mod.rs`
+|===
+
+== What moved
+`src/storage/engines/sst/oid_resolver_cache.rs` (6 tests: sharded byte-budgeted recency-LRU cache of
+parsed `OidPositionResolver`s, TD-DELVEC-1 WI-3c) → the EXISTING storage crate `proximadb-storage-common`,
+which already houses `oid_position_resolver`. Root `storage/engines/sst/mod.rs` re-exports it
+(`pub use proximadb_storage_common::oid_resolver_cache;`), so the lone consumer resolves unchanged.
+
+== Why into an existing crate
+oid_resolver_cache depended only on `proximadb-storage-common::oid_position_resolver::OidPositionResolver`
++ std — i.e. its sole non-std dep is a sibling already in this crate. Moving it in required one rewrite
+(`proximadb_storage_common::oid_position_resolver` → `crate::oid_position_resolver`) since the file now
+lives inside the crate. NO new crate, NO root `Cargo.toml` wiring → no stacked-PR conflict. Verified:
+standalone `cargo check --all-targets` + root `cargo check -p proximadb --lib` pass. (Pre-existing
+clippy debt in storage-common's test/bench code — storage_error.rs, zero_copy_traits.rs, wal_throughput
+bench — is unrelated to this move and not gated by CI's non-`--all-targets` clippy job.) SIFT recall
+ratchet RUNS on this PR (storage_changes) under the 45m cap (#1555).

--- a/src/storage/engines/sst/mod.rs
+++ b/src/storage/engines/sst/mod.rs
@@ -290,7 +290,7 @@ pub mod manifest;
 #[cfg(feature = "cold-deletion-vectors")]
 pub mod oid_resolve; // TD-DELVEC-1 WI-3c-1c: resolve_oid_positions + read_resolver lazy-load
 #[cfg(feature = "cold-deletion-vectors")]
-pub mod oid_resolver_cache; // TD-DELVEC-1 WI-3c: per-segment OID→position resolver cache
+pub use proximadb_storage_common::oid_resolver_cache;
 pub mod pca_manager; // PCA caching for Z-Order spatial encoding
 pub mod progressive_stages; // ISP-compliant progressive search stages
 pub mod search;


### PR DESCRIPTION
Part of the P2 god-crate decomposition initiative (root `proximadb` lib bundles 9,538 inline tests → OOMs the 16 GB runner at `BUILD_JOBS=1`; the structural fix is moving `src/` modules into workspace crates so tests leave with the code).

## What moves
`src/storage/engines/sst/oid_resolver_cache.rs` (**6 tests**: sharded byte-budgeted recency-LRU cache of parsed `OidPositionResolver`s — TD-DELVEC-1 WI-3c) → the **existing** storage crate `proximadb-storage-common`, which already houses `oid_position_resolver`.

## Why into an existing crate
oid_resolver_cache's sole non-std dependency was `proximadb-storage-common::oid_position_resolver::OidPositionResolver` — a sibling already in this crate. Moving it in required one self-import rewrite (`proximadb_storage_common::oid_position_resolver` → `crate::oid_position_resolver`). **No new crate, no root `Cargo.toml` wiring** → no stacked-PR `Cargo.toml` conflict.

## Shim
Root `storage/engines/sst/mod.rs`:
```rust
- pub mod oid_resolver_cache;
+ pub use proximadb_storage_common::oid_resolver_cache;
```
so the lone consumer resolves unchanged.

## CI note
Touches `src/storage/**` (`storage_changes`) → **SIFT recall ratchet RUNS** on this PR under the 45m cap (#1555) — expect ~35min for that job. (Pre-existing clippy debt in storage-common's test/bench code — storage_error.rs, zero_copy_traits.rs, wal_throughput bench — is unrelated to this move; CI clippy runs without `--all-targets` so it isn't gated.)

## Verified locally
- standalone `cargo check --all-targets` ✓
- root `cargo check -p proximadb --lib` ✓ (shim resolves)
- `check-layering.sh` (exit 0) + `check_workspace_boundaries.py` — No boundary findings ✓
- `cargo fmt --check` ✓; 6 oid_resolver_cache tests pass in-crate (nextest) ✓

Behavior-neutral, mixed-read-safe (no on-disk/wire format change), no AI attribution.