### PR TITLE
fix(bench): resume interrupted nprobe matrices safely

### DIFF
--- a/scripts/bench/nprobe_sweep.py
+++ b/scripts/bench/nprobe_sweep.py
@@ -11,6 +11,7 @@ from write geometry and avoids paying to retrain identical cells.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import importlib.util
 import json
 import subprocess
@@ -228,6 +229,49 @@ def validate_resume(existing: dict, expected: dict) -> set[tuple[int, int]]:
     return completed
 
 
+def load_resumable_checkpoint(output: Path) -> dict | None:
+    """Load an interrupted matrix, or return ``None`` for a new sweep.
+
+    The matrix file is the atomic checkpoint.  Requiring an additional CLI flag
+    to acknowledge that file made outer stage runners prone to treating
+    ``exists`` as ``complete`` and either skipping or deleting valid partial
+    measurements.  Resume is therefore automatic only for the two explicitly
+    non-terminal states.  Terminal results and malformed checkpoints remain
+    fail-closed.
+    """
+    if not output.exists():
+        return None
+    try:
+        existing = json.loads(output.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"cannot read matrix checkpoint {output}: {error}") from error
+    status = existing.get("status")
+    if status not in {"running", "incomplete"}:
+        raise RuntimeError(
+            f"matrix checkpoint is terminal or invalid ({status!r}); "
+            "refusing to overwrite it"
+        )
+    return existing
+
+
+def acquire_matrix_lock(output: Path):
+    """Acquire the single-writer lock for ``output`` until the handle closes.
+
+    The lock file may remain after a crash, but the kernel lock does not. This
+    makes interruption recoverable without allowing concurrent checkpoint
+    writers.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = output.with_name(f".{output.name}.lock")
+    handle = lock_path.open("a+b")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as error:
+        handle.close()
+        raise RuntimeError(f"matrix sweep already owns checkpoint: {output}") from error
+    return handle
+
+
 def write_checkpoint(
     output: Path,
     result: dict,
@@ -343,14 +387,6 @@ def main() -> int:
         ),
     )
     parser.add_argument("--azurite", action="store_true")
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help=(
-            "resume an incomplete atomic checkpoint only when binary, dataset, "
-            "storage geometry, query slice, and sweep configuration all match"
-        ),
-    )
     args = parser.parse_args()
 
     repository = Path(__file__).resolve().parents[2]
@@ -358,13 +394,12 @@ def main() -> int:
     config = args.config.resolve()
     run_root = args.run_root.resolve()
     output = args.output.resolve()
+    # Keep the handle live for all checkpoint reads and writes. The OS releases
+    # it even if the process is interrupted or killed.
+    _matrix_lock = acquire_matrix_lock(output)
     groundtruth_path = args.groundtruth_path.resolve()
     nprobes = comma_separated_ints(args.nprobes, "--nprobes")
     top_k_values = comma_separated_ints(args.top_k_values, "--top-k-values")
-    if output.exists() and not args.resume:
-        raise RuntimeError(f"refusing to overwrite matrix result: {output}")
-    if args.resume and not output.exists():
-        raise RuntimeError(f"resume checkpoint does not exist: {output}")
     if not config.is_file():
         raise RuntimeError(f"benchmark config not found: {config}")
     require_config_port(config, args.port)
@@ -498,8 +533,8 @@ def main() -> int:
         "quality_outcomes": [],
     }
 
-    if args.resume:
-        existing = json.loads(output.read_text())
+    existing = load_resumable_checkpoint(output)
+    if existing is not None:
         completed = validate_resume(existing, result)
         result = existing
         result["checkpoint"]["incomplete_reason"] = None

--- a/tests/python/test_nprobe_sweep.py
+++ b/tests/python/test_nprobe_sweep.py
@@ -87,6 +87,45 @@ def test_resume_rejects_terminal_checkpoint():
         SWEEP.validate_resume(existing, expected)
 
 
+def test_checkpoint_loading_auto_resumes_only_non_terminal_states(tmp_path: Path):
+    output = tmp_path / "matrix.json"
+    assert SWEEP.load_resumable_checkpoint(output) is None
+
+    for state in ("running", "incomplete"):
+        checkpoint = expected_result()
+        checkpoint["status"] = state
+        output.write_text(json.dumps(checkpoint))
+        assert SWEEP.load_resumable_checkpoint(output) == checkpoint
+
+    for state in ("pass", "fail", "unknown"):
+        checkpoint = expected_result()
+        checkpoint["status"] = state
+        output.write_text(json.dumps(checkpoint))
+        with pytest.raises(RuntimeError, match="terminal or invalid"):
+            SWEEP.load_resumable_checkpoint(output)
+
+
+def test_checkpoint_loading_rejects_malformed_json(tmp_path: Path):
+    output = tmp_path / "matrix.json"
+    output.write_text("{not-json")
+
+    with pytest.raises(RuntimeError, match="cannot read matrix checkpoint"):
+        SWEEP.load_resumable_checkpoint(output)
+
+
+def test_matrix_lock_is_single_writer_and_recovers_after_close(tmp_path: Path):
+    output = tmp_path / "matrix.json"
+    first = SWEEP.acquire_matrix_lock(output)
+    try:
+        with pytest.raises(RuntimeError, match="already owns checkpoint"):
+            SWEEP.acquire_matrix_lock(output)
+    finally:
+        first.close()
+
+    recovered = SWEEP.acquire_matrix_lock(output)
+    recovered.close()
+
+
 def test_quality_policy_reports_unattained_without_invalidating_measurement():
     points = [
         {"top_k": 10, "recall_at_k": 0.975},


### PR DESCRIPTION
## Outcome

Makes long nprobe matrices interruption-safe without weakening evidence provenance.

## Changes

- automatically resumes only atomic checkpoints in running or incomplete state
- rejects terminal, malformed, or provenance-mismatched matrices
- holds a kernel-released single-writer lock for the sweep lifetime
- removes the redundant opt-in resume switch that stage wrappers could omit
- tests checkpoint state classification, malformed input, lock exclusion, and recovery

## Verification

- 37 focused Python tests passed
- Ruff passed
- make work-commit-check passed
- live 384-d factorial resumed against the pinned release binary and Azurite bed