### PR TITLE
refactor(decomp): move smart_io traits+range_coalescer into storage-filesystem-types (TD-DECOMP-65)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8664,6 +8664,7 @@ dependencies = [
  "proximadb-kernel",
  "serde",
  "thiserror 2.0.19",
+ "tracing",
  "url",
 ]
 

--- a/crates/storage/proximadb-storage-filesystem-types/Cargo.toml
+++ b/crates/storage/proximadb-storage-filesystem-types/Cargo.toml
@@ -18,3 +18,4 @@ thiserror.workspace = true
 url = "2.4"
 memmap2 = "0.9"
 futures.workspace = true
+tracing = { workspace = true }

--- a/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/lib.rs
@@ -1018,3 +1018,5 @@ mod read_ranges_buffered_tests {
         assert!(res.is_err(), "expected short-circuit error, got {res:?}");
     }
 }
+pub mod range_coalescer;
+pub mod smart_io_traits;

--- a/crates/storage/proximadb-storage-filesystem-types/src/range_coalescer.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/range_coalescer.rs
@@ -22,7 +22,7 @@
 
 use tracing::{debug, trace};
 
-use super::traits::{ByteRange, RangeMapping, RangeOptimizer, RangeOptimizerWithMapping};
+use crate::smart_io_traits::{ByteRange, RangeMapping, RangeOptimizer, RangeOptimizerWithMapping};
 
 /// Default coalescing strategy that merges adjacent ranges
 #[derive(Debug, Clone)]

--- a/crates/storage/proximadb-storage-filesystem-types/src/smart_io_traits.rs
+++ b/crates/storage/proximadb-storage-filesystem-types/src/smart_io_traits.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use std::fmt::Debug;
 use std::ops::Range;
 
-use crate::storage::persistence::filesystem::FsResult;
+use crate::FsResult;
 
 /// Represents a byte range within a file
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/docs/10-quality/td/TD-DECOMP-65-extract-smart-io.adoc
+++ b/docs/10-quality/td/TD-DECOMP-65-extract-smart-io.adoc
@@ -1,0 +1,22 @@
+// Copyright (C) 2025 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-DECOMP-65: Move smart_io traits + range_coalescer into storage-filesystem-types
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | Landing
+| Severity | Low — behavior-neutral re-export (2 import rewrites + 1 dep add)
+| Component | `crates/storage/proximadb-storage-filesystem-types`; root `src/storage/persistence/filesystem/smart_io/mod.rs`
+|===
+
+== What moved
+`src/storage/persistence/filesystem/smart_io/traits.rs` (6 tests: ByteRange, RangeMapping,
+RangeOptimizer traits) + `range_coalescer.rs` (14 tests: AdaptiveRangeCoalescer,
+DefaultRangeCoalescer) → the EXISTING storage crate `proximadb-storage-filesystem-types`.
+Root `smart_io/mod.rs` re-exports both. FsResult + async_trait already in the crate; `tracing`
+added crate-locally. Two import rewrites: `crate::storage::...::FsResult` → `crate::FsResult`
+(within the crate) and `super::traits::{...}` → `crate::smart_io_traits::{...}`. This was the
+Phase 1a structural enabler from the remodularization plan — it resolved the last `crate::`
+climb-out ref in the smart_io subsystem. Verified: standalone + root lib compile. SIFT RUNS
+(storage_changes) under the 45m cap.

--- a/src/storage/persistence/filesystem/smart_io/mod.rs
+++ b/src/storage/persistence/filesystem/smart_io/mod.rs
@@ -83,8 +83,8 @@
 
 pub mod metrics;
 pub mod parallel_reader;
-pub mod range_coalescer;
-pub mod traits;
+pub use proximadb_storage_filesystem_types::range_coalescer;
+pub use proximadb_storage_filesystem_types::smart_io_traits as traits;
 
 use std::sync::Arc;
 use tracing::{debug, trace};


### PR DESCRIPTION
Part of the P2 god-crate remodularization plan (Phase 1a: structural decoupling enabler).

## What moves
`src/storage/persistence/filesystem/smart_io/traits.rs` (**6 tests**: ByteRange, RangeMapping, RangeOptimizer traits) + `range_coalescer.rs` (**14 tests**: AdaptiveRangeCoalescer, DefaultRangeCoalescer) → the **existing** storage crate `proximadb-storage-filesystem-types`.

## Why into an existing crate
`FsResult` + `async_trait` were already in the crate; only `tracing` needed adding (crate-local). Two import rewrites:
- `crate::storage::...::FsResult` → `crate::FsResult` (within the crate)
- `super::traits::{...}` → `crate::smart_io_traits::{...}` (within the crate)

This resolves the **last `crate::` climb-out ref** in the smart_io subsystem — the structural decoupling enabler from the remodularization plan.

## Shims
Root `smart_io/mod.rs`:
```rust
- pub mod traits;
+ pub use proximadb_storage_filesystem_types::smart_io_traits as traits;
- pub mod range_coalescer;
+ pub use proximadb_storage_filesystem_types::range_coalescer;
```

## CI note
Touches `src/storage/**` (`storage_changes`) → **SIFT recall ratchet RUNS** under the 45m cap (#1555).

## Verified
- standalone `cargo check --all-targets` ✓
- root `cargo check -p proximadb --lib` ✓ (CARGO_EXIT=0)
- boundary check: No boundary findings ✓; TD-unique 396 ✓; fmt ✓
- **30 tests pass in-crate** (existing + 20 new from smart_io)

No AI attribution.