### PR TITLE
refactor(decomp): extract geo queries → new crate (TD-DECOMP-61)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6749,6 +6749,7 @@ dependencies = [
  "proximadb-filterable-metadata",
  "proximadb-functions",
  "proximadb-geo-index",
+ "proximadb-geo-queries",
  "proximadb-geo-types",
  "proximadb-graph",
  "proximadb-graph-arrow",
@@ -7498,6 +7499,14 @@ name = "proximadb-geo-index"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "proximadb-geo-queries"
+version = "0.2.0"
+dependencies = [
+ "proximadb-geo-types",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "crates/horizontal/proximadb-implicit-id-generator",
     "crates/horizontal/proximadb-document-compression",
     "crates/horizontal/proximadb-arrow-block-index",
+    "crates/horizontal/proximadb-geo-queries",
     "crates/horizontal/proximadb-auth-sso",
     "crates/horizontal/proximadb-catapult",
     "crates/horizontal/proximadb-axis-tunnel",
@@ -322,6 +323,7 @@ proximadb-geo-types = { path = "crates/horizontal/proximadb-geo-types" }
 proximadb-implicit-id-generator = { path = "crates/horizontal/proximadb-implicit-id-generator" }
 proximadb-document-compression = { path = "crates/horizontal/proximadb-document-compression" }
 proximadb-arrow-block-index = { path = "crates/horizontal/proximadb-arrow-block-index" }
+proximadb-geo-queries = { path = "crates/horizontal/proximadb-geo-queries" }
 proximadb-auth-sso = { path = "crates/horizontal/proximadb-auth-sso" }
 proximadb-catapult = { path = "crates/horizontal/proximadb-catapult" }
 proximadb-axis-tunnel = { path = "crates/horizontal/proximadb-axis-tunnel" }
@@ -466,6 +468,7 @@ proximadb-geo-types = { workspace = true }
 proximadb-implicit-id-generator = { workspace = true }
 proximadb-document-compression = { workspace = true }
 proximadb-arrow-block-index = { workspace = true }
+proximadb-geo-queries = { workspace = true }
 proximadb-auth-sso = { workspace = true }
 proximadb-catapult = { workspace = true }
 proximadb-axis-tunnel = { workspace = true }

--- a/crates/horizontal/proximadb-geo-queries/Cargo.toml
+++ b/crates/horizontal/proximadb-geo-queries/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "proximadb-geo-queries"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Geospatial query builders (GeoQuery, GeoQueryBuilder, GeoQueryResult) — extracted from root index/geo (TD-DECOMP-61)"
+
+[lib]
+name = "proximadb_geo_queries"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+proximadb-geo-types = { workspace = true }

--- a/crates/horizontal/proximadb-geo-queries/src/lib.rs
+++ b/crates/horizontal/proximadb-geo-queries/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+//! Geospatial query builders, extracted from the root `index/geo` module
+//! (TD-DECOMP-61).
+//!
+//! [`queries`] provides [`queries::GeoQuery`], [`queries::GeoQueryBuilder`],
+//! and [`queries::GeoQueryResult`] over the [`proximadb_geo_types::types`]
+//! coordinate types. Depends only on `serde` + the sibling `proximadb-geo-types`
+//! crate, keeping it a clean horizontal-tier leaf.
+
+pub mod queries;

--- a/crates/horizontal/proximadb-geo-queries/src/queries.rs
+++ b/crates/horizontal/proximadb-geo-queries/src/queries.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::types::{GeoBoundingBox, GeoDistanceUnit, GeoPoint, GeoPolygon};
+use proximadb_geo_types::types::{GeoBoundingBox, GeoDistanceUnit, GeoPoint, GeoPolygon};
 
 /// A geospatial query
 #[derive(Debug, Clone)]

--- a/docs/10-quality/td/TD-DECOMP-61-extract-geo-queries.adoc
+++ b/docs/10-quality/td/TD-DECOMP-61-extract-geo-queries.adoc
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-61: Extract geo queries → new proximadb-geo-queries crate (horizontal)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export (one import rewrite)
+| Component | `crates/horizontal/proximadb-geo-queries`; root `src/index/geo/mod.rs`
+|===
+
+== What moved
+`src/index/geo/queries.rs` (8 tests: `GeoQuery` + `GeoQueryBuilder` + `GeoQueryResult`) → new horizontal
+crate `proximadb-geo-queries`. Root `index/geo/mod.rs` re-exports it
+(`pub use proximadb_geo_queries::queries;`), so the existing
+`pub use queries::{GeoQuery, GeoQueryBuilder, GeoQueryResult};` resolves unchanged. Deps: serde +
+`proximadb-geo-types` (zero `crate::` climb-out, `super::` test-only). The one
+`use super::types::{...}` rewritten to `use proximadb_geo_types::types::{...}` (the geo-types hub,
+TD-DECOMP-59). Verified: standalone + clippy -D warnings + root lib all pass. SIFT recall ratchet SKIPS
+(index/** is not storage_changes).

--- a/src/index/geo/mod.rs
+++ b/src/index/geo/mod.rs
@@ -11,7 +11,7 @@ pub mod geohash;
 /// Geo-spatial index implementation (R-tree style).
 pub mod index;
 /// Geo-spatial query types and builders.
-pub mod queries;
+pub use proximadb_geo_queries::queries;
 /// Core geo-spatial types (points, bounding boxes, polygons).
 pub use proximadb_geo_types::types;
 


### PR DESCRIPTION
Part of the P2 god-crate decomposition initiative (root `proximadb` lib bundles 9,538 inline tests → OOMs the 16 GB runner at `BUILD_JOBS=1`; the structural fix is moving `src/` modules into workspace crates so tests leave with the code).

## What moves
`src/index/geo/queries.rs` (**8 tests**: `GeoQuery` + `GeoQueryBuilder` + `GeoQueryResult`) → **new horizontal crate `proximadb-geo-queries`**.

## Why this leaf
Second of the index/geo dependents (after the TD-DECOMP-59 geo-types hub + TD-DECOMP-60 geohash). Deps: **serde + `proximadb-geo-types`** (zero `crate::` climb-out, `super::` test-only). One import rewrite: `use super::types::{...}` → `use proximadb_geo_types::types::{...}`.

## Shim
Root `index/geo/mod.rs`:
```rust
- pub mod queries;
+ pub use proximadb_geo_queries::queries;
```
so the existing `pub use queries::{GeoQuery, GeoQueryBuilder, GeoQueryResult};` resolves unchanged.

## CI note
Touches only `src/index/**` (not `storage_changes`) + `Cargo.toml` → **SIFT recall ratchet SKIPS** this PR.

## Verified locally
- standalone `cargo check --all-targets` ✓ + `cargo clippy --all-targets -- -D warnings` ✓
- root `cargo check -p proximadb --lib` ✓ (shim resolves)
- `check-layering.sh` (exit 0) + `check_workspace_boundaries.py` — No boundary findings ✓
- `cargo fmt --check` ✓; 8 tests pass in-crate (nextest) ✓

Behavior-neutral, mixed-read-safe (no on-disk/wire format change), no AI attribution.