### PR TITLE
fix(catalog): SystemCatalog mints object ids — relational ABAC was structurally inert

### DIFF
--- a/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
@@ -1,5 +1,5 @@
 = TD-AUTHZ-2: xcatalog.tables returns an empty object_id for SQL-created relational tables
-:status: Open
+:status: Partial
 :dim: D4
 :pillar: SEC
 
@@ -230,3 +230,36 @@ mirror it exactly:
 
 Deliberately not attempted in the same pass as the diagnosis: a half-built durable id allocator
 is worse than none, and the monotonicity/recovery properties need their own tests.
+
+
+== 2026-08-12 — FIXED: SystemCatalog now mints object ids
+
+`SystemCatalog::create_table` mints table, column and index object ids, matching
+`NativeCatalog::mint_object_id`'s semantics so the two implementations cannot drift on
+identity rules.
+
+**The floor is DERIVED, not persisted.** `SystemCatalogState::max_object_id()` scans recovered
+state; both constructors set `object_id_floor = max_object_id().map_or(1, |id| id + 1)` — the
+same shape `account_floor` already used. Object ids ride inside the persisted schemas, so WAL
+replay and snapshot load reconstruct the floor for free: no extra fsync, no second recovery
+path, and no way for a floor record to disagree with the objects it governs.
+
+**Adopt, don't overwrite.** A caller-supplied id is kept and merely raises the floor via
+`fetch_max` (not `store`, which under concurrent creates could LOWER a floor another thread
+raised — that would re-issue an id). Adoption is what preserves the ADR-031 unification where a
+vector collection pre-sets `schema.object_id` from `collection.id` before `create_table` runs.
+
+Three tests, each teeth-proven (they fail when only the minting line is neutered):
+`object_ids_are_never_reissued_across_a_restart` (the invariant whose failure grants a NEW
+table a DEAD table's policy bindings and grants), `a_caller_supplied_object_id_is_adopted_and_
+raises_the_floor`, and `object_id_survives_the_get_table_round_trip_on_system_catalog` — the
+sibling to #1559, written because that test proved the invariant on an implementation the
+server does not register.
+
+=== Still open
+
+The three `#[ignore = "TD-AUTHZ-2: ..."]` tests in
+`tests/abac_relational_transport_e2e.rs` are NOT lifted here. Minting is now correct at the
+catalog, but whether `xcatalog.tables` renders the value end-to-end for a SQL-created table
+should be verified against a live server before removing the ignores — this TD's own history
+is a record of what assuming reachability costs. Status stays `Partial` until then.

--- a/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
+++ b/docs/10-quality/td/TD-AUTHZ-2-xcatalog-relational-object-id-empty.adoc
@@ -171,3 +171,62 @@ This is the second time in this program that a verified-true finding was scoped 
 component: `NativeCatalog` was exonerated correctly and irrelevantly, exactly as the graph/RAG
 surface was analysed correctly and irrelevantly before discovering its router was never
 mounted. **Establish which implementation actually serves the path before testing one.**
+
+
+== 2026-08-12 (later) — ROOT CAUSE: `SystemCatalog::create_table` never mints `object_id`
+
+Located. `src/services/system_catalog.rs:819` (`impl Catalog for SystemCatalog`) validates the
+schema, boxes it, and returns it **verbatim**:
+
+[source,rust]
+----
+validate_schema(&schema)?;
+... schema: Box::new(schema.clone()) ...
+Ok(schema)
+----
+
+There is no `mint_object_id` and no allocator call. Compare `NativeCatalog::create_table`
+(`native.rs:~1507`), which mints for the table, every column, and every index. Since
+`SystemCatalog` is the catalog the server actually registers, tables created through SQL DDL
+get no object id at all.
+
+This also explains why VECTOR collections are unaffected: their `object_id` is pre-set from
+`collection.id` by the collection manager (`manager.rs:2313`) *before* `create_table` is
+called, so nothing needs minting. Only the SQL-DDL path depends on the catalog to mint — and
+the live catalog does not.
+
+=== The consequence is larger than three ignored tests
+
+The relational ABAC path denies when the ids are absent — `src/services/dml/mod.rs:1466-1472`:
+
+[source,rust]
+----
+let (Some(namespace), Some(table)) = (table_schema.stable_namespace_id, table_schema.object_id)
+else { return Some(AbacScanResult::Denied(DenyReason::NoApplicablePolicy)); };
+----
+
+So on the live catalog, **relational ABAC enforcement is structurally inert**: it can never
+admit, because the identity it scopes on is never minted. That is fail-closed (the safe
+direction) but it means relational policy bindings and grants cannot take effect at all today
+— not "are unconfigured", *cannot*. Any claim that ABAC covers relational tables should be
+read against this.
+
+=== Fix shape (not implemented here — durable identity deserves its own slice)
+
+`SystemCatalog` already carries the right pattern for a durable monotonic counter:
+`account_floor: AtomicU64`, "recovered from the WAL/snapshot". An object-id allocator should
+mirror it exactly:
+
+. Allocate table/column/index object ids in `SystemCatalog::create_table`, matching
+  `NativeCatalog::mint_object_id`'s adopt-or-allocate semantics (a caller-supplied id raises
+  the floor rather than being overwritten — that is what keeps vector collections' pre-set ids
+  intact).
+. Recover the floor from WAL replay and snapshot load, the way `account_floor` is, so a
+  restart never re-issues an id. Re-issuing an object id is an AUTHORIZATION defect, not just a
+  bookkeeping one: policy bindings and grants are keyed on it.
+. Give #1559's `object_id_survives_the_get_table_round_trip` a `SystemCatalog` sibling, so the
+  invariant is pinned for the implementation that actually serves.
+. Only then remove the three `#[ignore = "TD-AUTHZ-2: ..."]` attributes.
+
+Deliberately not attempted in the same pass as the diagnosis: a half-built durable id allocator
+is worse than none, and the monotonicity/recovery properties need their own tests.

