### PR TITLE
feat: add token-aware embedding contracts and xCatalog model registry

### DIFF
--- a/clients/python/examples/token_budgeted_open_rag.py
+++ b/clients/python/examples/token_budgeted_open_rag.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Chunk and embed a document with any catalogued open-weight model.
+
+Examples:
+  python token_budgeted_open_rag.py --list-models
+  python token_budgeted_open_rag.py --model nomic-ai/nomic-embed-text-v1.5 README.md
+  python token_budgeted_open_rag.py --model google/embeddinggemma-300m --dimension 256 README.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from proximadb_sdk.chunking import TextChunker
+from proximadb_sdk.chunking_strategies import (
+    ChunkingConfig,
+    ChunkingStrategy,
+    InputRole,
+    TokenBudget,
+)
+from proximadb_sdk.embedding_providers import get_open_embedding_model
+from proximadb_sdk.embedding_providers.catalog import list_open_models
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, nargs="?")
+    parser.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    parser.add_argument("--dimension", type=int)
+    parser.add_argument("--target-tokens", type=int)
+    parser.add_argument("--overlap-percent", type=float, default=15.0)
+    parser.add_argument("--list-models", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.list_models:
+        for spec in list_open_models():
+            model = spec.metadata
+            print(
+                f"{model.name}\t{model.dimension}d\t{model.max_length} tokens\t"
+                f"{model.license_id}\t{model.access}"
+            )
+        return
+    if args.path is None:
+        raise SystemExit("path is required unless --list-models is used")
+
+    provider = get_open_embedding_model(args.model, dimension=args.dimension)
+    contract = provider.get_input_contract()
+    target = args.target_tokens or min(480, contract.effective_context_limit)
+    overlap = round(target * args.overlap_percent / 100)
+    chunker = TextChunker(
+        ChunkingConfig(
+            strategy=ChunkingStrategy.RECURSIVE,
+            chunk_size=4096,
+            chunk_overlap=0,
+            min_chunk_size=1,
+            token_budget=TokenBudget(
+                target_tokens=target,
+                overlap_tokens=overlap,
+                min_content_tokens=16,
+            ),
+            input_contract=contract,
+            input_role=InputRole.DOCUMENT,
+        )
+    )
+    text = args.path.read_text(encoding="utf-8")
+    chunks = chunker.chunk_text(text, source_id=str(args.path))
+    embeddings = provider.embed_passages([chunk.text for chunk in chunks])
+    token_counts = [contract.count(chunk.text, InputRole.DOCUMENT) for chunk in chunks]
+    dimension = provider.get_dimension()
+
+    print(
+        json.dumps(
+            {
+                "model_contract": contract.to_manifest(),
+                "chunks": len(chunks),
+                "token_min": min(token_counts, default=0),
+                "token_max": max(token_counts, default=0),
+                "truncated_chunks": sum(
+                    count > contract.effective_context_limit for count in token_counts
+                ),
+                "embedding_shape": list(embeddings.shape),
+                "float32_vector_bytes": len(chunks) * dimension * 4,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/src/proximadb_sdk/chunking.py
+++ b/clients/python/src/proximadb_sdk/chunking.py
@@ -24,6 +24,8 @@ Usage:
     records = chunk_and_embed_text(text, source_id, embedding_provider, config)
 """
 
+import hashlib
+import json
 import threading
 from collections import defaultdict
 from collections.abc import Callable
@@ -103,7 +105,32 @@ class ChunkerPool:
 
     def _get_pool_key(self, config: ChunkingConfig) -> str:
         """Generate pool key for chunker configuration"""
-        return f"{config.strategy.value}_{config.chunk_size}_{config.chunk_overlap}_{config.min_chunk_size}"
+        token_budget = getattr(config, "token_budget", None)
+        input_contract = getattr(config, "input_contract", None)
+        if token_budget is None:
+            token_identity = None
+        else:
+            if input_contract is None:
+                raise ValueError(
+                    "input_contract is required when token_budget is configured"
+                )
+            role = getattr(config, "input_role", None) or "document"
+            role_value = getattr(role, "value", role)
+            token_identity = {
+                "budget": token_budget.to_manifest(),
+                "contract": input_contract.to_manifest(),
+                "role": str(role_value),
+            }
+        payload = {
+            "strategy": config.strategy.value,
+            "chunk_size": config.chunk_size,
+            "chunk_overlap": config.chunk_overlap,
+            "min_chunk_size": config.min_chunk_size,
+            "max_chunk_size": config.max_chunk_size,
+            "token_identity": token_identity,
+        }
+        serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
     def _get_or_create_pool(
         self, config: ChunkingConfig
@@ -225,6 +252,9 @@ class TextChunker:
             breakpoint_percentile_threshold=getattr(
                 self.config, "breakpoint_percentile_threshold", 95.0
             ),
+            token_budget=getattr(self.config, "token_budget", None),
+            input_contract=getattr(self.config, "input_contract", None),
+            input_role=getattr(self.config, "input_role", None),
         )
 
     def chunk_text(
@@ -343,8 +373,7 @@ def create_records(
     """
     if len(chunks) != len(embeddings):
         raise ValueError(
-            f"Chunks ({len(chunks)}) and embeddings ({len(embeddings)}) "
-            f"length mismatch"
+            f"Chunks ({len(chunks)}) and embeddings ({len(embeddings)}) length mismatch"
         )
 
     collection_metadata = collection_metadata or {}

--- a/clients/python/src/proximadb_sdk/chunking_strategies/__init__.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/__init__.py
@@ -58,6 +58,16 @@ from .code import (  # Parser classes - Primary languages; Parser classes - Addi
     register_file_extension,
     register_language_parser,
 )
+from .contracts import (
+    CompositeInputContract,
+    InputRenderer,
+    InputRole,
+    OverflowPolicy,
+    ResolvedInputContract,
+    ShortChunkPolicy,
+    TokenBudget,
+    TokenCounter,
+)
 
 # Document and binary parsers (OCR, reverse engineering)
 from .document_parsers import (  # Enums; Data structures; Tool detection; Parsers; Factory functions
@@ -116,6 +126,8 @@ from .semantic import SemanticStrategy
 from .semantic_embedding import SemanticEmbeddingStrategy
 from .sentence import SentenceStrategy
 from .sliding_window import SlidingWindowStrategy
+from .token_budget import TokenBudgetStrategy
+from .tokenizers import HuggingFaceTokenCounter
 
 __all__ = [
     # Base classes
@@ -123,6 +135,16 @@ __all__ = [
     "ChunkingStrategyInterface",
     "TextChunk",
     "ChunkingConfig",
+    "TokenBudget",
+    "TokenCounter",
+    "InputRole",
+    "InputRenderer",
+    "OverflowPolicy",
+    "ShortChunkPolicy",
+    "ResolvedInputContract",
+    "CompositeInputContract",
+    "TokenBudgetStrategy",
+    "HuggingFaceTokenCounter",
     # Text chunking strategies
     "SlidingWindowStrategy",
     "SentenceStrategy",

--- a/clients/python/src/proximadb_sdk/chunking_strategies/base.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/base.py
@@ -127,6 +127,14 @@ class ChunkingConfig:
     # breakpoint is placed (LlamaIndex default: 95th percentile).
     breakpoint_percentile_threshold: float = 95.0
 
+    # Optional model-input budget. When present, the selected strategy proposes
+    # preferred structural boundaries and TokenBudgetStrategy owns final token
+    # segmentation. These are typed as Any so importing the base module remains
+    # dependency-light and existing character-based configurations are unchanged.
+    token_budget: Any | None = None
+    input_contract: Any | None = None
+    input_role: Any | None = None
+
 
 class ChunkingStrategyInterface(ABC):
     """
@@ -161,6 +169,24 @@ class ChunkingStrategyInterface(ABC):
             List of TextChunk objects
         """
         pass
+
+    def preferred_boundaries(
+        self,
+        text: str,
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> list[int]:
+        """Return preferred raw-text end offsets for an external size budget.
+
+        The compatibility default derives boundaries from this strategy's
+        ordinary chunks. Structural strategies override it to expose every
+        atomic boundary, independent of their legacy character-size grouping.
+        """
+        return [
+            chunk.end_pos
+            for chunk in self.chunk(text, source_id, base_metadata)
+            if 0 < chunk.end_pos <= len(text)
+        ]
 
     def chunk_stream(
         self,

--- a/clients/python/src/proximadb_sdk/chunking_strategies/contracts.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/contracts.py
@@ -1,0 +1,297 @@
+"""Model-input contracts used by token-budgeted chunking.
+
+The chunker depends on these small protocols instead of an embedding provider.
+This keeps chunking usable without loading a model while still letting a loaded
+provider supply the exact tokenizer, role prefixes, and effective context cap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class InputRole(str, Enum):
+    """How text will be presented to a retrieval embedding model."""
+
+    DOCUMENT = "document"
+    QUERY = "query"
+
+
+class OverflowPolicy(str, Enum):
+    """Policy for a source span that is larger than the token budget."""
+
+    SPLIT = "split"
+    ERROR = "error"
+    DROP = "drop"
+
+
+class ShortChunkPolicy(str, Enum):
+    """Policy for a final span below ``TokenBudget.min_content_tokens``."""
+
+    KEEP = "keep"
+    DROP = "drop"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class TokenBudget:
+    """Desired rendered-input budget and source-token overlap.
+
+    ``target_tokens`` counts the exact rendered model input, including role
+    prefixes and tokenizer special tokens. ``overlap_tokens`` and
+    ``min_content_tokens`` are measured by the primary tokenizer over raw source
+    text, before role rendering.
+    """
+
+    target_tokens: int
+    overlap_tokens: int = 0
+    min_content_tokens: int = 1
+    overflow_policy: OverflowPolicy = OverflowPolicy.SPLIT
+    short_chunk_policy: ShortChunkPolicy = ShortChunkPolicy.KEEP
+
+    def __post_init__(self) -> None:
+        if self.target_tokens <= 0:
+            raise ValueError("target_tokens must be positive")
+        if self.overlap_tokens < 0:
+            raise ValueError("overlap_tokens cannot be negative")
+        if self.overlap_tokens >= self.target_tokens:
+            raise ValueError("overlap_tokens must be less than target_tokens")
+        if self.min_content_tokens < 0:
+            raise ValueError("min_content_tokens cannot be negative")
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "target_tokens": self.target_tokens,
+            "overlap_tokens": self.overlap_tokens,
+            "min_content_tokens": self.min_content_tokens,
+            "overflow_policy": self.overflow_policy.value,
+            "short_chunk_policy": self.short_chunk_policy.value,
+        }
+
+
+@runtime_checkable
+class TokenCounter(Protocol):
+    """Exact token measurement plus optional raw-text offset mapping."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def fingerprint(self) -> str: ...
+
+    @property
+    def advertised_limit(self) -> int | None: ...
+
+    def count(self, text: str) -> int:
+        """Count fully rendered text, including model special tokens."""
+        ...
+
+    def content_offsets(self, text: str) -> Sequence[tuple[int, int]] | None:
+        """Return raw-token character offsets without special tokens."""
+        ...
+
+
+@dataclass(frozen=True)
+class InputRenderer:
+    """Role-specific, deterministic text rendering."""
+
+    document_template: str = "{text}"
+    query_template: str = "{text}"
+
+    def __post_init__(self) -> None:
+        for name, template in (
+            ("document_template", self.document_template),
+            ("query_template", self.query_template),
+        ):
+            if template.count("{text}") != 1:
+                raise ValueError(
+                    f"{name} must contain exactly one '{{text}}' placeholder"
+                )
+
+    def render(self, text: str, role: InputRole) -> str:
+        template = (
+            self.document_template
+            if role == InputRole.DOCUMENT
+            else self.query_template
+        )
+        return template.format(text=text)
+
+    @property
+    def fingerprint(self) -> str:
+        payload = json.dumps(
+            {
+                "document_template": self.document_template,
+                "query_template": self.query_template,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ResolvedInputContract:
+    """Runtime-verified model input contract."""
+
+    model_id: str
+    model_revision: str
+    counter: TokenCounter = field(compare=False, repr=False)
+    effective_context_limit: int
+    renderer: InputRenderer = field(default_factory=InputRenderer)
+    native_dimension: int | None = None
+    output_dimension: int | None = None
+    supported_output_dimensions: tuple[int, ...] = ()
+    minimum_output_dimension: int | None = None
+    document_encode_parameters: tuple[tuple[str, str], ...] = ()
+    query_encode_parameters: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.effective_context_limit <= 0:
+            raise ValueError("effective_context_limit must be positive")
+        advertised = self.counter.advertised_limit
+        if advertised is not None and self.effective_context_limit > advertised:
+            raise ValueError(
+                f"effective context {self.effective_context_limit} exceeds "
+                f"tokenizer limit {advertised} for {self.model_id}"
+            )
+        if self.native_dimension is not None and self.native_dimension <= 0:
+            raise ValueError("native_dimension must be positive")
+        if self.output_dimension is not None and self.output_dimension <= 0:
+            raise ValueError("output_dimension must be positive")
+        if (
+            self.native_dimension is not None
+            and self.output_dimension is not None
+            and self.output_dimension > self.native_dimension
+        ):
+            raise ValueError("output_dimension cannot exceed native_dimension")
+        if any(dimension <= 0 for dimension in self.supported_output_dimensions):
+            raise ValueError("supported_output_dimensions must all be positive")
+        if self.native_dimension is not None and any(
+            dimension > self.native_dimension
+            for dimension in self.supported_output_dimensions
+        ):
+            raise ValueError(
+                "supported_output_dimensions cannot exceed native_dimension"
+            )
+        if self.minimum_output_dimension is not None:
+            if self.minimum_output_dimension <= 0:
+                raise ValueError("minimum_output_dimension must be positive")
+            if (
+                self.native_dimension is not None
+                and self.minimum_output_dimension > self.native_dimension
+            ):
+                raise ValueError(
+                    "minimum_output_dimension cannot exceed native_dimension"
+                )
+
+    def render(self, text: str, role: InputRole) -> str:
+        return self.renderer.render(text, role)
+
+    def count(self, text: str, role: InputRole) -> int:
+        return self.counter.count(self.render(text, role))
+
+    def validate(self, text: str, role: InputRole) -> int:
+        count = self.count(text, role)
+        if count > self.effective_context_limit:
+            raise ValueError(
+                f"{self.model_id} {role.value} input has {count} tokens, exceeding "
+                f"the effective limit {self.effective_context_limit}"
+            )
+        return count
+
+    def _manifest_payload(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "tokenizer": self.counter.name,
+            "tokenizer_fingerprint": self.counter.fingerprint,
+            "effective_context_limit": self.effective_context_limit,
+            "renderer_fingerprint": self.renderer.fingerprint,
+            "document_template": self.renderer.document_template,
+            "query_template": self.renderer.query_template,
+            "native_dimension": self.native_dimension,
+            "output_dimension": self.output_dimension,
+            "supported_output_dimensions": list(self.supported_output_dimensions),
+            "minimum_output_dimension": self.minimum_output_dimension,
+            "document_encode_parameters": dict(self.document_encode_parameters),
+            "query_encode_parameters": dict(self.query_encode_parameters),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        payload = json.dumps(
+            self._manifest_payload(), sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {**self._manifest_payload(), "contract_fingerprint": self.fingerprint}
+
+
+@dataclass(frozen=True)
+class CompositeInputContract:
+    """Compatibility contract for a byte-identical multi-model corpus."""
+
+    contracts: tuple[ResolvedInputContract, ...]
+    primary_index: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.contracts:
+            raise ValueError("at least one input contract is required")
+        if not 0 <= self.primary_index < len(self.contracts):
+            raise ValueError("primary_index is outside the contracts tuple")
+        model_ids = [contract.model_id for contract in self.contracts]
+        if len(set(model_ids)) != len(model_ids):
+            raise ValueError("composite contract model_id values must be unique")
+
+    @property
+    def primary(self) -> ResolvedInputContract:
+        return self.contracts[self.primary_index]
+
+    @property
+    def minimum_context_limit(self) -> int:
+        return min(contract.effective_context_limit for contract in self.contracts)
+
+    def counts(self, text: str, role: InputRole) -> dict[str, int]:
+        return {
+            contract.model_id: contract.count(text, role) for contract in self.contracts
+        }
+
+    def fits(self, text: str, role: InputRole, target_tokens: int) -> bool:
+        return all(
+            contract.count(text, role)
+            <= min(target_tokens, contract.effective_context_limit)
+            for contract in self.contracts
+        )
+
+    def validate(self, text: str, role: InputRole) -> dict[str, int]:
+        return {
+            contract.model_id: contract.validate(text, role)
+            for contract in self.contracts
+        }
+
+    def to_manifest(self) -> dict[str, Any]:
+        payload = {
+            "primary_model_id": self.primary.model_id,
+            "contracts": [contract.to_manifest() for contract in self.contracts],
+        }
+        serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return {
+            **payload,
+            "contract_fingerprint": hashlib.sha256(
+                serialized.encode("utf-8")
+            ).hexdigest(),
+        }
+
+
+def as_composite_contract(
+    contract: ResolvedInputContract | CompositeInputContract,
+) -> CompositeInputContract:
+    if isinstance(contract, CompositeInputContract):
+        return contract
+    return CompositeInputContract((contract,))

--- a/clients/python/src/proximadb_sdk/chunking_strategies/factory.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/factory.py
@@ -13,6 +13,7 @@ from .semantic import SemanticStrategy
 from .semantic_embedding import SemanticEmbeddingStrategy
 from .sentence import SentenceStrategy
 from .sliding_window import SlidingWindowStrategy
+from .token_budget import TokenBudgetStrategy
 
 
 class ChunkingStrategyFactory:
@@ -74,11 +75,32 @@ class ChunkingStrategyFactory:
                     chunk_overlap=config.chunk_overlap,
                     min_chunk_size=config.min_chunk_size,
                     max_chunk_size=config.max_chunk_size,
+                    token_budget=config.token_budget,
+                    input_contract=config.input_contract,
+                    input_role=config.input_role,
                 )
 
-        # Create and return strategy instance
+        # Create the boundary strategy, then optionally decorate it with the
+        # exact model-input budget. No token budget means legacy character
+        # semantics remain byte-for-byte compatible.
         strategy_class = cls._strategies[strategy]
-        return strategy_class(config)
+        boundary_strategy = strategy_class(config)
+        if config.token_budget is None:
+            return boundary_strategy
+        if config.input_contract is None:
+            raise ValueError("input_contract is required when token_budget is set")
+
+        from .contracts import InputRole
+
+        role = config.input_role or InputRole.DOCUMENT
+        if isinstance(role, str):
+            role = InputRole(role)
+        return TokenBudgetStrategy(
+            boundary_strategy,
+            config.token_budget,
+            config.input_contract,
+            role=role,
+        )
 
     @classmethod
     def register_strategy(

--- a/clients/python/src/proximadb_sdk/chunking_strategies/paragraph.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/paragraph.py
@@ -227,6 +227,18 @@ class ParagraphStrategy(ChunkingStrategyInterface):
 
         return chunks
 
+    def preferred_boundaries(
+        self,
+        text: str,
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> list[int]:
+        """Expose every paragraph end without legacy character grouping."""
+        return [
+            *(match.start() for match in self.paragraph_pattern.finditer(text)),
+            len(text),
+        ]
+
     def chunk_stream(
         self,
         text_source: "str | Iterable[str]",

--- a/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/pipeline.py
@@ -541,6 +541,21 @@ class ChunkingPipeline:
                         if self.config.chunking_config
                         else 50
                     ),
+                    token_budget=(
+                        self.config.chunking_config.token_budget
+                        if self.config.chunking_config
+                        else None
+                    ),
+                    input_contract=(
+                        self.config.chunking_config.input_contract
+                        if self.config.chunking_config
+                        else None
+                    ),
+                    input_role=(
+                        self.config.chunking_config.input_role
+                        if self.config.chunking_config
+                        else None
+                    ),
                 )
             self.chunker = ChunkingStrategyFactory.create_strategy(
                 self.config.chunking_strategy, config

--- a/clients/python/src/proximadb_sdk/chunking_strategies/recursive.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/recursive.py
@@ -81,6 +81,21 @@ class RecursiveStrategy(ChunkingStrategyInterface):
 
         return final_chunks
 
+    def preferred_boundaries(
+        self,
+        text: str,
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> list[int]:
+        """Prefer paragraphs, then sentences, independent of char budgets."""
+        paragraph_ends = self.paragraph_strategy.preferred_boundaries(
+            text, source_id, base_metadata
+        )
+        sentence_ends = self.sentence_strategy.preferred_boundaries(
+            text, source_id, base_metadata
+        )
+        return sorted(set(paragraph_ends + sentence_ends))
+
     def _recursive_split(
         self,
         text: str,

--- a/clients/python/src/proximadb_sdk/chunking_strategies/sentence.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/sentence.py
@@ -210,6 +210,28 @@ class SentenceStrategy(ChunkingStrategyInterface):
 
         return chunks
 
+    def preferred_boundaries(
+        self,
+        text: str,
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> list[int]:
+        """Expose every real sentence boundary without character grouping."""
+        boundaries: list[int] = []
+        current = ""
+        previous = 0
+        for match in self.sentence_pattern.finditer(text):
+            part = text[previous : match.start()].strip()
+            previous = match.end()
+            if not part:
+                continue
+            current += (" " if current else "") + part
+            if self._is_sentence_end(current):
+                boundaries.append(match.start())
+                current = ""
+        boundaries.append(len(text))
+        return boundaries
+
     def chunk_stream(
         self,
         text_source: "str | Iterable[str]",

--- a/clients/python/src/proximadb_sdk/chunking_strategies/token_budget.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/token_budget.py
@@ -1,0 +1,217 @@
+"""Token-budget decorator for all boundary-selection strategies."""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any
+
+from .base import ChunkingStrategyInterface, TextChunk
+from .contracts import (
+    CompositeInputContract,
+    InputRole,
+    OverflowPolicy,
+    ResolvedInputContract,
+    ShortChunkPolicy,
+    TokenBudget,
+    as_composite_contract,
+)
+
+
+class TokenBudgetStrategy(ChunkingStrategyInterface):
+    """Apply an exact model-input budget over preferred structural boundaries.
+
+    The wrapped strategy proposes useful end positions (sentences, paragraphs,
+    code symbols, semantic spans). This decorator owns final coverage, overlap,
+    splitting, and exact validation. It intentionally materializes the source;
+    tokenizer-safe incremental streaming requires a separate boundary-state
+    contract and is not claimed here.
+    """
+
+    supports_streaming = False
+
+    def __init__(
+        self,
+        boundary_strategy: ChunkingStrategyInterface,
+        budget: TokenBudget,
+        input_contract: ResolvedInputContract | CompositeInputContract,
+        *,
+        role: InputRole = InputRole.DOCUMENT,
+    ):
+        super().__init__(boundary_strategy.config)
+        self.boundary_strategy = boundary_strategy
+        self.budget = budget
+        self.input_contract = as_composite_contract(input_contract)
+        self.role = role
+        if budget.target_tokens > self.input_contract.minimum_context_limit:
+            raise ValueError(
+                f"target_tokens={budget.target_tokens} exceeds the smallest model "
+                f"context {self.input_contract.minimum_context_limit}"
+            )
+
+    def _preferred_token_ends(
+        self,
+        text: str,
+        source_id: str,
+        base_metadata: dict[str, Any] | None,
+        token_ends: Sequence[int],
+    ) -> list[int]:
+        preferred: set[int] = set()
+        for end_pos in self.boundary_strategy.preferred_boundaries(
+            text, source_id, base_metadata
+        ):
+            if not 0 < end_pos <= len(text):
+                continue
+            token_end = bisect.bisect_right(token_ends, end_pos)
+            if token_end > 0:
+                preferred.add(token_end)
+        preferred.add(len(token_ends))
+        return sorted(preferred)
+
+    @staticmethod
+    def _char_bounds(
+        offsets: Sequence[tuple[int, int]],
+        start_token: int,
+        end_token: int,
+        text_length: int,
+    ) -> tuple[int, int]:
+        start_char = 0 if start_token == 0 else offsets[start_token][0]
+        end_char = (
+            text_length if end_token == len(offsets) else offsets[end_token - 1][1]
+        )
+        return start_char, end_char
+
+    def _greatest_fitting_end(
+        self,
+        text: str,
+        offsets: Sequence[tuple[int, int]],
+        start_token: int,
+    ) -> int:
+        low = start_token + 1
+        high = min(len(offsets), start_token + self.budget.target_tokens)
+        best: int | None = None
+        while low <= high:
+            middle = (low + high) // 2
+            start_char, end_char = self._char_bounds(
+                offsets, start_token, middle, len(text)
+            )
+            candidate = text[start_char:end_char]
+            if self.input_contract.fits(
+                candidate, self.role, self.budget.target_tokens
+            ):
+                best = middle
+                low = middle + 1
+            else:
+                high = middle - 1
+        if best is None:
+            raise ValueError(
+                "role prefix and tokenizer overhead leave no room for one source token "
+                f"inside target_tokens={self.budget.target_tokens}"
+            )
+        return best
+
+    def chunk(
+        self, text: str, source_id: str, base_metadata: dict[str, Any] | None = None
+    ) -> list[TextChunk]:
+        if not text or not text.strip():
+            return []
+
+        primary_counter = self.input_contract.primary.counter
+        offsets = primary_counter.content_offsets(text)
+        if offsets is None:
+            raise ValueError(
+                f"token counter {primary_counter.name} cannot provide source offsets"
+            )
+        offsets = tuple(offsets)
+        if not offsets:
+            return []
+
+        whole_counts = self.input_contract.counts(text, self.role)
+        if not self.input_contract.fits(text, self.role, self.budget.target_tokens):
+            if self.budget.overflow_policy == OverflowPolicy.ERROR:
+                raise ValueError(
+                    f"source input token counts {whole_counts} exceed target "
+                    f"{self.budget.target_tokens} or a model context limit"
+                )
+            if self.budget.overflow_policy == OverflowPolicy.DROP:
+                return []
+
+        token_ends = [end for _, end in offsets]
+        preferred = self._preferred_token_ends(
+            text, source_id, base_metadata, token_ends
+        )
+        chunks: list[TextChunk] = []
+        start_token = 0
+        while start_token < len(offsets):
+            maximum_end = self._greatest_fitting_end(text, offsets, start_token)
+            minimum_end = min(
+                len(offsets), start_token + self.budget.min_content_tokens
+            )
+            candidate_boundaries = [
+                end for end in preferred if minimum_end <= end <= maximum_end
+            ]
+            end_token = (
+                candidate_boundaries[-1] if candidate_boundaries else maximum_end
+            )
+            content_tokens = end_token - start_token
+            is_tail = end_token == len(offsets)
+            if is_tail and content_tokens < self.budget.min_content_tokens:
+                if self.budget.short_chunk_policy == ShortChunkPolicy.DROP:
+                    break
+                if self.budget.short_chunk_policy == ShortChunkPolicy.ERROR:
+                    raise ValueError(
+                        f"final source span has only {content_tokens} primary tokens"
+                    )
+
+            start_char, end_char = self._char_bounds(
+                offsets, start_token, end_token, len(text)
+            )
+            chunk_text = text[start_char:end_char]
+            counts = self.input_contract.validate(chunk_text, self.role)
+            if any(count > self.budget.target_tokens for count in counts.values()):
+                raise AssertionError(
+                    "internal error: emitted chunk exceeds target budget"
+                )
+
+            index = len(chunks)
+            metadata = {
+                **(base_metadata or {}),
+                "source_id": source_id,
+                "chunk_type": "token_budget",
+                "boundary_strategy": self.config.strategy.value,
+                "length_unit": "tokens",
+                "token_counts": counts,
+                "primary_tokenizer": primary_counter.name,
+                "primary_content_tokens": content_tokens,
+                "token_budget": self.budget.to_manifest(),
+                "input_role": self.role.value,
+                "has_overlap": index > 0 and self.budget.overlap_tokens > 0,
+                "overlap_tokens": self.budget.overlap_tokens if index > 0 else 0,
+            }
+            chunk = TextChunk(
+                text=chunk_text,
+                start_pos=start_char,
+                end_pos=end_char,
+                chunk_id=f"{source_id}_chunk_{index}",
+                metadata=metadata,
+            )
+            self.add_chunk_metadata(chunk, index, -1, "token_budget")
+            chunks.append(chunk)
+
+            if is_tail:
+                break
+            next_start = end_token - self.budget.overlap_tokens
+            start_token = max(start_token + 1, next_start)
+
+        for chunk in chunks:
+            chunk.metadata["total_chunks"] = len(chunks)
+        return chunks
+
+    def chunk_stream(
+        self,
+        text_source: str | Iterable[str],
+        source_id: str,
+        base_metadata: dict[str, Any] | None = None,
+    ) -> Iterator[TextChunk]:
+        text = text_source if isinstance(text_source, str) else "".join(text_source)
+        yield from self.chunk(text, source_id, base_metadata)

--- a/clients/python/src/proximadb_sdk/chunking_strategies/tokenizers.py
+++ b/clients/python/src/proximadb_sdk/chunking_strategies/tokenizers.py
@@ -1,0 +1,99 @@
+"""Tokenizer adapters for model-agnostic chunk budget contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from typing import Any
+
+
+class HuggingFaceTokenCounter:
+    """Adapt a fast Hugging Face tokenizer to the ``TokenCounter`` protocol."""
+
+    def __init__(self, tokenizer: Any):
+        if not getattr(tokenizer, "is_fast", False):
+            raise ValueError("token-budget splitting requires a fast tokenizer")
+        self._tokenizer = tokenizer
+        backend = tokenizer.backend_tokenizer.to_str().encode("utf-8")
+        self._fingerprint = hashlib.sha256(backend).hexdigest()
+
+    @classmethod
+    def from_pretrained(
+        cls, model_id: str, *, revision: str | None = None, **kwargs: Any
+    ) -> HuggingFaceTokenCounter:
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(
+                "transformers is required for Hugging Face token-aware chunking; "
+                "install proximadb[embeddings]"
+            ) from exc
+        tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision, **kwargs)
+        return cls(tokenizer)
+
+    @property
+    def tokenizer(self) -> Any:
+        return self._tokenizer
+
+    @property
+    def name(self) -> str:
+        return str(getattr(self._tokenizer, "name_or_path", "huggingface-tokenizer"))
+
+    @property
+    def fingerprint(self) -> str:
+        return self._fingerprint
+
+    @property
+    def advertised_limit(self) -> int | None:
+        value = getattr(self._tokenizer, "model_max_length", None)
+        if not isinstance(value, int) or value <= 0 or value >= 1_000_000_000:
+            return None
+        return value
+
+    @property
+    def resolved_revision(self) -> str | None:
+        """Best-effort immutable Hub revision from tokenizer metadata/cache paths."""
+        init_kwargs = getattr(self._tokenizer, "init_kwargs", {}) or {}
+        direct = init_kwargs.get("_commit_hash") or init_kwargs.get("commit_hash")
+        if direct:
+            return str(direct)
+        candidates = [value for value in init_kwargs.values() if isinstance(value, str)]
+        for attribute in ("vocab_file", "tokenizer_file"):
+            value = getattr(self._tokenizer, attribute, None)
+            if isinstance(value, str):
+                candidates.append(value)
+        for candidate in candidates:
+            match = re.search(
+                r"[/\\]snapshots[/\\]([0-9a-f]{40})(?:[/\\]|$)", candidate
+            )
+            if match:
+                return match.group(1)
+        return None
+
+    def count(self, text: str) -> int:
+        encoded = self._tokenizer(
+            text,
+            add_special_tokens=True,
+            truncation=False,
+            return_attention_mask=False,
+            return_token_type_ids=False,
+            verbose=False,
+        )
+        return len(encoded["input_ids"])
+
+    def content_offsets(self, text: str) -> Sequence[tuple[int, int]]:
+        encoded = self._tokenizer(
+            text,
+            add_special_tokens=False,
+            truncation=False,
+            return_attention_mask=False,
+            return_token_type_ids=False,
+            return_offsets_mapping=True,
+            verbose=False,
+        )
+        return tuple(
+            (int(start), int(end))
+            for start, end in encoded["offset_mapping"]
+            if end > start
+        )

--- a/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/__init__.py
@@ -7,6 +7,8 @@ Clean, extensible embedding provider system with:
 - Plugin-based provider registration
 """
 
+from dataclasses import replace
+
 # Core components (light — registry, config, base classes; no model deps)
 from .core import (
     BaseEmbeddingProvider,
@@ -33,6 +35,11 @@ _PROVIDER_EXPORTS = {
     "BGEProvider": (".providers.local.bge", "BGEProvider"),
     "E5Provider": (".providers.local.e5", "E5Provider"),
     "GTEQwenProvider": (".providers.local.gte_qwen", "GTEQwenProvider"),
+    "NomicProvider": (".providers.local.nomic", "NomicProvider"),
+    "OpenWeightsProvider": (
+        ".providers.local.open_weights",
+        "OpenWeightsProvider",
+    ),
     "SentenceTransformerProvider": (
         ".providers.local.sentence_transformer",
         "SentenceTransformerProvider",
@@ -112,22 +119,42 @@ def get_provider(name: str, **config_kwargs):
 
     # Handle dimension specially
     if "dimension" in config_kwargs:
-        new_model = ModelMetadata(
-            name=default_config.model.name,
-            dimension=config_kwargs.pop("dimension"),
-            max_length=default_config.model.max_length,
-            provider_type=default_config.model.provider_type,
-            requires_instruction=default_config.model.requires_instruction,
-            instruction_template=default_config.model.instruction_template,
-            mteb_score=default_config.model.mteb_score,
-            languages=default_config.model.languages,
-            description=default_config.model.description,
-            use_case=default_config.model.use_case,
+        dimension = config_kwargs.pop("dimension")
+        dimension_policy = bool(
+            default_config.model.supported_output_dimensions
+            or default_config.model.minimum_output_dimension is not None
         )
-        config_kwargs["model"] = new_model
+        if dimension == default_config.model.dimension:
+            pass
+        elif default_config.model.supports_dimension(dimension):
+            extra = dict(config_kwargs.pop("extra", {}))
+            extra["truncate_dim"] = dimension
+            config_kwargs["extra"] = extra
+        elif dimension_policy:
+            raise ValueError(
+                f"{default_config.model.name} does not support {dimension} dimensions"
+            )
+        else:
+            config_kwargs["model"] = replace(default_config.model, dimension=dimension)
 
     config = default_config.merge(**config_kwargs)
     return provider_class(config)
+
+
+def get_open_embedding_model(
+    model_id: str, *, dimension: int | None = None, **config_kwargs
+):
+    """Create any model in the curated open-weight catalog."""
+    from .providers.local.open_weights import create_open_model_provider
+
+    return create_open_model_provider(model_id, dimension=dimension, **config_kwargs)
+
+
+def list_open_embedding_models(**filters):
+    """List curated open-weight model specs by family/license filter."""
+    from .catalog import list_open_models
+
+    return list_open_models(**filters)
 
 
 def list_providers(include_aliases: bool = False) -> list[str]:
@@ -214,12 +241,16 @@ __all__ = [
     "get_provider",
     "list_providers",
     "get_provider_info",
+    "get_open_embedding_model",
+    "list_open_embedding_models",
     "recommend_free_providers",
     # Backward compatibility (deprecated)
     "get_embedding_provider",
     "get_default_embedding_provider",
     # Providers
     "GTEQwenProvider",
+    "NomicProvider",
+    "OpenWeightsProvider",
     "SimulatedEmbeddingProvider",
     "OpenAIProvider",
     "CohereProvider",

--- a/clients/python/src/proximadb_sdk/embedding_providers/catalog.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/catalog.py
@@ -1,0 +1,297 @@
+"""Curated open-weight text embedding model contracts.
+
+Facts are intentionally declarative and source-linked. Runtime contracts still
+intersect these declarations with the loaded tokenizer/model and persist the
+resolved revision. Add variants here instead of creating provider subclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .core.config import ModelMetadata
+
+OPEN_MODEL_CATALOG_VERSION = "2026-08-11"
+
+
+@dataclass(frozen=True)
+class OpenModelSpec:
+    """Loading and adoption metadata around a model input/output contract."""
+
+    metadata: ModelMetadata
+    family: str
+    trust_remote_code: bool = False
+    notes: str = ""
+
+
+def _metadata(
+    name: str,
+    dimension: int,
+    max_length: int,
+    *,
+    license_id: str,
+    languages: str = "en",
+    document_template: str = "{text}",
+    query_template: str | None = None,
+    discrete_dimensions: tuple[int, ...] = (),
+    minimum_dimension: int | None = None,
+    access: str = "open",
+    source_url: str | None = None,
+    document_parameters: tuple[tuple[str, str], ...] = (),
+    query_parameters: tuple[tuple[str, str], ...] = (),
+) -> ModelMetadata:
+    return ModelMetadata(
+        name=name,
+        dimension=dimension,
+        max_length=max_length,
+        requires_instruction=query_template is not None,
+        document_template=document_template,
+        query_template=query_template,
+        supported_output_dimensions=discrete_dimensions,
+        minimum_output_dimension=minimum_dimension,
+        languages=languages,
+        license_id=license_id,
+        access=access,
+        source_url=source_url or f"https://huggingface.co/{name}",
+        document_encode_parameters=document_parameters,
+        query_encode_parameters=query_parameters,
+    )
+
+
+_BGE_QUERY = "Represent this sentence for searching relevant passages: {text}"
+_QWEN_QUERY = (
+    "Instruct: Given a web search query, retrieve relevant passages that answer "
+    "the query\nQuery:{text}"
+)
+
+
+OPEN_MODEL_CATALOG: dict[str, OpenModelSpec] = {
+    "sentence-transformers/all-MiniLM-L6-v2": OpenModelSpec(
+        _metadata(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            384,
+            256,
+            license_id="apache-2.0",
+        ),
+        "sentence-transformers",
+        notes="The model card says inputs beyond 256 WordPieces are truncated.",
+    ),
+    "sentence-transformers/all-mpnet-base-v2": OpenModelSpec(
+        _metadata(
+            "sentence-transformers/all-mpnet-base-v2",
+            768,
+            384,
+            license_id="apache-2.0",
+        ),
+        "sentence-transformers",
+        notes="SentenceTransformers max_seq_length is 384.",
+    ),
+    **{
+        model_id: OpenModelSpec(
+            _metadata(
+                model_id,
+                dimension,
+                512,
+                license_id="mit",
+                query_template=_BGE_QUERY,
+            ),
+            "bge-v1.5",
+        )
+        for model_id, dimension in (
+            ("BAAI/bge-small-en-v1.5", 384),
+            ("BAAI/bge-base-en-v1.5", 768),
+            ("BAAI/bge-large-en-v1.5", 1024),
+        )
+    },
+    "BAAI/bge-m3": OpenModelSpec(
+        _metadata(
+            "BAAI/bge-m3",
+            1024,
+            8192,
+            license_id="mit",
+            languages="multilingual",
+        ),
+        "bge-m3",
+        notes="Dense BGE-M3 does not require the BGE v1.5 query instruction.",
+    ),
+    **{
+        model_id: OpenModelSpec(
+            _metadata(
+                model_id,
+                dimension,
+                512,
+                license_id="mit",
+                document_template="passage: {text}",
+                query_template="query: {text}",
+            ),
+            "e5-v2",
+        )
+        for model_id, dimension in (
+            ("intfloat/e5-small-v2", 384),
+            ("intfloat/e5-base-v2", 768),
+            ("intfloat/e5-large-v2", 1024),
+            ("intfloat/multilingual-e5-large", 1024),
+        )
+    },
+    "nomic-ai/nomic-embed-text-v1.5": OpenModelSpec(
+        _metadata(
+            "nomic-ai/nomic-embed-text-v1.5",
+            768,
+            8192,
+            license_id="apache-2.0",
+            document_template="search_document: {text}",
+            query_template="search_query: {text}",
+            discrete_dimensions=(768, 512, 256, 128, 64),
+        ),
+        "nomic-v1.5",
+        trust_remote_code=True,
+    ),
+    "nomic-ai/nomic-embed-text-v2-moe": OpenModelSpec(
+        _metadata(
+            "nomic-ai/nomic-embed-text-v2-moe",
+            768,
+            512,
+            license_id="apache-2.0",
+            languages="100+",
+            document_template="search_document: {text}",
+            query_template="search_query: {text}",
+            minimum_dimension=256,
+        ),
+        "nomic-v2-moe",
+        trust_remote_code=True,
+    ),
+    "Alibaba-NLP/gte-multilingual-base": OpenModelSpec(
+        _metadata(
+            "Alibaba-NLP/gte-multilingual-base",
+            768,
+            8192,
+            license_id="apache-2.0",
+            languages="75",
+            minimum_dimension=128,
+        ),
+        "gte-multilingual",
+        trust_remote_code=True,
+    ),
+    "Snowflake/snowflake-arctic-embed-l-v2.0": OpenModelSpec(
+        _metadata(
+            "Snowflake/snowflake-arctic-embed-l-v2.0",
+            1024,
+            8192,
+            license_id="apache-2.0",
+            languages="multilingual",
+            query_template="query: {text}",
+            discrete_dimensions=(1024, 256),
+        ),
+        "arctic-embed-v2",
+    ),
+    "jinaai/jina-embeddings-v2-base-en": OpenModelSpec(
+        _metadata(
+            "jinaai/jina-embeddings-v2-base-en",
+            768,
+            8192,
+            license_id="apache-2.0",
+        ),
+        "jina-v2",
+        trust_remote_code=True,
+    ),
+    "jinaai/jina-embeddings-v3": OpenModelSpec(
+        _metadata(
+            "jinaai/jina-embeddings-v3",
+            1024,
+            8192,
+            license_id="cc-by-nc-4.0",
+            languages="94",
+            discrete_dimensions=(1024, 768, 512, 256, 128, 64, 32),
+            document_parameters=(("task", "retrieval.passage"),),
+            query_parameters=(("task", "retrieval.query"),),
+        ),
+        "jina-v3",
+        trust_remote_code=True,
+        notes="Non-commercial license; retrieval role is an adapter parameter.",
+    ),
+    "mixedbread-ai/mxbai-embed-large-v1": OpenModelSpec(
+        _metadata(
+            "mixedbread-ai/mxbai-embed-large-v1",
+            1024,
+            512,
+            license_id="apache-2.0",
+            query_template=_BGE_QUERY,
+            discrete_dimensions=(1024, 512),
+        ),
+        "mixedbread",
+        notes="Only dimensions explicitly demonstrated by the model card are listed.",
+    ),
+    **{
+        model_id: OpenModelSpec(
+            _metadata(
+                model_id,
+                dimension,
+                32768,
+                license_id="apache-2.0",
+                languages="100+",
+                query_template=_QWEN_QUERY,
+                minimum_dimension=32,
+            ),
+            "qwen3-embedding",
+        )
+        for model_id, dimension in (
+            ("Qwen/Qwen3-Embedding-0.6B", 1024),
+            ("Qwen/Qwen3-Embedding-4B", 2560),
+            ("Qwen/Qwen3-Embedding-8B", 4096),
+        )
+    },
+    "google/embeddinggemma-300m": OpenModelSpec(
+        _metadata(
+            "google/embeddinggemma-300m",
+            768,
+            2048,
+            license_id="gemma",
+            languages="100+",
+            document_template="title: none | text: {text}",
+            query_template="task: search result | query: {text}",
+            discrete_dimensions=(768, 512, 256, 128),
+            access="gated",
+        ),
+        "embeddinggemma",
+        notes="Weights require accepting the Gemma terms on Hugging Face.",
+    ),
+    "ibm-granite/granite-embedding-311m-multilingual-r2": OpenModelSpec(
+        _metadata(
+            "ibm-granite/granite-embedding-311m-multilingual-r2",
+            768,
+            32768,
+            license_id="apache-2.0",
+            languages="200+",
+            discrete_dimensions=(768, 512, 384, 256, 128),
+        ),
+        "granite-embedding-r2",
+    ),
+}
+
+
+def get_open_model_spec(model_id: str) -> OpenModelSpec:
+    """Return a curated spec or fail with a discoverable model list."""
+    try:
+        return OPEN_MODEL_CATALOG[model_id]
+    except KeyError as exc:
+        available = ", ".join(sorted(OPEN_MODEL_CATALOG))
+        raise ValueError(
+            f"unknown open embedding model {model_id!r}: {available}"
+        ) from exc
+
+
+def list_open_models(
+    *, family: str | None = None, commercially_usable: bool | None = None
+) -> list[OpenModelSpec]:
+    """List specs with optional family and permissive-license filtering."""
+    specs = list(OPEN_MODEL_CATALOG.values())
+    if family is not None:
+        specs = [spec for spec in specs if spec.family == family]
+    if commercially_usable is not None:
+        noncommercial = {"cc-by-nc-4.0"}
+        specs = [
+            spec
+            for spec in specs
+            if (spec.metadata.license_id not in noncommercial) == commercially_usable
+        ]
+    return sorted(specs, key=lambda spec: spec.metadata.name)

--- a/clients/python/src/proximadb_sdk/embedding_providers/core/base.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/core/base.py
@@ -150,7 +150,26 @@ class BaseEmbeddingProvider(ABC):
         Returns:
             Dimension of embedding vectors
         """
-        return self.config.model.dimension
+        truncate_dim = self.config.extra.get("truncate_dim")
+        if truncate_dim is None:
+            return self.config.model.dimension
+        if not isinstance(truncate_dim, int) or truncate_dim <= 0:
+            raise ValueError("extra['truncate_dim'] must be a positive integer")
+        model = self.config.model
+        if not model.supports_dimension(truncate_dim):
+            supported = model.supported_output_dimensions
+            guidance = (
+                str(supported)
+                if supported
+                else f"{model.minimum_output_dimension}..{model.dimension}"
+            )
+            raise ValueError(
+                f"dimension {truncate_dim} is not supported by "
+                f"{model.name}; choose {guidance}"
+            )
+        if truncate_dim > self.config.model.dimension:
+            raise ValueError("truncate_dim cannot exceed the native dimension")
+        return truncate_dim
 
     def embed_text(self, text: str) -> np.ndarray:
         """
@@ -211,8 +230,17 @@ class BaseEmbeddingProvider(ABC):
         """
         return {
             "name": self.config.model.name,
-            "dimension": self.config.model.dimension,
+            "dimension": self.get_dimension(),
+            "native_dimension": self.config.model.dimension,
             "max_length": self.config.model.max_length,
+            "revision": self.config.model.revision,
+            "supported_output_dimensions": list(
+                self.config.model.supported_output_dimensions
+            ),
+            "minimum_output_dimension": self.config.model.minimum_output_dimension,
+            "license_id": self.config.model.license_id,
+            "access": self.config.model.access,
+            "source_url": self.config.model.source_url,
             "mteb_score": self.config.model.mteb_score,
             "languages": self.config.model.languages,
             "description": self.config.model.description,

--- a/clients/python/src/proximadb_sdk/embedding_providers/core/config.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/core/config.py
@@ -27,6 +27,11 @@ class ModelMetadata:
         languages: Supported languages ("en", "multilingual", "100+", etc.)
         description: Human-readable description
         use_case: Recommended use cases
+        revision: Optional immutable model revision requested at load time
+        tokenizer_name: Tokenizer ID when it differs from the model ID
+        document_template: Exact document rendering template
+        query_template: Exact query rendering template
+        supported_output_dimensions: Valid Matryoshka/truncated dimensions
     """
 
     name: str
@@ -39,6 +44,60 @@ class ModelMetadata:
     languages: str = "en"
     description: str = ""
     use_case: str = ""
+    revision: str | None = None
+    tokenizer_name: str | None = None
+    document_template: str = "{text}"
+    query_template: str | None = None
+    supported_output_dimensions: tuple[int, ...] = ()
+    minimum_output_dimension: int | None = None
+    output_dimension_step: int = 1
+    license_id: str = "unknown"
+    access: str = "open"
+    source_url: str = ""
+    document_encode_parameters: tuple[tuple[str, str], ...] = ()
+    query_encode_parameters: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.dimension <= 0:
+            raise ValueError("dimension must be positive")
+        if self.max_length <= 0:
+            raise ValueError("max_length must be positive")
+        if self.document_template.count("{text}") != 1:
+            raise ValueError("document_template must contain exactly one '{text}'")
+        if self.query_template is not None and self.query_template.count("{text}") != 1:
+            raise ValueError("query_template must contain exactly one '{text}'")
+        if any(dimension <= 0 for dimension in self.supported_output_dimensions):
+            raise ValueError("supported_output_dimensions must all be positive")
+        if any(
+            dimension > self.dimension for dimension in self.supported_output_dimensions
+        ):
+            raise ValueError(
+                "supported_output_dimensions cannot exceed native dimension"
+            )
+        if self.minimum_output_dimension is not None:
+            if not 0 < self.minimum_output_dimension <= self.dimension:
+                raise ValueError(
+                    "minimum_output_dimension must be positive and no larger "
+                    "than dimension"
+                )
+        if self.output_dimension_step <= 0:
+            raise ValueError("output_dimension_step must be positive")
+        if self.access not in {"open", "gated"}:
+            raise ValueError("access must be 'open' or 'gated'")
+
+    def supports_dimension(self, dimension: int) -> bool:
+        """Return whether native/Matryoshka output supports ``dimension``."""
+        if dimension == self.dimension:
+            return True
+        if self.supported_output_dimensions:
+            return dimension in self.supported_output_dimensions
+        if self.minimum_output_dimension is None:
+            return False
+        return (
+            self.minimum_output_dimension <= dimension <= self.dimension
+            and (dimension - self.minimum_output_dimension) % self.output_dimension_step
+            == 0
+        )
 
     def __str__(self) -> str:
         """Human-readable representation"""

--- a/clients/python/src/proximadb_sdk/embedding_providers/mixins/instruction.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/mixins/instruction.py
@@ -54,30 +54,20 @@ class InstructionMixin:
             >>> result = mixin.apply_instruction("machine learning", is_query=True)
             >>> # Returns: "Instruct: Given a query, retrieve relevant passages\nQuery: machine learning"
         """
-        # Only apply to queries, not passages
-        if not is_query:
-            return text
-
-        # Check if model requires instruction
-        if not self.config.model.requires_instruction:
-            return text
-
-        # Get instruction template
-        template = self.config.model.instruction_template
+        if is_query:
+            template = self.config.model.query_template
+            if template is None and self.config.model.requires_instruction:
+                template = self.config.model.instruction_template
+        else:
+            template = self.config.model.document_template
         if not template:
-            logger.warning(
-                f"Model {self.config.model.name} requires_instruction=True "
-                f"but has no instruction_template. Using plain text."
-            )
             return text
 
-        # Apply template
         try:
-            return template.format(query=text)
+            return template.format(query=text, text=text)
         except KeyError as e:
             logger.error(
-                f"Invalid instruction template: {template}. "
-                f"Missing placeholder: {e}"
+                f"Invalid instruction template: {template}. Missing placeholder: {e}"
             )
             return text
 
@@ -97,9 +87,11 @@ class InstructionMixin:
             >>> print(query_emb.shape)
             (1536,)
         """
+        role_encoder = getattr(self, "_encode_with_prompt", None)
+        if callable(role_encoder):
+            return role_encoder([query], "query")[0]
         instructed_query = self.apply_instruction(query, is_query=True)
-        embeddings = self.embed([instructed_query])
-        return embeddings[0]
+        return self.embed([instructed_query])[0]
 
     def embed_queries(self, queries: list[str]) -> np.ndarray:
         """
@@ -118,6 +110,9 @@ class InstructionMixin:
             >>> print(query_embs.shape)
             (2, 1536)
         """
+        role_encoder = getattr(self, "_encode_with_prompt", None)
+        if callable(role_encoder):
+            return role_encoder(queries, "query")
         instructed_queries = [self.apply_instruction(q, is_query=True) for q in queries]
         return self.embed(instructed_queries)
 
@@ -138,8 +133,11 @@ class InstructionMixin:
             >>> print(passage_embs.shape)
             (2, 1536)
         """
-        # Passages don't get instructions
-        return self.embed(passages)
+        role_encoder = getattr(self, "_encode_with_prompt", None)
+        if callable(role_encoder):
+            return role_encoder(passages, "document")
+        rendered = [self.apply_instruction(text, is_query=False) for text in passages]
+        return self.embed(rendered)
 
     def embed_documents(self, documents: list[dict]) -> np.ndarray:
         """

--- a/clients/python/src/proximadb_sdk/embedding_providers/mixins/sentence_transformer.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/mixins/sentence_transformer.py
@@ -4,6 +4,7 @@ SentenceTransformer mixin
 Provides sentence-transformers integration with model caching.
 """
 
+import json
 import logging
 
 import numpy as np
@@ -65,13 +66,16 @@ class SentenceTransformerMixin:
         device = resolve_device(self.config.device)
         backend = self.config.backend
         prompts = self.config.extra.get("prompts")
+        revision = self.config.model.revision
+        truncate_dim = self.config.extra.get("truncate_dim")
 
         cache = ModelCache()
         # Device + backend + prompts participate in identity: two providers that
         # ask for different runtimes must NOT share a cached instance.
         cache_key = (
             f"st_{self.config.model.name}_{self.config.trust_remote_code}"
-            f"_{device}_{backend}_{sorted(prompts) if prompts else None}"
+            f"_{device}_{backend}_{revision}_{truncate_dim}_"
+            f"{json.dumps(prompts, sort_keys=True) if prompts else None}"
         )
 
         def loader():
@@ -90,9 +94,18 @@ class SentenceTransformerMixin:
                 kwargs["backend"] = backend
             if prompts:
                 kwargs["prompts"] = prompts
+            if revision is not None:
+                kwargs["revision"] = revision
+            if truncate_dim is not None:
+                kwargs["truncate_dim"] = truncate_dim
             try:
                 model = SentenceTransformer(self.config.model.name, **kwargs)
-            except TypeError:
+            except TypeError as exc:
+                if revision is not None or truncate_dim is not None:
+                    raise TypeError(
+                        "the installed sentence-transformers version cannot honor "
+                        "the requested revision/truncate_dim; upgrade the dependency"
+                    ) from exc
                 # Older sentence-transformers without backend/prompts kwargs:
                 # retry with the universally-supported subset.
                 logger.warning(
@@ -111,6 +124,95 @@ class SentenceTransformerMixin:
 
         return cache.get_or_load(cache_key, loader)
 
+    @staticmethod
+    def _prompt_template(prompt: str) -> str:
+        """Convert a SentenceTransformers prefix into an input template."""
+        return prompt if "{text}" in prompt else f"{prompt}{{text}}"
+
+    def get_input_contract(self):
+        """Resolve the exact tokenizer/rendering contract used for chunking.
+
+        Model metadata is a declaration. This method loads the configured runtime
+        and intersects that declaration with the actual tokenizer and model caps.
+        Corpus builders should persist ``contract.to_manifest()`` beside texts.
+        """
+        from ...chunking_strategies.contracts import (
+            InputRenderer,
+            ResolvedInputContract,
+        )
+        from ...chunking_strategies.tokenizers import HuggingFaceTokenCounter
+
+        self.ensure_initialized()
+        tokenizer = getattr(self._model, "tokenizer", None)
+        if tokenizer is None:
+            raise ValueError(
+                f"loaded model {self.config.model.name} exposes no tokenizer"
+            )
+        counter = HuggingFaceTokenCounter(tokenizer)
+
+        declared_limit = self.config.model.max_length
+        runtime_limit = getattr(self._model, "max_seq_length", None)
+        limits = [declared_limit]
+        if isinstance(runtime_limit, int) and runtime_limit > 0:
+            limits.append(runtime_limit)
+        if counter.advertised_limit is not None:
+            limits.append(counter.advertised_limit)
+        effective_limit = min(limits)
+
+        metadata = self.config.model
+        prompts = self.config.extra.get("prompts") or {}
+        if "document" in prompts:
+            document_template = self._prompt_template(prompts["document"])
+        else:
+            document_template = metadata.document_template
+
+        if "query" in prompts:
+            query_template = self._prompt_template(prompts["query"])
+        else:
+            query_template = metadata.query_template
+            if query_template is None and metadata.requires_instruction:
+                legacy = metadata.instruction_template
+                if legacy is not None:
+                    query_template = legacy.replace("{query}", "{text}")
+        if query_template is None:
+            query_template = "{text}"
+
+        configured_dimension = self.get_dimension()
+        dimension_getter = getattr(
+            self._model, "get_sentence_embedding_dimension", None
+        )
+        runtime_dimension = dimension_getter() if callable(dimension_getter) else None
+        if runtime_dimension is not None and runtime_dimension != configured_dimension:
+            raise ValueError(
+                f"configured output dimension {configured_dimension} does not match "
+                f"runtime dimension {runtime_dimension} for {metadata.name}"
+            )
+
+        init_kwargs = getattr(tokenizer, "init_kwargs", {}) or {}
+        resolved_revision = (
+            metadata.revision
+            or counter.resolved_revision
+            or init_kwargs.get("_commit_hash")
+            or init_kwargs.get("commit_hash")
+            or "unresolved"
+        )
+        return ResolvedInputContract(
+            model_id=metadata.name,
+            model_revision=str(resolved_revision),
+            counter=counter,
+            effective_context_limit=effective_limit,
+            renderer=InputRenderer(
+                document_template=document_template,
+                query_template=query_template,
+            ),
+            native_dimension=metadata.dimension,
+            output_dimension=configured_dimension,
+            supported_output_dimensions=metadata.supported_output_dimensions,
+            minimum_output_dimension=metadata.minimum_output_dimension,
+            document_encode_parameters=metadata.document_encode_parameters,
+            query_encode_parameters=metadata.query_encode_parameters,
+        )
+
     def _encode_with_prompt(self, texts: list[str], prompt_name: str) -> np.ndarray:
         """Encode using a registered native ST prompt, falling back to a plain
         encode if the prompt was not configured."""
@@ -118,11 +220,32 @@ class SentenceTransformerMixin:
             return np.array([])
         self.ensure_initialized()
         configured = self.config.extra.get("prompts") or {}
+        if prompt_name not in configured:
+            metadata = self.config.model
+            if prompt_name == "document":
+                template = metadata.document_template
+            else:
+                template = metadata.query_template
+                if template is None and metadata.requires_instruction:
+                    legacy = metadata.instruction_template
+                    template = (
+                        legacy.replace("{query}", "{text}")
+                        if legacy is not None
+                        else None
+                    )
+            if template:
+                texts = [template.format(text=text) for text in texts]
+        role_parameters = (
+            self.config.model.document_encode_parameters
+            if prompt_name == "document"
+            else self.config.model.query_encode_parameters
+        )
         encode_kwargs = {
             "batch_size": self.config.batch_size,
             "normalize_embeddings": self.config.normalize,
             "show_progress_bar": False,
             "convert_to_numpy": True,
+            **dict(role_parameters),
         }
         if prompt_name in configured:
             encode_kwargs["prompt_name"] = prompt_name

--- a/clients/python/src/proximadb_sdk/embedding_providers/providers/local/e5.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/providers/local/e5.py
@@ -4,8 +4,6 @@ E5 (Text Embeddings by Weakly-Supervised Contrastive Pre-training) Provider
 Microsoft's excellent general-purpose embeddings with query/passage prefix support.
 """
 
-import numpy as np
-
 from ...core.base import BaseEmbeddingProvider
 from ...core.config import ModelMetadata, ProviderConfig
 from ...core.registry import ProviderRegistry
@@ -20,6 +18,8 @@ E5_MODELS = {
         provider_type="sentence-transformer",
         requires_instruction=True,
         instruction_template="query: {query}",
+        document_template="passage: {text}",
+        query_template="query: {text}",
         mteb_score=65.0,
         languages="en",
         description="Best quality, top MTEB performer",
@@ -32,6 +32,8 @@ E5_MODELS = {
         provider_type="sentence-transformer",
         requires_instruction=True,
         instruction_template="query: {query}",
+        document_template="passage: {text}",
+        query_template="query: {text}",
         mteb_score=64.5,
         languages="en",
         description="Balanced quality and speed",
@@ -44,6 +46,8 @@ E5_MODELS = {
         provider_type="sentence-transformer",
         requires_instruction=True,
         instruction_template="query: {query}",
+        document_template="passage: {text}",
+        query_template="query: {text}",
         mteb_score=62.8,
         languages="en",
         description="Fast and efficient",
@@ -56,6 +60,8 @@ E5_MODELS = {
         provider_type="sentence-transformer",
         requires_instruction=True,
         instruction_template="query: {query}",
+        document_template="passage: {text}",
+        query_template="query: {text}",
         mteb_score=64.0,
         languages="100+",
         description="Multilingual support for 100+ languages",
@@ -99,9 +105,6 @@ class E5Provider(InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvid
     - Passages: "passage: {text}" (handled automatically)
     """
 
-    #: E5 models require this prefix on documents/passages (not just queries).
-    PASSAGE_PREFIX = "passage: "
-
     def default_config(self) -> ProviderConfig:
         """Default to large model"""
         return ProviderConfig(
@@ -110,14 +113,3 @@ class E5Provider(InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvid
             normalize=True,
             extra={"use_query_instruction": True},
         )
-
-    def embed_passages(self, passages: list[str]) -> np.ndarray:
-        """Embed passages with the mandatory E5 ``"passage: "`` prefix.
-
-        Unlike the generic :class:`InstructionMixin` (which leaves passages
-        unprefixed), E5 was trained with an asymmetric ``query:``/``passage:``
-        scheme. Omitting the passage prefix silently degrades retrieval recall,
-        so we prepend it here.
-        """
-        prefixed = [f"{self.PASSAGE_PREFIX}{p}" for p in passages]
-        return self.embed(prefixed)

--- a/clients/python/src/proximadb_sdk/embedding_providers/providers/local/nomic.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/providers/local/nomic.py
@@ -1,0 +1,34 @@
+"""Nomic retrieval embedding providers with explicit input contracts."""
+
+from ...catalog import OPEN_MODEL_CATALOG
+from ...core.base import BaseEmbeddingProvider
+from ...core.config import ProviderConfig
+from ...core.registry import ProviderRegistry
+from ...mixins.instruction import InstructionMixin
+from ...mixins.sentence_transformer import SentenceTransformerMixin
+
+NOMIC_MODELS = {
+    model_id: OPEN_MODEL_CATALOG[model_id].metadata
+    for model_id in (
+        "nomic-ai/nomic-embed-text-v1.5",
+        "nomic-ai/nomic-embed-text-v2-moe",
+    )
+}
+
+
+@ProviderRegistry.register(
+    name="nomic",
+    models=NOMIC_MODELS,
+    aliases=["nomic-embed"],
+    description="Nomic retrieval embeddings with role prefixes and Matryoshka output",
+)
+class NomicProvider(InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvider):
+    """Nomic provider; v1.5 defaults to 8192-token, 768-dimensional output."""
+
+    def default_config(self) -> ProviderConfig:
+        return ProviderConfig(
+            model=NOMIC_MODELS["nomic-ai/nomic-embed-text-v1.5"],
+            batch_size=16,
+            normalize=True,
+            trust_remote_code=True,
+        )

--- a/clients/python/src/proximadb_sdk/embedding_providers/providers/local/open_weights.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/providers/local/open_weights.py
@@ -1,0 +1,64 @@
+"""Generic provider for the curated open-weight embedding model catalog."""
+
+from dataclasses import replace
+
+from ...catalog import OPEN_MODEL_CATALOG, get_open_model_spec
+from ...core.base import BaseEmbeddingProvider
+from ...core.config import ProviderConfig
+from ...core.registry import ProviderRegistry
+from ...mixins.instruction import InstructionMixin
+from ...mixins.sentence_transformer import SentenceTransformerMixin
+
+
+@ProviderRegistry.register(
+    name="open-weights",
+    models={key: spec.metadata for key, spec in OPEN_MODEL_CATALOG.items()},
+    aliases=["huggingface-embedding"],
+    description="Curated open-weight SentenceTransformers-compatible models",
+)
+class OpenWeightsProvider(
+    InstructionMixin, SentenceTransformerMixin, BaseEmbeddingProvider
+):
+    """One runtime adapter for catalogued open-weight text embedders."""
+
+    def default_config(self) -> ProviderConfig:
+        spec = get_open_model_spec("sentence-transformers/all-MiniLM-L6-v2")
+        return ProviderConfig(model=spec.metadata, batch_size=32, normalize=True)
+
+    def embed(self, texts):
+        """Embed unqualified text as documents, the safe ingestion default."""
+        return self._encode_with_prompt(texts, "document")
+
+
+def create_open_model_provider(
+    model_id: str,
+    *,
+    dimension: int | None = None,
+    revision: str | None = None,
+    document_template: str | None = None,
+    query_template: str | None = None,
+    **config_kwargs,
+) -> OpenWeightsProvider:
+    """Create a catalogued provider with validated Matryoshka dimension."""
+    spec = get_open_model_spec(model_id)
+    metadata = replace(
+        spec.metadata,
+        revision=revision or spec.metadata.revision,
+        document_template=document_template or spec.metadata.document_template,
+        query_template=(
+            query_template
+            if query_template is not None
+            else spec.metadata.query_template
+        ),
+    )
+    extra = dict(config_kwargs.pop("extra", {}))
+    if dimension is not None and dimension != metadata.dimension:
+        if not metadata.supports_dimension(dimension):
+            raise ValueError(f"{model_id} does not support {dimension} dimensions")
+        extra["truncate_dim"] = dimension
+    config = ProviderConfig(
+        model=metadata,
+        trust_remote_code=spec.trust_remote_code,
+        extra=extra,
+    ).merge(**config_kwargs)
+    return OpenWeightsProvider(config)

--- a/clients/python/src/proximadb_sdk/embedding_providers/providers/local/sentence_transformer.py
+++ b/clients/python/src/proximadb_sdk/embedding_providers/providers/local/sentence_transformer.py
@@ -15,7 +15,7 @@ SENTENCE_TRANSFORMER_MODELS = {
     "all-mpnet-base-v2": ModelMetadata(
         name="all-mpnet-base-v2",
         dimension=768,
-        max_length=512,
+        max_length=384,
         provider_type="sentence-transformer",
         mteb_score=63.3,
         languages="en",
@@ -25,7 +25,7 @@ SENTENCE_TRANSFORMER_MODELS = {
     "all-MiniLM-L6-v2": ModelMetadata(
         name="all-MiniLM-L6-v2",
         dimension=384,
-        max_length=512,
+        max_length=256,
         provider_type="sentence-transformer",
         mteb_score=58.8,
         languages="en",
@@ -35,7 +35,7 @@ SENTENCE_TRANSFORMER_MODELS = {
     "all-MiniLM-L12-v2": ModelMetadata(
         name="all-MiniLM-L12-v2",
         dimension=384,
-        max_length=512,
+        max_length=256,
         provider_type="sentence-transformer",
         mteb_score=59.8,
         languages="en",
@@ -45,7 +45,7 @@ SENTENCE_TRANSFORMER_MODELS = {
     "paraphrase-MiniLM-L6-v2": ModelMetadata(
         name="paraphrase-MiniLM-L6-v2",
         dimension=384,
-        max_length=512,
+        max_length=256,
         provider_type="sentence-transformer",
         languages="en",
         description="Optimized for paraphrase detection",

--- a/clients/python/src/proximadb_sdk/integrations/mlops.py
+++ b/clients/python/src/proximadb_sdk/integrations/mlops.py
@@ -9,8 +9,210 @@ detected lazily so the base SDK remains dependency-light.
 from __future__ import annotations
 
 import importlib.util
+import re
 from dataclasses import dataclass, field
 from typing import Any
+
+from ..chunking_strategies.contracts import ResolvedInputContract
+
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class ArtifactDescriptor:
+    """Content-addressed bytes referenced by an xCatalog asset.
+
+    A URI locates bytes; the digest establishes their immutable identity.
+    Model repositories should use a deterministic package/manifest digest when
+    they contain more than one file.
+    """
+
+    uri: str
+    digest: str
+    size_bytes: int
+    media_type: str
+
+    def __post_init__(self) -> None:
+        if not self.uri.strip():
+            raise ValueError("artifact uri must not be empty")
+        if not _SHA256.fullmatch(self.digest):
+            raise ValueError("artifact digest must be sha256:<64 lowercase hex chars>")
+        if self.size_bytes < 0:
+            raise ValueError("artifact size_bytes cannot be negative")
+        if not self.media_type.strip():
+            raise ValueError("artifact media_type must not be empty")
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "uri": self.uri,
+            "digest": self.digest,
+            "size_bytes": self.size_bytes,
+            "media_type": self.media_type,
+        }
+
+
+@dataclass(frozen=True)
+class EmbeddingModelRegistration:
+    """SDK adapter from a runtime-resolved contract to native xCatalog JSON.
+
+    This object only builds the generated-API payload. It deliberately performs
+    no hand-written HTTP so the eventual REST surface remains OpenAPI-generated.
+    """
+
+    registered_name: str
+    version: int
+    contract: ResolvedInputContract
+    artifact: ArtifactDescriptor
+    created_at_ms: int
+    declared_context_limit: int
+    normalized: bool = True
+    pooling: str = "model-defined"
+    license_id: str = "unknown"
+    access: str = "unreviewed"
+    requires_remote_code: bool = False
+    approved_runtimes: tuple[str, ...] = ()
+    source_run_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.registered_name.strip():
+            raise ValueError("registered_name must not be empty")
+        if self.version <= 0:
+            raise ValueError("version must be positive")
+        if self.declared_context_limit < self.contract.effective_context_limit:
+            raise ValueError(
+                "declared_context_limit cannot be below the runtime effective limit"
+            )
+        if self.access not in {"open", "gated", "unreviewed"}:
+            raise ValueError("access must be open, gated, or unreviewed")
+        if not self.license_id.strip():
+            raise ValueError("license_id must not be empty")
+        if not self.pooling.strip():
+            raise ValueError("pooling must not be empty")
+        if any(not runtime.strip() for runtime in self.approved_runtimes):
+            raise ValueError("approved runtime names must not be empty")
+
+    @classmethod
+    def from_resolved_contract(
+        cls,
+        registered_name: str,
+        version: int,
+        contract: ResolvedInputContract,
+        artifact: ArtifactDescriptor,
+        created_at_ms: int,
+        *,
+        declared_context_limit: int | None = None,
+        normalized: bool = True,
+        pooling: str = "model-defined",
+        license_id: str = "unknown",
+        access: str = "unreviewed",
+        requires_remote_code: bool = False,
+        approved_runtimes: tuple[str, ...] = (),
+        source_run_id: str | None = None,
+    ) -> EmbeddingModelRegistration:
+        return cls(
+            registered_name=registered_name,
+            version=version,
+            contract=contract,
+            artifact=artifact,
+            created_at_ms=created_at_ms,
+            declared_context_limit=(
+                declared_context_limit or contract.effective_context_limit
+            ),
+            normalized=normalized,
+            pooling=pooling,
+            license_id=license_id,
+            access=access,
+            requires_remote_code=requires_remote_code,
+            approved_runtimes=approved_runtimes,
+            source_run_id=source_run_id,
+        )
+
+    @staticmethod
+    def _digest(value: str) -> str:
+        return value if value.startswith("sha256:") else f"sha256:{value}"
+
+    def _dimension_contract(self) -> dict[str, Any]:
+        native = self.contract.native_dimension
+        if native is None:
+            raise ValueError("native_dimension is required for model registration")
+        if self.contract.supported_output_dimensions:
+            dimensions = sorted(set(self.contract.supported_output_dimensions))
+            if native not in dimensions:
+                dimensions.append(native)
+                dimensions.sort()
+            policy: str | dict[str, dict[str, int]] = "discrete"
+        elif self.contract.minimum_output_dimension is not None:
+            dimensions = []
+            policy = {"range": {"minimum": self.contract.minimum_output_dimension}}
+        else:
+            dimensions = [native]
+            policy = "fixed"
+        return {
+            "native_dimension": native,
+            "dimension_policy": policy,
+            "supported_dimensions": dimensions,
+            "normalized": self.normalized,
+            "pooling": self.pooling,
+        }
+
+    def model_version(self) -> dict[str, Any]:
+        tokenizer_revision = (
+            getattr(self.contract.counter, "resolved_revision", None)
+            or self.contract.model_revision
+        )
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "provider_model_id": self.contract.model_id,
+            "artifact": self.artifact.to_manifest(),
+            "input": {
+                "model_revision": self.contract.model_revision,
+                "tokenizer_id": self.contract.counter.name,
+                "tokenizer_revision": str(tokenizer_revision),
+                "tokenizer_fingerprint": self._digest(
+                    self.contract.counter.fingerprint
+                ),
+                "declared_context_limit": self.declared_context_limit,
+                "effective_context_limit": self.contract.effective_context_limit,
+                "special_token_count": self.contract.counter.count(""),
+                "document_template": self.contract.renderer.document_template,
+                "query_template": self.contract.renderer.query_template,
+                "document_parameters": dict(self.contract.document_encode_parameters),
+                "query_parameters": dict(self.contract.query_encode_parameters),
+            },
+            "output": self._dimension_contract(),
+            "governance": {
+                "license_id": self.license_id,
+                "access": self.access,
+                "requires_remote_code": self.requires_remote_code,
+                "approved_runtimes": sorted(set(self.approved_runtimes)),
+            },
+            "lineage": {
+                "producer_execution_id": self.source_run_id,
+                "code_revision": self.contract.model_revision,
+                "inputs": [],
+            },
+            "created_at_ms": self.created_at_ms,
+        }
+        if self.source_run_id is not None:
+            payload["source_run_id"] = self.source_run_id
+        return payload
+
+    def xcatalog_asset(self) -> dict[str, Any]:
+        """Return the typed facet stored on a unified xCatalog object."""
+        return {
+            "kind": "embedding_model",
+            "contract": {
+                "schema_version": 1,
+                "revision": 0,
+                "name": self.registered_name,
+                "versions": {str(self.version): self.model_version()},
+                "aliases": {},
+                "evidence": [],
+                "decisions": [],
+                "deployments": {},
+                "tags": {},
+            },
+        }
 
 
 @dataclass(frozen=True)

--- a/clients/python/tests/fixtures/embedding_model_xcatalog_asset.json
+++ b/clients/python/tests/fixtures/embedding_model_xcatalog_asset.json
@@ -1,0 +1,57 @@
+{
+  "kind": "embedding_model",
+  "contract": {
+    "schema_version": 1,
+    "revision": 0,
+    "name": "search-embedding",
+    "versions": {
+      "1": {
+        "version": 1,
+        "provider_model_id": "BAAI/bge-base-en-v1.5",
+        "artifact": {
+          "uri": "hf://BAAI/bge-base-en-v1.5@aed724fc5",
+          "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "size_bytes": 438000000,
+          "media_type": "application/vnd.huggingface.repository.v1"
+        },
+        "input": {
+          "model_revision": "aed724fc5",
+          "tokenizer_id": "BAAI/bge-base-en-v1.5",
+          "tokenizer_revision": "aed724fc5",
+          "tokenizer_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "declared_context_limit": 512,
+          "effective_context_limit": 512,
+          "special_token_count": 2,
+          "document_template": "{text}",
+          "query_template": "Represent passages: {text}",
+          "document_parameters": {},
+          "query_parameters": {}
+        },
+        "output": {
+          "native_dimension": 768,
+          "dimension_policy": "fixed",
+          "supported_dimensions": [768],
+          "normalized": true,
+          "pooling": "model-defined"
+        },
+        "governance": {
+          "license_id": "mit",
+          "access": "unreviewed",
+          "requires_remote_code": false,
+          "approved_runtimes": ["sentence-transformers"]
+        },
+        "lineage": {
+          "producer_execution_id": null,
+          "code_revision": "aed724fc5",
+          "inputs": []
+        },
+        "created_at_ms": 1786400000000
+      }
+    },
+    "aliases": {},
+    "evidence": [],
+    "decisions": [],
+    "deployments": {},
+    "tags": {}
+  }
+}

--- a/clients/python/tests/unit/test_mlops_contracts.py
+++ b/clients/python/tests/unit/test_mlops_contracts.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from proximadb_sdk.chunking_strategies import InputRenderer, ResolvedInputContract
 from proximadb_sdk.integrations.mlops import (
+    ArtifactDescriptor,
     AutoMLRunSpec,
+    EmbeddingModelRegistration,
     ExperimentTrackerDDL,
     FeatureTableDDL,
     optional_integrations,
 )
+
+
+class _Counter:
+    name = "BAAI/bge-base-en-v1.5"
+    fingerprint = "c" * 64
+    advertised_limit = 512
+
+    def count(self, text: str) -> int:
+        return len(text.split()) + 2
+
+    def content_offsets(self, text: str):
+        return None
 
 
 def test_feature_table_ddl_emits_pgwire_catalog_contract() -> None:
@@ -74,3 +92,84 @@ def test_automl_spec_and_optional_integrations_are_dependency_light() -> None:
     availability = optional_integrations()
     assert set(availability) == {"mlflow", "autogluon", "pycaret"}
     assert all(isinstance(value, bool) for value in availability.values())
+
+
+def test_resolved_embedding_contract_maps_to_native_xcatalog_asset() -> None:
+    resolved = ResolvedInputContract(
+        model_id="BAAI/bge-base-en-v1.5",
+        model_revision="aed724fc5",
+        counter=_Counter(),
+        effective_context_limit=512,
+        renderer=InputRenderer(
+            document_template="{text}",
+            query_template="Represent passages: {text}",
+        ),
+        native_dimension=768,
+        output_dimension=768,
+    )
+    registration = EmbeddingModelRegistration.from_resolved_contract(
+        registered_name="search-embedding",
+        version=1,
+        contract=resolved,
+        artifact=ArtifactDescriptor(
+            uri="hf://BAAI/bge-base-en-v1.5@aed724fc5",
+            digest="sha256:" + "a" * 64,
+            size_bytes=438_000_000,
+            media_type="application/vnd.huggingface.repository.v1",
+        ),
+        created_at_ms=1_786_400_000_000,
+        license_id="mit",
+        approved_runtimes=("sentence-transformers",),
+    )
+
+    asset = registration.xcatalog_asset()
+    version = asset["contract"]["versions"]["1"]
+    assert asset["kind"] == "embedding_model"
+    assert version["input"]["effective_context_limit"] == 512
+    assert version["input"]["special_token_count"] == 2
+    assert version["input"]["tokenizer_fingerprint"] == "sha256:" + "c" * 64
+    assert version["output"]["dimension_policy"] == "fixed"
+    assert version["governance"]["approved_runtimes"] == ["sentence-transformers"]
+    fixture = Path(__file__).parents[1] / "fixtures/embedding_model_xcatalog_asset.json"
+    assert asset == json.loads(fixture.read_text(encoding="utf-8"))
+
+
+def test_matryoshka_contract_maps_discrete_and_range_dimension_policies() -> None:
+    discrete = ResolvedInputContract(
+        model_id="nomic-ai/nomic-embed-text-v1.5",
+        model_revision="model-sha",
+        counter=_Counter(),
+        effective_context_limit=512,
+        native_dimension=768,
+        supported_output_dimensions=(768, 512, 256),
+    )
+    ranged = ResolvedInputContract(
+        model_id="Qwen/Qwen3-Embedding-0.6B",
+        model_revision="model-sha",
+        counter=_Counter(),
+        effective_context_limit=512,
+        native_dimension=1024,
+        minimum_output_dimension=32,
+    )
+    artifact = ArtifactDescriptor(
+        "hf://model@sha", "sha256:" + "a" * 64, 1, "application/octet-stream"
+    )
+
+    discrete_payload = EmbeddingModelRegistration.from_resolved_contract(
+        "nomic", 1, discrete, artifact, 1, approved_runtimes=("st",)
+    ).model_version()["output"]
+    range_payload = EmbeddingModelRegistration.from_resolved_contract(
+        "qwen", 1, ranged, artifact, 1, approved_runtimes=("st",)
+    ).model_version()["output"]
+
+    assert discrete_payload["dimension_policy"] == "discrete"
+    assert range_payload["dimension_policy"] == {"range": {"minimum": 32}}
+
+
+def test_artifact_descriptor_requires_content_addressing() -> None:
+    try:
+        ArtifactDescriptor("hf://model@main", "main", 1, "application/octet-stream")
+    except ValueError as error:
+        assert "sha256" in str(error)
+    else:
+        raise AssertionError("mutable artifact reference must be rejected")

--- a/clients/python/tests/unit/test_token_budget_chunking.py
+++ b/clients/python/tests/unit/test_token_budget_chunking.py
@@ -1,0 +1,302 @@
+"""Contract tests for exact, model-agnostic token-budget chunking."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from proximadb_sdk.chunking import ChunkerPool
+from proximadb_sdk.chunking_strategies import (
+    ChunkingConfig,
+    ChunkingStrategy,
+    CompositeInputContract,
+    InputRenderer,
+    InputRole,
+    OverflowPolicy,
+    ResolvedInputContract,
+    ShortChunkPolicy,
+    TokenBudget,
+    get_chunking_strategy,
+)
+from proximadb_sdk.chunking_strategies.tokenizers import HuggingFaceTokenCounter
+from proximadb_sdk.embedding_providers import get_provider
+from proximadb_sdk.embedding_providers.catalog import OPEN_MODEL_CATALOG
+from proximadb_sdk.embedding_providers.providers.local.open_weights import (
+    create_open_model_provider,
+)
+
+
+class WordCounter:
+    """Fast-tokenizer-shaped test double: words plus two special tokens."""
+
+    def __init__(self, name: str = "words", advertised_limit: int = 512):
+        self.name = name
+        self.fingerprint = f"fingerprint:{name}"
+        self.advertised_limit = advertised_limit
+
+    def count(self, text: str) -> int:
+        return len(list(re.finditer(r"\S+", text))) + 2
+
+    def content_offsets(self, text: str) -> tuple[tuple[int, int], ...]:
+        return tuple(match.span() for match in re.finditer(r"\S+", text))
+
+
+def make_contract(
+    *, name: str = "model", document_template: str = "prefix: {text}", limit: int = 8
+) -> ResolvedInputContract:
+    return ResolvedInputContract(
+        model_id=name,
+        model_revision="revision",
+        counter=WordCounter(name, advertised_limit=limit),
+        effective_context_limit=limit,
+        renderer=InputRenderer(document_template=document_template),
+        native_dimension=768,
+    )
+
+
+def make_strategy(
+    contract=None,
+    *,
+    target: int = 7,
+    overlap: int = 1,
+    overflow: OverflowPolicy = OverflowPolicy.SPLIT,
+    short: ShortChunkPolicy = ShortChunkPolicy.KEEP,
+):
+    return get_chunking_strategy(
+        ChunkingStrategy.FIXED_SIZE,
+        chunk_size=10_000,
+        min_chunk_size=1,
+        token_budget=TokenBudget(
+            target_tokens=target,
+            overlap_tokens=overlap,
+            min_content_tokens=3,
+            overflow_policy=overflow,
+            short_chunk_policy=short,
+        ),
+        input_contract=contract or make_contract(),
+        input_role=InputRole.DOCUMENT,
+    )
+
+
+def test_exact_rendered_budget_splits_with_token_overlap_and_full_coverage():
+    strategy = make_strategy()
+    chunks = strategy.chunk("one two three four five six seven eight nine", "doc")
+
+    assert [chunk.text.split() for chunk in chunks] == [
+        ["one", "two", "three", "four"],
+        ["four", "five", "six", "seven"],
+        ["seven", "eight", "nine"],
+    ]
+    assert [chunk.metadata["token_counts"]["model"] for chunk in chunks] == [
+        7,
+        7,
+        6,
+    ]
+    assert all(chunk.metadata["total_chunks"] == 3 for chunk in chunks)
+    assert chunks[1].metadata["overlap_tokens"] == 1
+
+
+def test_composite_contract_uses_most_restrictive_rendered_input():
+    primary = make_contract(name="primary", document_template="p: {text}", limit=8)
+    secondary = make_contract(
+        name="secondary", document_template="long role prefix: {text}", limit=8
+    )
+    strategy = make_strategy(CompositeInputContract((primary, secondary)))
+
+    chunks = strategy.chunk("one two three four five", "doc")
+
+    assert [len(chunk.text.split()) for chunk in chunks] == [2, 2, 2, 2]
+    assert all(max(chunk.metadata["token_counts"].values()) <= 7 for chunk in chunks)
+
+
+def test_sentence_boundaries_are_independent_of_legacy_character_size():
+    strategy = get_chunking_strategy(
+        ChunkingStrategy.SENTENCE,
+        chunk_size=10_000,
+        min_chunk_size=1,
+        token_budget=TokenBudget(target_tokens=7),
+        input_contract=make_contract(limit=8),
+    )
+    chunks = strategy.chunk("One two three. Four five six. Seven eight.", "doc")
+    assert [chunk.text for chunk in chunks] == [
+        "One two three.",
+        "Four five six.",
+        "Seven eight.",
+    ]
+
+
+@pytest.mark.parametrize("policy", [OverflowPolicy.ERROR, OverflowPolicy.DROP])
+def test_oversized_source_policy_is_explicit(policy):
+    strategy = make_strategy(overflow=policy)
+    if policy == OverflowPolicy.ERROR:
+        with pytest.raises(ValueError, match="token counts"):
+            strategy.chunk("one two three four five", "doc")
+    else:
+        assert strategy.chunk("one two three four five", "doc") == []
+
+
+def test_short_tail_policy_is_explicit():
+    strategy = make_strategy(short=ShortChunkPolicy.DROP)
+    chunks = strategy.chunk("one two three four five", "doc")
+    assert [chunk.text.split() for chunk in chunks] == [["one", "two", "three", "four"]]
+
+
+def test_pool_identity_includes_model_contract():
+    pool = ChunkerPool()
+    budget = TokenBudget(target_tokens=7, overlap_tokens=1)
+    first = ChunkingConfig(token_budget=budget, input_contract=make_contract(name="a"))
+    second = ChunkingConfig(token_budget=budget, input_contract=make_contract(name="b"))
+    assert pool._get_pool_key(first) != pool._get_pool_key(second)
+
+
+class FakeBackend:
+    def to_str(self) -> str:
+        return '{"model":"fake"}'
+
+
+class FakeFastTokenizer:
+    is_fast = True
+    name_or_path = "fake/tokenizer"
+    model_max_length = 16
+    backend_tokenizer = FakeBackend()
+    init_kwargs = {"_commit_hash": "runtime-revision"}
+
+    def __call__(self, text, *, add_special_tokens, return_offsets_mapping=False, **_):
+        offsets = tuple(match.span() for match in re.finditer(r"\S+", text))
+        if return_offsets_mapping:
+            return {"input_ids": list(range(len(offsets))), "offset_mapping": offsets}
+        special = 2 if add_special_tokens else 0
+        return {"input_ids": list(range(len(offsets) + special))}
+
+
+def test_huggingface_adapter_counts_specials_and_exposes_offsets():
+    counter = HuggingFaceTokenCounter(FakeFastTokenizer())
+    assert counter.count("one two") == 4
+    assert counter.content_offsets("one two") == ((0, 3), (4, 7))
+    assert counter.advertised_limit == 16
+    assert counter.resolved_revision == "runtime-revision"
+    assert len(counter.fingerprint) == 64
+
+
+def test_nomic_provider_resolves_runtime_contract_and_matryoshka_dimension():
+    provider = get_provider("nomic", dimension=256, device="cpu")
+
+    class FakeModel:
+        tokenizer = FakeFastTokenizer()
+        max_seq_length = 12
+
+        @staticmethod
+        def get_sentence_embedding_dimension():
+            return 256
+
+    provider._model = FakeModel()
+    provider._initialized = True
+
+    contract = provider.get_input_contract()
+    assert provider.get_dimension() == 256
+    assert contract.native_dimension == 768
+    assert contract.output_dimension == 256
+    assert contract.effective_context_limit == 12
+    assert contract.model_revision == "runtime-revision"
+    assert contract.render("doc", InputRole.DOCUMENT) == "search_document: doc"
+    assert contract.render("q", InputRole.QUERY) == "search_query: q"
+
+
+def test_specialized_provider_rejects_unsupported_matryoshka_dimension():
+    with pytest.raises(ValueError, match="does not support 300 dimensions"):
+        get_provider("nomic", dimension=300)
+
+
+@pytest.mark.parametrize("model_id", sorted(OPEN_MODEL_CATALOG))
+def test_every_catalog_model_resolves_same_runtime_contract_shape(model_id):
+    spec = OPEN_MODEL_CATALOG[model_id]
+    provider = create_open_model_provider(model_id, device="cpu")
+
+    class FakeModel:
+        tokenizer = FakeFastTokenizer()
+        max_seq_length = spec.metadata.max_length
+
+        @staticmethod
+        def get_sentence_embedding_dimension():
+            return spec.metadata.dimension
+
+    provider._model = FakeModel()
+    provider._initialized = True
+    contract = provider.get_input_contract()
+
+    assert contract.model_id == model_id
+    assert contract.effective_context_limit == min(spec.metadata.max_length, 16)
+    payload = "UNIQUE_PAYLOAD"
+    assert contract.render(payload, InputRole.DOCUMENT).count(payload) == 1
+    assert contract.render(payload, InputRole.QUERY).count(payload) == 1
+    assert contract.document_encode_parameters == (
+        spec.metadata.document_encode_parameters
+    )
+    assert contract.query_encode_parameters == spec.metadata.query_encode_parameters
+    assert len(contract.fingerprint) == 64
+    assert contract.to_manifest()["contract_fingerprint"] == contract.fingerprint
+    assert spec.metadata.source_url == f"https://huggingface.co/{model_id}"
+
+
+def test_catalog_models_cover_discrete_and_range_matryoshka_policies():
+    gemma = OPEN_MODEL_CATALOG["google/embeddinggemma-300m"].metadata
+    qwen = OPEN_MODEL_CATALOG["Qwen/Qwen3-Embedding-0.6B"].metadata
+    assert gemma.supports_dimension(256)
+    assert not gemma.supports_dimension(300)
+    assert qwen.supports_dimension(300)
+    assert not qwen.supports_dimension(31)
+
+
+def test_role_specific_adapter_parameters_reach_model_encode():
+    provider = create_open_model_provider("jinaai/jina-embeddings-v3")
+    calls = []
+
+    class FakeModel:
+        def encode(self, texts, **kwargs):
+            calls.append((texts, kwargs))
+            return [[0.0] * 1024 for _ in texts]
+
+    provider._model = FakeModel()
+    provider._initialized = True
+    provider.embed_query("query")
+    provider.embed_passages(["document"])
+
+    assert calls[0][1]["task"] == "retrieval.query"
+    assert calls[1][1]["task"] == "retrieval.passage"
+
+
+def test_open_model_plain_embed_uses_document_rendering():
+    provider = create_open_model_provider("google/embeddinggemma-300m")
+    captured = {}
+
+    class FakeModel:
+        def encode(self, texts, **kwargs):
+            captured["texts"] = texts
+            return [[0.0] * 768 for _ in texts]
+
+    provider._model = FakeModel()
+    provider._initialized = True
+    provider.embed(["Mars is red"])
+    assert captured["texts"] == ["title: none | text: Mars is red"]
+
+
+def test_registered_runtime_prompts_override_catalog_templates_in_contract():
+    provider = create_open_model_provider(
+        "BAAI/bge-base-en-v1.5",
+        extra={"prompts": {"query": "custom query: ", "document": "custom doc: "}},
+    )
+
+    class FakeModel:
+        tokenizer = FakeFastTokenizer()
+        max_seq_length = 512
+
+        @staticmethod
+        def get_sentence_embedding_dimension():
+            return 768
+
+    provider._model = FakeModel()
+    provider._initialized = True
+    contract = provider.get_input_contract()
+    assert contract.render("x", InputRole.QUERY) == "custom query: x"
+    assert contract.render("x", InputRole.DOCUMENT) == "custom doc: x"

--- a/crates/control/proximadb-catalog/src/lib.rs
+++ b/crates/control/proximadb-catalog/src/lib.rs
@@ -47,6 +47,8 @@ pub mod tenant_posture;
 // up-edge).
 pub mod manager;
 pub use manager::{CatalogFilesystemResolver, CatalogManager, TableOpLockRegistry};
+/// Typed MLOps/model-registry facet for the unified xCatalog object model.
+pub mod mlops;
 // Catalog federation (Slice 3) — unified view across internal + external
 // catalogs, moved from root src/catalog/federation (now that CatalogManager is
 // in this crate).
@@ -592,6 +594,16 @@ pub struct CatalogEmbeddingConfig {
     /// embedding engine, e.g. `"bge-small"`, `"openai:text-embedding-3-small"`,
     /// or `"byo:https://…"`.
     pub model: String,
+    /// Stable xCatalog object ID of the registered `mlops.*` model. `None`
+    /// preserves the legacy opaque route-name behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_asset_id: Option<u64>,
+    /// Immutable registered-model version selected for this collection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<u64>,
+    /// Executable contract digest pinned with `model_version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract_sha256: Option<String>,
     /// Output dimensionality of the model.
     pub dimension: u32,
     /// Native scalar precision of the model output. Legacy/unset → `Fp32`.
@@ -600,6 +612,56 @@ pub struct CatalogEmbeddingConfig {
     /// Whether the engine L2-normalizes embeddings before they are stored.
     #[serde(default)]
     pub normalize: bool,
+}
+
+impl CatalogEmbeddingConfig {
+    /// Build a collection binding that cannot follow a mutable model alias.
+    pub fn pinned(
+        model: impl Into<String>,
+        dimension: u32,
+        model_asset_id: u64,
+        model_version: u64,
+        contract_sha256: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        let binding = Self {
+            model: model.into(),
+            model_asset_id: Some(model_asset_id),
+            model_version: Some(model_version),
+            contract_sha256: Some(contract_sha256.into()),
+            dimension,
+            ..Default::default()
+        };
+        binding.validate_model_binding()?;
+        Ok(binding)
+    }
+
+    pub fn validate_model_binding(&self) -> anyhow::Result<()> {
+        let pinned_fields = [
+            self.model_asset_id.is_some(),
+            self.model_version.is_some(),
+            self.contract_sha256.is_some(),
+        ];
+        if pinned_fields.iter().any(|set| *set) && !pinned_fields.iter().all(|set| *set) {
+            return Err(anyhow::anyhow!(
+                "model asset id, model version, and contract sha256 must be set together"
+            ));
+        }
+        if let Some(version) = self.model_version
+            && version == 0
+        {
+            return Err(anyhow::anyhow!("model version must be positive"));
+        }
+        if self.model_asset_id == Some(0) {
+            return Err(anyhow::anyhow!("model asset id must be positive"));
+        }
+        if let Some(digest) = &self.contract_sha256 {
+            mlops::validate_contract_digest(digest)?;
+        }
+        if self.dimension == 0 {
+            return Err(anyhow::anyhow!("embedding dimension must be positive"));
+        }
+        Ok(())
+    }
 }
 
 /// Catalog-authoritative table-level storage descriptor.
@@ -788,6 +850,12 @@ pub struct CatalogTableSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_config: Option<CatalogStorageConfig>,
 
+    /// Typed AI/MLOps facet. `None` for ordinary tables and every legacy
+    /// catalog row. The field is additive and inert until an `mlops.*` asset is
+    /// explicitly created; old readers ignore it and new readers default it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mlops_asset: Option<mlops::CatalogMlopsAsset>,
+
     /// Schema version
     pub schema_version: i32,
     /// Table properties
@@ -849,6 +917,7 @@ impl Default for CatalogTableSchema {
             quantization: None,
             embedding_config: None,
             storage_config: None,
+            mlops_asset: None,
             schema_version: 1,
             properties: HashMap::new(),
             location: None,
@@ -865,6 +934,13 @@ impl CatalogTableSchema {
             name: name.into(),
             ..Default::default()
         }
+    }
+
+    /// Attach a validated typed MLOps facet to this catalog object.
+    pub fn with_mlops_asset(mut self, asset: mlops::CatalogMlopsAsset) -> anyhow::Result<Self> {
+        asset.validate().map_err(anyhow::Error::new)?;
+        self.mlops_asset = Some(asset);
+        Ok(self)
     }
 
     /// Add a column
@@ -4103,6 +4179,7 @@ mod tests {
                 dimension: 384,
                 native_precision: proximadb_records::EmbeddingScalarType::Fp32,
                 normalize: true,
+                ..Default::default()
             })
             .with_storage_config(CatalogStorageConfig {
                 compression: Some(CompressionAlgorithm::Zstd),
@@ -4122,6 +4199,7 @@ mod tests {
                 dimension: 384,
                 native_precision: proximadb_records::EmbeddingScalarType::Fp32,
                 normalize: true,
+                ..Default::default()
             })
         );
         assert_eq!(
@@ -4747,6 +4825,21 @@ pub trait Catalog: Send + Sync {
         let _ = (identifier, layouts);
         Err(anyhow::anyhow!(
             "storage layout mutation not supported by this catalog"
+        ))
+    }
+
+    /// Atomically apply one command to a typed `mlops.*` model-registry asset.
+    /// Command-shaped mutation prevents compatibility adapters from replacing
+    /// immutable versions or append-only evidence with stale document writes.
+    async fn apply_model_registry_mutation(
+        &self,
+        identifier: &TableIdentifier,
+        expected_revision: u64,
+        mutation: mlops::CatalogModelRegistryMutation,
+    ) -> anyhow::Result<CatalogTableSchema> {
+        let _ = (identifier, expected_revision, mutation);
+        Err(anyhow::anyhow!(
+            "model registry mutation not supported by this catalog"
         ))
     }
 

--- a/crates/control/proximadb-catalog/src/mlops.rs
+++ b/crates/control/proximadb-catalog/src/mlops.rs
@@ -1,0 +1,1013 @@
+//! Typed xCatalog contracts for model registry and embedding execution metadata.
+//!
+//! The catalog stores small, versioned metadata and content descriptors. Model
+//! weights, tokenizer files, datasets, and evaluation payloads remain in object
+//! or external artifact storage and are addressed by immutable digests.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Current serialized model-contract schema. New readers default legacy rows to
+/// no MLOps facet; future incompatible shapes require a new version.
+pub const MODEL_CONTRACT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CatalogModelContractError {
+    #[error("{field} must not be empty")]
+    Empty { field: &'static str },
+    #[error("{field} must be a sha256 digest in the form sha256:<64 lowercase hex chars>")]
+    InvalidDigest { field: &'static str },
+    #[error("{field} must contain exactly one {{text}} placeholder")]
+    InvalidTemplate { field: &'static str },
+    #[error(
+        "special token count {special_tokens} must be smaller than context limit {context_limit}"
+    )]
+    InvalidSpecialTokenBudget {
+        special_tokens: u32,
+        context_limit: u32,
+    },
+    #[error("dimension {dimension} exceeds native dimension {native_dimension}")]
+    DimensionExceedsNative {
+        dimension: u32,
+        native_dimension: u32,
+    },
+    #[error("invalid output dimension policy: {reason}")]
+    InvalidDimensionPolicy { reason: String },
+    #[error("model version {version} is already registered and immutable")]
+    DuplicateVersion { version: u64 },
+    #[error("model version {version} is not registered")]
+    UnknownVersion { version: u64 },
+    #[error("alias '{alias}' is invalid")]
+    InvalidAlias { alias: String },
+    #[error("alias '{alias}' is not registered")]
+    UnknownAlias { alias: String },
+    #[error("evidence '{evidence_id}' is already recorded and append-only")]
+    DuplicateEvidence { evidence_id: String },
+    #[error("evidence '{evidence_id}' is not registered for model version {version}")]
+    UnknownEvidence { evidence_id: String, version: u64 },
+    #[error("decision '{decision_id}' is already recorded and append-only")]
+    DuplicateDecision { decision_id: String },
+    #[error("deployment '{deployment}' digest does not match immutable model version {version}")]
+    DeploymentDigestMismatch { deployment: String, version: u64 },
+    #[error("runtime '{runtime}' is not approved for model version {version}")]
+    RuntimeNotApproved { runtime: String, version: u64 },
+    #[error("model registry revision conflict: expected {expected}, current {current}")]
+    RevisionConflict { expected: u64, current: u64 },
+    #[error("contract serialization failed: {message}")]
+    Serialization { message: String },
+}
+
+fn require_non_empty(value: &str, field: &'static str) -> Result<(), CatalogModelContractError> {
+    if value.trim().is_empty() {
+        return Err(CatalogModelContractError::Empty { field });
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str, field: &'static str) -> Result<(), CatalogModelContractError> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(CatalogModelContractError::InvalidDigest { field });
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(CatalogModelContractError::InvalidDigest { field });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_contract_digest(value: &str) -> anyhow::Result<()> {
+    validate_sha256(value, "model contract digest").map_err(anyhow::Error::new)
+}
+
+fn validate_template(value: &str, field: &'static str) -> Result<(), CatalogModelContractError> {
+    if value.match_indices("{text}").count() != 1 {
+        return Err(CatalogModelContractError::InvalidTemplate { field });
+    }
+    Ok(())
+}
+
+/// Content-addressed reference to bytes held outside xCatalog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogArtifactDescriptor {
+    pub uri: String,
+    pub digest: String,
+    pub size_bytes: u64,
+    pub media_type: String,
+}
+
+impl CatalogArtifactDescriptor {
+    pub fn new(
+        uri: impl Into<String>,
+        digest: impl Into<String>,
+        size_bytes: u64,
+        media_type: impl Into<String>,
+    ) -> Result<Self, CatalogModelContractError> {
+        let descriptor = Self {
+            uri: uri.into(),
+            digest: digest.into(),
+            size_bytes,
+            media_type: media_type.into(),
+        };
+        descriptor.validate()?;
+        Ok(descriptor)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.uri, "artifact uri")?;
+        validate_sha256(&self.digest, "artifact digest")?;
+        require_non_empty(&self.media_type, "artifact media type")?;
+        Ok(())
+    }
+}
+
+/// Exact rendered-input and tokenizer budget consumed by an embedding runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogEmbeddingInputContract {
+    pub model_revision: String,
+    pub tokenizer_id: String,
+    pub tokenizer_revision: String,
+    pub tokenizer_fingerprint: String,
+    pub declared_context_limit: u32,
+    pub effective_context_limit: u32,
+    pub special_token_count: u32,
+    pub document_template: String,
+    pub query_template: String,
+    #[serde(default)]
+    pub document_parameters: BTreeMap<String, String>,
+    #[serde(default)]
+    pub query_parameters: BTreeMap<String, String>,
+}
+
+impl CatalogEmbeddingInputContract {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        model_revision: impl Into<String>,
+        tokenizer_id: impl Into<String>,
+        tokenizer_revision: impl Into<String>,
+        tokenizer_fingerprint: impl Into<String>,
+        context_limit: u32,
+        special_token_count: u32,
+        document_template: impl Into<String>,
+        query_template: impl Into<String>,
+    ) -> Result<Self, CatalogModelContractError> {
+        let contract = Self {
+            model_revision: model_revision.into(),
+            tokenizer_id: tokenizer_id.into(),
+            tokenizer_revision: tokenizer_revision.into(),
+            tokenizer_fingerprint: tokenizer_fingerprint.into(),
+            declared_context_limit: context_limit,
+            effective_context_limit: context_limit,
+            special_token_count,
+            document_template: document_template.into(),
+            query_template: query_template.into(),
+            document_parameters: BTreeMap::new(),
+            query_parameters: BTreeMap::new(),
+        };
+        contract.validate()?;
+        Ok(contract)
+    }
+
+    /// Intersect the model declaration with a tokenizer/runtime limit.
+    pub fn with_runtime_context_limit(
+        mut self,
+        runtime_limit: u32,
+    ) -> Result<Self, CatalogModelContractError> {
+        self.effective_context_limit = self.declared_context_limit.min(runtime_limit);
+        self.validate()?;
+        Ok(self)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.model_revision, "model revision")?;
+        require_non_empty(&self.tokenizer_id, "tokenizer id")?;
+        require_non_empty(&self.tokenizer_revision, "tokenizer revision")?;
+        validate_sha256(&self.tokenizer_fingerprint, "tokenizer fingerprint")?;
+        if self.declared_context_limit == 0 || self.effective_context_limit == 0 {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "context limits must be positive".to_string(),
+            });
+        }
+        if self.effective_context_limit > self.declared_context_limit {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "effective context cannot exceed the declared context".to_string(),
+            });
+        }
+        if self.special_token_count >= self.effective_context_limit {
+            return Err(CatalogModelContractError::InvalidSpecialTokenBudget {
+                special_tokens: self.special_token_count,
+                context_limit: self.effective_context_limit,
+            });
+        }
+        validate_template(&self.document_template, "document template")?;
+        validate_template(&self.query_template, "query template")?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogModelAccess {
+    Open,
+    Gated,
+    /// Fail-closed default for a legacy or incomplete registration.
+    #[default]
+    Unreviewed,
+}
+
+/// Supply-chain and runtime policy declared for an immutable model version.
+/// Approval decisions remain separate append-only audit records.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogModelGovernance {
+    #[serde(default = "unknown_license")]
+    pub license_id: String,
+    #[serde(default)]
+    pub access: CatalogModelAccess,
+    #[serde(default)]
+    pub requires_remote_code: bool,
+    #[serde(default)]
+    pub approved_runtimes: BTreeSet<String>,
+}
+
+fn unknown_license() -> String {
+    "unknown".to_string()
+}
+
+impl Default for CatalogModelGovernance {
+    fn default() -> Self {
+        Self {
+            license_id: unknown_license(),
+            access: CatalogModelAccess::Unreviewed,
+            requires_remote_code: false,
+            approved_runtimes: BTreeSet::new(),
+        }
+    }
+}
+
+impl CatalogModelGovernance {
+    pub fn new(
+        license_id: impl Into<String>,
+        access: CatalogModelAccess,
+        requires_remote_code: bool,
+        approved_runtimes: impl IntoIterator<Item = String>,
+    ) -> Result<Self, CatalogModelContractError> {
+        let policy = Self {
+            license_id: license_id.into(),
+            access,
+            requires_remote_code,
+            approved_runtimes: approved_runtimes.into_iter().collect(),
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.license_id, "license id")?;
+        if self
+            .approved_runtimes
+            .iter()
+            .any(|item| item.trim().is_empty())
+        {
+            return Err(CatalogModelContractError::Empty {
+                field: "approved runtime",
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogLineageInputKind {
+    Dataset,
+    FeatureSet,
+    Model,
+    Artifact,
+}
+
+/// Digest-pinned input consumed by the execution that produced a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogLineageInput {
+    pub kind: CatalogLineageInputKind,
+    pub name: String,
+    pub digest: String,
+}
+
+impl CatalogLineageInput {
+    pub fn new(
+        kind: CatalogLineageInputKind,
+        name: impl Into<String>,
+        digest: impl Into<String>,
+    ) -> Result<Self, CatalogModelContractError> {
+        let input = Self {
+            kind,
+            name: name.into(),
+            digest: digest.into(),
+        };
+        require_non_empty(&input.name, "lineage input name")?;
+        validate_sha256(&input.digest, "lineage input digest")?;
+        Ok(input)
+    }
+}
+
+/// MLMD/OpenLineage-shaped producer execution and its declared inputs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CatalogModelLineage {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer_execution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_revision: Option<String>,
+    #[serde(default)]
+    pub inputs: Vec<CatalogLineageInput>,
+}
+
+impl CatalogModelLineage {
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        if self
+            .producer_execution_id
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(CatalogModelContractError::Empty {
+                field: "producer execution id",
+            });
+        }
+        for input in &self.inputs {
+            require_non_empty(&input.name, "lineage input name")?;
+            validate_sha256(&input.digest, "lineage input digest")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogDimensionPolicy {
+    Fixed,
+    Discrete,
+    Range { minimum: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogEmbeddingOutputContract {
+    pub native_dimension: u32,
+    pub dimension_policy: CatalogDimensionPolicy,
+    pub supported_dimensions: Vec<u32>,
+    pub normalized: bool,
+    pub pooling: String,
+}
+
+impl CatalogEmbeddingOutputContract {
+    pub fn new(
+        native_dimension: u32,
+        dimension_policy: CatalogDimensionPolicy,
+        mut supported_dimensions: Vec<u32>,
+        normalized: bool,
+        pooling: impl Into<String>,
+    ) -> Result<Self, CatalogModelContractError> {
+        supported_dimensions.sort_unstable();
+        supported_dimensions.dedup();
+        let contract = Self {
+            native_dimension,
+            dimension_policy,
+            supported_dimensions,
+            normalized,
+            pooling: pooling.into(),
+        };
+        contract.validate()?;
+        Ok(contract)
+    }
+
+    pub fn supports(&self, dimension: u32) -> bool {
+        match self.dimension_policy {
+            CatalogDimensionPolicy::Fixed => dimension == self.native_dimension,
+            CatalogDimensionPolicy::Discrete => self.supported_dimensions.contains(&dimension),
+            CatalogDimensionPolicy::Range { minimum } => {
+                (minimum..=self.native_dimension).contains(&dimension)
+            }
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        if self.native_dimension == 0 {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "native dimension must be positive".to_string(),
+            });
+        }
+        require_non_empty(&self.pooling, "pooling")?;
+        for dimension in &self.supported_dimensions {
+            if *dimension == 0 {
+                return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                    reason: "supported dimensions must be positive".to_string(),
+                });
+            }
+            if *dimension > self.native_dimension {
+                return Err(CatalogModelContractError::DimensionExceedsNative {
+                    dimension: *dimension,
+                    native_dimension: self.native_dimension,
+                });
+            }
+        }
+        match self.dimension_policy {
+            CatalogDimensionPolicy::Fixed
+                if self.supported_dimensions.as_slice() != [self.native_dimension] =>
+            {
+                Err(CatalogModelContractError::InvalidDimensionPolicy {
+                    reason: "fixed policy must contain only the native dimension".to_string(),
+                })
+            }
+            CatalogDimensionPolicy::Discrete
+                if self.supported_dimensions.is_empty()
+                    || !self.supported_dimensions.contains(&self.native_dimension) =>
+            {
+                Err(CatalogModelContractError::InvalidDimensionPolicy {
+                    reason: "discrete policy must include the native dimension".to_string(),
+                })
+            }
+            CatalogDimensionPolicy::Range { minimum }
+                if minimum == 0 || minimum > self.native_dimension =>
+            {
+                Err(CatalogModelContractError::InvalidDimensionPolicy {
+                    reason: "range minimum must be between one and native dimension".to_string(),
+                })
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Immutable executable contract for one registered model version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogEmbeddingModelVersion {
+    pub version: u64,
+    pub provider_model_id: String,
+    pub artifact: CatalogArtifactDescriptor,
+    pub input: CatalogEmbeddingInputContract,
+    pub output: CatalogEmbeddingOutputContract,
+    #[serde(default)]
+    pub governance: CatalogModelGovernance,
+    #[serde(default)]
+    pub lineage: CatalogModelLineage,
+    pub created_at_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_run_id: Option<String>,
+}
+
+impl CatalogEmbeddingModelVersion {
+    pub fn new(
+        version: u64,
+        provider_model_id: impl Into<String>,
+        artifact: CatalogArtifactDescriptor,
+        input: CatalogEmbeddingInputContract,
+        output: CatalogEmbeddingOutputContract,
+        created_at_ms: i64,
+    ) -> Result<Self, CatalogModelContractError> {
+        let contract = Self {
+            version,
+            provider_model_id: provider_model_id.into(),
+            artifact,
+            input,
+            output,
+            governance: CatalogModelGovernance::default(),
+            lineage: CatalogModelLineage::default(),
+            created_at_ms,
+            source_run_id: None,
+        };
+        contract.validate()?;
+        Ok(contract)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        if self.version == 0 {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "model versions start at one".to_string(),
+            });
+        }
+        require_non_empty(&self.provider_model_id, "provider model id")?;
+        self.artifact.validate()?;
+        self.input.validate()?;
+        self.output.validate()?;
+        self.governance.validate()?;
+        self.lineage.validate()?;
+        Ok(())
+    }
+
+    pub fn with_governance(mut self, governance: CatalogModelGovernance) -> Self {
+        self.governance = governance;
+        self
+    }
+
+    pub fn with_lineage(mut self, lineage: CatalogModelLineage) -> Self {
+        self.lineage = lineage;
+        self
+    }
+
+    /// Hash only executable semantics, excluding timestamps, aliases, evidence,
+    /// approval, and deployment state.
+    pub fn contract_sha256(&self) -> Result<String, CatalogModelContractError> {
+        #[derive(Serialize)]
+        struct ExecutableContract<'a> {
+            schema_version: u32,
+            provider_model_id: &'a str,
+            artifact_digest: &'a str,
+            input: &'a CatalogEmbeddingInputContract,
+            output: &'a CatalogEmbeddingOutputContract,
+        }
+        let bytes = serde_json::to_vec(&ExecutableContract {
+            schema_version: MODEL_CONTRACT_SCHEMA_VERSION,
+            provider_model_id: &self.provider_model_id,
+            artifact_digest: &self.artifact.digest,
+            input: &self.input,
+            output: &self.output,
+        })
+        .map_err(|error| CatalogModelContractError::Serialization {
+            message: error.to_string(),
+        })?;
+        Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+    }
+}
+
+/// Append-only evaluation summary. Large row-level results remain external.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CatalogEvaluationEvidence {
+    pub evidence_id: String,
+    pub version: u64,
+    pub dataset_name: String,
+    pub dataset_digest: String,
+    pub evaluator: String,
+    pub metrics: BTreeMap<String, f64>,
+    pub created_at_ms: i64,
+}
+
+impl CatalogEvaluationEvidence {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        evidence_id: impl Into<String>,
+        version: u64,
+        dataset_name: impl Into<String>,
+        dataset_digest: impl Into<String>,
+        evaluator: impl Into<String>,
+        metrics: BTreeMap<String, f64>,
+        created_at_ms: i64,
+    ) -> Result<Self, CatalogModelContractError> {
+        let evidence = Self {
+            evidence_id: evidence_id.into(),
+            version,
+            dataset_name: dataset_name.into(),
+            dataset_digest: dataset_digest.into(),
+            evaluator: evaluator.into(),
+            metrics,
+            created_at_ms,
+        };
+        evidence.validate()?;
+        Ok(evidence)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.evidence_id, "evidence id")?;
+        require_non_empty(&self.dataset_name, "dataset name")?;
+        validate_sha256(&self.dataset_digest, "dataset digest")?;
+        require_non_empty(&self.evaluator, "evaluator")?;
+        if self.metrics.is_empty() || self.metrics.values().any(|value| !value.is_finite()) {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "evaluation metrics must be non-empty and finite".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogModelDecisionKind {
+    Approved,
+    Rejected,
+    Deprecated,
+}
+
+/// Append-only policy/audit decision, intentionally separate from evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogModelDecision {
+    pub decision_id: String,
+    pub version: u64,
+    pub decision: CatalogModelDecisionKind,
+    pub evidence_ids: Vec<String>,
+    pub principal: String,
+    pub created_at_ms: i64,
+}
+
+impl CatalogModelDecision {
+    pub fn new(
+        decision_id: impl Into<String>,
+        version: u64,
+        decision: CatalogModelDecisionKind,
+        evidence_ids: Vec<String>,
+        principal: impl Into<String>,
+        created_at_ms: i64,
+    ) -> Result<Self, CatalogModelContractError> {
+        let record = Self {
+            decision_id: decision_id.into(),
+            version,
+            decision,
+            evidence_ids,
+            principal: principal.into(),
+            created_at_ms,
+        };
+        record.validate()?;
+        Ok(record)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.decision_id, "decision id")?;
+        require_non_empty(&self.principal, "decision principal")?;
+        if self.decision == CatalogModelDecisionKind::Approved && self.evidence_ids.is_empty() {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "approval requires evaluation evidence".to_string(),
+            });
+        }
+        if self.evidence_ids.iter().collect::<BTreeSet<_>>().len() != self.evidence_ids.len() {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "decision evidence ids must be unique".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Mutable serving intent that always resolves to an immutable version/digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogDeploymentBinding {
+    pub name: String,
+    pub version: u64,
+    pub artifact_digest: String,
+    pub runtime: String,
+    pub endpoint: String,
+    pub updated_at_ms: i64,
+}
+
+impl CatalogDeploymentBinding {
+    pub fn new(
+        name: impl Into<String>,
+        version: u64,
+        artifact_digest: impl Into<String>,
+        runtime: impl Into<String>,
+        endpoint: impl Into<String>,
+        updated_at_ms: i64,
+    ) -> Result<Self, CatalogModelContractError> {
+        let binding = Self {
+            name: name.into(),
+            version,
+            artifact_digest: artifact_digest.into(),
+            runtime: runtime.into(),
+            endpoint: endpoint.into(),
+            updated_at_ms,
+        };
+        binding.validate()?;
+        Ok(binding)
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.name, "deployment name")?;
+        validate_sha256(&self.artifact_digest, "deployment artifact digest")?;
+        require_non_empty(&self.runtime, "deployment runtime")?;
+        require_non_empty(&self.endpoint, "deployment endpoint")?;
+        Ok(())
+    }
+}
+
+/// Registered embedding model: immutable versions plus separately mutable or
+/// append-only lifecycle records.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CatalogEmbeddingModelRegistry {
+    pub schema_version: u32,
+    /// Optimistic concurrency token for catalog/API mutations. Old rows default
+    /// to zero; every successful command increments it.
+    #[serde(default)]
+    pub revision: u64,
+    pub name: String,
+    #[serde(default)]
+    pub versions: BTreeMap<u64, CatalogEmbeddingModelVersion>,
+    #[serde(default)]
+    pub aliases: BTreeMap<String, u64>,
+    #[serde(default)]
+    pub evidence: Vec<CatalogEvaluationEvidence>,
+    #[serde(default)]
+    pub decisions: Vec<CatalogModelDecision>,
+    #[serde(default)]
+    pub deployments: BTreeMap<String, CatalogDeploymentBinding>,
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
+}
+
+/// Command-shaped mutations preserve version/evidence/decision immutability at
+/// the persistence boundary. API adapters lower into these commands instead
+/// of replacing a whole registry document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum CatalogModelRegistryMutation {
+    RegisterVersion(Box<CatalogEmbeddingModelVersion>),
+    SetAlias { alias: String, version: u64 },
+    AppendEvidence(CatalogEvaluationEvidence),
+    RecordDecision(CatalogModelDecision),
+    UpsertDeployment(CatalogDeploymentBinding),
+}
+
+impl CatalogModelRegistryMutation {
+    pub fn register_version(version: CatalogEmbeddingModelVersion) -> Self {
+        Self::RegisterVersion(Box::new(version))
+    }
+}
+
+impl CatalogEmbeddingModelRegistry {
+    pub fn new(name: impl Into<String>) -> Result<Self, CatalogModelContractError> {
+        let registry = Self {
+            schema_version: MODEL_CONTRACT_SCHEMA_VERSION,
+            revision: 0,
+            name: name.into(),
+            versions: BTreeMap::new(),
+            aliases: BTreeMap::new(),
+            evidence: Vec::new(),
+            decisions: Vec::new(),
+            deployments: BTreeMap::new(),
+            tags: BTreeMap::new(),
+        };
+        require_non_empty(&registry.name, "registered model name")?;
+        Ok(registry)
+    }
+
+    pub fn register_version(
+        &mut self,
+        version: CatalogEmbeddingModelVersion,
+    ) -> Result<(), CatalogModelContractError> {
+        version.validate()?;
+        if self.versions.contains_key(&version.version) {
+            return Err(CatalogModelContractError::DuplicateVersion {
+                version: version.version,
+            });
+        }
+        self.versions.insert(version.version, version);
+        Ok(())
+    }
+
+    pub fn version(
+        &self,
+        version: u64,
+    ) -> Result<&CatalogEmbeddingModelVersion, CatalogModelContractError> {
+        self.versions
+            .get(&version)
+            .ok_or(CatalogModelContractError::UnknownVersion { version })
+    }
+
+    pub fn set_alias(
+        &mut self,
+        alias: impl Into<String>,
+        version: u64,
+    ) -> Result<(), CatalogModelContractError> {
+        self.version(version)?;
+        let alias = alias.into();
+        if !Self::valid_alias(&alias) {
+            return Err(CatalogModelContractError::InvalidAlias { alias });
+        }
+        self.aliases.insert(alias, version);
+        Ok(())
+    }
+
+    fn valid_alias(alias: &str) -> bool {
+        !alias.is_empty()
+            && !alias
+                .bytes()
+                .any(|byte| byte.is_ascii_whitespace() || matches!(byte, b'/' | b'@'))
+    }
+
+    pub fn resolve_alias(
+        &self,
+        alias: &str,
+    ) -> Result<&CatalogEmbeddingModelVersion, CatalogModelContractError> {
+        let version =
+            self.aliases
+                .get(alias)
+                .ok_or_else(|| CatalogModelContractError::UnknownAlias {
+                    alias: alias.to_string(),
+                })?;
+        self.version(*version)
+    }
+
+    pub fn append_evidence(
+        &mut self,
+        evidence: CatalogEvaluationEvidence,
+    ) -> Result<(), CatalogModelContractError> {
+        self.version(evidence.version)?;
+        if self
+            .evidence
+            .iter()
+            .any(|item| item.evidence_id == evidence.evidence_id)
+        {
+            return Err(CatalogModelContractError::DuplicateEvidence {
+                evidence_id: evidence.evidence_id,
+            });
+        }
+        self.evidence.push(evidence);
+        Ok(())
+    }
+
+    pub fn record_decision(
+        &mut self,
+        decision: CatalogModelDecision,
+    ) -> Result<(), CatalogModelContractError> {
+        self.version(decision.version)?;
+        if self
+            .decisions
+            .iter()
+            .any(|item| item.decision_id == decision.decision_id)
+        {
+            return Err(CatalogModelContractError::DuplicateDecision {
+                decision_id: decision.decision_id,
+            });
+        }
+        for evidence_id in &decision.evidence_ids {
+            if !self
+                .evidence
+                .iter()
+                .any(|item| item.evidence_id == *evidence_id && item.version == decision.version)
+            {
+                return Err(CatalogModelContractError::UnknownEvidence {
+                    evidence_id: evidence_id.clone(),
+                    version: decision.version,
+                });
+            }
+        }
+        self.decisions.push(decision);
+        Ok(())
+    }
+
+    pub fn upsert_deployment(
+        &mut self,
+        deployment: CatalogDeploymentBinding,
+    ) -> Result<(), CatalogModelContractError> {
+        let version = self.version(deployment.version)?;
+        if version.artifact.digest != deployment.artifact_digest {
+            return Err(CatalogModelContractError::DeploymentDigestMismatch {
+                deployment: deployment.name,
+                version: deployment.version,
+            });
+        }
+        if !version
+            .governance
+            .approved_runtimes
+            .contains(&deployment.runtime)
+        {
+            return Err(CatalogModelContractError::RuntimeNotApproved {
+                runtime: deployment.runtime,
+                version: deployment.version,
+            });
+        }
+        self.deployments.insert(deployment.name.clone(), deployment);
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        require_non_empty(&self.name, "registered model name")?;
+        if self.schema_version != MODEL_CONTRACT_SCHEMA_VERSION {
+            return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                reason: format!(
+                    "unsupported model contract schema version {}",
+                    self.schema_version
+                ),
+            });
+        }
+        for (number, version) in &self.versions {
+            if number != &version.version {
+                return Err(CatalogModelContractError::InvalidDimensionPolicy {
+                    reason: format!("version map key {number} does not match payload"),
+                });
+            }
+            version.validate()?;
+        }
+        for (alias, version) in &self.aliases {
+            if !Self::valid_alias(alias) || !self.versions.contains_key(version) {
+                return Err(CatalogModelContractError::UnknownAlias {
+                    alias: alias.clone(),
+                });
+            }
+        }
+        let mut evidence_ids = BTreeSet::new();
+        for evidence in &self.evidence {
+            if !self.versions.contains_key(&evidence.version)
+                || !evidence_ids.insert(&evidence.evidence_id)
+            {
+                return Err(CatalogModelContractError::DuplicateEvidence {
+                    evidence_id: evidence.evidence_id.clone(),
+                });
+            }
+            evidence.validate()?;
+        }
+        let mut decision_ids = BTreeSet::new();
+        for decision in &self.decisions {
+            decision.validate()?;
+            if !self.versions.contains_key(&decision.version)
+                || !decision_ids.insert(&decision.decision_id)
+            {
+                return Err(CatalogModelContractError::DuplicateDecision {
+                    decision_id: decision.decision_id.clone(),
+                });
+            }
+            for evidence_id in &decision.evidence_ids {
+                if !self.evidence.iter().any(|item| {
+                    item.evidence_id == *evidence_id && item.version == decision.version
+                }) {
+                    return Err(CatalogModelContractError::UnknownEvidence {
+                        evidence_id: evidence_id.clone(),
+                        version: decision.version,
+                    });
+                }
+            }
+        }
+        for deployment in self.deployments.values() {
+            deployment.validate()?;
+            let version = self.version(deployment.version)?;
+            if version.artifact.digest != deployment.artifact_digest {
+                return Err(CatalogModelContractError::DeploymentDigestMismatch {
+                    deployment: deployment.name.clone(),
+                    version: deployment.version,
+                });
+            }
+            if !version
+                .governance
+                .approved_runtimes
+                .contains(&deployment.runtime)
+            {
+                return Err(CatalogModelContractError::RuntimeNotApproved {
+                    runtime: deployment.runtime.clone(),
+                    version: deployment.version,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn apply(
+        &mut self,
+        expected_revision: u64,
+        mutation: CatalogModelRegistryMutation,
+    ) -> Result<(), CatalogModelContractError> {
+        if expected_revision != self.revision {
+            return Err(CatalogModelContractError::RevisionConflict {
+                expected: expected_revision,
+                current: self.revision,
+            });
+        }
+        match mutation {
+            CatalogModelRegistryMutation::RegisterVersion(version) => {
+                self.register_version(*version)
+            }
+            CatalogModelRegistryMutation::SetAlias { alias, version } => {
+                self.set_alias(alias, version)
+            }
+            CatalogModelRegistryMutation::AppendEvidence(evidence) => {
+                self.append_evidence(evidence)
+            }
+            CatalogModelRegistryMutation::RecordDecision(decision) => {
+                self.record_decision(decision)
+            }
+            CatalogModelRegistryMutation::UpsertDeployment(deployment) => {
+                self.upsert_deployment(deployment)
+            }
+        }?;
+        self.revision = self.revision.checked_add(1).ok_or_else(|| {
+            CatalogModelContractError::InvalidDimensionPolicy {
+                reason: "model registry revision exhausted".to_string(),
+            }
+        })?;
+        Ok(())
+    }
+}
+
+/// Typed MLOps facet on the unified xCatalog object model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "contract", rename_all = "snake_case")]
+pub enum CatalogMlopsAsset {
+    EmbeddingModel(CatalogEmbeddingModelRegistry),
+}
+
+impl CatalogMlopsAsset {
+    pub fn validate(&self) -> Result<(), CatalogModelContractError> {
+        match self {
+            Self::EmbeddingModel(registry) => registry.validate(),
+        }
+    }
+
+    pub fn apply_model_mutation(
+        &mut self,
+        expected_revision: u64,
+        mutation: CatalogModelRegistryMutation,
+    ) -> Result<(), CatalogModelContractError> {
+        match self {
+            Self::EmbeddingModel(registry) => registry.apply(expected_revision, mutation),
+        }
+    }
+}

--- a/crates/control/proximadb-catalog/src/native.rs
+++ b/crates/control/proximadb-catalog/src/native.rs
@@ -150,6 +150,10 @@ pub struct NativeCatalog {
     /// Serializes mint + sidecar persistence. Without this, concurrent mints
     /// can publish whole-map snapshots out of order and lose the later tenant.
     account_registry_write_lock: Mutex<()>,
+    /// Serializes cold control-plane model registry read-modify-write commands.
+    /// This avoids lost alias/evidence updates without touching the serving
+    /// data path.
+    mlops_mutation_lock: Mutex<()>,
     /// u64 lets the allocator report u32 exhaustion instead of wrapping.
     account_floor: AtomicU64,
     /// ADR-031 Phase 4a: transient namespace-key → u16 map, so every collection
@@ -447,6 +451,7 @@ impl NativeCatalog {
             stable_ids: crate::id_allocator::CatalogIdService::new(),
             account_registry: DashMap::new(),
             account_registry_write_lock: Mutex::new(()),
+            mlops_mutation_lock: Mutex::new(()),
             account_floor: AtomicU64::new(1),
             namespace_registry: DashMap::new(),
             namespace_floor: AtomicU32::new(1),
@@ -1788,6 +1793,32 @@ impl Catalog for NativeCatalog {
         let mut meta = self.load_table(identifier).await?;
         meta.schema.storage_layouts = layouts;
         meta.updated_at = Self::now_millis();
+        self.save_table(&meta).await?;
+        self.cache
+            .invalidate_table_in_catalog(&self.name, identifier);
+        Ok(meta.schema)
+    }
+
+    async fn apply_model_registry_mutation(
+        &self,
+        identifier: &TableIdentifier,
+        expected_revision: u64,
+        mutation: crate::mlops::CatalogModelRegistryMutation,
+    ) -> Result<CatalogTableSchema> {
+        let _guard = self.mlops_mutation_lock.lock().await;
+        let mut meta = self.load_table(identifier).await?;
+        let asset = meta
+            .schema
+            .mlops_asset
+            .as_mut()
+            .ok_or_else(|| anyhow!("Catalog object '{}' is not an MLOps asset", identifier))?;
+        asset
+            .apply_model_mutation(expected_revision, mutation)
+            .map_err(anyhow::Error::new)?;
+        asset.validate().map_err(anyhow::Error::new)?;
+        let now = Self::now_millis();
+        meta.schema.updated_at_ms = now;
+        meta.updated_at = now;
         self.save_table(&meta).await?;
         self.cache
             .invalidate_table_in_catalog(&self.name, identifier);

--- a/crates/control/proximadb-catalog/src/schema.rs
+++ b/crates/control/proximadb-catalog/src/schema.rs
@@ -23,8 +23,17 @@ pub fn validate_schema(schema: &CatalogTableSchema) -> Result<()> {
         return Err(anyhow!("Schema name cannot be empty"));
     }
 
-    if schema.columns.is_empty() {
+    if schema.columns.is_empty() && schema.mlops_asset.is_none() {
         return Err(anyhow!("Schema must have at least one column"));
+    }
+
+    if let Some(asset) = &schema.mlops_asset {
+        asset
+            .validate()
+            .map_err(|error| anyhow!("Invalid MLOps asset: {error}"))?;
+    }
+    if let Some(binding) = &schema.embedding_config {
+        binding.validate_model_binding()?;
     }
 
     let mut seen = HashSet::new();

--- a/crates/control/proximadb-catalog/tests/mlops_model_contract.rs
+++ b/crates/control/proximadb-catalog/tests/mlops_model_contract.rs
@@ -1,0 +1,429 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use proximadb_catalog::mlops::{
+    CatalogArtifactDescriptor, CatalogDeploymentBinding, CatalogDimensionPolicy,
+    CatalogEmbeddingInputContract, CatalogEmbeddingModelRegistry, CatalogEmbeddingModelVersion,
+    CatalogEmbeddingOutputContract, CatalogEvaluationEvidence, CatalogMlopsAsset,
+    CatalogModelAccess, CatalogModelDecision, CatalogModelDecisionKind, CatalogModelGovernance,
+    CatalogModelRegistryMutation,
+};
+use proximadb_catalog::native::{NativeCatalog, NativeCatalogConfig};
+use proximadb_catalog::schema::validate_schema;
+use proximadb_catalog::{
+    Catalog, CatalogColumn, CatalogEmbeddingConfig, CatalogTableSchema, TableIdentifier,
+};
+
+const MODEL_DIGEST: &str =
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DATASET_DIGEST: &str =
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn version(number: u64) -> CatalogEmbeddingModelVersion {
+    let artifact = CatalogArtifactDescriptor::new(
+        "hf://BAAI/bge-base-en-v1.5@aed724fc5",
+        MODEL_DIGEST,
+        438_000_000,
+        "application/vnd.huggingface.safetensors",
+    )
+    .unwrap();
+    let input = CatalogEmbeddingInputContract::new(
+        "aed724fc5",
+        "BAAI/bge-base-en-v1.5",
+        "aed724fc5",
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        512,
+        2,
+        "{text}",
+        "Represent this sentence for searching relevant passages: {text}",
+    )
+    .unwrap();
+    let output = CatalogEmbeddingOutputContract::new(
+        768,
+        CatalogDimensionPolicy::Fixed,
+        vec![768],
+        true,
+        "mean",
+    )
+    .unwrap();
+
+    CatalogEmbeddingModelVersion::new(
+        number,
+        "BAAI/bge-base-en-v1.5",
+        artifact,
+        input,
+        output,
+        1_786_400_000_000,
+    )
+    .unwrap()
+    .with_governance(
+        CatalogModelGovernance::new(
+            "mit",
+            CatalogModelAccess::Open,
+            false,
+            ["kserve".to_string(), "sentence-transformers".to_string()],
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn artifact_requires_a_content_digest_not_only_a_mutable_uri() {
+    let error = CatalogArtifactDescriptor::new(
+        "hf://BAAI/bge-base-en-v1.5@main",
+        "main",
+        1,
+        "application/octet-stream",
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("sha256"));
+}
+
+#[test]
+fn rendered_input_budget_is_validated_at_the_contract_boundary() {
+    let error = CatalogEmbeddingInputContract::new(
+        "model-sha",
+        "tokenizer-id",
+        "tokenizer-sha",
+        MODEL_DIGEST,
+        512,
+        512,
+        "{text}",
+        "{text}",
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("special token"));
+
+    let duplicate_placeholder = CatalogEmbeddingInputContract::new(
+        "model-sha",
+        "tokenizer-id",
+        "tokenizer-sha",
+        MODEL_DIGEST,
+        512,
+        2,
+        "{text} {text}",
+        "{text}",
+    )
+    .unwrap_err();
+    assert!(duplicate_placeholder.to_string().contains("exactly one"));
+}
+
+#[test]
+fn dimension_policy_cannot_advertise_impossible_outputs() {
+    let error = CatalogEmbeddingOutputContract::new(
+        768,
+        CatalogDimensionPolicy::Discrete,
+        vec![1024, 768, 256],
+        true,
+        "mean",
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("native dimension"));
+}
+
+#[test]
+fn versions_are_immutable_while_aliases_are_mutable_references() {
+    let mut registry = CatalogEmbeddingModelRegistry::new("search-embedding").unwrap();
+    registry.register_version(version(1)).unwrap();
+    registry.set_alias("champion", 1).unwrap();
+
+    assert_eq!(registry.resolve_alias("champion").unwrap().version, 1);
+    assert!(registry.register_version(version(1)).is_err());
+
+    let mut second = version(2);
+    second.artifact.digest =
+        "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string();
+    registry.register_version(second).unwrap();
+    registry.set_alias("champion", 2).unwrap();
+
+    assert_eq!(registry.resolve_alias("champion").unwrap().version, 2);
+    assert_eq!(registry.version(1).unwrap().version, 1);
+}
+
+#[test]
+fn evidence_approval_and_deployment_are_distinct_version_pinned_records() {
+    let mut registry = CatalogEmbeddingModelRegistry::new("search-embedding").unwrap();
+    registry.register_version(version(1)).unwrap();
+
+    let evidence = CatalogEvaluationEvidence::new(
+        "eval-bge-1",
+        1,
+        "rag-retrieval-v3",
+        DATASET_DIGEST,
+        "proximadb-eval@2.1.0",
+        BTreeMap::from([
+            ("ndcg_at_10".to_string(), 0.73),
+            ("recall_at_10".to_string(), 0.82),
+        ]),
+        1_786_400_100_000,
+    )
+    .unwrap();
+    registry.append_evidence(evidence).unwrap();
+
+    registry
+        .record_decision(
+            CatalogModelDecision::new(
+                "decision-bge-1",
+                1,
+                CatalogModelDecisionKind::Approved,
+                vec!["eval-bge-1".to_string()],
+                "principal:ml-reviewers",
+                1_786_400_200_000,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    registry
+        .upsert_deployment(
+            CatalogDeploymentBinding::new(
+                "prod-search",
+                1,
+                MODEL_DIGEST,
+                "kserve",
+                "inference://prod/search-embedding",
+                1_786_400_300_000,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(registry.evidence.len(), 1);
+    assert_eq!(registry.decisions.len(), 1);
+    assert_eq!(registry.deployments["prod-search"].version, 1);
+
+    let bad_binding = CatalogDeploymentBinding::new(
+        "prod-search",
+        1,
+        "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "kserve",
+        "inference://prod/search-embedding",
+        1_786_400_400_000,
+    )
+    .unwrap();
+    assert!(registry.upsert_deployment(bad_binding).is_err());
+
+    let unapproved_runtime = CatalogDeploymentBinding::new(
+        "prod-search-onnx",
+        1,
+        MODEL_DIGEST,
+        "onnx-runtime",
+        "inference://prod/search-embedding-onnx",
+        1_786_400_500_000,
+    )
+    .unwrap();
+    assert!(registry.upsert_deployment(unapproved_runtime).is_err());
+}
+
+#[test]
+fn contract_hash_is_stable_and_changes_with_executable_semantics() {
+    let first = version(1);
+    let same = version(1);
+    assert_eq!(
+        first.contract_sha256().unwrap(),
+        same.contract_sha256().unwrap()
+    );
+
+    let mut changed = version(1);
+    changed.input.document_template = "passage: {text}".to_string();
+    assert_ne!(
+        first.contract_sha256().unwrap(),
+        changed.contract_sha256().unwrap()
+    );
+
+    let mut relocated = first.clone();
+    relocated.artifact.uri = "az://models/bge-base/aed724fc5".to_string();
+    assert_eq!(
+        first.contract_sha256().unwrap(),
+        relocated.contract_sha256().unwrap(),
+        "artifact location is not content identity"
+    );
+}
+
+#[test]
+fn collection_embedding_binding_requires_asset_version_and_contract_hash_together() {
+    let schema = CatalogTableSchema::new("documents")
+        .with_column(CatalogColumn::new(
+            1,
+            "id",
+            proximadb_data_model::ProximaType::String,
+        ))
+        .with_embedding_config(CatalogEmbeddingConfig {
+            model: "search-embedding".to_string(),
+            dimension: 768,
+            model_asset_id: Some(42),
+            ..Default::default()
+        });
+
+    let error = validate_schema(&schema).unwrap_err();
+    assert!(error.to_string().contains("model version"));
+
+    let valid = CatalogTableSchema::new("documents")
+        .with_column(CatalogColumn::new(
+            1,
+            "id",
+            proximadb_data_model::ProximaType::String,
+        ))
+        .with_embedding_config(
+            CatalogEmbeddingConfig::pinned(
+                "search-embedding",
+                768,
+                42,
+                1,
+                "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            )
+            .unwrap(),
+        );
+    validate_schema(&valid).unwrap();
+}
+
+#[test]
+fn optimistic_revision_rejects_stale_catalog_writers() {
+    let mut registry = CatalogEmbeddingModelRegistry::new("search-embedding").unwrap();
+    registry
+        .apply(
+            0,
+            CatalogModelRegistryMutation::register_version(version(1)),
+        )
+        .unwrap();
+    assert_eq!(registry.revision, 1);
+
+    let error = registry
+        .apply(
+            0,
+            CatalogModelRegistryMutation::SetAlias {
+                alias: "champion".to_string(),
+                version: 1,
+            },
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("revision conflict"));
+    assert!(registry.aliases.is_empty());
+}
+
+#[test]
+fn imported_registry_revalidates_nested_evidence_and_decisions() {
+    let approval_without_evidence = CatalogModelDecision::new(
+        "unsafe-approval",
+        1,
+        CatalogModelDecisionKind::Approved,
+        vec![],
+        "principal:reviewer",
+        1,
+    )
+    .unwrap_err();
+    assert!(approval_without_evidence.to_string().contains("evidence"));
+
+    let mut registry = CatalogEmbeddingModelRegistry::new("search-embedding").unwrap();
+    registry.register_version(version(1)).unwrap();
+    registry.evidence.push(CatalogEvaluationEvidence {
+        evidence_id: "imported-invalid".to_string(),
+        version: 1,
+        dataset_name: "rag-eval".to_string(),
+        dataset_digest: DATASET_DIGEST.to_string(),
+        evaluator: "eval@1".to_string(),
+        metrics: BTreeMap::from([("recall".to_string(), f64::NAN)]),
+        created_at_ms: 1,
+    });
+    assert!(registry.validate().is_err());
+}
+
+#[test]
+fn legacy_catalog_rows_default_to_no_mlops_facet() {
+    let legacy = serde_json::json!({
+        "name": "legacy",
+        "columns": [],
+        "primary_key": [],
+        "indexes": [],
+        "schema_version": 1,
+        "properties": {},
+        "location": null,
+        "created_at_ms": 0,
+        "updated_at_ms": 0
+    });
+
+    let schema: CatalogTableSchema = serde_json::from_value(legacy).unwrap();
+    assert!(schema.mlops_asset.is_none());
+}
+
+#[test]
+fn python_sdk_golden_asset_is_native_serde_compatible() {
+    let json = include_str!(
+        "../../../../clients/python/tests/fixtures/embedding_model_xcatalog_asset.json"
+    );
+    let asset: CatalogMlopsAsset = serde_json::from_str(json).unwrap();
+    asset.validate().unwrap();
+
+    let CatalogMlopsAsset::EmbeddingModel(registry) = asset;
+    assert_eq!(registry.name, "search-embedding");
+    assert_eq!(registry.version(1).unwrap().input.special_token_count, 2);
+}
+
+#[tokio::test]
+async fn native_xcatalog_persists_command_shaped_registry_mutations() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = NativeCatalogConfig {
+        storage_url: tmp.path().to_string_lossy().to_string(),
+        metadata_format: "json".to_string(),
+        versioned: false,
+        max_versions: 100,
+    };
+    let cache = Arc::new(proximadb_catalog::cache::CatalogCache::new(64, 60));
+    let catalog = NativeCatalog::new("test".to_string(), config.clone(), cache)
+        .await
+        .unwrap();
+    let namespace = vec!["tenant-a".to_string(), "mlops".to_string()];
+    catalog
+        .create_namespace(&namespace, HashMap::new())
+        .await
+        .unwrap();
+    let id = TableIdentifier::new(namespace, "search-embedding");
+    let asset = CatalogMlopsAsset::EmbeddingModel(
+        CatalogEmbeddingModelRegistry::new("search-embedding").unwrap(),
+    );
+    catalog
+        .create_table(
+            &id,
+            CatalogTableSchema::new("search-embedding")
+                .with_mlops_asset(asset)
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    catalog
+        .apply_model_registry_mutation(
+            &id,
+            0,
+            CatalogModelRegistryMutation::register_version(version(1)),
+        )
+        .await
+        .unwrap();
+    catalog
+        .apply_model_registry_mutation(
+            &id,
+            1,
+            CatalogModelRegistryMutation::SetAlias {
+                alias: "champion".to_string(),
+                version: 1,
+            },
+        )
+        .await
+        .unwrap();
+
+    drop(catalog);
+    let reloaded = NativeCatalog::new(
+        "test".to_string(),
+        config,
+        Arc::new(proximadb_catalog::cache::CatalogCache::new(64, 60)),
+    )
+    .await
+    .unwrap();
+    let schema = reloaded.get_table(&id).await.unwrap();
+    let CatalogMlopsAsset::EmbeddingModel(registry) = schema.mlops_asset.unwrap();
+    assert_eq!(registry.revision, 2);
+    assert_eq!(registry.resolve_alias("champion").unwrap().version, 1);
+}

--- a/docs/12-design/MODEL_INPUT_CONTRACT_AND_TOKEN_BUDGETED_CHUNKING_2026_08_11.adoc
+++ b/docs/12-design/MODEL_INPUT_CONTRACT_AND_TOKEN_BUDGETED_CHUNKING_2026_08_11.adoc
@@ -1,0 +1,247 @@
+= Model Input Contract and Token-Budgeted Chunking Co-Design
+:toc:
+:toclevels: 3
+
+Status: implemented SDK foundation; xCatalog persistence is a separately gated catalog evolution.
+
+== Outcome
+
+Chunking is constrained by the exact input consumed by an embedding runtime, not by characters and
+not by a tokenizer name alone. The authoritative implementation lives in
+`clients/python/src/proximadb_sdk/chunking_strategies/`. Benchmark scripts consume it; they do not
+own a second splitter.
+
+The design is model-agnostic across WordPiece, BPE, SentencePiece and custom fast Hugging Face
+tokenizers. A model is usable when its runtime can resolve:
+
+* exact tokenizer behavior and immutable fingerprint;
+* effective context limit, intersecting catalog declaration, tokenizer and loaded runtime;
+* document/query rendering, including special tokens and task prefixes;
+* non-text role parameters such as Jina v3's retrieval adapter;
+* native and supported Matryoshka output dimensions;
+* model revision, license and access requirements.
+
+== Incident and invariant
+
+The TD-IVF-3 BGE corpus used 2,000-character windows with a 1,750-character stride as a proxy for
+512 tokens. A 400-chunk audit measured 74..1,585 tokens and found 312/400 inputs above 512. The
+embedding library silently truncated them, leaving source coverage gaps because the character
+stride exceeded the content actually encoded.
+
+The replacement invariant is:
+
+[source,text]
+----
+for every emitted chunk c and every controlled model m:
+  tokens_m(render_m(c, DOCUMENT), add_special_tokens=true)
+    <= min(target_tokens, effective_context_m)
+----
+
+The builder fails rather than publishing a corpus when the invariant is false. Split, drop and
+short-tail policies are explicit manifest fields. The production default for oversized spans is
+`split`; `drop` is never inferred.
+
+== Design patterns and authority
+
+[cols="1,2,3", options="header"]
+|===
+| Pattern | Type | Responsibility
+
+| Strategy
+| `ChunkingStrategyInterface`
+| Proposes structural sentence, paragraph, recursive, semantic or code boundaries.
+
+| Decorator
+| `TokenBudgetStrategy`
+| Owns exact fitting, overlap, source coverage, overflow policy and final validation.
+
+| Adapter
+| `HuggingFaceTokenCounter`
+| Adapts any fast tokenizer to exact counts, source offsets, context declaration and fingerprint.
+
+| Value object
+| `ResolvedInputContract`
+| Binds model revision, tokenizer, effective limit, role rendering, role parameters and dimensions.
+
+| Composite
+| `CompositeInputContract`
+| Emits one byte-identical corpus that is valid for every model in a controlled comparison.
+
+| Factory
+| `ChunkingStrategyFactory`
+| Preserves legacy character behavior unless both a budget and contract are explicitly supplied.
+
+| Seed catalog
+| `embedding_providers/catalog.py`
+| Versioned, source-linked discovery defaults for common open-weight model families.
+
+| Durable authority
+| xCatalog `mlops.*` model-contract asset
+| Tenant-approved resolved revision, contract hash, policy, lineage and collection bindings.
+|===
+
+Structural boundaries are independent of the legacy character grouping. Sentence and paragraph
+strategies expose their atomic ends; the decorator selects the latest boundary that fits. It only
+hard-splits by tokenizer offsets when no structural boundary fits.
+
+== Why tokenizer identity is insufficient
+
+Two models can share a tokenizer and still have different effective limits, prefixes, task
+adapters or output semantics. Conversely, the BGE small/base/large v1.5 models share the same
+tokenizer and 512 cap, so a composite contract correctly permits one controlled corpus.
+
+A pool/cache identity includes the complete budget and contract manifests. A tokenizer fingerprint
+alone cannot key a chunker.
+
+== Open-model pressure-test catalog
+
+The SDK seed catalog covers representative, commonly deployed families rather than claiming every
+Hub checkpoint:
+
+* Sentence Transformers MiniLM and MPNet;
+* BGE v1.5 and BGE-M3;
+* E5 v2 and multilingual E5;
+* Nomic Embed v1.5 and v2 MoE;
+* GTE multilingual;
+* Snowflake Arctic Embed v2;
+* Jina Embeddings v2/v3;
+* Mixedbread mxbai;
+* Qwen3 Embedding 0.6B/4B/8B;
+* Google's gated EmbeddingGemma;
+* IBM Granite Embedding multilingual R2.
+
+Catalog inclusion requires an official model-card source, context and native dimension, role
+semantics, license/access classification, and a SentenceTransformers-compatible runtime path.
+Runtime verification remains authoritative. New variants are data entries, not provider classes.
+
+This review corrected two existing declarations: `all-MiniLM-L6-v2` truncates beyond 256
+WordPieces, and `all-mpnet-base-v2` uses a 384-token SentenceTransformers limit even though the
+underlying tokenizer/model can represent more positions.
+
+Model-card sources:
+
+* https://huggingface.co/BAAI/bge-m3[BGE-M3]
+* https://huggingface.co/intfloat/multilingual-e5-large[multilingual E5]
+* https://huggingface.co/nomic-ai/nomic-embed-text-v1.5[Nomic v1.5]
+* https://huggingface.co/nomic-ai/nomic-embed-text-v2-moe[Nomic v2 MoE]
+* https://huggingface.co/Alibaba-NLP/gte-multilingual-base[GTE multilingual]
+* https://huggingface.co/Snowflake/snowflake-arctic-embed-l-v2.0[Arctic Embed v2]
+* https://huggingface.co/jinaai/jina-embeddings-v3[Jina v3]
+* https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1[mxbai]
+* https://huggingface.co/Qwen/Qwen3-Embedding-0.6B[Qwen3 Embedding]
+* https://huggingface.co/google/embeddinggemma-300m[EmbeddingGemma]
+* https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2[Granite R2]
+
+The seed catalog records Jina v3's non-commercial license and EmbeddingGemma's gated access. A
+model being downloadable is not equivalent to unrestricted production use.
+
+== xCatalog relationship
+
+There should not be two durable catalogs. There are three lifecycle layers:
+
+[source,text]
+----
+SDK seed catalog (discovery defaults, shipped with a client version)
+        |
+        v resolve + approve
+xCatalog mlops model-contract asset (durable authority, tenant policy, versioned)
+        |
+        v reference by stable asset/version + contract hash
+collection / embedding projection / corpus manifest
+----
+
+xCatalog should be omnipresent as the policy and lineage plane, but typed. Model contracts live in
+an `mlops.*` namespace; collection/index objects reference them. They must not be flattened into an
+untyped global property bag. The current collection proto's `embedding_models: repeated string` is
+not rich enough to be this authority.
+
+The native catalog now carries an additive, typed `CatalogMlopsAsset::EmbeddingModel` facet. It
+contains:
+
+* provider/model ID, immutable model and tokenizer revisions;
+* tokenizer and renderer fingerprints, effective context and role parameters;
+* native/allowed dimensions, normalization and pooling contract;
+* license/access/trust policy and approved deployment backends;
+* append-only evaluation evidence and approval/rejection/deprecation decisions;
+* lineage to corpora, embedding projections and collections.
+
+Registered versions are immutable. Aliases and deployment bindings are mutable references, but a
+serving deployment and a collection persist a concrete version, artifact digest and executable
+contract digest. Optimistic registry revisions reject stale control-plane writes. Legacy rows
+deserialize with no MLOps facet, and the old opaque embedding-model name remains the mixed-read
+fallback. See
+link:XCATALOG_MLOPS_MODEL_REGISTRY_2026_08_12.adoc[xCatalog MLOps Model Registry Co-Design].
+
+== Economics: context and dimension are independent
+
+Let `S` be corpus source tokens, `L` raw content tokens per chunk, `r` overlap fraction, `d` output
+dimension and `b` bytes per scalar. Ignoring document boundaries:
+
+[source,text]
+----
+rows N ~= S / ((1-r) * L)
+raw vector bytes ~= N * d * b
+----
+
+Increasing `L` can reduce row count and fixed per-row/index/object overhead. Reducing `d` reduces
+vector bytes without changing row count. A long-context Matryoshka model exposes both levers, but
+neither is a free win:
+
+* full-attention ingestion work grows approximately with `S * L / (1-r)`;
+* longer chunks can dilute retrieval relevance and enlarge reranker/generator payloads;
+* fewer, larger chunks amplify updates and reduce fine-grained access control/citations;
+* model quality at a truncated dimension must be measured, not inferred from native quality.
+
+Choose `(model, L, r, d, index)` by minimizing measured lifecycle cost subject to recall/NDCG,
+latency, citation and policy constraints. Context capacity is a ceiling, not a chunk-size target.
+
+== User paths
+
+List and run catalogued models:
+
+[source,bash]
+----
+python clients/python/examples/token_budgeted_open_rag.py --list-models
+python clients/python/examples/token_budgeted_open_rag.py \
+  --model nomic-ai/nomic-embed-text-v1.5 --dimension 256 README.md
+----
+
+Validate cached or downloadable tokenizers without loading model weights:
+
+[source,bash]
+----
+python scripts/bench/validate_open_embedding_tokenizers.py \
+  --model BAAI/bge-base-en-v1.5 --local-files-only
+----
+
+Build a benchmark corpus from JSONL with one or more pinned contracts:
+
+[source,bash]
+----
+python scripts/bench/build_token_budget_corpus.py \
+  --input documents.jsonl --contracts contracts.toml --output-dir corpus \
+  --target-tokens 480 --overlap-tokens 72 --overflow-policy split
+----
+
+The output includes shared `texts.json`, per-chunk provenance in `chunks.jsonl`, and
+`corpus.manifest.json` with hashes, policies, contract fingerprints, histograms and a zero-truncation
+assertion.
+
+== Verification and migration gates
+
+Unit tests use tokenizer-shaped doubles and cover exact special-token accounting, structural
+boundaries, overlap, composite contracts, overflow/short-tail policies, pool isolation, discrete
+and ranged Matryoshka dimensions, role adapter parameters, and every seed-catalog entry.
+
+The BGE migration gate is:
+
+1. produce a shared BGE small/base corpus at target 480 with 15% overlap and `split` policy;
+2. require every model histogram maximum <= 512 and zero over-target inputs;
+3. persist immutable revisions and tokenizer fingerprints;
+4. re-embed resumably from 20k-row shards;
+5. recompute full-corpus PCA spectrum and compare with the truncated baseline;
+6. keep prior projection-width geometry findings; the rebuild is for realistic RAG quality and
+   corpus guidance, not to relitigate controlled index geometry.
+
+Timing measurements require a quiet machine. Token correctness, recall and GET/query checks do not
+become timing evidence merely because they ran successfully under contention.

--- a/docs/12-design/README.adoc
+++ b/docs/12-design/README.adoc
@@ -125,6 +125,12 @@ Read these in order for future-shaping architecture work:
    hand-written ergonomic facade, and split the kitchen-sink per-language packages (e.g. Python's
    ~86k `proximadb_sdk`, of which the wire client is only ~19k) into focused, opt-in packages
    (core client / chunking / embeddings / integrations). Tracked as TD-126.
+   Companion model-input blueprint:
+   link:MODEL_INPUT_CONTRACT_AND_TOKEN_BUDGETED_CHUNKING_2026_08_11.adoc[model-agnostic token-budgeted
+   chunking, open-weight model seed catalog, and native xCatalog model-contract binding].
+   Companion native catalog blueprint:
+   link:XCATALOG_MLOPS_MODEL_REGISTRY_2026_08_12.adoc[xCatalog MLOps model registry co-design,
+   MLflow/MLMD/OpenLineage pressure test, and TDD rollout seams].
 21. `CODE_GRAPH_CORRELATED_SUBSTRATE_2026_06_22.adoc` +
    Co-design spec for hosting an external coding agent's Code Property Graph as a correlated
    OLTP + graph + vector substrate: one `ProximaRecord`/`oid` per code symbol simultaneously a

--- a/docs/12-design/XCATALOG_MLOPS_MODEL_REGISTRY_2026_08_12.adoc
+++ b/docs/12-design/XCATALOG_MLOPS_MODEL_REGISTRY_2026_08_12.adoc
@@ -1,0 +1,187 @@
+= xCatalog MLOps Model Registry Co-Design
+:toc: left
+:toclevels: 3
+:icons: font
+:revdate: 2026-08-12
+
+[.lead]
+This design makes embedding execution contracts first-class, typed xCatalog assets while keeping
+MLflow, SDK discovery and serving runtimes as adapters. It is the native control-plane half of
+token-budgeted chunking: the tokenizer, renderer, context and output geometry used to chunk must be
+the same immutable contract pinned by collections and deployments.
+
+Status: *core contract and NativeCatalog persistence implemented; public lifecycle API and MLflow
+REST compatibility are rollout slices*. The shape is additive and legacy-read-safe.
+
+== First principles
+
+An embedding is not identified by a model name. Its executable meaning is the artifact digest,
+model and tokenizer revisions, tokenizer fingerprint, query/document rendering, effective context,
+pooling, normalization and output dimension policy. Therefore:
+
+. registered versions are immutable;
+. a URI locates bytes while a digest identifies them;
+. aliases select versions, but collections and deployments pin the resolved version and digest;
+. evidence does not grant approval; approval is an audited decision;
+. producer executions and input datasets are typed lineage, not tags;
+. request-hot embedding consumes a cached immutable snapshot, not a live catalog lookup;
+. weights, tokenizer files and row-level eval results remain outside catalog metadata.
+
+== One authority, several adapters
+
+[source,text]
+----
+SDK seed catalog         MLflow API          OpenLineage/MLMD events
+       \                    |                       /
+        +---------------- xCatalog mlops.* ----------------+
+                          durable authority
+                                  |
+              +-------------------+------------------+
+              |                                      |
+ collection binding                         deployment binding
+ asset id + version +                       version + artifact digest
+ contract hash + dimension                  runtime + endpoint
+              |                                      |
+          data/index plane                    serving runtime
+          cached snapshot                     cached snapshot
+----
+
+The curated SDK catalog proposes defaults but cannot approve them and is never a second durable
+registry. MLflow compatibility must lower to the same xCatalog commands; it must not own another
+metadata database.
+
+== Standards pressure test
+
+[cols="1,2,3", options="header"]
+|===
+| External concept | Native mapping | Consequence
+
+| MLflow registered model/version
+| `CatalogEmbeddingModelRegistry` and immutable version
+| Duplicate versions fail; source run identity is retained.
+
+| MLflow aliases/tags
+| Mutable aliases and annotations outside versions
+| No data-plane record stores an unresolved alias.
+
+| MLflow signature
+| Typed input/output contracts
+| Embeddings add tokenizer/rendering/context semantics beyond tensor schemas.
+
+| MLflow deprecated stages
+| No built-in staging/production state machine
+| Decisions express policy; deployments express actual serving state.
+
+| MLflow datasets
+| Name plus content digest in lineage/evidence
+| Reproducibility never depends on a mutable path.
+
+| MLMD artifact/execution/event/context
+| Content-addressed artifact, producer execution, typed inputs and namespace
+| Lineage is structural and queryable.
+
+| OpenLineage job/run/dataset facets
+| Producer execution and typed dataset/artifact inputs
+| Its facade imports/exports records without changing authority.
+
+| OCI descriptor
+| URI, SHA-256 digest, media type and byte size
+| Artifact relocation does not change executable contract identity.
+
+| KServe model/storage contract
+| Deployment runtime, endpoint, immutable version and digest
+| Runtime must be explicitly approved for that version.
+
+| Unity Catalog model/version hierarchy
+| Unified tenant catalog object under `mlops.*`
+| Models inherit stable identity, namespace, policy and audit boundaries.
+|===
+
+Authoritative references:
+
+* https://www.mlflow.org/docs/latest/ml/model-registry/workflow/[MLflow Model Registry workflows]
+* https://mlflow.org/docs/latest/dataset/[MLflow dataset tracking]
+* https://www.tensorflow.org/tfx/guide/mlmd[TensorFlow ML Metadata]
+* https://github.com/OpenLineage/OpenLineage[OpenLineage core model]
+* https://specs.opencontainers.org/image-spec/descriptor/[OCI content descriptor]
+* https://docs.unitycatalog.io/usage/models/[Unity Catalog registered models]
+* https://kserve.github.io/website/docs/model-serving/storage/multiple-storage-uris[KServe storage]
+
+== Native model and seams
+
+[source,text]
+----
+CatalogMlopsAsset::EmbeddingModel
+  CatalogEmbeddingModelRegistry
+    schema_version + optimistic revision
+    versions[version]                 immutable
+      artifact descriptor             digest identity
+      input contract                  tokenizer/rendering/context
+      output contract                 dimension/pooling/normalization
+      governance                      license/access/remote-code/runtime allow-list
+      lineage                         producer execution + digest-pinned inputs
+    aliases[name -> version]          mutable catalog transaction
+    evidence[]                        append-only
+    decisions[]                       append-only audit
+    deployments[name]                 mutable, version/digest pinned
+----
+
+Mutations are commands (`RegisterVersion`, `SetAlias`, `AppendEvidence`, `RecordDecision`,
+`UpsertDeployment`) with an expected revision. Stale whole-document writes cannot erase concurrent
+evidence or alias changes.
+
+`CatalogEmbeddingConfig` remains the collection projection. Legacy rows may carry only `model`.
+A native binding sets `model_asset_id`, `model_version` and `contract_sha256` together; partial
+bindings fail. Output dimension stays on the collection because one Matryoshka model can back
+several vector geometries.
+
+== Control plane versus data plane
+
+. Resolve aliases and validate policy on the control plane.
+. Commit a concrete version, artifact digest and contract hash to collection/deployment state.
+. Load and cache the immutable snapshot by contract hash in the embedding service.
+. Record that hash in corpus and index manifests.
+. Alias changes affect future resolution only; existing collections do not drift.
+
+Catalog unavailability blocks lifecycle mutation but not a serving process holding a valid pinned
+snapshot. Revocation requires an explicit audited invalidation event.
+
+== Co-design economics and security
+
+[cols="1,2,2", options="header"]
+|===
+| Dimension | Dominant term | Response
+| Object storage | artifact bytes and requests | Catalog stores descriptors, not weights/results.
+| Network | downloads and catalog latency | Digest caches; no request-hot catalog lookup.
+| Local cache | duplicate weights and drift | Verify/cache by content and contract digest.
+| Compute | tokens, context and dimension | Persist exact contract so quality/cost is comparable.
+| Governance | code/license/tenant risk | Fail-closed unreviewed defaults and runtime allow-list.
+|===
+
+Credentials never live in the contract. Registering a remote-code model does not execute it;
+execution requires a separately approved sandbox/runtime and existing tenant secret policy.
+
+== TDD acceptance matrix
+
+Tests require digest identity, valid templates/budgets/dimensions, immutable versions, append-only
+evidence/decisions, optimistic conflict rejection, alias history preservation, digest-pinned and
+runtime-approved deployments, relocation-stable hashes, legacy JSON compatibility, NativeCatalog
+reload persistence, all-or-none collection bindings, and Python conversion from a real
+`ResolvedInputContract` to native JSON.
+
+== Rollout
+
+. *Implemented*: typed contracts, validation, collection pins, stable hash, command mutations,
+  optimistic concurrency, NativeCatalog persistence and SDK payload adapter.
+. Add generated REST/gRPC lifecycle handlers; regenerate SDKs from OpenAPI/proto. No handwritten
+  Python transport.
+. Add MLflow model/version/alias/tag compatibility with conformance tests.
+. Add OpenLineage import/export over producer/input lineage.
+. Add transactional OLTP-catalog overrides and cross-backend conformance tests before advertising
+  that backend's MLOps lifecycle surface.
+. Bind embedding workers and collection creation to resolved snapshots default-OFF, dual-reading
+  the legacy route until baked.
+. Ratchet retrieval and economic evals per contract hash before making native binding the default.
+
+The public API is a distinct slice because it requires generated API changes plus authorization and
+audit review. The core catalog seam is usable now and keeps those adapters thin.

--- a/scripts/bench/build_token_budget_corpus.py
+++ b/scripts/bench/build_token_budget_corpus.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Build an auditable token-budgeted embedding corpus from JSONL documents.
+
+This is the benchmark transport around the authoritative SDK chunking contracts.
+It deliberately contains no splitting algorithm of its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import tomllib
+from proximadb_sdk.chunking_strategies import (
+    ChunkingConfig,
+    ChunkingStrategy,
+    CompositeInputContract,
+    HuggingFaceTokenCounter,
+    InputRenderer,
+    InputRole,
+    OverflowPolicy,
+    ResolvedInputContract,
+    ShortChunkPolicy,
+    TokenBudget,
+    get_chunking_strategy,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _load_contracts(path: Path) -> CompositeInputContract:
+    with path.open("rb") as handle:
+        config = tomllib.load(handle)
+    models = config.get("models")
+    if not isinstance(models, list) or not models:
+        raise ValueError("contract TOML must contain at least one [[models]] table")
+
+    contracts = []
+    for index, model in enumerate(models):
+        for required in ("model_id", "revision", "effective_context_limit"):
+            if required not in model:
+                raise ValueError(f"models[{index}] is missing {required!r}")
+        tokenizer_id = model.get("tokenizer_id", model["model_id"])
+        tokenizer_revision = model.get("tokenizer_revision", model["revision"])
+        if re.fullmatch(r"[0-9a-f]{40}", str(model["revision"])) is None:
+            raise ValueError(
+                f"models[{index}].revision must be an immutable 40-character "
+                "Hugging Face commit SHA"
+            )
+        if re.fullmatch(r"[0-9a-f]{40}", str(tokenizer_revision)) is None:
+            raise ValueError(
+                f"models[{index}].tokenizer_revision must be an immutable "
+                "40-character Hugging Face commit SHA"
+            )
+        counter = HuggingFaceTokenCounter.from_pretrained(
+            tokenizer_id,
+            revision=tokenizer_revision,
+            trust_remote_code=bool(model.get("trust_remote_code", False)),
+            local_files_only=bool(model.get("local_files_only", False)),
+        )
+        dimensions = tuple(int(value) for value in model.get("output_dimensions", ()))
+        document_parameters = tuple(
+            sorted(
+                (str(key), str(value))
+                for key, value in model.get(
+                    "document_encode_parameters", {}
+                ).items()
+            )
+        )
+        query_parameters = tuple(
+            sorted(
+                (str(key), str(value))
+                for key, value in model.get("query_encode_parameters", {}).items()
+            )
+        )
+        contracts.append(
+            ResolvedInputContract(
+                model_id=str(model["model_id"]),
+                model_revision=str(model["revision"]),
+                counter=counter,
+                effective_context_limit=int(model["effective_context_limit"]),
+                renderer=InputRenderer(
+                    document_template=str(model.get("document_template", "{text}")),
+                    query_template=str(model.get("query_template", "{text}")),
+                ),
+                native_dimension=(
+                    int(model["native_dimension"])
+                    if "native_dimension" in model
+                    else None
+                ),
+                output_dimension=(
+                    int(model["output_dimension"])
+                    if "output_dimension" in model
+                    else None
+                ),
+                supported_output_dimensions=dimensions,
+                minimum_output_dimension=(
+                    int(model["minimum_output_dimension"])
+                    if "minimum_output_dimension" in model
+                    else None
+                ),
+                document_encode_parameters=document_parameters,
+                query_encode_parameters=query_parameters,
+            )
+        )
+    return CompositeInputContract(tuple(contracts))
+
+
+def _percentile(sorted_values: list[int], fraction: float) -> int | None:
+    if not sorted_values:
+        return None
+    index = round((len(sorted_values) - 1) * fraction)
+    return sorted_values[index]
+
+
+def _histogram(values: list[int]) -> dict[str, int | None]:
+    ordered = sorted(values)
+    return {
+        "min": ordered[0] if ordered else None,
+        "p50": _percentile(ordered, 0.50),
+        "p90": _percentile(ordered, 0.90),
+        "p99": _percentile(ordered, 0.99),
+        "max": ordered[-1] if ordered else None,
+    }
+
+
+def _atomic_paths(output_dir: Path) -> tuple[Path, Path, Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    texts_fd, texts_name = tempfile.mkstemp(
+        prefix="texts.", suffix=".tmp", dir=output_dir
+    )
+    chunks_fd, chunks_name = tempfile.mkstemp(
+        prefix="chunks.", suffix=".tmp", dir=output_dir
+    )
+    os.close(texts_fd)
+    os.close(chunks_fd)
+    texts_tmp = Path(texts_name)
+    chunks_tmp = Path(chunks_name)
+    return texts_tmp, chunks_tmp, output_dir / "texts.json", output_dir / "chunks.jsonl"
+
+
+def build(args: argparse.Namespace) -> dict[str, Any]:
+    input_sha256 = _sha256(args.input)
+    contracts = _load_contracts(args.contracts)
+    budget = TokenBudget(
+        target_tokens=args.target_tokens,
+        overlap_tokens=args.overlap_tokens,
+        min_content_tokens=args.min_content_tokens,
+        overflow_policy=OverflowPolicy(args.overflow_policy),
+        short_chunk_policy=ShortChunkPolicy(args.short_chunk_policy),
+    )
+    config = ChunkingConfig(
+        strategy=ChunkingStrategy(args.strategy),
+        chunk_size=args.boundary_char_size,
+        chunk_overlap=0,
+        min_chunk_size=1,
+        max_chunk_size=args.boundary_char_size,
+        token_budget=budget,
+        input_contract=contracts,
+        input_role=InputRole.DOCUMENT,
+    )
+    strategy = get_chunking_strategy(
+        config.strategy,
+        **{key: value for key, value in vars(config).items() if key != "strategy"},
+    )
+
+    texts_tmp, chunks_tmp, texts_path, chunks_path = _atomic_paths(args.output_dir)
+    token_lengths: dict[str, list[int]] = defaultdict(list)
+    source_count = 0
+    chunk_count = 0
+    split_sources = 0
+    dropped_spans: list[dict[str, Any]] = []
+    try:
+        with (
+            args.input.open("r", encoding="utf-8") as source,
+            texts_tmp.open("w", encoding="utf-8") as texts,
+            chunks_tmp.open("w", encoding="utf-8") as chunks_out,
+        ):
+            texts.write("[")
+            first_text = True
+            for line_number, line in enumerate(source, 1):
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                text = record.get(args.text_field)
+                if not isinstance(text, str):
+                    raise ValueError(
+                        f"line {line_number}: {args.text_field!r} must be a string"
+                    )
+                source_id = str(record.get(args.id_field, line_number))
+                source_count += 1
+                was_oversized = not contracts.fits(
+                    text, InputRole.DOCUMENT, budget.target_tokens
+                )
+                emitted = strategy.chunk(text, source_id, {"source_line": line_number})
+                if was_oversized and emitted:
+                    split_sources += 1
+                if not emitted and text.strip():
+                    dropped_spans.append(
+                        {
+                            "source_id": source_id,
+                            "start_pos": 0,
+                            "end_pos": len(text),
+                            "reason": "oversized_source_or_short_chunk_policy",
+                        }
+                    )
+                elif emitted:
+                    offsets = contracts.primary.counter.content_offsets(text) or ()
+                    content_end = offsets[-1][1] if offsets else 0
+                    if emitted[-1].end_pos < content_end:
+                        dropped_spans.append(
+                            {
+                                "source_id": source_id,
+                                "start_pos": emitted[-1].end_pos,
+                                "end_pos": content_end,
+                                "reason": "short_chunk_policy",
+                            }
+                        )
+
+                for chunk in emitted:
+                    if not first_text:
+                        texts.write(",")
+                    json.dump(chunk.text, texts, ensure_ascii=False)
+                    first_text = False
+                    counts = contracts.validate(chunk.text, InputRole.DOCUMENT)
+                    for model_id, count in counts.items():
+                        if count > budget.target_tokens:
+                            raise AssertionError(
+                                f"chunk {chunk_count} exceeds target for {model_id}"
+                            )
+                        token_lengths[model_id].append(count)
+                    chunks_out.write(
+                        json.dumps(
+                            {
+                                "chunk_index": chunk_count,
+                                "chunk_id": chunk.chunk_id,
+                                "source_id": source_id,
+                                "start_pos": chunk.start_pos,
+                                "end_pos": chunk.end_pos,
+                                "token_counts": counts,
+                            },
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        )
+                        + "\n"
+                    )
+                    chunk_count += 1
+            texts.write("]\n")
+        if _sha256(args.input) != input_sha256:
+            raise RuntimeError("input JSONL changed while the corpus was being built")
+        os.replace(texts_tmp, texts_path)
+        os.replace(chunks_tmp, chunks_path)
+    finally:
+        texts_tmp.unlink(missing_ok=True)
+        chunks_tmp.unlink(missing_ok=True)
+
+    histogram = {
+        model_id: {
+            **_histogram(values),
+            "over_effective_context": sum(
+                value
+                > next(
+                    contract.effective_context_limit
+                    for contract in contracts.contracts
+                    if contract.model_id == model_id
+                )
+                for value in values
+            ),
+            "over_target": sum(value > budget.target_tokens for value in values),
+        }
+        for model_id, values in token_lengths.items()
+    }
+    manifest = {
+        "schema_version": 1,
+        "input": str(args.input.resolve()),
+        "input_sha256": input_sha256,
+        "texts_sha256": _sha256(texts_path),
+        "chunks_sha256": _sha256(chunks_path),
+        "source_count": source_count,
+        "chunk_count": chunk_count,
+        "split_oversized_source_count": split_sources,
+        "dropped_spans": dropped_spans,
+        "boundary_strategy": args.strategy,
+        "token_budget": budget.to_manifest(),
+        "input_contract": contracts.to_manifest(),
+        "token_histogram": histogram,
+        "zero_truncation_asserted": all(
+            values["over_effective_context"] == 0 and values["over_target"] == 0
+            for values in histogram.values()
+        ),
+    }
+    manifest_path = args.output_dir / "corpus.manifest.json"
+    manifest_fd, manifest_name = tempfile.mkstemp(
+        prefix="corpus.manifest.", suffix=".tmp", dir=args.output_dir
+    )
+    os.close(manifest_fd)
+    manifest_tmp = Path(manifest_name)
+    try:
+        with manifest_tmp.open("w", encoding="utf-8") as handle:
+            json.dump(manifest, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(manifest_tmp, manifest_path)
+    finally:
+        manifest_tmp.unlink(missing_ok=True)
+    if not manifest["zero_truncation_asserted"]:
+        raise AssertionError("emitted corpus contains inputs that would truncate")
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="JSONL source")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--contracts", type=Path, required=True, help="TOML model contracts"
+    )
+    parser.add_argument("--text-field", default="text")
+    parser.add_argument("--id-field", default="id")
+    parser.add_argument(
+        "--strategy",
+        choices=[value.value for value in ChunkingStrategy],
+        default="recursive",
+    )
+    parser.add_argument("--target-tokens", type=int, default=480)
+    parser.add_argument("--overlap-tokens", type=int, default=72)
+    parser.add_argument("--min-content-tokens", type=int, default=32)
+    parser.add_argument("--boundary-char-size", type=int, default=4096)
+    parser.add_argument(
+        "--overflow-policy",
+        choices=[value.value for value in OverflowPolicy],
+        default="split",
+    )
+    parser.add_argument(
+        "--short-chunk-policy",
+        choices=[value.value for value in ShortChunkPolicy],
+        default="keep",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    manifest = build(parse_args())
+    print(
+        json.dumps(
+            {
+                "chunk_count": manifest["chunk_count"],
+                "texts_sha256": manifest["texts_sha256"],
+                "token_histogram": manifest["token_histogram"],
+                "zero_truncation_asserted": manifest["zero_truncation_asserted"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/open_embedding_contracts.toml.example
+++ b/scripts/bench/open_embedding_contracts.toml.example
@@ -1,0 +1,25 @@
+# Copy this file, replace every revision with the immutable Hugging Face commit
+# resolved by provider.get_input_contract(), then pass it to
+# scripts/bench/build_token_budget_corpus.py --contracts <copy>.
+
+[[models]]
+model_id = "BAAI/bge-base-en-v1.5"
+revision = "REPLACE_WITH_IMMUTABLE_COMMIT_SHA"
+effective_context_limit = 512
+document_template = "{text}"
+query_template = "Represent this sentence for searching relevant passages: {text}"
+native_dimension = 768
+output_dimension = 768
+output_dimensions = [768]
+local_files_only = true
+
+[[models]]
+model_id = "BAAI/bge-small-en-v1.5"
+revision = "REPLACE_WITH_IMMUTABLE_COMMIT_SHA"
+effective_context_limit = 512
+document_template = "{text}"
+query_template = "Represent this sentence for searching relevant passages: {text}"
+native_dimension = 384
+output_dimension = 384
+output_dimensions = [384]
+local_files_only = true

--- a/scripts/bench/validate_open_embedding_tokenizers.py
+++ b/scripts/bench/validate_open_embedding_tokenizers.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate real tokenizer/rendering contracts for the open-model catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from proximadb_sdk.chunking_strategies import HuggingFaceTokenCounter
+from proximadb_sdk.embedding_providers.catalog import (
+    OPEN_MODEL_CATALOG,
+    get_open_model_spec,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", action="append", dest="models")
+    parser.add_argument("--local-files-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_ids = args.models or sorted(OPEN_MODEL_CATALOG)
+    results = []
+    failed = False
+    for model_id in model_ids:
+        spec = get_open_model_spec(model_id)
+        metadata = spec.metadata
+        try:
+            counter = HuggingFaceTokenCounter.from_pretrained(
+                metadata.tokenizer_name or metadata.name,
+                revision=metadata.revision,
+                trust_remote_code=spec.trust_remote_code,
+                local_files_only=args.local_files_only,
+            )
+            document = metadata.document_template.format(text="alpha beta gamma")
+            query_template = metadata.query_template or "{text}"
+            query = query_template.format(text="alpha beta gamma")
+            offsets = counter.content_offsets("alpha beta gamma")
+            result = {
+                "model_id": model_id,
+                "status": "ok",
+                "declared_context": metadata.max_length,
+                "tokenizer_context": counter.advertised_limit,
+                "document_tokens": counter.count(document),
+                "query_tokens": counter.count(query),
+                "offset_count": len(offsets or ()),
+                "tokenizer_fingerprint": counter.fingerprint,
+            }
+            if counter.advertised_limit is not None:
+                if metadata.max_length > counter.advertised_limit:
+                    raise ValueError("declared model context exceeds tokenizer context")
+            if not offsets:
+                raise ValueError("tokenizer returned no source offsets")
+        except Exception as exc:
+            failed = True
+            result = {
+                "model_id": model_id,
+                "status": "error",
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        results.append(result)
+        print(json.dumps(result, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "models": len(results),
+                "passed": sum(row["status"] == "ok" for row in results),
+                "failed": sum(row["status"] != "ok" for row in results),
+            },
+            sort_keys=True,
+        )
+    )
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Replace character heuristics with tokenizer-resolved, rendered-input token budgets, configurable overlap, explicit oversize policy, coverage metadata, and fail-closed maximum-context validation.
- Add a model-agnostic open embedding catalog spanning 22 commonly used models across BGE, E5, GTE, Nomic, Jina, Snowflake Arctic, and related families, with dimensions, context, tokenizer, prefixes, pooling, normalization, trust, and Matryoshka capabilities represented as executable contracts.
- Add reproducible benchmark tooling that emits text plus provenance manifests and validates zero truncation with the same tokenizer and rendering contract used for embedding.
- Add a typed xCatalog MLOps facet with immutable content-addressed versions, mutable aliases, evidence and approval records, deployment lineage, optimistic revision control, and optional collection bindings.

## Design boundaries

- xCatalog remains the metadata authority. Model registry is a logically separate facet over the same asset identity and lineage substrate, avoiding a competing catalog.
- MLflow remains an external experiment and workflow system. The Python integration only projects a pure registration payload; it does not add a second source of truth or a handwritten REST transport.
- Model input contracts hash tokenizer revision, rendering semantics, context limit, output dimensions, pooling, normalization, trust requirements, and runtime allow-list. A mutable model URI alone is rejected.
- Larger context is exposed as a policy input, not assumed to be an economic win. Chunk count, embedding cost, retrieval quality, and downstream answer quality must be evaluated together.

The model lifecycle follows the separation used by [MLflow Model Registry](https://mlflow.org/docs/latest/ml/model-registry/workflow/), while artifact identity is content-addressed in the spirit of the [OCI descriptor contract](https://specs.opencontainers.org/image-spec/descriptor/) and lineage records align with [OpenLineage](https://github.com/OpenLineage/OpenLineage).

## TDD evidence

- `cargo test -p proximadb-catalog`: 470 unit tests, 1 bridge test, and 12 new MLOps integration tests passed.
- `cargo test -p proximadb-catalog --test mlops_model_contract`: 12 passed after rebase.
- Focused Python token-budget and MLOps contract suite: 38 passed, 4 optional-tokenizer skips.
- `cargo check -p proximadb-server`: passed on the rebased branch.
- `cargo clippy -p proximadb-catalog --tests -- -D warnings`: passed.
- Focused Ruff checks: passed.
- `make work-commit-check`, layering, TD/ADR uniqueness, formatting, diff hygiene, and attribution checks: passed.

## Compatibility and rollout

- Catalog schema additions are optional and serde-defaulted, so legacy rows remain readable.
- No public REST, protobuf, or generated SDK transport contract changes are included.
- Existing index-geometry results and the pinned benchmark worktree are unchanged.
- Local scratchpad orchestration and generated benchmark corpora are intentionally excluded; `scripts/bench/build_token_budget_corpus.py` is the tracked authoritative corpus path.
- Absolute retrieval and PCA claims remain evidence-gated until the external corpus rebuild and eval run complete.