### PR TITLE
fix(authz): a failure to resolve must DENY, not degrade to an unfiltered read

### DIFF
--- a/src/services/operations/vectors/legacy.rs
+++ b/src/services/operations/vectors/legacy.rs
@@ -674,9 +674,26 @@ impl VectorOperationsService {
         tenant_stable_id: u64,
         collection_id: &str,
     ) -> Option<Result<proximadb_abac::AuthorizedReadContext, proximadb_abac::DenyReason>> {
+        // `None` here means "ABAC is not configured" and is the ONLY legitimate
+        // absence: `records_read_context` maps `None` to `ReadContext::system`,
+        // an UNFILTERED read. Every other early return must therefore be a
+        // DENIAL (`Some(Err(..))`), never `None` — otherwise a failure to
+        // resolve silently becomes unrestricted access.
         let enforcer = self.abac_enforcer.as_ref()?;
-        let collection = self.get_or_load_collection(collection_id).await.ok()?;
-        let object_id: crate::core::stable_id::CollectionObjectId = collection.id.parse().ok()?;
+
+        // A collection that will not load, or whose id will not parse, is a
+        // FAILURE to authorize — not an absence of authorization. Both used to
+        // `?` out to `None` and hand back an unfiltered System read; they now
+        // deny, so the caller returns empty results instead of every row.
+        let Ok(collection) = self.get_or_load_collection(collection_id).await else {
+            return Some(Err(proximadb_abac::DenyReason::NoApplicablePolicy));
+        };
+        let Ok(object_id) = collection
+            .id
+            .parse::<crate::core::stable_id::CollectionObjectId>()
+        else {
+            return Some(Err(proximadb_abac::DenyReason::NoApplicablePolicy));
+        };
         // B3: build the Target FALLIBLY rather than truncating `object_id as u32`.
         // `Target.table` is u32 while catalog object ids come from a global u64
         // allocator, and `scope_covers` matches with `==` — a wrapped id can

--- a/tests/abac_vector_pushdown_integration_test.rs
+++ b/tests/abac_vector_pushdown_integration_test.rs
@@ -214,6 +214,45 @@ async fn system_context_does_not_filter() {
 /// resolver's `Target.namespace = 0`) so the assertion is independent of the
 /// collection's generated object id.
 #[tokio::test]
+async fn resolver_denies_rather_than_degrading_to_unfiltered_when_it_cannot_resolve() {
+    // REGRESSION: `resolve_vector_read_context` used to `?` out to `None` when
+    // the collection would not load. `records_read_context` maps `None` to
+    // `ReadContext::system` — an UNFILTERED read — so a failure to authorize
+    // silently became unrestricted access to every row.
+    //
+    // A failure to resolve is a DENIAL, not an absence of policy. This asserts
+    // the distinction that the `Option<Result<..>>` shape makes so easy to get
+    // backwards: `Some(Err(..))` (deny), never `None` (ABAC off ⇒ unfiltered).
+    let env = UnifiedTestEnvironment::new().await.expect("test env");
+    let enforcer = Arc::new(
+        AbacEnforcer::new(
+            Arc::new(InMemoryAttributeAuthority::default()),
+            Arc::new(InMemoryPredicateObjectStore::default()),
+            Arc::new(InMemoryPolicyEpochs::new()),
+        )
+        .with_bindings(vec![]),
+    );
+    let (svc, _collections) = env
+        .vector_operations_service_with_abac(enforcer)
+        .await
+        .expect("vector service with abac");
+
+    // A collection that does not exist cannot be resolved.
+    let outcome = svc
+        .resolve_vector_read_context(&SubjectId("alice".into()), TENANT, "no-such-collection")
+        .await;
+
+    match outcome {
+        Some(Err(_)) => {} // correct: an explicit denial
+        None => panic!(
+            "resolver returned None for an unresolvable collection — that maps to \
+             ReadContext::system (UNFILTERED). A failure to authorize must DENY."
+        ),
+        Some(Ok(_)) => panic!("an unresolvable collection must not be admitted"),
+    }
+}
+
+#[tokio::test]
 async fn resolve_vector_read_context_admits_and_denies() {
     let env = UnifiedTestEnvironment::new().await.expect("test env");
     let mut authority = InMemoryAttributeAuthority::new();


### PR DESCRIPTION
`resolve_vector_read_context` returns `Option<Result<AuthorizedReadContext, DenyReason>>`, and `records_read_context` maps the three outcomes as:

```rust
Some(Ok(ctx)) => ReadContext::Client(ctx)   // enforced
Some(Err(_))  => None                        // deny => fail-closed
None          => ReadContext::system(..)     // UNFILTERED
```

So **`None` means "ABAC is not configured — read everything"**, and `?` produces exactly that value on *any* failure. Two fallible steps used it:

```rust
let collection = self.get_or_load_collection(collection_id).await.ok()?;
let object_id  = collection.id.parse().ok()?;
```

A collection that wouldn't load, or whose id wouldn't parse, therefore **silently became an unrestricted read of every row**.

The type actively encouraged the mistake: `Option`'s `None` carried two incompatible meanings — *"not applicable"* and *"failed"* — and `?` always chose the dangerous one. Both now deny explicitly, and `abac_enforcer.as_ref()?` remains the **only** legitimate `None` (ABAC genuinely off), commented as such so the distinction survives the next edit.

## No escape-hatch gate — deliberately

Unlike other security flips in this program, there's no gate. A gate here would be a switch labelled *"return unfiltered results when authorization fails"* — dead config at best, a footgun at worst. The previous behavior isn't a compatibility mode; it's the bug.

## Blast radius: bounded and correct

Both callers already treat the deny as fail-closed (`None => None` for get-record, `None => return Ok((Vec::new(), None))` for search), so an unresolvable collection now yields **empty results** instead of every row.

## Teeth-proven, not assumed

| step | result |
|---|---|
| with the fix | ✅ PASS |
| restore **only** the old `.ok()?`, test untouched | ❌ FAIL — *"resolver returned None for an unresolvable collection — that maps to ReadContext::system (UNFILTERED). A failure to authorize must DENY."* |
| restore | ✅ PASS |

## Verification

default `--lib` ✅ (fix doesn't depend on the abac feature) · `--features abac-policy` ✅ · `cargo check --all-targets` ✅ · `make work-commit-check` ✅

Same defect family as B2/B3 (#1575) and the TD-SEC-2 register: a mechanism whose failure mode is indistinguishable from a benign one, so it reads as coverage.

Ref TD-AUTHZ-1 (L2.2), TD-SEC-2, ADR-090, #1575.
