### PR TITLE
docs(authz): L2.2 ordering — threading identity first would break RAG reads

### DIFF
--- a/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-1-adr090-program-tracker.adoc
@@ -425,3 +425,43 @@ the code. A search that returns zero is evidence about the SEARCH until the same
 to return non-zero on a known-positive control. Two earlier instances this session: a
 `grep | head -6` that made a guarded read path look unguarded, and a regex that matched zero
 blocks while an assertion caught it.
+
+
+== L2.2 item 1 — VERIFIED ordering constraint: do NOT thread identity first (2026-08-12)
+
+The obvious next slice is "extract identity in `rag_query` and pass `Some(tenant_context)`
+instead of the hardcoded `None`". **That would break RAG reads**, and the reason is verified:
+
+* Passing `Some(..)` activates `validate_search_results_tenant_isolation`
+  (`legacy.rs:2765`), which is currently unreachable because all 6 callers pass `None`.
+* That validator DROPS any result whose metadata lacks a `tenant_id`
+  (`legacy.rs:2826`, "Vector result without tenant_id found!").
+* **No ordinary vector write path stamps `tenant_id` into record metadata.** Searching for the
+  write is decisive: the only occurrences are an audit-details map
+  (`security_coordinator.rs:605`) and a bulk-load SPOOF fixture
+  (`bulk_load.rs:490`). Result metadata is otherwise copied verbatim from the user's own
+  record metadata (`legacy.rs:~5040`).
+
+So ordinary records carry no tenant metadata, and the validator would drop all of them: RAG
+would return EMPTY rather than leaking. Fail-closed, but an outage.
+
+=== Required order
+
+. **Fix the validator's model first.** Metadata-string matching is the wrong mechanism —
+  isolation here should come from the same `ReadContext`/ABAC path the other read surfaces use
+  (`records_read_context`), not from comparing a `tenant_id` string that the write path never
+  writes. While it exists, it must also stop treating "no metadata" as a security verdict in
+  either direction: today absent ⇒ drop, and a non-`StringValue` variant matches no arm and is
+  dropped with NO log at all.
+. **Then** extract identity at the graph surface and thread it.
+. **Then** ABAC on the search path, and the retriever carrying the context.
+
+Reversing steps 1 and 2 produces an immediate regression that looks like a security fix.
+
+=== Status of the surrounding claims
+
+VERIFIED: the handlers extract no identity (33 handlers, zero `Extension`/`TenantContext`/
+`PortIdentity`); the write path does not stamp tenant metadata; the validator drops unlabeled
+results. NOT VERIFIED and still open: whether `graph_operations_service` enforces tenancy
+internally by another route — establish that before characterising the graph surface's
+isolation posture.


### PR DESCRIPTION
The obvious next slice is *"extract identity in `rag_query` and pass `Some(tenant_context)` instead of the hardcoded `None`."* **Verified: that would break RAG reads.**

## The mechanism

1. Passing `Some(..)` activates `validate_search_results_tenant_isolation` (`legacy.rs:2765`) — currently unreachable, because all 6 callers pass `None`.
2. That validator **drops** any result whose metadata lacks a `tenant_id` (`legacy.rs:2826`).
3. **No ordinary vector write path stamps `tenant_id` into record metadata.** The search for the *write* is decisive: the only occurrences are an audit-details map (`security_coordinator.rs:605`) and a bulk-load **spoof fixture** (`bulk_load.rs:490`). Result metadata is otherwise copied verbatim from the user's own record metadata.

So ordinary records carry no tenant metadata and would all be dropped — RAG returns **empty**. Fail-closed, but an outage, and it would *look like a security fix while being a regression*.

## Required order

1. **Fix the validator's model first.** Metadata-string matching is the wrong mechanism — isolation here belongs on the same `ReadContext`/ABAC path the other read surfaces use. While it exists, it must also stop treating "no metadata" as a security verdict in either direction: today absent ⇒ drop, and a non-`StringValue` variant matches no arm and is dropped **with no log at all**.
2. **Then** extract identity at the graph surface and thread it.
3. **Then** ABAC on the search path, with the retriever carrying the context.

Reversing 1 and 2 is the trap.

## Verified vs not

**Verified:** handlers extract no identity (33 handlers, zero `Extension`/`TenantContext`/`PortIdentity`); the write path doesn't stamp tenant metadata; the validator drops unlabeled results.

**Not verified:** whether `graph_operations_service` enforces tenancy internally by another route. That distinction is why this is a docs commit and not a code change.

Docs only · `make work-commit-check` green.

Ref TD-AUTHZ-1 (L2.2), TD-SEC-2, ADR-090, #1585.
