### PR TITLE
refactor(decomp): extract geohash → new crate (TD-DECOMP-60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6750,6 +6750,7 @@ dependencies = [
  "proximadb-functions",
  "proximadb-geo-index",
  "proximadb-geo-types",
+ "proximadb-geohash",
  "proximadb-graph",
  "proximadb-graph-arrow",
  "proximadb-graph-engine-traits",
@@ -7505,6 +7506,13 @@ name = "proximadb-geo-types"
 version = "0.2.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "proximadb-geohash"
+version = "0.2.0"
+dependencies = [
+ "proximadb-geo-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "crates/horizontal/proximadb-llm-config",
     "crates/horizontal/proximadb-subscription",
     "crates/horizontal/proximadb-geo-types",
+    "crates/horizontal/proximadb-geohash",
     "crates/horizontal/proximadb-implicit-id-generator",
     "crates/horizontal/proximadb-document-compression",
     "crates/horizontal/proximadb-arrow-block-index",
@@ -319,6 +320,7 @@ proximadb-scan-cursor = { path = "crates/horizontal/proximadb-scan-cursor" }
 proximadb-llm-config = { path = "crates/horizontal/proximadb-llm-config" }
 proximadb-subscription = { path = "crates/horizontal/proximadb-subscription" }
 proximadb-geo-types = { path = "crates/horizontal/proximadb-geo-types" }
+proximadb-geohash = { path = "crates/horizontal/proximadb-geohash" }
 proximadb-implicit-id-generator = { path = "crates/horizontal/proximadb-implicit-id-generator" }
 proximadb-document-compression = { path = "crates/horizontal/proximadb-document-compression" }
 proximadb-arrow-block-index = { path = "crates/horizontal/proximadb-arrow-block-index" }
@@ -463,6 +465,7 @@ proximadb-scan-cursor = { workspace = true }
 proximadb-llm-config = { workspace = true }
 proximadb-subscription = { workspace = true }
 proximadb-geo-types = { workspace = true }
+proximadb-geohash = { workspace = true }
 proximadb-implicit-id-generator = { workspace = true }
 proximadb-document-compression = { workspace = true }
 proximadb-arrow-block-index = { workspace = true }

--- a/crates/horizontal/proximadb-geohash/Cargo.toml
+++ b/crates/horizontal/proximadb-geohash/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "proximadb-geohash"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Geohash encoding/decoding + neighbor lookup — extracted from root index/geo (TD-DECOMP-60)"
+
+[lib]
+name = "proximadb_geohash"
+path = "src/lib.rs"
+
+[dependencies]
+proximadb-geo-types = { workspace = true }

--- a/crates/horizontal/proximadb-geohash/src/geohash.rs
+++ b/crates/horizontal/proximadb-geohash/src/geohash.rs
@@ -4,7 +4,7 @@
 // geographic coordinates into a short string. Adjacent geohashes
 // share common prefixes, enabling efficient range queries.
 
-use super::types::{GeoBoundingBox, GeoPoint};
+use proximadb_geo_types::types::{GeoBoundingBox, GeoPoint};
 
 /// Base32 alphabet for geohash encoding
 const BASE32: &[u8] = b"0123456789bcdefghjkmnpqrstuvwxyz";

--- a/crates/horizontal/proximadb-geohash/src/lib.rs
+++ b/crates/horizontal/proximadb-geohash/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Geohash encoding/decoding, extracted from the root `index/geo` module
+//! (TD-DECOMP-60).
+//!
+//! [`geohash`] provides [`geohash::GeoHash`] + [`geohash::encode_geohash`] /
+//! [`geohash::decode_geohash`] / [`geohash::geohash_neighbors`] over the
+//! [`proximadb_geo_types::types`] coordinate types. Depends only on the sibling
+//! `proximadb-geo-types` crate, keeping it a clean horizontal-tier leaf.
+
+pub mod geohash;

--- a/docs/10-quality/td/TD-DECOMP-60-extract-geohash.adoc
+++ b/docs/10-quality/td/TD-DECOMP-60-extract-geohash.adoc
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-60: Extract geohash → new proximadb-geohash crate (horizontal)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export (one import rewrite)
+| Component | `crates/horizontal/proximadb-geohash`; root `src/index/geo/mod.rs`
+|===
+
+== What moved
+`src/index/geo/geohash.rs` (9 tests: `GeoHash` + `encode_geohash` / `decode_geohash` /
+`geohash_neighbors`) → new horizontal crate `proximadb-geohash`. Root `index/geo/mod.rs` re-exports it
+(`pub use proximadb_geohash::geohash;`), so the existing `pub use geohash::{GeoHash, decode_geohash,
+encode_geohash, geohash_neighbors};` resolves unchanged. Deps: `proximadb-geo-types` only (zero `crate::`
+climb-out, `super::` test-only). The one `use super::types::{GeoBoundingBox, GeoPoint};` was rewritten to
+`use proximadb_geo_types::types::{GeoBoundingBox, GeoPoint};` (the sibling geo-types hub, TD-DECOMP-59).
+Verified: standalone + clippy -D warnings + root lib all pass. SIFT recall ratchet SKIPS (index/** is not
+storage_changes).

--- a/src/index/geo/mod.rs
+++ b/src/index/geo/mod.rs
@@ -7,7 +7,7 @@
 // - Query operators: distance, within, intersects
 
 /// Geohash encoding and decoding for spatial partitioning.
-pub mod geohash;
+pub use proximadb_geohash::geohash;
 /// Geo-spatial index implementation (R-tree style).
 pub mod index;
 /// Geo-spatial query types and builders.


### PR DESCRIPTION
Part of the P2 god-crate decomposition initiative (root `proximadb` lib bundles 9,538 inline tests → OOMs the 16 GB runner at `BUILD_JOBS=1`; the structural fix is moving `src/` modules into workspace crates so tests leave with the code).

## What moves
`src/index/geo/geohash.rs` (**9 tests**: `GeoHash` + `encode_geohash` / `decode_geohash` / `geohash_neighbors`) → **new horizontal crate `proximadb-geohash`**.

## Why this leaf
First of the index/geo dependents (after the TD-DECOMP-59 geo-types hub). Deps: **`proximadb-geo-types` only** (zero `crate::` climb-out, `super::` test-only). One import rewrite: `use super::types::{...}` → `use proximadb_geo_types::types::{...}`.

## Shim
Root `index/geo/mod.rs`:
```rust
- pub mod geohash;
+ pub use proximadb_geohash::geohash;
```
so the existing `pub use geohash::{GeoHash, decode_geohash, encode_geohash, geohash_neighbors};` resolves unchanged.

## CI note
Touches only `src/index/**` (not `storage_changes`) + `Cargo.toml` → **SIFT recall ratchet SKIPS** this PR.

## Verified locally
- standalone `cargo check --all-targets` ✓ + `cargo clippy --all-targets -- -D warnings` ✓
- root `cargo check -p proximadb --lib` ✓ (shim resolves)
- `check-layering.sh` (exit 0) + `check_workspace_boundaries.py` — No boundary findings ✓
- `cargo fmt --check` ✓; 9 tests pass in-crate (nextest) ✓

Behavior-neutral, mixed-read-safe (no on-disk/wire format change), no AI attribution.