### PR TITLE
docs(authz): L2.2 item 1 re-scoped — the graph/RAG surface extracts no identity

### DIFF
--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -385,3 +385,43 @@ live read path (a transient collection-load failure would begin denying instead 
 unfiltered results) and deserves its own slice with its own ratchet. Sequence it with the L2.2
 `System`-bypass work, which is already the owner of "client-facing reads must not run as
 System".
+
+
+== L2.2 item 1 RE-SCOPED (2026-08-11): the graph/RAG REST surface extracts no identity
+
+The tracker framed this as "`unified_search_with_tenant_context` has no ABAC". Tracing its
+production caller shows the fix is not where that framing points.
+
+* `unified_search` ← `src/graph/rag/engine_impls.rs:53`, on `VectorNodeRetriever`, whose fields
+  are only `{ vector_ops, collection, limit }` — no identity.
+* `VectorNodeRetriever` is constructed at `src/network/rest/canonical/graph.rs:1348`, inside
+  `pub async fn rag_query(State(app_state), Path(graph_id), Json(request))` — **no identity
+  extractor in the signature**.
+
+VERIFIED (by mechanism, not by pattern-guessing): `src/network/rest/v2/records.rs` obtains
+identity as `Extension(tenant): Extension<TenantContext>` (`:1107`, importing
+`crate::network::middleware::tenant::TenantContext`). `src/network/rest/canonical/graph.rs`
+contains **zero** occurrences of `Extension`, `TenantContext`, or `PortIdentity` across its
+**33** handlers.
+
+So there is no identity at the graph REST boundary to thread anywhere. Adding a `ReadContext`
+parameter to `unified_search` would produce a parameter with nothing to put in it. **The fix is
+identity extraction at the graph surface**, mirroring the records surface — then ABAC on the
+search path, then the RAG retriever carrying it.
+
+=== NOT verified — do not conclude the surface is unisolated
+
+Whether `graph_operations_service` enforces tenancy internally by some other route was NOT
+checked. The verified claim is narrow and specific: *the handlers do not extract the
+middleware's `TenantContext`*. Establish the internal behavior before characterising the graph
+surface's isolation posture — the B1 entry in this tracker is a standing reminder of what
+overclaiming here costs.
+
+=== Method note (third occurrence this session)
+
+The first pass used `grep -A 6 "^pub async fn" | grep -c Extension...` and reported **0 for
+`records.rs` too** — a file that demonstrably does thread identity. The pattern was wrong, not
+the code. A search that returns zero is evidence about the SEARCH until the same search is shown
+to return non-zero on a known-positive control. Two earlier instances this session: a
+`grep | head -6` that made a guarded read path look unguarded, and a regex that matched zero
+blocks while an assertion caught it.


### PR DESCRIPTION
The tracker framed this as *"`unified_search_with_tenant_context` has no ABAC."* Tracing its production caller shows **the fix is not where that framing points**.

- `unified_search` ← `graph/rag/engine_impls.rs:53`, on `VectorNodeRetriever`, whose fields are only `{ vector_ops, collection, limit }` — no identity.
- That retriever is built at `graph.rs:1348` inside `rag_query(State, Path, Json)` — **no identity extractor in the signature**.

**Verified by mechanism:** `records.rs` obtains identity as `Extension(tenant): Extension<TenantContext>` (`:1107`). `graph.rs` contains **zero** occurrences of `Extension`, `TenantContext`, or `PortIdentity` across its **33** handlers.

So there is no identity at the graph REST boundary to thread. Adding a `ReadContext` parameter to `unified_search` would create a parameter with nothing to put in it. **The fix is identity extraction at the graph surface**, mirroring the records surface — then ABAC on the search path, then the retriever carrying it. A different and larger slice than the tracker described.

## Explicitly NOT verified

Whether `graph_operations_service` enforces tenancy internally by some other route. The verified claim is narrow: *the handlers do not extract the middleware's `TenantContext`*. Don't characterise the graph surface's isolation posture until the internal behavior is checked — the B1 entry in this tracker is the standing reminder of what overclaiming costs.

## Method note (third occurrence this session)

My first pass used `grep -A 6 "^pub async fn" | grep -c Extension…` and reported **0 for `records.rs` too** — a file that demonstrably threads identity. The pattern was wrong, not the code.

**A search returning zero is evidence about the search** until that search is shown to return non-zero on a known-positive control. Earlier instances: a `grep | head -6` that made a guarded read path look unguarded, and a regex that matched zero blocks (caught by an assertion).

Docs only · `make work-commit-check` green.

Ref TD-AUTHZ-1 (L2.2), TD-SEC-2, ADR-090, #1575, #1582.
