### PR TITLE
ci+docs(promotion): guard promotion ancestry and write down the procedure

### DIFF
--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -57,6 +57,54 @@ jobs:
           fi
           echo "ok: main PR originates from qa"
 
+  # Catch a SEVERED promotion ancestry before it compounds.
+  #
+  # develop -> qa promotions were squash-merged for several cycles. A squash gives
+  # qa develop's *content* with no link to its *history*, so the merge-base between
+  # the branches stops advancing: it sat at 1ab38bac7 (2026-07-21) while develop ran
+  # 377 commits ahead, and git recomputed that whole diff on every promotion —
+  # 47 conflicts, essentially all phantom, growing worse each cycle.
+  #
+  # Nothing on the feature -> develop path can see this; it is a property of how the
+  # promotion PR itself is merged. So assert it here, where promotions are gated.
+  # A promotion opened from a current base has a merge-base at (or very near) the
+  # base tip; a severed one is hundreds of commits back.
+  promotion-ancestry-guard:
+    name: Promotion Ancestry Guard (merge-base is current)
+    if: github.event_name == 'pull_request' && (github.base_ref == 'qa' || github.base_ref == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: the target must be fully contained in this branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_REF" >/dev/null 2>&1
+          base_tip="$(git rev-parse "origin/$BASE_REF")"
+          merge_base="$(git merge-base "$base_tip" HEAD)"
+          behind="$(git rev-list --count "$merge_base..$base_tip")"
+          echo "base=$BASE_REF tip=${base_tip:0:9} merge-base=${merge_base:0:9} behind=$behind"
+          # The invariant is exact, so assert it exactly rather than pick a
+          # threshold: the merge-base must BE the base tip, i.e. the target is an
+          # ancestor of this branch. Anything else means the target holds commits
+          # this branch has never seen, which is precisely when a promotion
+          # explodes into phantom conflicts.
+          #
+          # Calibrated against real history: promotion branches that had merged the
+          # target in measure 0; the r5 branch cut as a bare develop snapshot
+          # measured 44. An earlier draft of this guard allowed 150 and would have
+          # passed the broken case — hence the exact check.
+          if [ "$behind" -ne 0 ]; then
+            echo "::error::'$BASE_REF' is $behind commits ahead of this branch's merge-base — the target is not fully merged in."
+            echo "::error::Fix: 'git merge origin/$BASE_REF' (or 'git merge -s ours origin/$BASE_REF' if you have verified the target carries no unique work), then push."
+            echo "::error::If this recurs every cycle, the previous promotion was SQUASHED. Squashing discards the merge that reconciled the branches, so the target never gains the source's ancestry and the next promotion re-diffs from the last real merge. Promotion PRs must be merged with a MERGE COMMIT."
+            exit 1
+          fi
+          echo "ok: '$BASE_REF' is fully contained in this branch"
+
   # SINGLE combined job: compile all pgwire + recall test binaries ONCE on this
   # runner, then run them. Same runner => the compiled target/ is reused across
   # the runs (cargo sees its own artifacts as up-to-date, no recompile between

--- a/docs/04-operations/release/PROMOTION_PROCEDURE.adoc
+++ b/docs/04-operations/release/PROMOTION_PROCEDURE.adoc
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= Branch promotion procedure (develop → qa → main)
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Active.** Written 2026-08-12 after a promotion opened with 47 conflicts that were almost entirely phantom.
+| Applies to | PRs targeting `qa` and `main`
+| Enforced by | `promotion-ancestry-guard` and `promotion-source-guard` in `.github/workflows/qa-gate.yml`
+|===
+
+== The one rule that matters
+
+**Promotion PRs are merged with a MERGE COMMIT. Never squashed.**
+
+Squash is correct for `feature → develop`: it keeps develop's history readable and the
+workspace tooling already detects squash-merged branches. It is wrong for a long-lived
+release branch, and the failure is silent and compounding.
+
+== Why squashing a promotion breaks the next one
+
+A promotion branch normally merges its target in to resolve conflicts. Squashing the PR
+**discards that merge**: `qa` receives develop's _content_ with no link to its _history_. The
+merge-base between the two branches therefore stops advancing.
+
+Measured on 2026-08-11, after several squashed cycles:
+
+[source]
+----
+merge-base(develop, qa):  1ab38bac7   2026-07-21   <- the last real merge
+develop ahead of it:      377 commits
+conflicts in the next promotion: 47
+----
+
+Git was recomputing a three-week diff every time. The conflicts were not real divergence —
+`qa` held no unique work — but they landed in `abac/context.rs`, `security/rls/abac_adapter.rs`,
+`grpc/auth.rs` and `write_ahead_log/mod.rs`, where a careless resolution is a security or
+durability bug rather than a formatting nit.
+
+After one *merged* promotion the merge-base moved to the previous day and develop was 10
+commits ahead; a dry-run of the following promotion reported **zero conflicts**.
+
+NOTE: Nothing on the `feature → develop` path can catch this. develop is consistent and its
+CI is doing its job — the defect is entirely in how the release PR is merged.
+
+== Cutting a promotion
+
+. Create a **pinned snapshot branch**, do not point the PR head at `develop`:
++
+[source,sh]
+----
+git worktree add ../proximaDB.worktrees/promote-rN -b promote/develop-to-qa-v0X-rN <develop-sha>
+----
++
+A PR whose head *is* `develop` re-runs the whole heavy gate on every subsequent merge to
+develop. Pinning keeps this PR's gate result meaningful and stops it churning under review.
+
+. Merge the target in so the ancestry guard passes:
++
+[source,sh]
+----
+git merge origin/qa
+----
++
+If the target genuinely carries no unique work, `git merge -s ours origin/qa` keeps the
+source tree byte-exact while still recording the ancestry. **Verify before using `-s ours`** —
+`git diff origin/develop HEAD` must be empty afterwards, and check the target for commits
+that never flowed back (CI tuning is the usual case).
+
+. Open the PR and **merge it with a merge commit**.
+
+WARNING: `gh pr merge --merge --auto` has been observed to arm **SQUASH** regardless of the
+flag. Always verify: `gh pr view <n> --json autoMergeRequest`. If it reports `SQUASH`,
+disable auto-merge and re-arm through the API with `mergeMethod: MERGE`.
+
+== If develop moves while the gate runs
+
+Do not re-merge develop into an in-flight promotion. That restarts the full gate and the
+branch goes stale again immediately. Let the pinned snapshot land, then cut the next
+promotion — with ancestry intact it should open clean.
+
+== Recovering a severed ancestry
+
+If `promotion-ancestry-guard` fails, the target holds commits the promotion branch has never
+seen:
+
+[source,sh]
+----
+git merge origin/qa                 # or -s ours, having verified as above
+git diff origin/develop HEAD        # must be empty when using -s ours
+----
+
+Then merge the PR **with a merge commit**, or the next cycle repeats.
+
+== Where this lives
+
+* Ancestry guard + `main ← qa` source guard: `.github/workflows/qa-gate.yml`
+* Branch protection currently permits squash on `qa`/`main`. Restricting those branches to
+  merge-commit-only would make the guard a backstop instead of the only defence.


### PR DESCRIPTION
## What happened

Promotion #1573 opened with **47 conflicts**. They were not real divergence — `qa` held no unique work — they were the residue of **squashing** previous promotions.

A promotion branch merges its target in to resolve conflicts. Squashing the PR **discards that merge**, so `qa` receives develop's *content* without its *history*, and the merge-base stops advancing:

```
merge-base(develop, qa)   1ab38bac7   2026-07-21   <- the last real merge
develop ahead of it       377 commits
conflicts                 47
```

Git recomputed a three-week diff every cycle, and each squash made the next worse. The conflicts landed in `abac/context.rs`, `security/rls/abac_adapter.rs`, `grpc/auth.rs`, `write_ahead_log/mod.rs` — places where a careless resolution is a security or durability bug.

**After one *merged* promotion:** merge-base moved to the previous day, develop 10 ahead, and a dry-run of the next promotion reported **zero conflicts**.

## Why CI didn't catch it

It couldn't. `feature → develop` gating works and develop is consistent — the defect is entirely in how the **release PR** is merged. So the guard belongs where promotions are gated, which is `qa-gate.yml` (already carrying `promotion-source-guard` for `main ← qa`).

## The guard

`promotion-ancestry-guard`, on PRs targeting `qa`/`main`. It asserts the **exact invariant** — the merge-base must *be* the base tip, i.e. the target is an ancestor of the promotion branch — rather than a tuned threshold.

Calibrated against real history:

| branch state | measured | verdict |
|---|---|---|
| had merged the target in | 0 | PASS |
| bare develop snapshot (the broken case) | 44 | FAIL |
| after the ancestry fix | 0 | PASS |

**My first draft allowed 150 commits and would have passed the broken case.** That is why it now asserts the invariant instead of guessing a limit.

## Two admissions worth recording

**This guard was originally committed onto the promotion branch itself** — the wrong home. Promotion branches get rebuilt and force-pushed, and that one was, taking the guard with it. Mainline CI belongs on `develop`, which is where this PR puts it.

**`gh pr merge --merge --auto` armed SQUASH regardless of the flag** during that promotion. Had it not been caught, it would have discarded the ancestry merge and reset the problem. The doc records the check (`gh pr view <n> --json autoMergeRequest`) and the API workaround.

## The doc

`docs/04-operations/release/PROMOTION_PROCEDURE.adoc` — there was no written promotion procedure, which is how the convention drifted. Covers: pinned snapshot branches (not `head=develop`, which re-runs the heavy gate on every develop merge), merge-never-squash, what to do when develop moves mid-gate, and how to recover a severed ancestry.

## Not in scope

Branch protection still permits squash on `qa`/`main`. Restricting those to merge-commit-only would make this guard a backstop rather than the only defence — that needs repo admin.