--- a/src/services/system_catalog.rs
+++ b/src/services/system_catalog.rs
@@ -105,6 +105,15 @@ pub struct SystemCatalog {
     /// Next durable account/tenant stable id. Recovered from the WAL/snapshot
     /// state at boot; u64 lets us detect u32 exhaustion instead of wrapping.
     account_floor: AtomicU64,
+    /// Next `object_id` for catalog objects (tables, columns, indexes — one
+    /// shared sequence, matching `NativeCatalog::mint_object_id`). Like
+    /// `account_floor`, the floor is DERIVED from recovered state rather than
+    /// persisted separately, so it cannot disagree with the objects it governs.
+    ///
+    /// Authorization-critical: policy bindings and grants are keyed on
+    /// `object_id`, so re-issuing one after a restart would grant a NEW table
+    /// the permissions of a DEAD one.
+    object_id_floor: AtomicU64,
     appender: Arc<dyn TableWalAppender>,
     /// Serializes the durable-append → in-RAM-apply pair so concurrent DDL can
     /// never interleave such that a lower-LSN mutation applies after a higher
@@ -150,11 +159,13 @@ impl SystemCatalog {
         appender: Arc<dyn TableWalAppender>,
     ) -> Self {
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
+        let object_id_floor = state.max_object_id().map_or(1, |id| id + 1);
         Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
+            object_id_floor: AtomicU64::new(object_id_floor),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: None,
@@ -290,11 +301,13 @@ impl SystemCatalog {
             .unwrap_or(DEFAULT_SNAPSHOT_THRESHOLD);
 
         let account_floor = state.max_account_id().map_or(1, |id| u64::from(id) + 1);
+        let object_id_floor = state.max_object_id().map_or(1, |id| id + 1);
         Ok(Self {
             name: name.into(),
             role: proximadb_catalog::CatalogRole::Operator,
             state: Arc::new(state),
             account_floor: AtomicU64::new(account_floor),
+            object_id_floor: AtomicU64::new(object_id_floor),
             appender,
             write_lock: tokio::sync::Mutex::new(()),
             snapshot: Some(SnapshotConfig {
@@ -647,6 +660,21 @@ impl SystemCatalog {
     }
 }
 
+impl SystemCatalog {
+    /// Adopt a caller-supplied `object_id` (raising the floor past it) or
+    /// allocate the next one. Mirrors `NativeCatalog::mint_object_id` so the two
+    /// implementations cannot drift on identity semantics.
+    fn mint_object_id(&self, existing: Option<u64>) -> u64 {
+        match existing {
+            Some(id) => {
+                self.object_id_floor.fetch_max(id + 1, Ordering::SeqCst);
+                id
+            }
+            None => self.object_id_floor.fetch_add(1, Ordering::SeqCst),
+        }
+    }
+}
+
 #[async_trait]
 impl Catalog for SystemCatalog {
     fn name(&self) -> &str {
@@ -822,6 +850,24 @@ impl Catalog for SystemCatalog {
         schema: CatalogTableSchema,
     ) -> Result<CatalogTableSchema> {
         validate_schema(&schema)?;
+        // TD-AUTHZ-2: mint object ids. ADOPT-or-allocate, matching
+        // `NativeCatalog::mint_object_id`: a caller-supplied id is KEPT and
+        // merely raises the floor, never overwritten — that is what preserves
+        // the ADR-031 unification where a vector collection pre-sets
+        // `schema.object_id` from `collection.id` before this call.
+        //
+        // Without this the live catalog left `object_id` None for every
+        // SQL-created table, and the relational ABAC path denies on absent ids
+        // (dml/mod.rs:1466) — so relational policy bindings and grants could
+        // never take effect at all.
+        let mut schema = schema;
+        schema.object_id = Some(self.mint_object_id(schema.object_id));
+        for column in &mut schema.columns {
+            column.object_id = Some(self.mint_object_id(column.object_id));
+        }
+        for index in &mut schema.indexes {
+            index.object_id = Some(self.mint_object_id(index.object_id));
+        }
         if !self.state.namespace_exists(&identifier.namespace) {
             return Err(anyhow!(
                 "Namespace '{}' does not exist",
@@ -1094,6 +1140,113 @@ mod tests {
             reopened.account_id_u32("acme").await?,
             Some(2),
             "a new tenant must mint above the replayed floor"
+        );
+        Ok(())
+    }
+
+    /// TD-AUTHZ-2 THE INVARIANT THAT MATTERS: an object_id is never re-issued
+    /// across a restart.
+    ///
+    /// Policy bindings and grants are keyed on object_id, so handing a NEW table
+    /// a DEAD table's id would hand it that table's permissions. The floor is
+    /// derived from recovered state (`max_object_id`), so WAL replay must lift
+    /// it above everything already minted.
+    #[tokio::test]
+    async fn object_ids_are_never_reissued_across_a_restart() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let wal = dir.path().join("catalog.wal");
+        let ns = nslevels(&["t"]);
+
+        let first_id = {
+            let cat = SystemCatalog::open("default", &wal).await?;
+            cat.create_namespace(&ns, std::collections::HashMap::new())
+                .await?;
+            let a = cat
+                .create_table(&TableIdentifier::new(ns.clone(), "a"), vec_schema("a"))
+                .await?;
+            let b = cat
+                .create_table(&TableIdentifier::new(ns.clone(), "b"), vec_schema("b"))
+                .await?;
+            let (ida, idb) = (
+                a.object_id.expect("table a minted"),
+                b.object_id.expect("table b minted"),
+            );
+            assert!(idb > ida, "monotonic within a run: {idb} > {ida}");
+            idb
+        };
+
+        // Restart: rebuild from the same WAL.
+        let reopened = SystemCatalog::open("default", &wal).await?;
+        let c = reopened
+            .create_table(&TableIdentifier::new(ns.clone(), "c"), vec_schema("c"))
+            .await?;
+        let idc = c.object_id.expect("table c minted after restart");
+        assert!(
+            idc > first_id,
+            "an object_id minted after restart ({idc}) must be above every id \
+             minted before it ({first_id}) — re-issuing one would grant a new \
+             table the policy bindings and grants of a dead one"
+        );
+        Ok(())
+    }
+
+    /// A caller-supplied object_id is ADOPTED, not overwritten — this is what
+    /// preserves the ADR-031 unification where a vector collection pre-sets
+    /// `schema.object_id` from `collection.id` before create_table runs.
+    /// Adoption must also raise the floor, so the next allocation cannot collide.
+    #[tokio::test]
+    async fn a_caller_supplied_object_id_is_adopted_and_raises_the_floor() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let ns = nslevels(&["t"]);
+        let cat = catalog(dir.path()).await;
+        cat.create_namespace(&ns, std::collections::HashMap::new())
+            .await?;
+
+        let mut preset = vec_schema("preset");
+        preset.object_id = Some(5_000);
+        let adopted = cat
+            .create_table(&TableIdentifier::new(ns.clone(), "preset"), preset)
+            .await?;
+        assert_eq!(
+            adopted.object_id,
+            Some(5_000),
+            "a pre-set id must be KEPT — overwriting it splits one collection \
+             into two identities and detaches any policy bound to the first"
+        );
+
+        let next = cat
+            .create_table(
+                &TableIdentifier::new(ns.clone(), "next"),
+                vec_schema("next"),
+            )
+            .await?;
+        assert!(
+            next.object_id.expect("minted") > 5_000,
+            "adoption must raise the floor so the next allocation cannot collide"
+        );
+        Ok(())
+    }
+
+    /// The read-back invariant, for the implementation that ACTUALLY SERVES.
+    /// #1559 proved this for NativeCatalog — which the server does not register,
+    /// so the invariant went unverified where it mattered.
+    #[tokio::test]
+    async fn object_id_survives_the_get_table_round_trip_on_system_catalog() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let ns = nslevels(&["t"]);
+        let cat = catalog(dir.path()).await;
+        cat.create_namespace(&ns, std::collections::HashMap::new())
+            .await?;
+        let ident = TableIdentifier::new(ns.clone(), "rt");
+        let created = cat.create_table(&ident, vec_schema("rt")).await?;
+        let minted = created.object_id.expect("create_table mints");
+
+        let fetched = cat.get_table(&ident).await?;
+        assert_eq!(
+            fetched.object_id,
+            Some(minted),
+            "xcatalog.tables projects this value; an empty one is what \
+             TD-AUTHZ-2 reports and what makes relational ABAC deny"
         );
         Ok(())
     }

--- a/src/services/system_catalog_state.rs
+++ b/src/services/system_catalog_state.rs
@@ -301,6 +301,33 @@ impl SystemCatalogState {
         self.inner.read().account_ids.values().copied().max()
     }
 
+    /// The highest `object_id` folded into state, across tables AND the columns
+    /// and indexes they carry (they all draw from one sequence).
+    ///
+    /// The allocator floor is DERIVED from recovered state rather than persisted
+    /// separately — the same shape as `max_account_id` above. Object ids already
+    /// ride inside the persisted schemas, so WAL replay and snapshot load yield
+    /// the floor for free: no second durable structure, no extra fsync, and no
+    /// way for a floor record to disagree with the objects it governs.
+    ///
+    /// This is authorization-critical, not bookkeeping: policy bindings and
+    /// grants are keyed on `object_id`, so re-issuing one after a restart would
+    /// hand a NEW table the DEAD table's permissions.
+    pub fn max_object_id(&self) -> Option<u64> {
+        let guard = self.inner.read();
+        guard
+            .tables
+            .values()
+            .flat_map(|schema| {
+                schema
+                    .object_id
+                    .into_iter()
+                    .chain(schema.columns.iter().filter_map(|c| c.object_id))
+                    .chain(schema.indexes.iter().filter_map(|i| i.object_id))
+            })
+            .max()
+    }
+
     /// The highest WAL sequence number folded in (replay watermark / snapshot
     /// cutover LSN).
     pub fn applied_seq(&self) -> u64 {


### PR DESCRIPTION
**TD-AUTHZ-2 root cause, fixed.** `SystemCatalog::create_table` validated the schema and returned it **verbatim** — no minting — while `NativeCatalog::create_table` mints for the table, every column and every index. **`SystemCatalog` is what the server registers**, so every SQL-created table got no object id.

**The consequence was not cosmetic.** The relational ABAC path denies when the ids are absent (`dml/mod.rs:1466`), so relational policy bindings and grants **could never take effect at all** — not *"were unconfigured"*, **could not**. Fail-closed, so the safe direction, but inert.

## Design

**The floor is derived, not persisted.** `SystemCatalogState::max_object_id()` scans recovered state; both constructors set `object_id_floor = max_object_id().map_or(1, |id| id + 1)` — mirroring the `account_floor` pattern already in this file.

Object ids ride inside the persisted schemas, so WAL replay and snapshot load reconstruct the floor **for free**: no extra fsync, no second recovery path, and no way for a separately-persisted floor to disagree with the objects it governs. The codebase had already reached this conclusion for account ids; mirroring it beat inventing a parallel mechanism.

**Adopt, don't overwrite.** A caller-supplied id is kept and merely raises the floor via **`fetch_max`** — not `store`, which under concurrent creates could *lower* a floor another thread had raised, re-issuing an id. Adoption preserves the ADR-031 unification where a vector collection pre-sets `schema.object_id` from `collection.id` before `create_table` runs; overwriting would split one collection into two identities and detach any policy bound to the first. *(This is also why vector collections were unaffected by the bug — their id never needed minting.)*

**Why these invariants are authorization-critical, not bookkeeping:** policy bindings and grants are keyed on `object_id`. Re-issuing one after a restart hands a **new** table the permissions of a **dead** one.

## Tests — all teeth-proven

Neutering *only* the minting line fails them (verified: `"table a minted"`):

| test | invariant |
|---|---|
| `object_ids_are_never_reissued_across_a_restart` | drops the handle and reopens from the same WAL — tests **recovery**, not an in-memory counter |
| `a_caller_supplied_object_id_is_adopted_and_raises_the_floor` | adoption preserves ADR-031 identity unification |
| `object_id_survives_the_get_table_round_trip_on_system_catalog` | the sibling to #1559, which proved that invariant on an implementation the server **doesn't register** |

## Deliberately not lifted

The three `#[ignore = "TD-AUTHZ-2: …"]` e2e tests stay ignored. Minting is correct at the catalog, but end-to-end `xcatalog` rendering should be verified against a live server first — **this TD's own history is a record of what assuming reachability costs.** Status `Open` → `Partial`.

## Verification

`--features abac-policy` ✅ · `cargo check --all-targets` ✅ · **26/26 SystemCatalog tests** ✅ (the sibling `account_floor` allocator untouched) · `make work-commit-check` ✅

Ref TD-AUTHZ-2, TD-AUTHZ-1, ADR-031, #1559, #1606, #1607.
