### PR TITLE
docs(td): complete the TD-IVF-3 factorial; file TD-COST-1 (cold-tier posture)

### DIFF
--- a/docs/10-quality/td/TD-COST-1-cold-tier-posture-unsafe-for-query-serving-collections.adoc
+++ b/docs/10-quality/td/TD-COST-1-cold-tier-posture-unsafe-for-query-serving-collections.adoc
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 ProximaDB
+// SPDX-License-Identifier: Apache-2.0
+= TD-COST-1: the Cool/Cold default posture is unsafe for query-serving vector collections — read amplification moves the break-even by orders of magnitude
+:status: Open
+:dim: D1
+:pillar: COST
+
+[cols="1,3", options="header"]
+|===
+| Field | Value
+| Status | **Open — measured on one bed. Proposes a guidance change, not a code change.**
+| Priority | **P2 — cost correctness.** No incorrect behaviour ships today (tiering is an unset per-PUT knob), but the documented posture would be expensive if followed for query-serving collections.
+| Component | `docs/12-design/adr/ADR-036-azure-objectstore-orientation.adoc` :56 ("default cold posture is flat Blob + Cool/Cold access tier"). Knob is `ObjectAccessTier` / `FileOptions.storage_class`; no automatic or lifecycle tiering exists.
+| Evidence | 768-d BGE bed, 491,655 rows, k_c=90, n_comp=32, at the recall-0.98 floor: **41.0 GET/query, 116 MB/query** on the cold object path. Binary `62677fb4…` @ `aed724fc5`.
+|===
+
+== The finding
+
+ADR-036 is right that the access tier is the dominant *at-rest* cost lever, and
+right that it is the thing to reach for. What the posture does not account for is
+that **vector search reads ~116 MB per query at the SLA** — four to five orders of
+magnitude more than the few-KB reads that generic blob-tiering guidance assumes.
+Cool and Cold bill **per GB retrieved**, in-region, on every read. Hot does not.
+
+Measured read cost per query on this bed (Azure Blob LRS list prices):
+
+[cols="1,1,1,1,1", options="header"]
+|===
+| cache hit | Hot | Cool | Cold | Cool/Hot
+| 0% | $1.80e-05 | $1.17e-03 | $3.81e-03 | **65×**
+| 50% | $9.02e-06 | $5.87e-04 | $1.90e-03 | 65×
+| 90% | $1.80e-06 | $1.17e-04 | $3.81e-04 | 65×
+| 99% | $1.80e-07 | $1.17e-05 | $3.81e-05 | 65×
+|===
+
+The ratio is cache-invariant: caching scales both tiers equally, so it changes the
+absolute bill but never which tier wins.
+
+== Where the break-even actually sits
+
+Cool saves **$0.0093/GB-month** at rest and costs more on every read. Equating the
+two gives the query rate above which Hot is cheaper overall:
+
+[cols="1,1,1", options="header"]
+|===
+| cache hit ratio | queries/month per GB | for a 0.485 GB collection
+| 0% | 8.0 | 3.9 /month
+| 50% | 16.1 | 7.8 /month
+| 90% | 80.5 | 39 /month
+| 99% | 804.7 | 390 /month
+|===
+
+So a half-gigabyte collection served from a warm (90%) cache needs only **~39
+queries a month** before Hot is the cheaper posture. Generic tiering guidance —
+written for workloads that read kilobytes — puts this threshold orders of
+magnitude higher, which is why the posture reads as safe and is not.
+
+== Proposed resolution
+
+. **Amend ADR-036's posture.** "Default cold posture = Cool/Cold" should become:
+  Hot is the default for **query-serving** collections; Cool/Cold is for
+  collections that are archival *by access rate*, not by age.
+. **Require an access-rate justification**, not an age heuristic, before tiering a
+  collection down. The break-even is computable from quantities already metered:
+  bytes/query, queries/month, stored GB, cache hit ratio.
+. Do **not** add automatic/lifecycle tiering by object age. On this workload an
+  age-based demotion would move actively-queried collections onto a tier that is
+  65× more expensive per read, and nothing in the current design would surface it.
+. If tiering is applied, revisit cell geometry with it — see the related finding
+  below; the two interact.
+
+NOTE: this is a guidance change. `ObjectAccessTier` defaults to unset (account
+default) and no lifecycle policy ships, so **no incorrect behaviour is live** —
+the risk is that someone follows the documented posture.
+
+== Related: the optimal cell size is also tier-dependent
+
+The same measurement sweep shows GET/query is U-shaped in `k_c` with its minimum
+at the natural `k_c` (≈4 MiB cells, vindicating ADR-065's IOP target), while
+**bytes/query fall monotonically** as cells get finer:
+
+....
+   k_c  MiB/cell  floor@10   GET/q   MB/q   %corpus touched
+    30      12.0        12    49.5    170        40.0%
+    90       4.0        25    41.0    116        27.8%   <- GET minimum
+   300       1.2        60    57.4     93        20.0%
+....
+
+Because Hot bills requests and Cool bills bytes, the two tiers want different
+geometries: **Hot → k_c=90 (cheaper by 29%); Cool → k_c=300 (cheaper by 18%)**.
+`iop_target` is currently a single constant. If tiering is ever applied to a
+query-serving collection, its cell geometry is then optimised for a cost model it
+no longer pays. Filed here as an observation; a geometry change needs its own
+measurement.
+
+== What is NOT established
+
+* **One bed, one dimensionality.** 768-d/491k rows/k_c=90. Read amplification
+  scales with corpus and `k_c`, so the break-even moves; the *method* transfers,
+  the constants do not.
+* Azure Blob LRS **list prices** as of 2026-08. Reserved capacity, other clouds,
+  and negotiated rates shift the arithmetic — S3 IA and GCS Nearline have the same
+  shape (per-GB retrieval on cold classes) but different constants.
+* Cool/Cold also carry **minimum retention** (early-deletion penalties) which this
+  analysis ignores; they make tiering-down worse, not better.
+* The cache-hit ratios above are illustrative. Production hit ratio is the single
+  largest term in the absolute bill and is not measured here.

--- a/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
+++ b/docs/10-quality/td/TD-IVF-3-coarse-pca-projection-width-miscalibrated.adoc
@@ -77,26 +77,106 @@ not a portable constant. The two-constraint clamp rule this TD previously propos
 (a variance target AND an independent estimation floor) is therefore **wrong in
 structure**, not merely mis-parameterised: the two terms trade off continuously.
 
-We are left with two solid measurements and a two-point interpolation:
+The interpolation this TD previously offered — `n_comp ~= 4.9 * dim^0.387`,
+predicting ~49 at 384-d — has since been **measured and refuted**. See the
+factorial below.
 
-....
-  measured:   128-d -> 32 comps (25.0% of dims)
-              768-d -> 64 comps ( 8.3% of dims)
+== The factorial this TD asked for (completed 2026-08-12)
 
-  interpolation:  n_comp ~= 4.9 * dim^0.387
-      dim= 128 ->  32   (matches)          dim= 768 ->  64   (matches)
-      dim= 384 ->  49   UNTESTED           dim=1024 ->  72   UNTESTED
-      dim=1536 ->  84   UNTESTED
+384-d BGE, same 491,655 chunks as the 768-d bed, `k_c` FORCED to 90 so embedding
+dimension is the only variable:
 
-  today's formula, for contrast:
-      dim= 128 ->  10   dim= 384 ->  12   dim= 768 ->  14   dim=1536 ->  15
-....
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+| n_comp | % of dim | s/p | floor@10 | GET/q | floor@20 | GET/q
+| 12 (default) | 3.1% | 45.5 | 30 | 34.6 | 30 | 34.4
+| **24** | 6.2% | 22.8 | **25** | **29.6** | 30 | 32.0
+| 32 | 8.3% | 17.1 | 25 | 29.4 | 30 | 32.5
+| 48 | 12.5% | 11.4 | 25 | 29.4 | 30 | 33.0
+| **64** | 16.7% | 8.5 | 25 | 29.4 | **25** | **28.6**
+|===
 
-A two-point fit reproduces two points by construction. It is an **interpolation
-between measurements, explicitly not a law**. It cannot establish that dimension
-is the correct policy key, especially when the fixed-dimension experiment above
-identifies `k_c` as the larger effect. The 384-d prediction of ~49 is one
-falsifiable test, not a default candidate.
+Sub-0.98 mean deltas: `24 vs 12 = +0.0198`, `32 vs 24 = +0.0019`,
+`48 vs 32 = +0.0023`, `64 vs 48 = +0.0219`.
+
+**The curve is two-stepped, not smooth.** A large gain 12→24, a **plateau across
+24/32/48**, then a second gain at 64. So the interpolation's prediction of 49 lands
+squarely inside the dead zone — 48 is measurably no better than 24, at twice the
+width. Dimension is not the policy key.
+
+NOTE: quote the **sub-0.98** statistic, not the full-grid mean. Above the floor
+every width converges to 0.994–0.998 (the TD-WLP-4b saturation), and averaging
+those ties in dilutes real effects by 30–40%.
+
+=== `k_c` does not move the optimum
+
+768-d, the same corpus, `k_c` forced apart from N:
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| k_c | MiB/cell | width | floor@10 | GET/q | 64-vs-32 (sub-0.98)
+| 30 | 12.0 | 32 | 12 | 49.5 | —
+| 30 | 12.0 | 64 | 10 | 39.7 | **+0.0221**
+| 90 | 4.0 | 32 | 25 | 41.0 | —
+| 90 | 4.0 | 64 | 25 | 38.7 | **+0.0151**
+|===
+
+64 wins at both cell counts, so **the width policy needs no `k_c` term**. A second
+effect appears though: a wider projection largely *cancels* the penalty for coarse
+cells. At `n_comp=32`, moving 90→30 costs +21% GET/query; at `n_comp=64` it costs
+**+2.6%**. Width buys robustness to `k_c` misconfiguration, not just probes.
+
+=== The best invariant found: between-centroid variance
+
+Coarse ranking needs the ability to separate *centroids*, which is not what PCA
+maximises. Measuring `eta^2 = between-centroid variance / total variance` per
+component (60k sample, k-means in the full PCA space):
+
+[cols="1,1,1,1", options="header"]
+|===
+| corpus | measured optimum | % BETWEEN-centroid | % total variance
+| 128-d BIGANN | 32 | 96.8% | 79.1%
+| 384-d BGE | 64 | 92.4% | 59.5%
+| 768-d BGE | 64 | 93.1% | 56.9%
+| *spread* | | *4.4 pp* | *22.2 pp*
+|===
+
+**5× tighter than total variance**, and within one model family essentially exact
+(92.4 vs 93.1 — 0.7 pp, at different ambient dims). It is still **not** a single
+threshold: `T_b=92%` predicts BIGANN at 24 (measured 32); `T_b=96%` predicts both
+BGE at 128 (measured 64). BIGANN sits ~4 pp higher — a corpus-family effect.
+
+Consequence for any future rule: **target between-centroid variance, not total
+variance.** `T=0.79` of total variance demands ~147 components at 384-d, while 64
+already captures 92.4% of what ranking actually needs. Targeting the wrong
+quantity is why earlier drafts of this TD over-demanded width and wrongly
+concluded that neural embeddings were infeasible under the training cap. The
+quantity is computable at compaction time from the centroids and projection the
+engine already holds.
+
+REFUTED, recorded so it is not retried: the 48→64 step is *not* explained by
+discriminative directions arriving late in the PCA ordering. Between-variance
+added by components 49–64 versus 33–48 is a ratio of 0.55, against a
+total-variance ratio of 0.77 — i.e. those components contribute *less* separation
+per unit variance, the opposite of what that hypothesis requires. The step remains
+unexplained; the spectrum, the eta^2 profile and cell balance are all smooth, and
+beds are deterministic.
+
+=== The sqrt-based nprobe policy is BIGANN-specific
+
+`ceil(1.7*sqrt(k_c))` = 17 at `k_c`≈90–100:
+
+[cols="2,1,1,1,1", options="header"]
+|===
+| bed | k_c | policy | measured floor | verdict
+| 128-d BIGANN | 100 | 17 | 12 | MEETS (over-provisions)
+| 384-d BGE | 90 | 17 | 25 | **MISSES** (0.9672 @ np20)
+| 768-d BGE | 90 | 17 | 25 | **MISSES** (0.9758 @ np20)
+|===
+
+Probe requirement is not a function of cell count alone — embedding geometry
+matters. A policy fitted on BIGANN under-provisions neural corpora at identical
+`k_c`, landing below the 0.98 SLA.
 
 == Proposed resolution
 
@@ -193,6 +273,23 @@ tracks the same underlying quantity and degrades gracefully. The ×1.05 toleranc
 exists to absorb CI hardware/threading differences, not scatter.
 
 == Adjacent findings (measured, not proposed here)
+
+* **The 4MiB IOP target is vindicated, and now bracketed on both sides.** GET/query
+  is U-shaped in `k_c` with its minimum at the natural value, while bytes/query
+  fall monotonically as cells get finer:
++
+....
+   k_c  MiB/cell  floor@10   GET/q   MB/q   %corpus touched
+    30      12.0        12    49.5    170        40.0%
+    90       4.0        25    41.0    116        27.8%   <- GET minimum
+   300       1.2        60    57.4     93        20.0%
+....
++
+Coarser was already known to lose (a `k_c=50`/8MiB test at 128-d cost +7.2% GETs
+at iso-recall). Finer loses too: more probes cost more round-trips than the byte
+saving is worth. Because Hot bills requests and Cool bills bytes, the two tiers
+want different geometries — see link:TD-COST-1-cold-tier-posture-unsafe-for-query-serving-collections.adoc[TD-COST-1].
+
 
 * **The cell-size conclusion is conditional on the 4 MiB read cap.** Forcing
   `k_c=50` at 3.3M (approximately 8 MiB cells) measured **+7.2% application


### PR DESCRIPTION
Docs only. Completes the factorial TD-IVF-3 explicitly asked for, and files one new TD that follows from it.

## The factorial TD-IVF-3 requested

TD-IVF-3 (merged in #1558) declined to propose a rule and asked for a minimal factorial first — sweep the predicted width neighbourhood at independently forced `k_c` values, on a second dimensionality, so width / cell-count / corpus-content effects could be separated. Done: **26 beds, one binary, one corpus family.**

**384-d BGE** (same 491,655 chunks as the 768-d bed, `k_c` forced to 90 so dimension is the only variable):

| n_comp | %dim | floor@10 | GET/q | floor@20 | GET/q | sub-0.98 delta |
|---|---|---|---|---|---|---|
| 12 (default) | 3.1% | 30 | 34.6 | 30 | 34.4 | — |
| **24** | 6.2% | **25** | **29.6** | 30 | 32.0 | +0.0198 over 12 |
| 32 | 8.3% | 25 | 29.4 | 30 | 32.5 | +0.0019 (null) |
| 48 | 12.5% | 25 | 29.4 | 30 | 33.0 | +0.0023 (null) |
| **64** | 16.7% | 25 | 29.4 | **25** | **28.6** | +0.0219 over 48 |

The curve is **two-stepped with a plateau across 24/32/48**. The interpolation the TD carried (`n_comp ≈ 4.9·dim^0.387`, predicting ~49) lands inside that dead zone and is **refuted** — 48 is no better than 24 at twice the width. Dimension is not the policy key.

## `k_c` does not move the optimum

64 beats 32 at both `k_c=30` (+0.0221) and `k_c=90` (+0.0151), so the width policy needs no `k_c` term. A second effect turned up: **a wider projection cancels most of the penalty for coarse cells** — moving `k_c` 90→30 costs +21% GET/query at `n_comp=32` but only **+2.6%** at 64.

## Best invariant: between-centroid variance

| corpus | optimum | % between-centroid | % total variance |
|---|---|---|---|
| 128-d BIGANN | 32 | 96.8% | 79.1% |
| 384-d BGE | 64 | 92.4% | 59.5% |
| 768-d BGE | 64 | 93.1% | 56.9% |
| **spread** | | **4.4 pp** | **22.2 pp** |

**5× tighter than total variance.** Still not a single threshold (BIGANN sits ~4pp above the BGE pair), so the calibrated table stands — but keyed on a far more stable quantity, computable at compaction time from the centroids the engine already holds. Also records as **refuted** the hypothesis that the 48→64 step comes from late-arriving discriminative directions; the step remains unexplained.

## Two policies refuted

- **sqrt-nprobe is BIGANN-specific.** `ceil(1.7·√k_c)` = 17 meets the SLA on BIGANN (real floor 12) but **misses on both neural corpora** at identical `k_c` (real floor 25).
- **4MiB IOP target is vindicated**, now bracketed both ways: GET/query is U-shaped in `k_c` with its minimum at the natural value, while bytes/query fall monotonically. Coarser loses (8MiB, 12MiB), finer loses (1.2MiB).

## TD-COST-1 (new)

Follows directly from that byte/request split. Cool/Cold bill **per GB retrieved**, and vector search reads **~116 MB/query** — 4–5 orders of magnitude more than the few-KB reads generic tiering guidance assumes. ADR-036's stated default cold posture is therefore unsafe for query-serving collections: Cool costs **65× more per query**, and break-even is only **8–80 queries/month/GB** depending on cache hit ratio.

Guidance change only — `ObjectAccessTier` defaults to unset and no lifecycle tiering ships, so no incorrect behaviour is live.

## Commands run

```
python3 scripts/check_td_adr_unique.py           # 90 ADRs, 401 TD ids, 0 errors
python3 scripts/check_no_agent_attribution.py --range origin/develop..HEAD
```

## Deployment impact

None. Two `.adoc` files under `docs/10-quality/td/`. No code, no defaults changed.